### PR TITLE
fix: org derivation when existing value provided [HEAD-137]

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -4,7 +4,6 @@ package api
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -25,7 +24,7 @@ type snykApiClient struct {
 }
 
 func (a *snykApiClient) GetOrgIdFromSlug(slugName string) (string, error) {
-	url := a.url + "/api/v1/orgs"
+	url := a.url + "/v1/orgs"
 	res, err := a.client.Get(url)
 	if err != nil {
 		return "", err
@@ -40,13 +39,14 @@ func (a *snykApiClient) GetOrgIdFromSlug(slugName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	for _, org := range userOrgInfo.Organizations {
 		if org.Slug == slugName {
 			return org.ID, nil
 		}
 	}
 
-	return "", errors.New(fmt.Sprintf("org ID not found for slug %v", slugName))
+	return "", fmt.Errorf("org ID not found for slug %v", slugName)
 }
 
 func (a *snykApiClient) GetDefaultOrgId() (string, error) {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -54,8 +54,9 @@ func initConfiguration(config configuration.Configuration, apiClient api.ApiClie
 				if err == nil {
 					return orgId
 				}
+			} else {
+				return orgId
 			}
-			return orgId
 		}
 
 		orgId, _ := apiClient.GetDefaultOrgId()

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -72,6 +73,28 @@ func Test_initConfiguration_useDefaultOrgId(t *testing.T) {
 
 	config := configuration.New()
 	initConfiguration(config, mockApiClient)
+
+	actualOrgId := config.GetString(configuration.ORGANIZATION)
+	assert.Equal(t, defaultOrgId, actualOrgId)
+}
+
+func Test_initConfiguration_useDefaultOrgIdWhenGetOrgIdFromSlugFails(t *testing.T) {
+	orgName := "someOrgName"
+	defaultOrgId := "someDefaultOrgId"
+
+	// setup mock
+	ctrl := gomock.NewController(t)
+	mockApiClient := mocks.NewMockApiClient(ctrl)
+
+	// mock assertion
+	mockApiClient.EXPECT().Init(gomock.Any(), gomock.Any()).Times(1)
+	mockApiClient.EXPECT().GetOrgIdFromSlug(orgName).Return("", errors.New("Failed to fetch org id from slug")).Times(1)
+	mockApiClient.EXPECT().GetDefaultOrgId().Return(defaultOrgId, nil).Times(1)
+
+	config := configuration.New()
+	initConfiguration(config, mockApiClient)
+
+	config.Set(configuration.ORGANIZATION, orgName)
 
 	actualOrgId := config.GetString(configuration.ORGANIZATION)
 	assert.Equal(t, defaultOrgId, actualOrgId)


### PR DESCRIPTION
- Fix wrong API url path when querying for fetching org from a slug.
- Default to user default org, when org derivation from slug fails.