### PR TITLE
feat: Handle additional mime types in output module

### DIFF
--- a/pkg/local_workflows/output_workflow.go
+++ b/pkg/local_workflows/output_workflow.go
@@ -64,12 +64,21 @@ func outputWorkflowEntryPoint(invocation workflow.InvocationContext, input []wor
 				outputDestination.Remove(writeJsonToFile)
 				outputDestination.WriteFile(writeJsonToFile, singleData, iUtils.FILEPERM_666)
 			}
-		} else if mimeType == "text/plain" { // handle text/pain
-			singleData := input[i].GetPayload().([]byte)
-			outputDestination.Println(string(singleData))
-		} else {
-			err := fmt.Errorf("Unsupported output type: %s", mimeType)
-			return output, err
+		} else { // handle text/pain and unknown the same way
+			// try to convert payload to a string
+			singleDataAsString := ""
+			singleData, typeCastSuccessful := input[i].GetPayload().([]byte)
+			if !typeCastSuccessful {
+				singleDataAsString, typeCastSuccessful = input[i].GetPayload().(string)
+				if !typeCastSuccessful {
+					err := fmt.Errorf("Unsupported output type: %s", mimeType)
+					return output, err
+				}
+			} else {
+				singleDataAsString = string(singleData)
+			}
+
+			outputDestination.Println(singleDataAsString)
 		}
 	}
 

--- a/pkg/local_workflows/output_workflow_test.go
+++ b/pkg/local_workflows/output_workflow_test.go
@@ -123,9 +123,24 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 		assert.Equal(t, []workflow.Data{}, output)
 	})
 
+	t.Run("should print unsupported mimeTypes that are string convertible", func(t *testing.T) {
+		workflowIdentifier := workflow.NewTypeIdentifier(WORKFLOWID_OUTPUT_WORKFLOW, "output")
+		data := workflow.NewData(workflowIdentifier, "hammer/head", string(payload))
+
+		// mock assertions
+		outputDestination.EXPECT().Println(payload).Return(0, nil).Times(1)
+
+		// execute
+		output, err := outputWorkflowEntryPoint(invocationContextMock, []workflow.Data{data}, outputDestination)
+
+		// assert
+		assert.Nil(t, err)
+		assert.Equal(t, []workflow.Data{}, output)
+	})
+
 	t.Run("should reject unsupported mimeTypes", func(t *testing.T) {
 		workflowIdentifier := workflow.NewTypeIdentifier(WORKFLOWID_OUTPUT_WORKFLOW, "output")
-		data := workflow.NewData(workflowIdentifier, "hammer/head", []byte(payload))
+		data := workflow.NewData(workflowIdentifier, "hammer/head", workflowIdentifier) // re-using workflowIdentifier as data to have some non string data
 
 		// execute
 		output, err := outputWorkflowEntryPoint(invocationContextMock, []workflow.Data{data}, outputDestination)


### PR DESCRIPTION
This PR adds support for unknown mime types which are convertible to string by default, so that they are displayed on the console as if they would be text/plain.