### PR TITLE
chore: handle token specified via env var [HEAD-156]

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -21,7 +21,7 @@ import (
 func initConfiguration(config configuration.Configuration, apiClient api.ApiClient, logger *log.Logger) {
 	dir, _ := utils.SnykCacheDir()
 
-	config.AddDefaultValue(configuration.OAUTH_AUTH_FLOW_ENABLED, configuration.StandardDefaultValueFunction(false))
+	config.AddDefaultValue(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, configuration.StandardDefaultValueFunction(false))
 	config.AddDefaultValue(configuration.ANALYTICS_DISABLED, configuration.StandardDefaultValueFunction(false))
 	config.AddDefaultValue(configuration.WORKFLOW_USE_STDIO, configuration.StandardDefaultValueFunction(false))
 	config.AddDefaultValue(configuration.PROXY_AUTHENTICATION_MECHANISM, configuration.StandardDefaultValueFunction(httpauth.StringFromAuthenticationMechanism(httpauth.AnyAuth)))
@@ -70,7 +70,7 @@ func initConfiguration(config configuration.Configuration, apiClient api.ApiClie
 		return orgId
 	})
 
-	config.AddDefaultValue(configuration.OAUTH_AUTH_FLOW_ENABLED, func(existingValue any) any {
+	config.AddDefaultValue(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, func(existingValue any) any {
 		alternativeBearerKeys := config.GetAlternativeKeys(configuration.AUTHENTICATION_BEARER_TOKEN)
 		alternativeAuthKeys := config.GetAlternativeKeys(configuration.AUTHENTICATION_TOKEN)
 		alternativeKeys := append(alternativeBearerKeys, alternativeAuthKeys...)

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"log"
+	"os"
 
 	"github.com/google/uuid"
 	"github.com/snyk/go-application-framework/internal/api"
@@ -78,6 +79,12 @@ func CreateAppEngine() workflow.Engine {
 	apiClient := api.NewApiInstance()
 
 	initConfiguration(config, apiClient)
+
+	// update config if oauth token is set via env var
+	oAuthEnabled, ok := os.LookupEnv("AUTHENTICATION_BEARER_TOKEN")
+	if ok {
+		config.Set(configuration.AUTHENTICATION_BEARER_TOKEN, oAuthEnabled)
+	}
 
 	engine := workflow.NewWorkFlowEngine(config)
 

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -45,18 +44,16 @@ func Test_CreateAppEngine_config_replaceV1inApi(t *testing.T) {
 func Test_CreateAppEngine_oAuthEnvVarOverridesAuthFlow(t *testing.T) {
 	for _, envVar := range []string{"SNYK_TOKEN", "SNYK_OAUTH_TOKEN", "SNYK_DOCKER_TOKEN"} {
 		t.Run(fmt.Sprintf("For %s envVar", envVar), func(t *testing.T) {
-			// loop through all env vars that can be used for authentication
 			engine := CreateAppEngine()
 			assert.NotNil(t, engine)
 
 			config := engine.GetConfiguration()
-			config.Set(configuration.OAUTH_AUTH_FLOW_ENABLED, true)
-			assert.Equal(t, true, config.GetBool(configuration.OAUTH_AUTH_FLOW_ENABLED))
+			config.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, true)
+			assert.Equal(t, true, config.GetBool(configuration.FF_OAUTH_AUTH_FLOW_ENABLED))
 
-			// setting this env var should override the config
-			os.Setenv(envVar, "token")
-			assert.Equal(t, false, config.GetBool(configuration.OAUTH_AUTH_FLOW_ENABLED))
-			os.Unsetenv(envVar)
+			// setting this env var should override the config setting for OAUTH_AUTH_FLOW_ENABLED
+			t.Setenv(envVar, envVar+"_token")
+			assert.Equal(t, false, config.GetBool(configuration.FF_OAUTH_AUTH_FLOW_ENABLED))
 		})
 	}
 }

--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -21,12 +21,10 @@ type Authenticator interface {
 func CreateAuthenticator(config configuration.Configuration, httpClient *http.Client) Authenticator {
 	var authenticator Authenticator
 
-	if config.GetBool(configuration.OAUTH_AUTH_ENABLED) {
-		// try oauth authenticator
-		tmpAuthenticator := NewOAuth2Authenticator(config, httpClient)
-		if tmpAuthenticator.IsSupported() {
-			authenticator = tmpAuthenticator
-		}
+	// try oauth authenticator
+	tmpAuthenticator := NewOAuth2Authenticator(config, httpClient)
+	if tmpAuthenticator.IsSupported() {
+		authenticator = tmpAuthenticator
 	}
 
 	// create token authenticator

--- a/pkg/auth/authenticator_test.go
+++ b/pkg/auth/authenticator_test.go
@@ -34,7 +34,7 @@ func Test_CreateAuthenticator_token_oauthDisabled(t *testing.T) {
 	config := configuration.NewFromFiles("")
 	config.Set(CONFIG_KEY_OAUTH_TOKEN, getTestOauthTokenStorageType())
 	config.Set(configuration.AUTHENTICATION_TOKEN, "api token")
-	config.Set(configuration.OAUTH_AUTH_FLOW_ENABLED, false)
+	config.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, false)
 
 	authenticator := CreateAuthenticator(config, http.DefaultClient)
 	_, ok := authenticator.(*tokenAuthenticator)
@@ -45,7 +45,7 @@ func Test_CreateAuthenticator_oauth_oauthEnabled(t *testing.T) {
 	config := configuration.NewFromFiles("")
 	config.Set(CONFIG_KEY_OAUTH_TOKEN, getTestOauthTokenStorageType())
 	config.Set(configuration.AUTHENTICATION_TOKEN, "api token")
-	config.Set(configuration.OAUTH_AUTH_FLOW_ENABLED, true)
+	config.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, true)
 
 	authenticator := CreateAuthenticator(config, http.DefaultClient)
 	_, ok := authenticator.(*oAuth2Authenticator)

--- a/pkg/auth/authenticator_test.go
+++ b/pkg/auth/authenticator_test.go
@@ -34,7 +34,7 @@ func Test_CreateAuthenticator_token_oauthDisabled(t *testing.T) {
 	config := configuration.NewFromFiles("")
 	config.Set(CONFIG_KEY_OAUTH_TOKEN, getTestOauthTokenStorageType())
 	config.Set(configuration.AUTHENTICATION_TOKEN, "api token")
-	config.Set(configuration.OAUTH_AUTH_ENABLED, false)
+	config.Set(configuration.OAUTH_AUTH_FLOW_ENABLED, false)
 
 	authenticator := CreateAuthenticator(config, http.DefaultClient)
 	_, ok := authenticator.(*tokenAuthenticator)
@@ -45,7 +45,7 @@ func Test_CreateAuthenticator_oauth_oauthEnabled(t *testing.T) {
 	config := configuration.NewFromFiles("")
 	config.Set(CONFIG_KEY_OAUTH_TOKEN, getTestOauthTokenStorageType())
 	config.Set(configuration.AUTHENTICATION_TOKEN, "api token")
-	config.Set(configuration.OAUTH_AUTH_ENABLED, true)
+	config.Set(configuration.OAUTH_AUTH_FLOW_ENABLED, true)
 
 	authenticator := CreateAuthenticator(config, http.DefaultClient)
 	_, ok := authenticator.(*oAuth2Authenticator)

--- a/pkg/auth/oauth2authenticator.go
+++ b/pkg/auth/oauth2authenticator.go
@@ -154,7 +154,7 @@ func NewOAuth2AuthenticatorWithCustomFuncs(
 }
 
 func (o *oAuth2Authenticator) IsSupported() bool {
-	return o.token != nil && o.config.GetBool(configuration.OAUTH_AUTH_FLOW_ENABLED)
+	return o.token != nil && o.config.GetBool(configuration.FF_OAUTH_AUTH_FLOW_ENABLED)
 }
 
 func (o *oAuth2Authenticator) persistToken(token *oauth2.Token) {

--- a/pkg/auth/oauth2authenticator.go
+++ b/pkg/auth/oauth2authenticator.go
@@ -154,7 +154,7 @@ func NewOAuth2AuthenticatorWithCustomFuncs(
 }
 
 func (o *oAuth2Authenticator) IsSupported() bool {
-	return o.token != nil
+	return o.token != nil && o.config.GetBool(configuration.OAUTH_AUTH_ENABLED)
 }
 
 func (o *oAuth2Authenticator) persistToken(token *oauth2.Token) {

--- a/pkg/auth/oauth2authenticator.go
+++ b/pkg/auth/oauth2authenticator.go
@@ -154,7 +154,7 @@ func NewOAuth2AuthenticatorWithCustomFuncs(
 }
 
 func (o *oAuth2Authenticator) IsSupported() bool {
-	return o.token != nil && o.config.GetBool(configuration.OAUTH_AUTH_ENABLED)
+	return o.token != nil && o.config.GetBool(configuration.OAUTH_AUTH_FLOW_ENABLED)
 }
 
 func (o *oAuth2Authenticator) persistToken(token *oauth2.Token) {

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -32,6 +32,7 @@ type Configuration interface {
 	AllKeys() []string
 	AddDefaultValue(key string, defaultValue DefaultValueFunction)
 	AddAlternativeKeys(key string, altKeys []string)
+	GetAlternativeKeys(key string) []string
 
 	// PersistInConfigFile ensures that when Set is called with the given key, it will be persisted in the config file.
 	PersistInConfigFile(key string)
@@ -306,6 +307,11 @@ func (ev *extendedViper) AddDefaultValue(key string, defaultValue DefaultValueFu
 // AddAlternativeKeys adds alternative keys to the configuration.
 func (ev *extendedViper) AddAlternativeKeys(key string, altKeys []string) {
 	ev.alternativeKeys[key] = altKeys
+}
+
+// GetAlternativeKeys returns alternative keys from the configuration.
+func (ev *extendedViper) GetAlternativeKeys(key string) []string {
+	return ev.alternativeKeys[key]
 }
 
 func (ev *extendedViper) PersistInConfigFile(key string) {

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -97,6 +97,16 @@ func Test_ConfigurationGet_ANALYTICS_DISABLED(t *testing.T) {
 	cleanUpEnvVars()
 }
 
+func Test_ConfigurationGet_ALTERNATE_KEYS(t *testing.T) {
+	alternateKeys := []string{"snyk_token", "snyk_cfg_api", "api"}
+
+	config := NewFromFiles(TEST_FILENAME)
+	config.AddAlternativeKeys(AUTHENTICATION_TOKEN, alternateKeys)
+
+	actualValue := config.GetAlternativeKeys(AUTHENTICATION_TOKEN)
+	assert.Equal(t, alternateKeys, actualValue)
+}
+
 func Test_ConfigurationGet_unset(t *testing.T) {
 	assert.Nil(t, prepareConfigstore(`{"api": "mytoken", "somethingElse": 12}`))
 

--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -16,5 +16,6 @@ const (
 	WORKFLOW_USE_STDIO             string = "wflstdio"
 	RAW_CMD_ARGS                   string = "raw_cmd_args"
 	WEB_APP_URL                    string = "internal_snyk_app"
-	OAUTH_AUTH_ENABLED             string = "internal_snyk_oauth_enabled"
+	// feature flag to enable the new oAuth user flow
+	OAUTH_AUTH_FLOW_ENABLED string = "internal_snyk_oauth_enabled"
 )

--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -16,6 +16,6 @@ const (
 	WORKFLOW_USE_STDIO             string = "wflstdio"
 	RAW_CMD_ARGS                   string = "raw_cmd_args"
 	WEB_APP_URL                    string = "internal_snyk_app"
-	// feature flag to enable the new oAuth user flow
-	OAUTH_AUTH_FLOW_ENABLED string = "internal_snyk_oauth_enabled"
+	// feature flags
+	FF_OAUTH_AUTH_FLOW_ENABLED string = "internal_snyk_oauth_enabled"
 )

--- a/pkg/local_workflows/local_workflows.go
+++ b/pkg/local_workflows/local_workflows.go
@@ -17,7 +17,7 @@ func Init(engine workflow.Engine) error {
 		InitWhoAmIWorkflow,
 	}
 
-	if config.GetBool(configuration.OAUTH_AUTH_FLOW_ENABLED) {
+	if config.GetBool(configuration.FF_OAUTH_AUTH_FLOW_ENABLED) {
 		initMethods = append(initMethods, InitAuth) //Use legacy CLI for authentication for now, until OAuth is ready
 	}
 

--- a/pkg/local_workflows/local_workflows.go
+++ b/pkg/local_workflows/local_workflows.go
@@ -17,7 +17,7 @@ func Init(engine workflow.Engine) error {
 		InitWhoAmIWorkflow,
 	}
 
-	if config.GetBool(configuration.OAUTH_AUTH_ENABLED) {
+	if config.GetBool(configuration.OAUTH_AUTH_FLOW_ENABLED) {
 		initMethods = append(initMethods, InitAuth) //Use legacy CLI for authentication for now, until OAuth is ready
 	}
 

--- a/pkg/mocks/configuration.go
+++ b/pkg/mocks/configuration.go
@@ -116,6 +116,20 @@ func (mr *MockConfigurationMockRecorder) Get(key interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockConfiguration)(nil).Get), key)
 }
 
+// GetAlternativeKeys mocks base method.
+func (m *MockConfiguration) GetAlternativeKeys(key string) []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAlternativeKeys", key)
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// GetAlternativeKeys indicates an expected call of GetAlternativeKeys.
+func (mr *MockConfigurationMockRecorder) GetAlternativeKeys(key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAlternativeKeys", reflect.TypeOf((*MockConfiguration)(nil).GetAlternativeKeys), key)
+}
+
 // GetBool mocks base method.
 func (m *MockConfiguration) GetBool(key string) bool {
 	m.ctrl.T.Helper()

--- a/pkg/networking/networking_test.go
+++ b/pkg/networking/networking_test.go
@@ -25,7 +25,7 @@ func getConfig() configuration.Configuration {
 	config.Set(configuration.API_URL, constants.SNYK_DEFAULT_API_URL)
 	config.Set(auth.CONFIG_KEY_OAUTH_TOKEN, "")
 	config.Set(configuration.AUTHENTICATION_TOKEN, "")
-	config.Set(configuration.OAUTH_AUTH_ENABLED, true)
+	config.Set(configuration.OAUTH_AUTH_FLOW_ENABLED, true)
 	return config
 }
 

--- a/pkg/networking/networking_test.go
+++ b/pkg/networking/networking_test.go
@@ -25,7 +25,7 @@ func getConfig() configuration.Configuration {
 	config.Set(configuration.API_URL, constants.SNYK_DEFAULT_API_URL)
 	config.Set(auth.CONFIG_KEY_OAUTH_TOKEN, "")
 	config.Set(configuration.AUTHENTICATION_TOKEN, "")
-	config.Set(configuration.OAUTH_AUTH_FLOW_ENABLED, true)
+	config.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, true)
 	return config
 }
 


### PR DESCRIPTION
This PR should ensure that api token environment variables override what is stored in a configuration file of the CLI.

This should mean that the OAuth flow should be skipped if an OAuth token env var is provided, even if the OAuth flow feature flag is enabled in the config.