### PR TITLE
fix: added support for dev flag

### DIFF
--- a/pkg/local_workflows/depgraph_workflow.go
+++ b/pkg/local_workflows/depgraph_workflow.go
@@ -54,6 +54,7 @@ func InitDepGraphWorkflow(engine workflow.Engine) error {
 	depGraphConfig := pflag.NewFlagSet("depgraph", pflag.ExitOnError)
 	depGraphConfig.Bool("fail-fast", false, "Fail fast when scanning all projects")
 	depGraphConfig.Bool("all-projects", false, "Enable all projects")
+	depGraphConfig.Bool("dev", false, "Include dev dependencies")
 	depGraphConfig.String("file", "", "Input file")
 	depGraphConfig.String("detection-depth", "", "Detection depth")
 	depGraphConfig.BoolP("prune-repeated-subdependencies", "p", false, "Prune repeated sub-dependencies")
@@ -118,6 +119,10 @@ func depgraphWorkflowEntryPoint(invocation workflow.InvocationContext, input []w
 
 	if config.GetBool(configuration.DEBUG) {
 		snykCmdArguments = append(snykCmdArguments, "--debug")
+	}
+
+	if config.GetBool("dev") {
+		snykCmdArguments = append(snykCmdArguments, "--dev")
 	}
 
 	config.Set(configuration.RAW_CMD_ARGS, snykCmdArguments)

--- a/pkg/local_workflows/depgraph_workflow_test.go
+++ b/pkg/local_workflows/depgraph_workflow_test.go
@@ -191,6 +191,27 @@ func Test_Depgraph_depgraphWorkflowEntryPoint(t *testing.T) {
 		assert.Contains(t, commandArgs, "--debug")
 	})
 
+	t.Run("should support 'dev' flag", func(t *testing.T) {
+		// setup
+		config.Set("dev", true)
+
+		dataIdentifier := workflow.NewTypeIdentifier(WORKFLOWID_DEPGRAPH_WORKFLOW, "depgraph")
+		data := workflow.NewData(dataIdentifier, "application/json", []byte(payload))
+
+		// engine mocks
+		id := workflow.NewWorkflowIdentifier("legacycli")
+		engineMock.EXPECT().InvokeWithConfig(id, config).Return([]workflow.Data{data}, nil).Times(1)
+
+		// execute
+		_, err := depgraphWorkflowEntryPoint(invocationContextMock, []workflow.Data{})
+
+		// assert
+		assert.Nil(t, err)
+
+		commandArgs := config.Get(configuration.RAW_CMD_ARGS)
+		assert.Contains(t, commandArgs, "--dev")
+	})
+
 	t.Run("should support 'fail-fast' flag", func(t *testing.T) {
 		// setup
 		config.Set("fail-fast", true)


### PR DESCRIPTION
In order to support sbom generation for maven including dev-dependencies we need to add support to pass the dev flag to the cli. See jira ticket for more info.

[JIRA](https://snyksec.atlassian.net/browse/SUP-1187)