### PR TITLE
Workflows

### DIFF
--- a/pkg/local_workflows/depgraph_workflow.go
+++ b/pkg/local_workflows/depgraph_workflow.go
@@ -1,19 +1,139 @@
 package localworkflows
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
-	"github.com/spf13/pflag"
 )
 
-var WORKFLOWID_DEPGRAPH_WORKFLOW workflow.Identifier = workflow.NewWorkflowIdentifier("depgraph")
-var DATATYPEID_DEPGRAPH workflow.Identifier = workflow.NewTypeIdentifier(WORKFLOWID_DEPGRAPH_WORKFLOW, "depgraph")
+var (
+	WORKFLOWID_DEPGRAPH_WORKFLOW workflow.Identifier = OpenSourceDepGraph.Identifier()
+	DATATYPEID_DEPGRAPH          workflow.Identifier = OpenSourceDepGraph.TypeIdentifier()
+
+	genericFlags = genericDepGraphFlags{
+		Debug: workflow.Flag[bool]{Name: configuration.DEBUG, DefaultValue: false},
+	}
+
+	// The depgraph workflow is responsible for handling the depgraph data
+	// As part of the localworkflows package, it is registered via the localworkflows.Init method
+	OpenSourceDepGraph = &osDepGraphWorkflow{
+		Workflow: &workflow.Workflow{
+			Name:     "depgraph",
+			Visible:  false,
+			TypeName: "depgraph",
+			Flags: OpenSourceDepGraphFlags{
+				genericDepGraphFlags: genericFlags,
+				AllProjects: workflow.Flag[bool]{
+					Name:         "all-projects",
+					Usage:        "Auto-detect all projects in the working directory (including Yarn workspaces).",
+					DefaultValue: false,
+				},
+				FailFast: workflow.Flag[bool]{
+					Name:         "fail-fast",
+					Usage:        "Fail fast when scanning all projects",
+					DefaultValue: false,
+				},
+				Exclude: workflow.Flag[string]{
+					Name:         "exclude",
+					Usage:        "Can be used with --all-projects to indicate directory Names and file Names to exclude. Must be comma separated.",
+					DefaultValue: "",
+				},
+				DetectionDepth: workflow.Flag[string]{
+					Name: "detection-depth",
+					Usage: "Use with --all-projects to indicate how many subdirectories to search. " +
+						"DEPTH must be a number, 1 or greater; zero (0) is the current directory.",
+					DefaultValue: "",
+				},
+				Dev: workflow.Flag[bool]{
+					Name:         "dev",
+					Usage:        "Include dev dependencies",
+					DefaultValue: false,
+				},
+				PruneRepeatedSubdependencies: workflow.Flag[bool]{
+					Name:         "prune-repeated-subdependencies",
+					Shorthand:    "p",
+					DefaultValue: false,
+					Usage:        "Prune dependency trees, removing duplicate sub-dependencies.",
+				},
+				Unmanaged: workflow.Flag[bool]{
+					Name:         "unmanaged",
+					Usage:        "For C/C++ only, scan all files for known open source dependencies and build an SBOM.",
+					DefaultValue: false,
+				},
+				// file is only relevant for OS, in container the `Dockerfile` could be specified, but
+				// doesn't really influence the results (only the advice).
+				File: workflow.Flag[string]{
+					Name:         "file",
+					Usage:        "Specify a package file.",
+					DefaultValue: "",
+				},
+			},
+		},
+	}
+)
+
+// InitDepGraphWorkflow initializes the depgraph workflow
+// The depgraph workflow is responsible for handling the depgraph data
+// As part of the localworkflows package, it is registered via the localworkflows.Init method
+// Deprecated: use `workflow.Register(OpenSourceDepGraph, engine)` directly.
+func InitDepGraphWorkflow(engine workflow.Engine) error {
+	return workflow.Register(OpenSourceDepGraph, engine)
+}
+
+type osDepGraphWorkflow struct {
+	*workflow.Workflow
+}
+
+func (o osDepGraphWorkflow) Flags() OpenSourceDepGraphFlags {
+	return o.Workflow.Flags.(OpenSourceDepGraphFlags)
+}
+
+type genericDepGraphFlags struct {
+	Debug workflow.Flag[bool]
+}
+
+func (g genericDepGraphFlags) GetFlags() workflow.Flags {
+	return workflow.Flags{g.Debug}
+}
+
+type OpenSourceDepGraphFlags struct {
+	genericDepGraphFlags
+
+	AllProjects                  workflow.Flag[bool]
+	DetectionDepth               workflow.Flag[string]
+	Exclude                      workflow.Flag[string]
+	FailFast                     workflow.Flag[bool]
+	Dev                          workflow.Flag[bool]
+	File                         workflow.Flag[string]
+	PruneRepeatedSubdependencies workflow.Flag[bool]
+	Unmanaged                    workflow.Flag[bool]
+}
+
+func (o OpenSourceDepGraphFlags) GetFlags() workflow.Flags {
+	return append(
+		o.genericDepGraphFlags.GetFlags(),
+		o.AllProjects,
+		o.DetectionDepth,
+		o.Dev,
+		o.Exclude,
+		o.FailFast,
+		o.File,
+		o.PruneRepeatedSubdependencies,
+		o.Unmanaged,
+	)
+}
+
+func (o *osDepGraphWorkflow) Entrypoint(invocation workflow.InvocationContext, input []workflow.Data) ([]workflow.Data, error) {
+	return depGraphEntrypoint(
+		o, []string{"test", "--print-graph", "--json"},
+		invocation, input,
+	)
+}
 
 // LegacyCliJsonError is the error type returned by the legacy cli
 type LegacyCliJsonError struct {
@@ -47,118 +167,64 @@ func extractLegacyCLIError(input error, data []workflow.Data) (output error) {
 	return output
 }
 
-// InitDepGraphWorkflow initializes the depgraph workflow
-// The depgraph workflow is responsible for handling the depgraph data
-// As part of the localworkflows package, it is registered via the localworkflows.Init method
-func InitDepGraphWorkflow(engine workflow.Engine) error {
-	depGraphConfig := pflag.NewFlagSet("depgraph", pflag.ExitOnError)
-	depGraphConfig.Bool("fail-fast", false, "Fail fast when scanning all projects")
-	depGraphConfig.Bool("all-projects", false, "Enable all projects")
-	depGraphConfig.Bool("dev", false, "Include dev dependencies")
-	depGraphConfig.String("file", "", "Input file")
-	depGraphConfig.String("detection-depth", "", "Detection depth")
-	depGraphConfig.BoolP("prune-repeated-subdependencies", "p", false, "Prune repeated sub-dependencies")
+func depGraphEntrypoint(
+	d workflow.WorkflowRegisterer,
+	cmdArgs []string,
+	invocation workflow.InvocationContext,
+	input []workflow.Data,
+) (depGraphList []workflow.Data, err error) {
+	debugLogger := d.Logger(invocation)
+	debugLogger.Printf("start")
 
-	_, err := engine.Register(WORKFLOWID_DEPGRAPH_WORKFLOW, workflow.ConfigurationOptionsFromFlagset(depGraphConfig), depgraphWorkflowEntryPoint)
-	return err
-}
-
-// depgraphWorkflowEntryPoint defines the depgraph entry point
-// the entry point is called by the engine when the workflow is invoked
-func depgraphWorkflowEntryPoint(invocation workflow.InvocationContext, input []workflow.Data) (depGraphList []workflow.Data, err error) {
-	err = nil
-	depGraphList = []workflow.Data{}
-
-	engine := invocation.GetEngine()
 	config := invocation.GetConfiguration()
-	debugLogger := invocation.GetLogger()
-
-	debugLogger.Println("depgraph workflow start")
-
-	jsonSeparatorEnd := []byte("DepGraph end")
-	jsonSeparatorData := []byte("DepGraph data:")
-	jsonSeparatorTarget := []byte("DepGraph target:")
-
-	// prepare invocation of the legacy cli
-	snykCmdArguments := []string{"test", "--print-graph", "--json"}
-	if allProjects := config.GetBool("all-projects"); allProjects {
-		snykCmdArguments = append(snykCmdArguments, "--all-projects")
-	}
-
-	if config.GetBool("fail-fast") {
-		snykCmdArguments = append(snykCmdArguments, "--fail-fast")
-	}
-
-	if exclude := config.GetString("exclude"); exclude != "" {
-		snykCmdArguments = append(snykCmdArguments, "--exclude="+exclude)
-		debugLogger.Println("Exclude:", exclude)
-	}
-
-	if detectionDepth := config.GetString("detection-depth"); detectionDepth != "" {
-		snykCmdArguments = append(snykCmdArguments, "--detection-depth="+detectionDepth)
-		debugLogger.Println("Detection depth:", detectionDepth)
-	}
-
-	if pruneRepeatedSubDependencies := config.GetBool("prune-repeated-subdependencies"); pruneRepeatedSubDependencies {
-		snykCmdArguments = append(snykCmdArguments, "--prune-repeated-subdependencies")
-		debugLogger.Println("Prune repeated sub-dependencies:", pruneRepeatedSubDependencies)
-	}
-
-	if targetDirectory := config.GetString("targetDirectory"); err == nil {
-		snykCmdArguments = append(snykCmdArguments, targetDirectory)
-	}
-
-	if unmanaged := config.GetBool("unmanaged"); unmanaged {
-		snykCmdArguments = append(snykCmdArguments, "--unmanaged")
-	}
-
-	if file := config.GetString("file"); len(file) > 0 {
-		snykCmdArguments = append(snykCmdArguments, "--file="+file)
-		debugLogger.Println("File:", file)
-	}
-
-	if config.GetBool(configuration.DEBUG) {
-		snykCmdArguments = append(snykCmdArguments, "--debug")
-	}
-
-	if config.GetBool("dev") {
-		snykCmdArguments = append(snykCmdArguments, "--dev")
-	}
-
-	config.Set(configuration.RAW_CMD_ARGS, snykCmdArguments)
-	legacyData, legacyCLIError := engine.InvokeWithConfig(workflow.NewWorkflowIdentifier("legacycli"), config)
-	if legacyCLIError != nil {
-		legacyCLIError = extractLegacyCLIError(legacyCLIError, legacyData)
-		return depGraphList, legacyCLIError
-	}
-
-	snykOutput := legacyData[0].GetPayload().([]byte)
-
-	snykOutputLength := len(snykOutput)
-	if snykOutputLength <= 0 {
-		return depGraphList, fmt.Errorf("No dependency graphs found")
-	}
-
-	// split up dependency data from legacy cli
-	separatedJsonRawData := bytes.Split(snykOutput, jsonSeparatorEnd)
-	for i := range separatedJsonRawData {
-		rawData := separatedJsonRawData[i]
-		if bytes.Contains(rawData, jsonSeparatorData) {
-			graphStartIndex := bytes.Index(rawData, jsonSeparatorData) + len(jsonSeparatorData)
-			graphEndIndex := bytes.Index(rawData, jsonSeparatorTarget)
-			targetNameStartIndex := graphEndIndex + len(jsonSeparatorTarget)
-			targetNameEndIndex := len(rawData) - 1
-
-			targetName := rawData[targetNameStartIndex:targetNameEndIndex]
-			depGraphJson := rawData[graphStartIndex:graphEndIndex]
-
-			data := workflow.NewData(DATATYPEID_DEPGRAPH, "application/json", depGraphJson)
-			data.SetMetaData("Content-Location", strings.TrimSpace(string(targetName)))
-			depGraphList = append(depGraphList, data)
+	for _, flag := range d.GetFlags() {
+		if arg, ok := flag.AsArgument(config); ok {
+			cmdArgs = append(cmdArgs, arg)
 		}
 	}
 
-	debugLogger.Printf("depgraph workflow done (%d)", len(depGraphList))
+	// This is the directory for OS, or the container name for container. It's not a flag, but a
+	// positional argument.
+	cmdArgs = append(cmdArgs, config.GetString("targetDirectory"))
+	debugLogger.Printf("cli invocation args: %v", cmdArgs)
 
-	return depGraphList, err
+	config.Set(configuration.RAW_CMD_ARGS, cmdArgs)
+	data, err := invocation.GetEngine().InvokeWithConfig(workflow.NewWorkflowIdentifier("legacycli"), config)
+	if err != nil {
+		return nil, extractLegacyCLIError(err, data)
+	}
+
+	depGraphList, err = extractDepGraphsFromCLIOutput(data[0].GetPayload().([]byte))
+	if err != nil {
+		return nil, fmt.Errorf("could not extract depGraphs from CLI output: %w", err)
+	}
+
+	debugLogger.Printf("done (%d)", len(depGraphList))
+
+	return depGraphList, nil
+}
+
+// depGraphSeparator separates the depgraph from the target name and the rest.
+// The DepGraph and the name are caught in a capturing group.
+//
+// The `(?s)` at the beginning enables multiline-matching.
+var depGraphSeparator = regexp.MustCompile(`(?s)DepGraph data:(.*?)DepGraph target:(.*?)DepGraph end`)
+
+func extractDepGraphsFromCLIOutput(output []byte) ([]workflow.Data, error) {
+	if len(output) == 0 {
+		return nil, fmt.Errorf("no dependency graphs found")
+	}
+
+	var depGraphs []workflow.Data
+	for _, match := range depGraphSeparator.FindAllSubmatch(output, -1) {
+		if len(match) != 3 {
+			return nil, fmt.Errorf("malformed CLI output, got %v matches", len(match))
+		}
+
+		data := workflow.NewData(DATATYPEID_DEPGRAPH, "application/json", match[1])
+		data.SetMetaData("Content-Location", strings.TrimSpace(string(match[2])))
+		depGraphs = append(depGraphs, data)
+	}
+
+	return depGraphs, nil
 }

--- a/pkg/local_workflows/depgraph_workflow_test.go
+++ b/pkg/local_workflows/depgraph_workflow_test.go
@@ -49,7 +49,7 @@ func Test_Depgraph_InitDepGraphWorkflow(t *testing.T) {
 	config := configuration.New()
 	engine := workflow.NewWorkFlowEngine(config)
 
-	err := InitDepGraphWorkflow(engine)
+	err := workflow.Register(OpenSourceDepGraph, engine)
 	assert.Nil(t, err)
 
 	allProjects := config.Get("all-projects")
@@ -154,7 +154,7 @@ func Test_Depgraph_depgraphWorkflowEntryPoint(t *testing.T) {
 		engineMock.EXPECT().InvokeWithConfig(id, config).Return([]workflow.Data{data}, nil).Times(1)
 
 		// execute
-		depGraphList, err := depgraphWorkflowEntryPoint(invocationContextMock, []workflow.Data{})
+		depGraphList, err := OpenSourceDepGraph.Entrypoint(invocationContextMock, []workflow.Data{})
 
 		// assert
 		assert.Nil(t, err)
@@ -182,7 +182,7 @@ func Test_Depgraph_depgraphWorkflowEntryPoint(t *testing.T) {
 		engineMock.EXPECT().InvokeWithConfig(id, config).Return([]workflow.Data{data}, nil).Times(1)
 
 		// execute
-		_, err := depgraphWorkflowEntryPoint(invocationContextMock, []workflow.Data{})
+		_, err := OpenSourceDepGraph.Entrypoint(invocationContextMock, []workflow.Data{})
 
 		// assert
 		assert.Nil(t, err)
@@ -203,7 +203,7 @@ func Test_Depgraph_depgraphWorkflowEntryPoint(t *testing.T) {
 		engineMock.EXPECT().InvokeWithConfig(id, config).Return([]workflow.Data{data}, nil).Times(1)
 
 		// execute
-		_, err := depgraphWorkflowEntryPoint(invocationContextMock, []workflow.Data{})
+		_, err := OpenSourceDepGraph.Entrypoint(invocationContextMock, []workflow.Data{})
 
 		// assert
 		assert.Nil(t, err)
@@ -224,7 +224,7 @@ func Test_Depgraph_depgraphWorkflowEntryPoint(t *testing.T) {
 		engineMock.EXPECT().InvokeWithConfig(id, config).Return([]workflow.Data{data}, nil).Times(1)
 
 		// execute
-		_, err := depgraphWorkflowEntryPoint(invocationContextMock, []workflow.Data{})
+		_, err := OpenSourceDepGraph.Entrypoint(invocationContextMock, []workflow.Data{})
 
 		// assert
 		assert.Nil(t, err)
@@ -245,7 +245,7 @@ func Test_Depgraph_depgraphWorkflowEntryPoint(t *testing.T) {
 		engineMock.EXPECT().InvokeWithConfig(id, config).Return([]workflow.Data{data}, nil).Times(1)
 
 		// execute
-		_, err := depgraphWorkflowEntryPoint(invocationContextMock, []workflow.Data{})
+		_, err := OpenSourceDepGraph.Entrypoint(invocationContextMock, []workflow.Data{})
 
 		// assert
 		assert.Nil(t, err)
@@ -266,7 +266,7 @@ func Test_Depgraph_depgraphWorkflowEntryPoint(t *testing.T) {
 		engineMock.EXPECT().InvokeWithConfig(id, config).Return([]workflow.Data{data}, nil).Times(1)
 
 		// execute
-		_, err := depgraphWorkflowEntryPoint(invocationContextMock, []workflow.Data{})
+		_, err := OpenSourceDepGraph.Entrypoint(invocationContextMock, []workflow.Data{})
 
 		// assert
 		assert.Nil(t, err)
@@ -287,7 +287,7 @@ func Test_Depgraph_depgraphWorkflowEntryPoint(t *testing.T) {
 		engineMock.EXPECT().InvokeWithConfig(id, config).Return([]workflow.Data{data}, nil).Times(1)
 
 		// execute
-		_, err := depgraphWorkflowEntryPoint(invocationContextMock, []workflow.Data{})
+		_, err := OpenSourceDepGraph.Entrypoint(invocationContextMock, []workflow.Data{})
 
 		// assert
 		assert.Nil(t, err)
@@ -308,7 +308,7 @@ func Test_Depgraph_depgraphWorkflowEntryPoint(t *testing.T) {
 		engineMock.EXPECT().InvokeWithConfig(id, config).Return([]workflow.Data{data}, nil).Times(1)
 
 		// execute
-		_, err := depgraphWorkflowEntryPoint(invocationContextMock, []workflow.Data{})
+		_, err := OpenSourceDepGraph.Entrypoint(invocationContextMock, []workflow.Data{})
 
 		// assert
 		assert.Nil(t, err)
@@ -329,7 +329,7 @@ func Test_Depgraph_depgraphWorkflowEntryPoint(t *testing.T) {
 		engineMock.EXPECT().InvokeWithConfig(id, config).Return([]workflow.Data{data}, nil).Times(1)
 
 		// execute
-		_, err := depgraphWorkflowEntryPoint(invocationContextMock, []workflow.Data{})
+		_, err := OpenSourceDepGraph.Entrypoint(invocationContextMock, []workflow.Data{})
 
 		// assert
 		assert.Nil(t, err)
@@ -350,7 +350,7 @@ func Test_Depgraph_depgraphWorkflowEntryPoint(t *testing.T) {
 		engineMock.EXPECT().InvokeWithConfig(id, config).Return([]workflow.Data{data}, nil).Times(1)
 
 		// execute
-		_, err := depgraphWorkflowEntryPoint(invocationContextMock, []workflow.Data{})
+		_, err := OpenSourceDepGraph.Entrypoint(invocationContextMock, []workflow.Data{})
 
 		// assert
 		assert.Nil(t, err)
@@ -368,9 +368,9 @@ func Test_Depgraph_depgraphWorkflowEntryPoint(t *testing.T) {
 		engineMock.EXPECT().InvokeWithConfig(id, config).Return([]workflow.Data{data}, nil).Times(1)
 
 		// execute
-		_, err := depgraphWorkflowEntryPoint(invocationContextMock, []workflow.Data{})
+		_, err := OpenSourceDepGraph.Entrypoint(invocationContextMock, []workflow.Data{})
 
 		// assert
-		assert.Equal(t, "No dependency graphs found", err.Error())
+		assert.Equal(t, "could not extract depGraphs from CLI output: no dependency graphs found", err.Error())
 	})
 }

--- a/pkg/local_workflows/whoami_workflow_test.go
+++ b/pkg/local_workflows/whoami_workflow_test.go
@@ -52,7 +52,7 @@ func Test_WhoAmI_whoAmIWorkflowEntryPoint_requireExperimentalFlag(t *testing.T) 
 	expectedError := errors.New("set `--experimental` flag to enable whoAmI command")
 
 	// run test
-	_, err := whoAmIWorkflowEntryPoint(invocationContextMock, nil)
+	_, err := WhoAmI.Entrypoint(invocationContextMock, nil)
 	assert.Equal(t, expectedError.Error(), err.Error())
 }
 
@@ -108,7 +108,7 @@ func Test_WhoAmI_whoAmIWorkflowEntryPoint_happyPath(t *testing.T) {
 		expectedResponse := "user.name@snyk.io"
 
 		// execute
-		output, err := whoAmIWorkflowEntryPoint(invocationContextMock, nil)
+		output, err := WhoAmI.Entrypoint(invocationContextMock, nil)
 
 		// assert
 		assert.Nil(t, err)
@@ -121,7 +121,7 @@ func Test_WhoAmI_whoAmIWorkflowEntryPoint_happyPath(t *testing.T) {
 		config.Set("json", true)
 
 		// execute
-		output, err := whoAmIWorkflowEntryPoint(invocationContextMock, nil)
+		output, err := WhoAmI.Entrypoint(invocationContextMock, nil)
 
 		// assert
 		assert.Nil(t, err)
@@ -175,7 +175,7 @@ func Test_WhoAmI_whoAmIWorkflowEntryPoint_fetchUserFailures(t *testing.T) {
 		expectedError := errors.New("error while fetching user: invalid API key (status 401)")
 
 		// execute
-		_, err := whoAmIWorkflowEntryPoint(invocationContextMock, nil)
+		_, err := WhoAmI.Entrypoint(invocationContextMock, nil)
 
 		// assert
 		// assert.Nil(t, err)
@@ -202,7 +202,7 @@ func Test_WhoAmI_whoAmIWorkflowEntryPoint_fetchUserFailures(t *testing.T) {
 		expectedError := errors.New("error while fetching user: request failed (status 500)")
 
 		// execute
-		_, err := whoAmIWorkflowEntryPoint(invocationContextMock, nil)
+		_, err := WhoAmI.Entrypoint(invocationContextMock, nil)
 
 		// assert
 		assert.Equal(t, expectedError.Error(), err.Error())
@@ -259,7 +259,7 @@ func Test_WhoAmI_whoAmIWorkflowEntryPoint_extractUserFailures(t *testing.T) {
 	expectedError := errors.New("error while extracting user: missing property 'username'")
 
 	// execute
-	_, err := whoAmIWorkflowEntryPoint(invocationContextMock, nil)
+	_, err := WhoAmI.Entrypoint(invocationContextMock, nil)
 
 	// assert
 	assert.Error(t, err)

--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -1,0 +1,177 @@
+package workflow
+
+import (
+	"log"
+	"net/url"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/spf13/pflag"
+)
+
+// A WorkflowRegisterer is a Workflow that has been extended with an Entrypoint method that defines
+// the Workflow's action.
+type WorkflowRegisterer interface {
+	Identifier() *url.URL
+	GetName() string
+	GetFlags() Flags
+	// IsVisible defines whether this workflow should be visible to users or not.
+	IsVisible() bool
+	Logger(InvocationContext) *log.Logger
+
+	Entrypoint(invocation InvocationContext, input []Data) ([]Data, error)
+}
+
+// Register a given Workflow with the engine.
+func Register(w WorkflowRegisterer, e Engine) error {
+	fs := pflag.NewFlagSet(w.GetName(), pflag.ExitOnError)
+	w.GetFlags().AddToFlagSet(fs)
+
+	entry, err := e.Register(w.Identifier(), ConfigurationOptionsFromFlagset(fs), w.Entrypoint)
+	if err != nil {
+		return err
+	}
+
+	entry.SetVisibility(w.IsVisible())
+	return nil
+}
+
+type Workflow struct {
+	// Name is the name of the workflow. It also defines the command where this workflow will be
+	// made available. For example, the name "x y" would make the workflow available at `snyk x y`.
+	Name     string
+	TypeName string
+	// Visible defines whether this workflow should be visible to users or not.
+	Visible bool
+	// Flags for this workflow.
+	Flags Flagger
+}
+
+func (w *Workflow) GetName() string            { return w.Name }
+func (w *Workflow) GetFlags() Flags            { return w.Flags.GetFlags() }
+func (w *Workflow) IsVisible() bool            { return w.Visible }
+func (w *Workflow) Identifier() Identifier     { return NewWorkflowIdentifier(w.Name) }
+func (w *Workflow) TypeIdentifier() Identifier { return NewTypeIdentifier(w.Identifier(), w.TypeName) }
+
+// Logger returns a log.Logger that is prefixed with the workflow name for identification.
+func (w *Workflow) Logger(ictx InvocationContext) *log.Logger {
+	l := ictx.GetLogger()
+	l.SetPrefix(w.Name + " workflow: ")
+	return l
+}
+
+// Flagger returns a list of flags. The `Flags` type itself implements the Flagger interface as
+// well. However, for easier access of specific flags, we recommend creating an intermediate type to
+// hold your flags and implementing the Flagger interface yourself, e.g.:
+//
+//	type MyFlags struct {
+//	    One Flag[bool]
+//	}
+//
+//	func (m MyFlags) GetFlags() Flags {
+//	  return Flags{m.One}
+//	 }
+type Flagger interface {
+	GetFlags() Flags
+}
+
+// Flags is a list of Flags, and because we can't mix generic types (e.g. flag[string] and
+// flag[bool]) in a single flag[T] slice, we need to use an interface instead.
+// It implements the Flagger interface, so can be used to specify a simple list of flags.
+//
+//	f := Flags{
+//	  Flag[bool]{...},
+//	}
+type Flags []interface {
+	// AddToFlagSet adds a flag to the given flagset, registering the helptext and default values.
+	AddToFlagSet(*pflag.FlagSet)
+	// AsArgument returns the given flag plus a potential value extracted from the configuration.
+	// For example, if there is a string flag "x", and the configuration has a value "y" set,
+	// AsArgument would return "--x=y".
+	// If the value is not set in the config, ok will be false to indicate the flag is not set.
+	AsArgument(configuration.Configuration) (arg string, ok bool)
+}
+
+// https://preview.redd.it/bekphnqftcb41.jpg?auto=webp&s=26c9684c7326870bfa6680be462341be38bb0635
+func (f Flags) GetFlags() Flags { return f }
+
+// AddToFlagSet adds all flags to the given flag set.
+func (f Flags) AddToFlagSet(fs *pflag.FlagSet) {
+	for _, flag := range f {
+		flag.AddToFlagSet(fs)
+	}
+}
+
+// Flag is a generic flag type.
+type Flag[T string | bool] struct {
+	// Name is the name of the flag.
+	Name string
+	// Shorthand of the flag, optional.
+	Shorthand string
+	// Usage text for this flag.
+	Usage string
+	// DefaultValue of this flag.
+	DefaultValue T
+}
+
+func (f Flag[T]) AddToFlagSet(fs *pflag.FlagSet) {
+	// The "any().(type)" statements are a workaround for https://github.com/golang/go/issues/49206,
+	// which once implemented could be removed.
+	switch any(f.DefaultValue).(type) {
+	case string:
+		if f.Shorthand != "" {
+			fs.StringP(f.Name, f.Shorthand, any(f.DefaultValue).(string), f.Usage)
+		} else {
+			fs.String(f.Name, any(f.DefaultValue).(string), f.Usage)
+		}
+	case bool:
+		if f.Shorthand != "" {
+			fs.BoolP(f.Name, f.Shorthand, any(f.DefaultValue).(bool), f.Usage)
+		} else {
+			fs.Bool(f.Name, any(f.DefaultValue).(bool), f.Usage)
+		}
+	}
+}
+
+// AsArgument returns the flag including it's value as rendered on a command line. ok will be true
+// if the flag is being set, and false otherwise. For boolean values, it treats the flag as a simple
+// "switch" and will return ("", false) if the flag's value is "false" (instead of returning
+// something like `-x=false`).
+func (f Flag[T]) AsArgument(c configuration.Configuration) (arg string, ok bool) {
+	val := f.Value(c)
+	// Workaround for https://github.com/golang/go/issues/49206
+	switch any(f.DefaultValue).(type) {
+	case string:
+		if s := any(val).(string); s != "" {
+			return "--" + f.Name + "=" + s, true
+		}
+
+	case bool:
+		if any(val).(bool) {
+			return "--" + f.Name, true
+		}
+	}
+
+	return "", false
+}
+
+// Value returns the value for this flag as stored in the configuration. If the flag is not set
+// (e.g. is the zero-value for the respective type), the flag's DefaultValue will be returned.
+func (f Flag[T]) Value(c configuration.Configuration) (val T) {
+	// Workaround for https://github.com/golang/go/issues/49206
+	switch any(f.DefaultValue).(type) {
+	case string:
+		if s := c.GetString(f.Name); s != "" {
+			return any(s).(T)
+		}
+
+		if any(f.DefaultValue).(string) != "" {
+			return f.DefaultValue
+		}
+
+	case bool:
+		return any(c.GetBool(f.Name)).(T)
+	}
+
+	// return the zero value for the given type.
+	return val
+}

--- a/pkg/workflow/workflow_test.go
+++ b/pkg/workflow/workflow_test.go
@@ -1,0 +1,104 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkflowRegister(t *testing.T) {
+	w := newNoOpWorkflow()
+	config := configuration.New()
+	e := NewWorkFlowEngine(config)
+	require.NoError(t, Register(w, e))
+
+	entry, ok := e.GetWorkflow(w.Identifier())
+	require.True(t, ok)
+	require.Equal(t, w.IsVisible(), entry.IsVisible())
+	require.NoError(t, e.Init())
+
+	config.Set(w.Flags().NoOpOutput.Name, "test-output")
+
+	data, err := e.InvokeWithConfig(w.Identifier(), config)
+	require.NoError(t, err)
+	require.Equal(t, "test-output", data[0].GetPayload().(string))
+}
+
+func TestFlagWithNonZeroDefaultValue(t *testing.T) {
+	f := Flag[string]{
+		Name:         "hello",
+		Shorthand:    "h",
+		Usage:        "say hello",
+		DefaultValue: "hi!",
+	}
+
+	config := configuration.New()
+
+	arg, ok := f.AsArgument(config)
+	require.True(t, ok)
+	require.Equal(t, "--hello=hi!", arg)
+	// if the DefaultValue is not the zero-value for a type, we expect that to be returned.
+	require.Equal(t, "hi!", f.Value(config))
+
+	config.Set(f.Name, "hallo!")
+	require.Equal(t, f.Value(config), "hallo!")
+	arg, ok = f.AsArgument(config)
+	require.True(t, ok)
+	require.Equal(t, arg, "--hello=hallo!")
+}
+
+func TestFlagWithZeroValue(t *testing.T) {
+	f := Flag[string]{
+		Name:         "hello",
+		Usage:        "say hello",
+		DefaultValue: "",
+	}
+	config := configuration.New()
+	_, ok := f.AsArgument(config)
+	require.False(t, ok)
+
+	require.Equal(t, "", f.Value(config))
+
+	config.Set(f.Name, "hallo!")
+	require.Equal(t, f.Value(config), "hallo!")
+	arg, ok := f.AsArgument(config)
+	require.True(t, ok)
+	require.Equal(t, arg, "--hello=hallo!")
+
+	require.Equal(t, f.Value(config), "hallo!")
+}
+
+type noOpWorkflow struct{ *Workflow }
+type noOpWorkflowFlags struct {
+	NoOpOutput Flag[string]
+}
+
+func (n noOpWorkflowFlags) GetFlags() Flags {
+	return Flags{n.NoOpOutput}
+}
+
+func (n noOpWorkflow) Flags() noOpWorkflowFlags {
+	return n.Workflow.Flags.(noOpWorkflowFlags)
+}
+
+func newNoOpWorkflow() noOpWorkflow {
+	return noOpWorkflow{&Workflow{
+		Name:     "no-op",
+		TypeName: "no-op",
+		Visible:  true,
+		Flags: noOpWorkflowFlags{
+			NoOpOutput: Flag[string]{
+				Name:         "no-op-output",
+				DefaultValue: "",
+			},
+		},
+	}}
+}
+
+func (n noOpWorkflow) Entrypoint(ictx InvocationContext, _ []Data) ([]Data, error) {
+	output := n.Flags().NoOpOutput.Value(ictx.GetConfiguration())
+	return []Data{
+		NewData(n.TypeIdentifier(), "", output),
+	}, nil
+}


### PR DESCRIPTION
This commit introduces a `Workflow` type that can be leveraged to build workflows more easily & in a more standardised fashion. to go with that, this commit also introduces a `Flag` type to easily define & re-use (and potentially access) defined flags of commands.

To demonstrate this new functionality, this commit also changes the `local_workflows` package to use it.

While doing so, I've also refactored the implementations a bit.

Some notes:
- I wasn't sure whether I should make public variables for the Workflows, or if they'd be better off "hidden" behind functions (e.g. `func Auth() *authWorkflow` instead of a `var Auth = &authWorkflow{}`). Let me know if you'd prefer the functions.
- I haven't (yet) updated the contributors-guide, let me know what you think about these changes and if that works out, I'll be happy to update those. Should get a bit shorter now with this new framework.
- Let me know if introducing breaking changes would be okay. for now, I've kept all existing global variables (& constants), although some are definitely redundant now (like the `WORKFLOWID_AUTH`). Personally, I think it should be okay to remove them, but wanted to get some guidance on this first.
- The DepGraph workflow is already built for being extended with a `ContainerDepGraph` workflow - you can view those changes / commits on the [workflows branch](https://github.com/snyk/go-application-framework/compare/main...workflows).
- Sorry if this is a bit much, I got carried away 😅 
- While there's a lot of changes, I barely touched the tests (only made sure they compile). They still work, so I'd say the changes themselves can be considered refactors :) 