### PR TITLE
feat: Introduce functional options for OAuthAuthenticator

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -134,7 +134,7 @@ func CreateAppEngineWithOptions(opts ...Opts) workflow.Engine {
 	return engine
 }
 
-// CreateAppEngineWithLogger creates an App engine with logger injected
+// Deprecated: Use CreateAppEngineWithOptions instead.
 func CreateAppEngineWithLogger(logger *log.Logger) workflow.Engine {
 	return CreateAppEngineWithOptions(WithLogger(logger))
 }

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -142,7 +142,7 @@ func Test_initConfiguration_uuidOrgId(t *testing.T) {
 func Test_CreateAppEngineWithLogger(t *testing.T) {
 	logger := log.New(os.Stdout, "", 0)
 
-	engine := CreateAppEngineWithLogger(logger)
+	engine := CreateAppEngineWithOptions(WithLogger(logger))
 
 	assert.NotNil(t, engine)
 	assert.Equal(t, logger, engine.GetLogger())

--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -22,7 +22,7 @@ func CreateAuthenticator(config configuration.Configuration, httpClient *http.Cl
 	var authenticator Authenticator
 
 	// try oauth authenticator
-	tmpAuthenticator := NewOAuth2Authenticator(config, httpClient)
+	tmpAuthenticator := NewOAuth2AuthenticatorWithOpts(config, WithHttpClient(httpClient))
 	if tmpAuthenticator.IsSupported() {
 		authenticator = tmpAuthenticator
 	}

--- a/pkg/auth/oauth2authenticator.go
+++ b/pkg/auth/oauth2authenticator.go
@@ -132,7 +132,7 @@ func GetOAuthToken(config configuration.Configuration) (*oauth2.Token, error) {
 	return nil, nil
 }
 
-func refreshToken(ctx context.Context, oauthConfig *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error) {
+func RefreshToken(ctx context.Context, oauthConfig *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error) {
 	tokenSource := oauthConfig.TokenSource(ctx, token)
 	return tokenSource.Token()
 }
@@ -153,7 +153,7 @@ func NewOAuth2AuthenticatorWithOpts(config configuration.Configuration, opts ...
 	o.httpClient = http.DefaultClient
 	o.openBrowserFunc = OpenBrowser
 	o.shutdownServerFunc = ShutdownServer
-	o.tokenRefresherFunc = refreshToken
+	o.tokenRefresherFunc = RefreshToken
 
 	// apply options
 	for _, opt := range opts {

--- a/pkg/auth/oauth2authenticator_test.go
+++ b/pkg/auth/oauth2authenticator_test.go
@@ -86,7 +86,7 @@ func Test_AddAuthenticationHeader_validToken(t *testing.T) {
 	}
 
 	config := configuration.NewInMemory()
-	authenticator := NewOAuth2Authenticator(config, http.DefaultClient)
+	authenticator := NewOAuth2AuthenticatorWithOpts(config)
 	authenticator.(*oAuth2Authenticator).persistToken(newToken)
 	authenticator.(*oAuth2Authenticator).tokenRefresherFunc = func(_ context.Context, _ *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error) {
 		assert.False(t, true, "The token is valid and no refresh is required!")
@@ -130,7 +130,7 @@ func Test_AddAuthenticationHeader_expiredToken(t *testing.T) {
 	}
 
 	config := configuration.NewInMemory()
-	authenticator := NewOAuth2Authenticator(config, http.DefaultClient)
+	authenticator := NewOAuth2AuthenticatorWithOpts(config)
 	authenticator.(*oAuth2Authenticator).persistToken(expiredToken)
 	authenticator.(*oAuth2Authenticator).tokenRefresherFunc = func(_ context.Context, _ *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error) {
 		return newToken, nil
@@ -173,7 +173,7 @@ func Test_AddAuthenticationHeader_expiredToken_somebodyUpdated(t *testing.T) {
 	}
 
 	config := configuration.NewInMemory()
-	authenticator := NewOAuth2Authenticator(config, http.DefaultClient)
+	authenticator := NewOAuth2AuthenticatorWithOpts(config)
 	authenticator.(*oAuth2Authenticator).persistToken(expiredToken)
 	authenticator.(*oAuth2Authenticator).tokenRefresherFunc = func(_ context.Context, _ *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error) {
 		assert.False(t, true, "The token is valid and no refresh is required!")
@@ -185,7 +185,7 @@ func Test_AddAuthenticationHeader_expiredToken_somebodyUpdated(t *testing.T) {
 	}
 
 	// have authenticator2 update the token "in parallel"
-	authenticator2 := NewOAuth2Authenticator(config, http.DefaultClient)
+	authenticator2 := NewOAuth2AuthenticatorWithOpts(config)
 	authenticator2.(*oAuth2Authenticator).persistToken(newToken)
 
 	// run method under test

--- a/pkg/auth/oauth2authenticatoroptions.go
+++ b/pkg/auth/oauth2authenticatoroptions.go
@@ -1,0 +1,34 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+
+	"golang.org/x/oauth2"
+)
+
+type OAuth2AuthenticatorOption func(authenticator *oAuth2Authenticator)
+
+func WithOpenBrowserFunc(openBrowserFunc func(string)) OAuth2AuthenticatorOption {
+	return func(authenticator *oAuth2Authenticator) {
+		authenticator.openBrowserFunc = openBrowserFunc
+	}
+}
+
+func WithShutdownServerFunc(shutdownServerFunc func(server *http.Server)) OAuth2AuthenticatorOption {
+	return func(authenticator *oAuth2Authenticator) {
+		authenticator.shutdownServerFunc = shutdownServerFunc
+	}
+}
+
+func WithTokenRefresherFunc(refreshFunc func(ctx context.Context, oauthConfig *oauth2.Config, token *oauth2.Token) (*oauth2.Token, error)) OAuth2AuthenticatorOption {
+	return func(authenticator *oAuth2Authenticator) {
+		authenticator.tokenRefresherFunc = refreshFunc
+	}
+}
+
+func WithHttpClient(httpClient *http.Client) OAuth2AuthenticatorOption {
+	return func(authenticator *oAuth2Authenticator) {
+		authenticator.httpClient = httpClient
+	}
+}

--- a/pkg/local_workflows/auth_workflow.go
+++ b/pkg/local_workflows/auth_workflow.go
@@ -58,7 +58,12 @@ func authEntryPoint(invocationCtx workflow.InvocationContext, _ []workflow.Data)
 		logger.Println("Headless:", headless)
 
 		httpClient := invocationCtx.GetNetworkAccess().GetUnauthorizedHttpClient()
-		authenticator := auth.NewOAuth2AuthenticatorWithCustomFuncs(config, httpClient, OpenBrowser, auth.ShutdownServer)
+		authenticator := auth.NewOAuth2AuthenticatorWithOpts(
+			config,
+			auth.WithHttpClient(httpClient),
+			auth.WithOpenBrowserFunc(OpenBrowser),
+			auth.WithShutdownServerFunc(auth.ShutdownServer),
+		)
 		err = authenticator.Authenticate()
 		if err != nil {
 			return nil, err

--- a/pkg/networking/networking_test.go
+++ b/pkg/networking/networking_test.go
@@ -220,8 +220,8 @@ func Test_AddHeaders_AddsDefaultAndAuthHeaders(t *testing.T) {
 	net := NewNetworkAccess(config)
 	net.AddHeaderField("secret-header", "secret-value")
 
-	request, err := http.NewRequest("GET", "https://api.snyk.io", nil)
-	err = net.AddHeaders(request)
+	request, _ := http.NewRequest("GET", "https://api.snyk.io", nil)
+	err := net.AddHeaders(request)
 	assert.Nil(t, err)
 
 	keys := make([]string, 0, len(request.Header))


### PR DESCRIPTION
- creates an option based constructor with defaults
- makes all other constructors use it
- deprecates previous custom constructors
- Dependent on https://github.com/snyk/go-application-framework/pull/51 (should be merged onto that branch/PR)