### PR TITLE
fix: missing default HTTP headers [HEAD-936]

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -15,12 +15,11 @@ import (
 	"github.com/snyk/go-application-framework/pkg/auth"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
-	"github.com/snyk/go-application-framework/pkg/networking"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )
 
 // initConfiguration initializes the configuration with initial values.
-func initConfiguration(config configuration.Configuration, apiClient api.ApiClient, logger *zerolog.Logger) {
+func initConfiguration(engine workflow.Engine, config configuration.Configuration, apiClient api.ApiClient, logger *zerolog.Logger) {
 	if logger == nil {
 		logger = &zlog.Logger
 	}
@@ -60,7 +59,7 @@ func initConfiguration(config configuration.Configuration, apiClient api.ApiClie
 	})
 
 	config.AddDefaultValue(configuration.ORGANIZATION, func(existingValue any) any {
-		client := networking.NewNetworkAccess(config).GetHttpClient()
+		client := engine.GetNetworkAccess().GetHttpClient()
 		url := config.GetString(configuration.API_URL)
 		apiClient.Init(url, client)
 		if existingValue != nil && len(existingValue.(string)) > 0 {
@@ -120,7 +119,7 @@ func CreateAppEngineWithOptions(opts ...Opts) workflow.Engine {
 
 	config := engine.GetConfiguration()
 	if config != nil {
-		initConfiguration(config, api.NewApiInstance(), engine.GetLogger())
+		initConfiguration(engine, config, api.NewApiInstance(), engine.GetLogger())
 	}
 
 	engine.AddExtensionInitializer(localworkflows.Init)

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/snyk/go-application-framework/internal/constants"
 	"github.com/snyk/go-application-framework/internal/mocks"
 	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/workflow"
 )
 
 func Test_CreateAppEngine(t *testing.T) {
@@ -54,7 +55,8 @@ func Test_initConfiguration_updateDefaultOrgId(t *testing.T) {
 	mockApiClient.EXPECT().GetOrgIdFromSlug(orgName).Return(orgId, nil).Times(1)
 
 	config := configuration.NewInMemory()
-	initConfiguration(config, mockApiClient, &zlog.Logger)
+	engine := workflow.NewWorkFlowEngine(config)
+	initConfiguration(engine, config, mockApiClient, &zlog.Logger)
 
 	config.Set(configuration.ORGANIZATION, orgName)
 
@@ -74,7 +76,8 @@ func Test_initConfiguration_useDefaultOrgId(t *testing.T) {
 	mockApiClient.EXPECT().GetDefaultOrgId().Return(defaultOrgId, nil).Times(1)
 
 	config := configuration.NewInMemory()
-	initConfiguration(config, mockApiClient, &zlog.Logger)
+	engine := workflow.NewWorkFlowEngine(config)
+	initConfiguration(engine, config, mockApiClient, &zlog.Logger)
 
 	actualOrgId := config.GetString(configuration.ORGANIZATION)
 	assert.Equal(t, defaultOrgId, actualOrgId)
@@ -94,7 +97,8 @@ func Test_initConfiguration_useDefaultOrgIdWhenGetOrgIdFromSlugFails(t *testing.
 	mockApiClient.EXPECT().GetDefaultOrgId().Return(defaultOrgId, nil).Times(1)
 
 	config := configuration.NewInMemory()
-	initConfiguration(config, mockApiClient, &zlog.Logger)
+	engine := workflow.NewWorkFlowEngine(config)
+	initConfiguration(engine, config, mockApiClient, &zlog.Logger)
 
 	config.Set(configuration.ORGANIZATION, orgName)
 
@@ -113,7 +117,8 @@ func Test_initConfiguration_uuidOrgId(t *testing.T) {
 	mockApiClient.EXPECT().Init(gomock.Any(), gomock.Any()).Times(1)
 
 	config := configuration.NewInMemory()
-	initConfiguration(config, mockApiClient, &zlog.Logger)
+	engine := workflow.NewWorkFlowEngine(config)
+	initConfiguration(engine, config, mockApiClient, &zlog.Logger)
 
 	config.Set(configuration.ORGANIZATION, orgId)
 
@@ -150,7 +155,7 @@ func Test_initConfiguration_existingValueOfOAuthFFRespected(t *testing.T) {
 	mockApiClient := mocks.NewMockApiClient(ctrl)
 
 	config := configuration.NewInMemory()
-	initConfiguration(config, mockApiClient, &zlog.Logger)
+	initConfiguration(workflow.NewWorkFlowEngine(config), config, mockApiClient, &zlog.Logger)
 
 	config.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, existingValue)
 	config.Set(configuration.API_URL, endpoint)
@@ -167,7 +172,7 @@ func Test_initConfiguration_snykgov(t *testing.T) {
 	mockApiClient := mocks.NewMockApiClient(ctrl)
 
 	config := configuration.NewInMemory()
-	initConfiguration(config, mockApiClient, &zlog.Logger)
+	initConfiguration(workflow.NewWorkFlowEngine(config), config, mockApiClient, &zlog.Logger)
 
 	config.Set(configuration.API_URL, endpoint)
 
@@ -186,7 +191,7 @@ func Test_initConfiguration_NOT_snykgov(t *testing.T) {
 	mockApiClient := mocks.NewMockApiClient(ctrl)
 
 	config := configuration.NewInMemory()
-	initConfiguration(config, mockApiClient, &zlog.Logger)
+	initConfiguration(workflow.NewWorkFlowEngine(config), config, mockApiClient, &zlog.Logger)
 
 	config.Set(configuration.API_URL, endpoint)
 

--- a/pkg/workflow/engineimpl.go
+++ b/pkg/workflow/engineimpl.go
@@ -98,8 +98,7 @@ func (e *EngineImpl) Init() error {
 	var err error
 
 	e.invocationCounter = 0
-	e.networkAccess = networking.NewNetworkAccess(e.config)
-	e.networkAccess.SetLogger(e.logger)
+	_ = e.GetNetworkAccess()
 
 	for i := range e.extensionInitializer {
 		err = e.extensionInitializer[i](e)
@@ -252,6 +251,11 @@ func (e *EngineImpl) GetAnalytics() analytics.Analytics {
 
 // GetNetworkAccess returns the network access object.
 func (e *EngineImpl) GetNetworkAccess() networking.NetworkAccess {
+	if e.networkAccess == nil {
+		e.networkAccess = networking.NewNetworkAccess(e.config)
+		e.networkAccess.SetLogger(e.logger)
+	}
+
 	return e.networkAccess
 }
 


### PR DESCRIPTION
Some of the pre-configured HTTP clients were missing the configured default headers.