### PR TITLE
feat: add fail-fast option to depgraph workflow

### DIFF
--- a/pkg/local_workflows/depgraph_workflow.go
+++ b/pkg/local_workflows/depgraph_workflow.go
@@ -52,6 +52,7 @@ func extractLegacyCLIError(input error, data []workflow.Data) (output error) {
 // As part of the localworkflows package, it is registered via the localworkflows.Init method
 func InitDepGraphWorkflow(engine workflow.Engine) error {
 	depGraphConfig := pflag.NewFlagSet("depgraph", pflag.ExitOnError)
+	depGraphConfig.Bool("fail-fast", false, "Fail fast when scanning all projects")
 	depGraphConfig.Bool("all-projects", false, "Enable all projects")
 	depGraphConfig.String("file", "", "Input file")
 	depGraphConfig.String("detection-depth", "", "Detection depth")
@@ -81,6 +82,10 @@ func depgraphWorkflowEntryPoint(invocation workflow.InvocationContext, input []w
 	snykCmdArguments := []string{"test", "--print-graph", "--json"}
 	if allProjects := config.GetBool("all-projects"); allProjects {
 		snykCmdArguments = append(snykCmdArguments, "--all-projects")
+	}
+
+	if config.GetBool("fail-fast") {
+		snykCmdArguments = append(snykCmdArguments, "--fail-fast")
 	}
 
 	if exclude := config.GetString("exclude"); exclude != "" {

--- a/pkg/local_workflows/depgraph_workflow_test.go
+++ b/pkg/local_workflows/depgraph_workflow_test.go
@@ -191,6 +191,27 @@ func Test_Depgraph_depgraphWorkflowEntryPoint(t *testing.T) {
 		assert.Contains(t, commandArgs, "--debug")
 	})
 
+	t.Run("should support 'fail-fast' flag", func(t *testing.T) {
+		// setup
+		config.Set("fail-fast", true)
+
+		dataIdentifier := workflow.NewTypeIdentifier(WORKFLOWID_DEPGRAPH_WORKFLOW, "depgraph")
+		data := workflow.NewData(dataIdentifier, "application/json", []byte(payload))
+
+		// engine mocks
+		id := workflow.NewWorkflowIdentifier("legacycli")
+		engineMock.EXPECT().InvokeWithConfig(id, config).Return([]workflow.Data{data}, nil).Times(1)
+
+		// execute
+		_, err := depgraphWorkflowEntryPoint(invocationContextMock, []workflow.Data{})
+
+		// assert
+		assert.Nil(t, err)
+
+		commandArgs := config.Get(configuration.RAW_CMD_ARGS)
+		assert.Contains(t, commandArgs, "--fail-fast")
+	})
+
 	t.Run("should support 'all-projects' flag", func(t *testing.T) {
 		// setup
 		config.Set("all-projects", true)


### PR DESCRIPTION
This adds an option to `fail-fast` when invoking the `DepGraphWorkflow`. This is to avoid missing SCA results when some manifest files cannot be analysed when invkoing with `all-projects`.