### PR TITLE
fix: generic bearer_token name to avoid collisions

### DIFF
--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -4,7 +4,7 @@ const (
 	API_URL                         string = "snyk_api"                // AKA "endpoint" in the config file
 	AUTHENTICATION_SUBDOMAINS       string = "internal_auth_subdomain" // array of additional subdomains to add authentication for
 	AUTHENTICATION_TOKEN            string = "snyk_token"
-	AUTHENTICATION_BEARER_TOKEN     string = "bearer_token"
+	AUTHENTICATION_BEARER_TOKEN     string = "snyk_oauth_token"
 	INTEGRATION_NAME                string = "snyk_integration_name"
 	INTEGRATION_VERSION             string = "snyk_integration_version"
 	INTEGRATION_ENVIRONMENT         string = "snyk_integration_environment"


### PR DESCRIPTION
Currently we do not identify all Snyk/GAF specific bearer token environment variable, this can lead to issues where a bearer_token env var is used by the client for non-snyk purposes. This PR uses the Snyk specific bearer_token env var to avoid this.