### PR TITLE
fix: forward --debug flag in depgraph workflow

### DIFF
--- a/pkg/local_workflows/depgraph_workflow.go
+++ b/pkg/local_workflows/depgraph_workflow.go
@@ -111,6 +111,10 @@ func depgraphWorkflowEntryPoint(invocation workflow.InvocationContext, input []w
 		debugLogger.Println("File:", file)
 	}
 
+	if config.GetBool(configuration.DEBUG) {
+		snykCmdArguments = append(snykCmdArguments, "--debug")
+	}
+
 	config.Set(configuration.RAW_CMD_ARGS, snykCmdArguments)
 	legacyData, legacyCLIError := engine.InvokeWithConfig(workflow.NewWorkflowIdentifier("legacycli"), config)
 	if legacyCLIError != nil {

--- a/pkg/local_workflows/depgraph_workflow_test.go
+++ b/pkg/local_workflows/depgraph_workflow_test.go
@@ -170,6 +170,27 @@ func Test_Depgraph_depgraphWorkflowEntryPoint(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 
+	t.Run("should support 'debug' flag", func(t *testing.T) {
+		// setup
+		config.Set(configuration.DEBUG, true)
+
+		dataIdentifier := workflow.NewTypeIdentifier(WORKFLOWID_DEPGRAPH_WORKFLOW, "depgraph")
+		data := workflow.NewData(dataIdentifier, "application/json", []byte(payload))
+
+		// engine mocks
+		id := workflow.NewWorkflowIdentifier("legacycli")
+		engineMock.EXPECT().InvokeWithConfig(id, config).Return([]workflow.Data{data}, nil).Times(1)
+
+		// execute
+		_, err := depgraphWorkflowEntryPoint(invocationContextMock, []workflow.Data{})
+
+		// assert
+		assert.Nil(t, err)
+
+		commandArgs := config.Get(configuration.RAW_CMD_ARGS)
+		assert.Contains(t, commandArgs, "--debug")
+	})
+
 	t.Run("should support 'all-projects' flag", func(t *testing.T) {
 		// setup
 		config.Set("all-projects", true)


### PR DESCRIPTION
This forwards the `--debug` flag to the `legacycli` workflow when being called in the `depgraph` workflow.