### PR TITLE
fix: rename config key for auth token to avoid collisions

### DIFF
--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -3,7 +3,7 @@ package configuration
 const (
 	API_URL                         string = "snyk_api"                // AKA "endpoint" in the config file
 	AUTHENTICATION_SUBDOMAINS       string = "internal_auth_subdomain" // array of additional subdomains to add authentication for
-	AUTHENTICATION_TOKEN            string = "token"
+	AUTHENTICATION_TOKEN            string = "snyk_token"
 	AUTHENTICATION_BEARER_TOKEN     string = "bearer_token"
 	INTEGRATION_NAME                string = "snyk_integration_name"
 	INTEGRATION_VERSION             string = "snyk_integration_version"


### PR DESCRIPTION
Currently all Environment Variables are used when looking up config values. This can lead to conflicts when a TOKEN and SNYK_TOKEN environment variable is existing, as TOKEN is the first key to be looked up.