### PR TITLE
Fix: add endpoint alias when reading API Url configuration

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,4 +1,4 @@
 package constants
 
-const SNYK_DEFAULT_API_URL = "https://api.snyk.io"
+const SNYK_DEFAULT_API_URL = "https://app.snyk.io/api"
 const SNYK_API_VERSION = "2022-09-15~experimental"

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -64,6 +64,7 @@ func initConfiguration(config configuration.Configuration) {
 
 	config.AddAlternativeKeys(configuration.AUTHENTICATION_TOKEN, []string{"snyk_token", "snyk_cfg_api", "api"})
 	config.AddAlternativeKeys(configuration.AUTHENTICATION_BEARER_TOKEN, []string{"snyk_oauth_token", "snyk_docker_token"})
+	config.AddAlternativeKeys(configuration.API_URL, []string{"endpoint"})
 }
 
 func CreateAppEngine() workflow.Engine {


### PR DESCRIPTION
* When accessing the configured API_URL, consider the 'endpoint' value configured in the snyk.json file
* adapted default API_URL