### PR TITLE
feat: allow to construct oauth2 authenticator with a custom token refresh function

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -134,7 +134,7 @@ func CreateAppEngineWithOptions(opts ...Opts) workflow.Engine {
 	return engine
 }
 
-// CreateAppEngineWithLogger creates an App engine with logger injected
+// Deprecated: Use CreateAppEngineWithOptions instead.
 func CreateAppEngineWithLogger(logger *log.Logger) workflow.Engine {
 	return CreateAppEngineWithOptions(WithLogger(logger))
 }

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -142,7 +142,7 @@ func Test_initConfiguration_uuidOrgId(t *testing.T) {
 func Test_CreateAppEngineWithLogger(t *testing.T) {
 	logger := log.New(os.Stdout, "", 0)
 
-	engine := CreateAppEngineWithLogger(logger)
+	engine := CreateAppEngineWithOptions(WithLogger(logger))
 
 	assert.NotNil(t, engine)
 	assert.Equal(t, logger, engine.GetLogger())

--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -22,7 +22,7 @@ func CreateAuthenticator(config configuration.Configuration, httpClient *http.Cl
 	var authenticator Authenticator
 
 	// try oauth authenticator
-	tmpAuthenticator := NewOAuth2Authenticator(config, httpClient)
+	tmpAuthenticator := NewOAuth2AuthenticatorWithOpts(config, WithHttpClient(httpClient))
 	if tmpAuthenticator.IsSupported() {
 		authenticator = tmpAuthenticator
 	}

--- a/pkg/auth/oauth2authenticator.go
+++ b/pkg/auth/oauth2authenticator.go
@@ -132,7 +132,7 @@ func GetOAuthToken(config configuration.Configuration) (*oauth2.Token, error) {
 	return nil, nil
 }
 
-func refreshToken(ctx context.Context, oauthConfig *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error) {
+func RefreshToken(ctx context.Context, oauthConfig *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error) {
 	tokenSource := oauthConfig.TokenSource(ctx, token)
 	return tokenSource.Token()
 }
@@ -153,7 +153,7 @@ func NewOAuth2AuthenticatorWithOpts(config configuration.Configuration, opts ...
 	o.httpClient = http.DefaultClient
 	o.openBrowserFunc = OpenBrowser
 	o.shutdownServerFunc = ShutdownServer
-	o.tokenRefresherFunc = refreshToken
+	o.tokenRefresherFunc = RefreshToken
 
 	// apply options
 	for _, opt := range opts {

--- a/pkg/auth/oauth2authenticator_test.go
+++ b/pkg/auth/oauth2authenticator_test.go
@@ -86,7 +86,7 @@ func Test_AddAuthenticationHeader_validToken(t *testing.T) {
 	}
 
 	config := configuration.NewInMemory()
-	authenticator := NewOAuth2Authenticator(config, http.DefaultClient)
+	authenticator := NewOAuth2AuthenticatorWithOpts(config)
 	authenticator.(*oAuth2Authenticator).persistToken(newToken)
 	authenticator.(*oAuth2Authenticator).tokenRefresherFunc = func(_ context.Context, _ *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error) {
 		assert.False(t, true, "The token is valid and no refresh is required!")
@@ -130,7 +130,7 @@ func Test_AddAuthenticationHeader_expiredToken(t *testing.T) {
 	}
 
 	config := configuration.NewInMemory()
-	authenticator := NewOAuth2Authenticator(config, http.DefaultClient)
+	authenticator := NewOAuth2AuthenticatorWithOpts(config)
 	authenticator.(*oAuth2Authenticator).persistToken(expiredToken)
 	authenticator.(*oAuth2Authenticator).tokenRefresherFunc = func(_ context.Context, _ *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error) {
 		return newToken, nil
@@ -173,7 +173,7 @@ func Test_AddAuthenticationHeader_expiredToken_somebodyUpdated(t *testing.T) {
 	}
 
 	config := configuration.NewInMemory()
-	authenticator := NewOAuth2Authenticator(config, http.DefaultClient)
+	authenticator := NewOAuth2AuthenticatorWithOpts(config)
 	authenticator.(*oAuth2Authenticator).persistToken(expiredToken)
 	authenticator.(*oAuth2Authenticator).tokenRefresherFunc = func(_ context.Context, _ *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error) {
 		assert.False(t, true, "The token is valid and no refresh is required!")
@@ -185,7 +185,7 @@ func Test_AddAuthenticationHeader_expiredToken_somebodyUpdated(t *testing.T) {
 	}
 
 	// have authenticator2 update the token "in parallel"
-	authenticator2 := NewOAuth2Authenticator(config, http.DefaultClient)
+	authenticator2 := NewOAuth2AuthenticatorWithOpts(config)
 	authenticator2.(*oAuth2Authenticator).persistToken(newToken)
 
 	// run method under test

--- a/pkg/auth/oauth2authenticator_test.go
+++ b/pkg/auth/oauth2authenticator_test.go
@@ -1,7 +1,9 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
+	"net/http"
 	"testing"
 	"time"
 
@@ -27,7 +29,7 @@ func Test_getToken(t *testing.T) {
 
 	expectedTokenString, _ := json.Marshal(expectedToken)
 
-	config := configuration.New()
+	config := configuration.NewInMemory()
 	config.Set(CONFIG_KEY_OAUTH_TOKEN, string(expectedTokenString))
 
 	// method under test
@@ -39,7 +41,7 @@ func Test_getToken(t *testing.T) {
 }
 
 func Test_getToken_NoToken_ReturnsNil(t *testing.T) {
-	config := configuration.New()
+	config := configuration.NewInMemory()
 	config.Set(CONFIG_KEY_OAUTH_TOKEN, "")
 
 	// method under test
@@ -50,7 +52,7 @@ func Test_getToken_NoToken_ReturnsNil(t *testing.T) {
 }
 
 func Test_getToken_BadToken_ReturnsError(t *testing.T) {
-	config := configuration.New()
+	config := configuration.NewInMemory()
 	config.Set(CONFIG_KEY_OAUTH_TOKEN, "something else")
 
 	// method under test
@@ -63,7 +65,7 @@ func Test_getToken_BadToken_ReturnsError(t *testing.T) {
 func Test_getOAuthConfiguration(t *testing.T) {
 	webapp := "https://app.fedramp-alpha.snykgov.io"
 
-	config := configuration.New()
+	config := configuration.NewInMemory()
 	config.Set(configuration.WEB_APP_URL, webapp)
 
 	oauthConfig := getOAuthConfiguration(config)
@@ -72,4 +74,132 @@ func Test_getOAuthConfiguration(t *testing.T) {
 	assert.Equal(t, OAUTH_CLIENT_ID, oauthConfig.ClientID)
 	assert.Equal(t, webapp+"/oauth/authorize", oauthConfig.Endpoint.AuthURL)
 	// assert.Equal(t, "https://id.fedramp-alpha.snykgov.io/oauth2/default/v1/token", oauthConfig.Endpoint.TokenURL)
+}
+
+func Test_AddAuthenticationHeader_validToken(t *testing.T) {
+	// prepare test
+	newToken := &oauth2.Token{
+		AccessToken:  "a",
+		TokenType:    "b",
+		RefreshToken: "c",
+		Expiry:       time.Now().Add(60 * time.Second).UTC(),
+	}
+
+	config := configuration.NewInMemory()
+	authenticator := NewOAuth2Authenticator(config, http.DefaultClient)
+	authenticator.(*oAuth2Authenticator).persistToken(newToken)
+	authenticator.(*oAuth2Authenticator).tokenRefresherFunc = func(_ context.Context, _ *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error) {
+		assert.False(t, true, "The token is valid and no refresh is required!")
+		return newToken, nil
+	}
+
+	emptyRequest := &http.Request{
+		Header: http.Header{},
+	}
+
+	// run method under test
+	err := authenticator.AddAuthenticationHeader(emptyRequest)
+	assert.Nil(t, err)
+
+	// compare
+	expectedAuthHeader := "Bearer " + newToken.AccessToken
+	actualAuthHeader := emptyRequest.Header.Get("Authorization")
+	assert.Equal(t, expectedAuthHeader, actualAuthHeader)
+
+	// compare changed token in config
+	actualToken, err := GetOAuthToken(config)
+	assert.Nil(t, err)
+	assert.Equal(t, *newToken, *actualToken)
+	assert.Equal(t, *newToken, *authenticator.(*oAuth2Authenticator).token)
+}
+
+func Test_AddAuthenticationHeader_expiredToken(t *testing.T) {
+	// prepare test
+	expiredToken := &oauth2.Token{
+		AccessToken:  "expired",
+		TokenType:    "b",
+		RefreshToken: "c",
+		Expiry:       time.Now().Add(-60 * time.Second),
+	}
+
+	newToken := &oauth2.Token{
+		AccessToken:  "a",
+		TokenType:    "b",
+		RefreshToken: "c",
+		Expiry:       time.Now().Add(60 * time.Second).UTC(),
+	}
+
+	config := configuration.NewInMemory()
+	authenticator := NewOAuth2Authenticator(config, http.DefaultClient)
+	authenticator.(*oAuth2Authenticator).persistToken(expiredToken)
+	authenticator.(*oAuth2Authenticator).tokenRefresherFunc = func(_ context.Context, _ *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error) {
+		return newToken, nil
+	}
+
+	emptyRequest := &http.Request{
+		Header: http.Header{},
+	}
+
+	// run method under test
+	err := authenticator.AddAuthenticationHeader(emptyRequest)
+	assert.Nil(t, err)
+
+	// compare
+	expectedAuthHeader := "Bearer " + newToken.AccessToken
+	actualAuthHeader := emptyRequest.Header.Get("Authorization")
+	assert.Equal(t, expectedAuthHeader, actualAuthHeader)
+
+	// compare changed token in config
+	actualToken, err := GetOAuthToken(config)
+	assert.Nil(t, err)
+	assert.Equal(t, *newToken, *actualToken)
+	assert.Equal(t, *newToken, *authenticator.(*oAuth2Authenticator).token)
+}
+
+func Test_AddAuthenticationHeader_expiredToken_somebodyUpdated(t *testing.T) {
+	// prepare test
+	expiredToken := &oauth2.Token{
+		AccessToken:  "expired",
+		TokenType:    "b",
+		RefreshToken: "c",
+		Expiry:       time.Now().Add(-60 * time.Second),
+	}
+
+	newToken := &oauth2.Token{
+		AccessToken:  "a",
+		TokenType:    "b",
+		RefreshToken: "c",
+		Expiry:       time.Now().Add(60 * time.Second).UTC(),
+	}
+
+	config := configuration.NewInMemory()
+	authenticator := NewOAuth2Authenticator(config, http.DefaultClient)
+	authenticator.(*oAuth2Authenticator).persistToken(expiredToken)
+	authenticator.(*oAuth2Authenticator).tokenRefresherFunc = func(_ context.Context, _ *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error) {
+		assert.False(t, true, "The token is valid and no refresh is required!")
+		return newToken, nil
+	}
+
+	emptyRequest := &http.Request{
+		Header: http.Header{},
+	}
+
+	// have authenticator2 update the token "in parallel"
+	authenticator2 := NewOAuth2Authenticator(config, http.DefaultClient)
+	authenticator2.(*oAuth2Authenticator).persistToken(newToken)
+
+	// run method under test
+	err := authenticator.AddAuthenticationHeader(emptyRequest)
+	assert.Nil(t, err)
+
+	// compare
+	expectedAuthHeader := "Bearer " + newToken.AccessToken
+	actualAuthHeader := emptyRequest.Header.Get("Authorization")
+	assert.Equal(t, expectedAuthHeader, actualAuthHeader)
+
+	// compare changed token in config
+	actualToken, err := GetOAuthToken(config)
+	assert.Nil(t, err)
+	assert.Equal(t, *newToken, *actualToken)
+	assert.Equal(t, *newToken, *authenticator.(*oAuth2Authenticator).token)
 }

--- a/pkg/auth/oauth2authenticatoroptions.go
+++ b/pkg/auth/oauth2authenticatoroptions.go
@@ -1,0 +1,34 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+
+	"golang.org/x/oauth2"
+)
+
+type OAuth2AuthenticatorOption func(authenticator *oAuth2Authenticator)
+
+func WithOpenBrowserFunc(openBrowserFunc func(string)) OAuth2AuthenticatorOption {
+	return func(authenticator *oAuth2Authenticator) {
+		authenticator.openBrowserFunc = openBrowserFunc
+	}
+}
+
+func WithShutdownServerFunc(shutdownServerFunc func(server *http.Server)) OAuth2AuthenticatorOption {
+	return func(authenticator *oAuth2Authenticator) {
+		authenticator.shutdownServerFunc = shutdownServerFunc
+	}
+}
+
+func WithTokenRefresherFunc(refreshFunc func(ctx context.Context, oauthConfig *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error)) OAuth2AuthenticatorOption {
+	return func(authenticator *oAuth2Authenticator) {
+		authenticator.tokenRefresherFunc = refreshFunc
+	}
+}
+
+func WithHttpClient(httpClient *http.Client) OAuth2AuthenticatorOption {
+	return func(authenticator *oAuth2Authenticator) {
+		authenticator.httpClient = httpClient
+	}
+}

--- a/pkg/local_workflows/auth_workflow.go
+++ b/pkg/local_workflows/auth_workflow.go
@@ -58,7 +58,12 @@ func authEntryPoint(invocationCtx workflow.InvocationContext, _ []workflow.Data)
 		logger.Println("Headless:", headless)
 
 		httpClient := invocationCtx.GetNetworkAccess().GetUnauthorizedHttpClient()
-		authenticator := auth.NewOAuth2AuthenticatorWithCustomFuncs(config, httpClient, OpenBrowser, auth.ShutdownServer)
+		authenticator := auth.NewOAuth2AuthenticatorWithOpts(
+			config,
+			auth.WithHttpClient(httpClient),
+			auth.WithOpenBrowserFunc(OpenBrowser),
+			auth.WithShutdownServerFunc(auth.ShutdownServer),
+		)
 		err = authenticator.Authenticate()
 		if err != nil {
 			return nil, err

--- a/pkg/networking/networking_test.go
+++ b/pkg/networking/networking_test.go
@@ -220,8 +220,8 @@ func Test_AddHeaders_AddsDefaultAndAuthHeaders(t *testing.T) {
 	net := NewNetworkAccess(config)
 	net.AddHeaderField("secret-header", "secret-value")
 
-	request, err := http.NewRequest("GET", "https://api.snyk.io", nil)
-	err = net.AddHeaders(request)
+	request, _ := http.NewRequest("GET", "https://api.snyk.io", nil)
+	err := net.AddHeaders(request)
 	assert.Nil(t, err)
 
 	keys := make([]string, 0, len(request.Header))


### PR DESCRIPTION
- creates an option based constructor with defaults
- makes all other constructors use it
- deprecates previous custom constructors

Dependent on https://github.com/snyk/go-application-framework/pull/51