### PR TITLE
fix: config organization value is unexpectedly the org ID and not org slug 

### DIFF
--- a/internal/api/contract/OrgResponse.go
+++ b/internal/api/contract/OrgResponse.go
@@ -16,3 +16,20 @@ type Group struct {
 type OrganizationsResponse struct {
 	Organizations []Organization `json:"orgs"`
 }
+
+type RestApiOrganizationAttributes struct {
+	GroupId    string `json:"group_id,omitempty"`
+	IsPersonal bool   `json:"is_personal,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Slug       string `json:"slug,omitempty"`
+}
+
+type RestApiOrganizationData struct {
+	Attributes RestApiOrganizationAttributes `json:"attributes,omitempty"`
+	Id         string                        `json:"id,omitempty"`
+	Type       string                        `json:"type,omitempty"`
+}
+
+type RestApiOrganizationsResponse struct {
+	Data RestApiOrganizationData
+}

--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -64,6 +64,21 @@ func (mr *MockApiClientMockRecorder) GetOrgIdFromSlug(slugName interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgIdFromSlug", reflect.TypeOf((*MockApiClient)(nil).GetOrgIdFromSlug), slugName)
 }
 
+// GetSlugFromOrgId mocks base method.
+func (m *MockApiClient) GetSlugFromOrgId(orgId string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSlugFromOrgId", orgId)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSlugFromOrgId indicates an expected call of GetSlugFromOrgId.
+func (mr *MockApiClientMockRecorder) GetSlugFromOrgId(orgId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSlugFromOrgId", reflect.TypeOf((*MockApiClient)(nil).GetSlugFromOrgId), orgId)
+}
+
 // Init mocks base method.
 func (m *MockApiClient) Init(url string, client *http.Client) {
 	m.ctrl.T.Helper()

--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -11,6 +11,7 @@ const (
 	INTEGRATION_ENVIRONMENT_VERSION string = "snyk_integration_environment_version"
 	ANALYTICS_DISABLED              string = "snyk_disable_analytics"
 	ORGANIZATION                    string = "org"
+	ORGANIZATION_SLUG               string = "org_slug"
 	DEBUG                           string = "debug"
 	DEBUG_FORMAT                    string = "debug_format"
 	INSECURE_HTTPS                  string = "insecure"


### PR DESCRIPTION
This PR should add a new configuration field, `ORGANIZATION_SLUG` to differentiate the org ID from the org slug name.