### PR TITLE
chore: return snyk instead of empty string

### DIFF
--- a/internal/utils/cache-dir.go
+++ b/internal/utils/cache-dir.go
@@ -8,13 +8,15 @@ import (
 func SnykCacheDir() (string, error) {
 	baseDirectory, err := os.UserCacheDir()
 	if err != nil {
-		return "", err
+		// Returning "snyk" to be used as the cache directory name later.
+		return "snyk", err
 	}
 
 	snykCacheDir := path.Join(baseDirectory, "snyk")
 	err = os.MkdirAll(snykCacheDir, FILEPERM_755)
 	if err != nil {
-		return "", err
+		// Returning "snyk" to be used as the cache directory name later.
+		return "snyk", err
 	}
 
 	return snykCacheDir, nil


### PR DESCRIPTION
Return “snyk” instead of empty string, to be used later as the cache directory name.