### PR TITLE
feat: add additional flags for depGraph workflow

### DIFF
--- a/pkg/local_workflows/depgraph_workflow.go
+++ b/pkg/local_workflows/depgraph_workflow.go
@@ -54,6 +54,8 @@ func InitDepGraphWorkflow(engine workflow.Engine) error {
 	depGraphConfig := pflag.NewFlagSet("depgraph", pflag.ExitOnError)
 	depGraphConfig.Bool("all-projects", false, "Enable all projects")
 	depGraphConfig.String("file", "", "Input file")
+	depGraphConfig.String("detection-depth", "", "Detection depth")
+	depGraphConfig.BoolP("prune-repeated-subdependencies", "p", false, "Prune repeated sub-dependencies")
 
 	_, err := engine.Register(WORKFLOWID_DEPGRAPH_WORKFLOW, workflow.ConfigurationOptionsFromFlagset(depGraphConfig), depgraphWorkflowEntryPoint)
 	return err
@@ -84,6 +86,16 @@ func depgraphWorkflowEntryPoint(invocation workflow.InvocationContext, input []w
 	if exclude := config.GetString("exclude"); exclude != "" {
 		snykCmdArguments = append(snykCmdArguments, "--exclude="+exclude)
 		debugLogger.Println("Exclude:", exclude)
+	}
+
+	if detectionDepth := config.GetString("detection-depth"); detectionDepth != "" {
+		snykCmdArguments = append(snykCmdArguments, "--detection-depth="+detectionDepth)
+		debugLogger.Println("Detection depth:", detectionDepth)
+	}
+
+	if pruneRepeatedSubDependencies := config.GetBool("prune-repeated-subdependencies"); pruneRepeatedSubDependencies {
+		snykCmdArguments = append(snykCmdArguments, "--prune-repeated-subdependencies")
+		debugLogger.Println("Prune repeated sub-dependencies:", pruneRepeatedSubDependencies)
 	}
 
 	if targetDirectory := config.GetString("targetDirectory"); err == nil {

--- a/pkg/local_workflows/depgraph_workflow_test.go
+++ b/pkg/local_workflows/depgraph_workflow_test.go
@@ -254,6 +254,48 @@ func Test_Depgraph_depgraphWorkflowEntryPoint(t *testing.T) {
 		assert.Contains(t, commandArgs, "--exclude=path/to/target/file.js")
 	})
 
+	t.Run("should support 'detection-depth' flag", func(t *testing.T) {
+		// setup
+		config.Set("detection-depth", "42")
+
+		dataIdentifier := workflow.NewTypeIdentifier(WORKFLOWID_DEPGRAPH_WORKFLOW, "depgraph")
+		data := workflow.NewData(dataIdentifier, "application/json", []byte(payload))
+
+		// engine mocks
+		id := workflow.NewWorkflowIdentifier("legacycli")
+		engineMock.EXPECT().InvokeWithConfig(id, config).Return([]workflow.Data{data}, nil).Times(1)
+
+		// execute
+		_, err := depgraphWorkflowEntryPoint(invocationContextMock, []workflow.Data{})
+
+		// assert
+		assert.Nil(t, err)
+
+		commandArgs := config.Get(configuration.RAW_CMD_ARGS)
+		assert.Contains(t, commandArgs, "--detection-depth=42")
+	})
+
+	t.Run("should support 'prune-repeated-subdependencies' flag", func(t *testing.T) {
+		// setup
+		config.Set("prune-repeated-subdependencies", true)
+
+		dataIdentifier := workflow.NewTypeIdentifier(WORKFLOWID_DEPGRAPH_WORKFLOW, "depgraph")
+		data := workflow.NewData(dataIdentifier, "application/json", []byte(payload))
+
+		// engine mocks
+		id := workflow.NewWorkflowIdentifier("legacycli")
+		engineMock.EXPECT().InvokeWithConfig(id, config).Return([]workflow.Data{data}, nil).Times(1)
+
+		// execute
+		_, err := depgraphWorkflowEntryPoint(invocationContextMock, []workflow.Data{})
+
+		// assert
+		assert.Nil(t, err)
+
+		commandArgs := config.Get(configuration.RAW_CMD_ARGS)
+		assert.Contains(t, commandArgs, "--prune-repeated-subdependencies")
+	})
+
 	t.Run("should error if no dependency graphs found", func(t *testing.T) {
 		dataIdentifier := workflow.NewTypeIdentifier(WORKFLOWID_DEPGRAPH_WORKFLOW, "depgraph")
 		data := workflow.NewData(dataIdentifier, "application/json", []byte{})


### PR DESCRIPTION
This PR adds the `--detection-depth` and `--prune-repeated-subdependencies` flags for `depGraph` workflow.