### PR TITLE
feat: support fips configuration and validation

### DIFF
--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -52,7 +52,7 @@ func Test_initConfiguration_updateDefaultOrgId(t *testing.T) {
 	mockApiClient.EXPECT().Init(gomock.Any(), gomock.Any()).Times(1)
 	mockApiClient.EXPECT().GetOrgIdFromSlug(orgName).Return(orgId, nil).Times(1)
 
-	config := configuration.New()
+	config := configuration.NewInMemory()
 	initConfiguration(config, mockApiClient, &zlog.Logger)
 
 	config.Set(configuration.ORGANIZATION, orgName)
@@ -72,7 +72,7 @@ func Test_initConfiguration_useDefaultOrgId(t *testing.T) {
 	mockApiClient.EXPECT().Init(gomock.Any(), gomock.Any()).Times(1)
 	mockApiClient.EXPECT().GetDefaultOrgId().Return(defaultOrgId, nil).Times(1)
 
-	config := configuration.New()
+	config := configuration.NewInMemory()
 	initConfiguration(config, mockApiClient, &zlog.Logger)
 
 	actualOrgId := config.GetString(configuration.ORGANIZATION)
@@ -92,7 +92,7 @@ func Test_initConfiguration_useDefaultOrgIdWhenGetOrgIdFromSlugFails(t *testing.
 	mockApiClient.EXPECT().GetOrgIdFromSlug(orgName).Return("", errors.New("Failed to fetch org id from slug")).Times(1)
 	mockApiClient.EXPECT().GetDefaultOrgId().Return(defaultOrgId, nil).Times(1)
 
-	config := configuration.New()
+	config := configuration.NewInMemory()
 	initConfiguration(config, mockApiClient, &zlog.Logger)
 
 	config.Set(configuration.ORGANIZATION, orgName)
@@ -111,7 +111,7 @@ func Test_initConfiguration_uuidOrgId(t *testing.T) {
 	// mock assertion
 	mockApiClient.EXPECT().Init(gomock.Any(), gomock.Any()).Times(1)
 
-	config := configuration.New()
+	config := configuration.NewInMemory()
 	initConfiguration(config, mockApiClient, &zlog.Logger)
 
 	config.Set(configuration.ORGANIZATION, orgId)
@@ -148,7 +148,7 @@ func Test_initConfiguration_existingValueOfOAuthFFRespected(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockApiClient := mocks.NewMockApiClient(ctrl)
 
-	config := configuration.New()
+	config := configuration.NewInMemory()
 	initConfiguration(config, mockApiClient, &zlog.Logger)
 
 	config.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, existingValue)
@@ -165,7 +165,7 @@ func Test_initConfiguration_setValueOfOAuthFF(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockApiClient := mocks.NewMockApiClient(ctrl)
 
-	config := configuration.New()
+	config := configuration.NewInMemory()
 	initConfiguration(config, mockApiClient, &zlog.Logger)
 
 	config.Set(configuration.API_URL, endpoint)

--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -21,6 +21,7 @@ const (
 	WEB_APP_URL                     string = "internal_snyk_app"
 	INPUT_DIRECTORY                 string = "targetDirectory"
 	ADD_TRUSTED_CA_FILE             string = "internal_additional_trusted_ca_file" // pem file location containing additional CAs to trust
+	FIPS_ENABLED                    string = "gofips"
 
 	// feature flags
 	FF_OAUTH_AUTH_FLOW_ENABLED string = "internal_snyk_oauth_enabled"

--- a/pkg/networking/fips/fips_crypto.go
+++ b/pkg/networking/fips/fips_crypto.go
@@ -1,0 +1,14 @@
+//go:build boringcrypto || goexperiment.systemcrypto || goexperiment.cngcrypto || goexperiment.opensslcrypto
+
+package fips
+
+import "github.com/snyk/go-application-framework/pkg/configuration"
+import _ "crypto/tls/fipsonly"
+
+func Validate(configuration configuration.Configuration) error {
+	return nil
+}
+
+func IsAvailable() bool {
+	return true
+}

--- a/pkg/networking/fips/fips_crypto_test.go
+++ b/pkg/networking/fips/fips_crypto_test.go
@@ -1,0 +1,22 @@
+//go:build boringcrypto || goexperiment.systemcrypto || goexperiment.cngcrypto || goexperiment.opensslcrypto
+
+package fips
+
+import (
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_FIPS_CRYPTO_Validate(t *testing.T) {
+	config := configuration.NewInMemory()
+	config.Set(configuration.FIPS_ENABLED, "1")
+	assert.Nil(t, Validate(config))
+
+	config.Set(configuration.FIPS_ENABLED, "0")
+	assert.Nil(t, Validate(config))
+}
+
+func Test_FIPS_CRYPTO_IsAvailable(t *testing.T) {
+	assert.True(t, IsAvailable())
+}

--- a/pkg/networking/fips/non_fips_crypto.go
+++ b/pkg/networking/fips/non_fips_crypto.go
@@ -1,0 +1,22 @@
+//go:build !boringcrypto && !goexperiment.systemcrypto && !goexperiment.cngcrypto && !goexperiment.opensslcrypto
+
+package fips
+
+import (
+	"fmt"
+	"github.com/snyk/go-application-framework/pkg/configuration"
+)
+
+func Validate(config configuration.Configuration) error {
+	var err error
+
+	if config.GetBool(configuration.FIPS_ENABLED) {
+		err = fmt.Errorf("FIPS is enabled but the application doesn't support it")
+	}
+
+	return err
+}
+
+func IsAvailable() bool {
+	return false
+}

--- a/pkg/networking/fips/non_fips_crypto_test.go
+++ b/pkg/networking/fips/non_fips_crypto_test.go
@@ -1,0 +1,22 @@
+//go:build !boringcrypto && !goexperiment.systemcrypto && !goexperiment.cngcrypto && !goexperiment.opensslcrypto
+
+package fips
+
+import (
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_NON_FIPS_CRYPTO_Validate(t *testing.T) {
+	config := configuration.NewInMemory()
+	config.Set(configuration.FIPS_ENABLED, "1")
+	assert.NotNil(t, Validate(config))
+
+	config.Set(configuration.FIPS_ENABLED, "0")
+	assert.Nil(t, Validate(config))
+}
+
+func Test_NON_FIPS_CRYPTO_IsAvailable(t *testing.T) {
+	assert.False(t, IsAvailable())
+}


### PR DESCRIPTION
* Enable reading the fips status/configuration via the configuration package
* Implement conditional compiling fips package that enables to detect if fips is available and validates a given config
* Boy Scout Rule: use in-memory config in some tests that weren't using it before