### PR TITLE
feat: add report analytics extension [HEAD- 879]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,9 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,7 @@ github.com/spf13/viper v1.13.0/go.mod h1:Icm2xNL3/8uyh/wFuB1jI7TiTNKp8632Nwegu+z
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -218,6 +219,12 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.4.1 h1:jyEFiXpy21Wm81FBN71l9VoMMV8H8jG+qIK3GCpY6Qs=
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/local_workflows/json_schemas/scan_done_analytics_event.json
+++ b/pkg/local_workflows/json_schemas/scan_done_analytics_event.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "type": "object",
+      "required": [
+        "type",
+        "attributes"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of data (\"analytics\")."
+        },
+        "attributes": {
+          "type": "object",
+          "required": [
+            "deviceId",
+            "application",
+            "application_version",
+            "os",
+            "arch",
+            "integration_name",
+            "integration_version",
+            "integration_environment",
+            "integration_environment_version",
+            "event_type",
+            "status",
+            "scan_type",
+            "unique_issue_count",
+            "duration_ms",
+            "timestamp_finished"
+          ],
+          "properties": {
+            "deviceId": {
+              "type": "string",
+              "description": "The unique identifier for the device."
+            },
+            "application": {
+              "type": "string",
+              "description": "The application name."
+            },
+            "application_version": {
+              "type": "string",
+              "description": "The version of the application."
+            },
+            "os": {
+              "type": "string",
+              "description": "The operating system."
+            },
+            "arch": {
+              "type": "string",
+              "description": "The architecture (AMD64, ARM64, 386, ALPINE)."
+            },
+            "integration_name": {
+              "type": "string",
+              "description": "The name of the integration."
+            },
+            "integration_version": {
+              "type": "string",
+              "description": "The version of the integration."
+            },
+            "integration_environment": {
+              "type": "string",
+              "description": "The environment for the integration (e.g., IntelliJ Ultimate, Pycharm)."
+            },
+            "integration_environment_version": {
+              "type": "string",
+              "description": "The version of the integration environment (e.g. 2023.3)"
+            },
+            "event_type": {
+              "type": "string",
+              "description": "The type of event (e.g., Scan done)."
+            },
+            "status": {
+              "type": "string",
+              "description": "The status of the event (e.g., Succeeded)."
+            },
+            "scan_type": {
+              "type": "string",
+              "description": "The scan type (e.g., Snyk Open Source)."
+            },
+            "unique_issue_count": {
+              "type": "object",
+              "required": [
+                "critical",
+                "high",
+                "medium",
+                "low"
+              ],
+              "properties": {
+                "critical": {
+                  "type": "integer",
+                  "description": "The count of critical issues."
+                },
+                "high": {
+                  "type": "integer",
+                  "description": "The count of high issues."
+                },
+                "medium": {
+                  "type": "integer",
+                  "description": "The count of medium issues."
+                },
+                "low": {
+                  "type": "integer",
+                  "description": "The count of low issues."
+                }
+              },
+              "description": "The count of unique issues."
+            },
+            "duration_ms": {
+              "type": "string",
+              "description": "The scan duration in milliseconds."
+            },
+            "timestamp_finished": {
+              "type": "string",
+              "format": "date-time",
+              "description": "The timestamp when the scan was finished in UTC (Zulu time)."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/pkg/local_workflows/json_schemas/schemas.go
+++ b/pkg/local_workflows/json_schemas/schemas.go
@@ -1,4 +1,6 @@
-{
+package json_schemas
+
+const ScanDoneSchema = `{
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "required": [
@@ -127,3 +129,4 @@
     }
   }
 }
+`

--- a/pkg/local_workflows/json_schemas/schemas.go
+++ b/pkg/local_workflows/json_schemas/schemas.go
@@ -1,6 +1,8 @@
 package json_schemas
 
-const ScanDoneSchema = `{
+import "time"
+
+const ScanDoneEventSchema = `{
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "required": [
@@ -130,3 +132,31 @@ const ScanDoneSchema = `{
   }
 }
 `
+
+type ScanDoneEvent struct {
+	Data struct {
+		Type       string `json:"type"`
+		Attributes struct {
+			DeviceId                      string `json:"deviceId"`
+			Application                   string `json:"application"`
+			ApplicationVersion            string `json:"application_version"`
+			Os                            string `json:"os"`
+			Arch                          string `json:"arch"`
+			IntegrationName               string `json:"integration_name"`
+			IntegrationVersion            string `json:"integration_version"`
+			IntegrationEnvironment        string `json:"integration_environment"`
+			IntegrationEnvironmentVersion string `json:"integration_environment_version"`
+			EventType                     string `json:"event_type"`
+			Status                        string `json:"status"`
+			ScanType                      string `json:"scan_type"`
+			UniqueIssueCount              struct {
+				Critical int `json:"critical"`
+				High     int `json:"high"`
+				Medium   int `json:"medium"`
+				Low      int `json:"low"`
+			} `json:"unique_issue_count"`
+			DurationMs        string    `json:"duration_ms"`
+			TimestampFinished time.Time `json:"timestamp_finished"`
+		} `json:"attributes"`
+	} `json:"data"`
+}

--- a/pkg/local_workflows/local_workflows.go
+++ b/pkg/local_workflows/local_workflows.go
@@ -13,6 +13,7 @@ func Init(engine workflow.Engine) error {
 		InitOutputWorkflow,
 		InitWhoAmIWorkflow,
 		InitAuth,
+		InitReportAnalyticsWorkflow,
 	}
 
 	for i := range initMethods {

--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -2,7 +2,6 @@ package localworkflows
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
@@ -31,26 +30,23 @@ func reportAnalyticsEntrypoint(invocationCtx workflow.InvocationContext, inputDa
 	logger := invocationCtx.GetLogger()
 	logger.Println(reportAnalyticsWorkflowName + " workflow start")
 
-	url := fmt.Sprintf("%s/rest/%s/analytics", config.GetString(configuration.API_URL), config.Get(configuration.ORGANIZATION))
+	url := fmt.Sprintf("%s/rest/api/orgs/%s/analytics", config.GetString(configuration.API_URL), config.Get(configuration.ORGANIZATION))
 
 	for i, input := range inputData {
 		logger.Println(fmt.Sprintf("%s: processing element %d", reportAnalyticsWorkflowName, i))
 		err = callEndpoint(invocationCtx, input, url)
+		if err != nil {
+			break
+		}
 	}
-	return []workflow.Data{}, err
+	return nil, err
 }
 
 func callEndpoint(invocationCtx workflow.InvocationContext, input workflow.Data, url string) error {
 	logger := invocationCtx.GetLogger()
-	// Marshal the payload to JSON
-	payloadBytes, err := json.Marshal(input.GetPayload())
-	if err != nil {
-		logger.Printf("Error marshaling payload: %v\n", err)
-		return err
-	}
 
 	// Create a request
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payloadBytes))
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(input.GetPayload().([]byte)))
 	if err != nil {
 		logger.Printf("Error creating request: %v\n", err)
 		return err

--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -23,20 +23,12 @@ func InitReportAnalyticsWorkflow(engine workflow.Engine) error {
 	// initialise workflow configuration
 	config := pflag.NewFlagSet(reportAnalyticsWorkflowName, pflag.ExitOnError)
 
-	err := initializeSchemaLoader()
-	if err != nil {
-		return err
-	}
+	// load json schema for scan done event
+	scanDoneSchemaLoader = gojsonschema.NewStringLoader(json_schemas.ScanDoneEventSchema)
 
 	// register workflow with engine
-	_, err = engine.Register(WORKFLOWID_REPORT_ANALYTICS, workflow.ConfigurationOptionsFromFlagset(config), reportAnalyticsEntrypoint)
+	_, err := engine.Register(WORKFLOWID_REPORT_ANALYTICS, workflow.ConfigurationOptionsFromFlagset(config), reportAnalyticsEntrypoint)
 	return err
-}
-
-// initializeSchemaLoader initializes the schema loader for the reportAnalytics workflow.
-func initializeSchemaLoader() error {
-	scanDoneSchemaLoader = gojsonschema.NewStringLoader(json_schemas.ScanDoneEventSchema)
-	return nil
 }
 
 // reportAnalyticsEntrypoint is the entry point for the reportAnalytics workflow.

--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/pflag"
 	"io"
 	"net/http"
+	"time"
 )
 
 const reportAnalyticsWorkflowName = "reportAnalytics"
@@ -67,4 +68,36 @@ func callEndpoint(invocationCtx workflow.InvocationContext, input workflow.Data,
 
 	defer func(Body io.ReadCloser) { _ = Body.Close() }(resp.Body)
 	return nil
+}
+
+type ScanDoneAnalyticsData struct {
+	Data struct {
+		Type       string `json:"type"`
+		Attributes struct {
+			DeviceId                      string `json:"deviceId"`
+			Application                   string `json:"application"`
+			ApplicationVersion            string `json:"application_version"`
+			Os                            string `json:"os"`
+			Arch                          string `json:"arch"`
+			IntegrationName               string `json:"integration_name"`
+			IntegrationVersion            string `json:"integration_version"`
+			IntegrationEnvironment        string `json:"integration_environment"`
+			IntegrationEnvironmentVersion string `json:"integration_environment_version"`
+			EventType                     string `json:"event_type"`
+			Status                        string `json:"status"`
+			ScanType                      string `json:"scan_type"`
+			UniqueIssueCount              struct {
+				Critical int `json:"critical"`
+				High     int `json:"high"`
+				Medium   int `json:"medium"`
+				Low      int `json:"low"`
+			} `json:"unique_issue_count"`
+			DurationMs        string    `json:"duration_ms"`
+			TimestampFinished time.Time `json:"timestamp_finished"`
+		} `json:"attributes"`
+	} `json:"data"`
+}
+
+func NewScanDoneAnalyticsData() *ScanDoneAnalyticsData {
+	panic("not implemented")
 }

--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -137,7 +137,3 @@ type ScanDoneAnalyticsData struct {
 		} `json:"attributes"`
 	} `json:"data"`
 }
-
-func NewScanDoneAnalyticsData() *ScanDoneAnalyticsData {
-	panic("not implemented")
-}

--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -1,0 +1,74 @@
+package localworkflows
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+	"github.com/spf13/pflag"
+	"io"
+	"net/http"
+)
+
+const reportAnalyticsWorkflowName = "reportAnalytics"
+
+var WORKFLOWID_REPORT_ANALYTICS workflow.Identifier = workflow.NewWorkflowIdentifier(reportAnalyticsWorkflowName)
+
+// InitReportAnalyticsWorkflow initialises the whoAmI workflow before registering it with the engine.
+func InitReportAnalyticsWorkflow(engine workflow.Engine) error {
+	// initialise workflow configuration
+	config := pflag.NewFlagSet(reportAnalyticsWorkflowName, pflag.ExitOnError)
+	// register workflow with engine
+	_, err := engine.Register(WORKFLOWID_REPORT_ANALYTICS, workflow.ConfigurationOptionsFromFlagset(config), reportAnalyticsEntrypoint)
+	return err
+}
+
+// reportAnalyticsEntrypoint is the entry point for the reportAnalytics workflow.
+func reportAnalyticsEntrypoint(invocationCtx workflow.InvocationContext, inputData []workflow.Data) (output []workflow.Data, err error) {
+	// get necessary objects from invocation context
+	config := invocationCtx.GetConfiguration()
+	logger := invocationCtx.GetLogger()
+	logger.Println(reportAnalyticsWorkflowName + " workflow start")
+
+	url := fmt.Sprintf("%s/rest/%s/analytics", config.GetString(configuration.API_URL), config.Get(configuration.ORGANIZATION))
+
+	for i, input := range inputData {
+		logger.Println(fmt.Sprintf("%s: processing element %d", reportAnalyticsWorkflowName, i))
+		err = callEndpoint(invocationCtx, input, url)
+	}
+	return []workflow.Data{}, err
+}
+
+func callEndpoint(invocationCtx workflow.InvocationContext, input workflow.Data, url string) error {
+	logger := invocationCtx.GetLogger()
+	// Marshal the payload to JSON
+	payloadBytes, err := json.Marshal(input.GetPayload())
+	if err != nil {
+		logger.Printf("Error marshaling payload: %v\n", err)
+		return err
+	}
+
+	// Create a request
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payloadBytes))
+	if err != nil {
+		logger.Printf("Error creating request: %v\n", err)
+		return err
+	}
+	req.Header.Set("Content-Type", input.GetContentType())
+
+	// Send the request
+
+	resp, err := invocationCtx.GetNetworkAccess().GetHttpClient().Do(req)
+	if err != nil {
+		logger.Printf("Error sending request: %v\n", err)
+		return err
+	}
+
+	if resp.StatusCode != 201 {
+		return fmt.Errorf("Error sending request: %v\n", resp.Status)
+	}
+
+	defer func(Body io.ReadCloser) { _ = Body.Close() }(resp.Body)
+	return nil
+}

--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -3,10 +3,9 @@ package localworkflows
 import (
 	"bytes"
 	"fmt"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
 	"io"
 	"net/http"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
@@ -38,17 +37,7 @@ func InitReportAnalyticsWorkflow(engine workflow.Engine) error {
 
 // initializeSchemaLoader initializes the schema loader for the reportAnalytics workflow.
 func initializeSchemaLoader() error {
-	filePath, err := filepath.Abs(filepath.Join("json_schemas", "scan_done_analytics_event.json"))
-	if err != nil {
-		return err
-	}
-
-	schema, err := os.ReadFile(filePath)
-	if err != nil {
-		return err
-	}
-
-	scanDoneSchemaLoader = gojsonschema.NewStringLoader(string(schema))
+	scanDoneSchemaLoader = gojsonschema.NewStringLoader(json_schemas.ScanDoneSchema)
 	return nil
 }
 

--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -3,15 +3,13 @@ package localworkflows
 import (
 	"bytes"
 	"fmt"
-	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
-	"io"
-	"net/http"
-	"time"
-
 	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 	"github.com/spf13/pflag"
 	"github.com/xeipuuv/gojsonschema"
+	"io"
+	"net/http"
 )
 
 const reportAnalyticsWorkflowName = "reportAnalytics"
@@ -37,7 +35,7 @@ func InitReportAnalyticsWorkflow(engine workflow.Engine) error {
 
 // initializeSchemaLoader initializes the schema loader for the reportAnalytics workflow.
 func initializeSchemaLoader() error {
-	scanDoneSchemaLoader = gojsonschema.NewStringLoader(json_schemas.ScanDoneSchema)
+	scanDoneSchemaLoader = gojsonschema.NewStringLoader(json_schemas.ScanDoneEventSchema)
 	return nil
 }
 
@@ -97,32 +95,4 @@ func callEndpoint(invocationCtx workflow.InvocationContext, input workflow.Data,
 
 	defer func(Body io.ReadCloser) { _ = Body.Close() }(resp.Body)
 	return nil
-}
-
-type ScanDoneAnalyticsData struct {
-	Data struct {
-		Type       string `json:"type"`
-		Attributes struct {
-			DeviceId                      string `json:"deviceId"`
-			Application                   string `json:"application"`
-			ApplicationVersion            string `json:"application_version"`
-			Os                            string `json:"os"`
-			Arch                          string `json:"arch"`
-			IntegrationName               string `json:"integration_name"`
-			IntegrationVersion            string `json:"integration_version"`
-			IntegrationEnvironment        string `json:"integration_environment"`
-			IntegrationEnvironmentVersion string `json:"integration_environment_version"`
-			EventType                     string `json:"event_type"`
-			Status                        string `json:"status"`
-			ScanType                      string `json:"scan_type"`
-			UniqueIssueCount              struct {
-				Critical int `json:"critical"`
-				High     int `json:"high"`
-				Medium   int `json:"medium"`
-				Low      int `json:"low"`
-			} `json:"unique_issue_count"`
-			DurationMs        string    `json:"duration_ms"`
-			TimestampFinished time.Time `json:"timestamp_finished"`
-		} `json:"attributes"`
-	} `json:"data"`
 }

--- a/pkg/local_workflows/report_analytics_workflow_test.go
+++ b/pkg/local_workflows/report_analytics_workflow_test.go
@@ -169,7 +169,6 @@ func Test_ReportAnalytics_ReportAnalyticsEntryPoint_validatesInput(t *testing.T)
 	_, err := reportAnalyticsEntrypoint(invocationContextMock, []workflow.Data{input})
 	require.Error(t, err)
 }
-
 func testGetScanDonePayload(payload string) workflow.Data {
 	return workflow.NewData(workflow.NewTypeIdentifier(WORKFLOWID_REPORT_ANALYTICS, reportAnalyticsWorkflowName), "application/json", []byte(payload))
 }

--- a/pkg/local_workflows/report_analytics_workflow_test.go
+++ b/pkg/local_workflows/report_analytics_workflow_test.go
@@ -2,8 +2,6 @@ package localworkflows
 
 import (
 	"bytes"
-	"github.com/snyk/go-application-framework/pkg/workflow"
-	"github.com/stretchr/testify/require"
 	"io"
 	"io/ioutil"
 	"log"
@@ -11,12 +9,15 @@ import (
 	"os"
 	"testing"
 
+	"github.com/snyk/go-application-framework/pkg/workflow"
+	"github.com/stretchr/testify/require"
+
 	"github.com/golang/mock/gomock"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/mocks"
 )
 
-func Test_ReportAnalytics_ReportAnalyticsEntryPoint_happyPath(t *testing.T) {
+func Test_ReportAnalytics_ReportAnalyticsEntryPoint_shouldReportToApi(t *testing.T) {
 	// setup
 	logger := log.New(os.Stderr, "test", 0)
 	config := configuration.New()
@@ -24,33 +25,114 @@ func Test_ReportAnalytics_ReportAnalyticsEntryPoint_happyPath(t *testing.T) {
 
 	config.Set(configuration.ORGANIZATION, orgId)
 
-	requestPayload := `{
-		"data": {
-			"type": "analytics",
-			"attributes": {
-				"deviceId": "unique-uuid",
-				"application": "snyk-cli",
-				"application_version": "1.1233.0",
-				"os": "macOS",
-				"arch": "ARM64",
-							"integration_name": "IntelliJ",
-							"integration_version": "2.5.5",
-							"integration_environment": "Pycharm",
-							"integration_environment_version": "2023.1",
-				"event_type": "Scan done",
-				"status": "Succeeded",
-				"scan_type": "Snyk Open Source",
-				"unique_issue_count": {
-						"critical": 15,
-											"high": 10,
-						"medium": 1,
-						"low": 2
-				},
-				"duration_ms": "1000",
-				"timestamp_finished": "2023-09-01T12:00:00Z"
-			}
+	requestPayload := testGetScanDonePayloadString()
+
+	// setup mocks
+	ctrl := gomock.NewController(t)
+	networkAccessMock := mocks.NewMockNetworkAccess(ctrl)
+	invocationContextMock := mocks.NewMockInvocationContext(ctrl)
+	testInitReportAnalyticsWorkflow(ctrl)
+
+	mockClient := newTestClient(func(req *http.Request) *http.Response {
+		// Test request parameters
+		require.Equal(t, "/rest/api/orgs/"+orgId+"/analytics", req.URL.String())
+		require.Equal(t, "POST", req.Method)
+		require.Equal(t, "application/json", req.Header.Get("Content-Type"))
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		require.Equal(t, requestPayload, string(body))
+
+		return &http.Response{
+			StatusCode: 201,
+			// Send response to be tested
+			Body: ioutil.NopCloser(bytes.NewBufferString(requestPayload)),
+			// Must be set to non-nil value or it panics
+			Header: make(http.Header),
 		}
-	}`
+	})
+
+	// invocation context mocks
+	invocationContextMock.EXPECT().GetConfiguration().Return(config).AnyTimes()
+	invocationContextMock.EXPECT().GetLogger().Return(logger).AnyTimes()
+	invocationContextMock.EXPECT().GetNetworkAccess().Return(networkAccessMock).AnyTimes()
+	networkAccessMock.EXPECT().GetHttpClient().Return(mockClient).AnyTimes()
+
+	_, err := reportAnalyticsEntrypoint(invocationContextMock, []workflow.Data{testGetScanDonePayload(requestPayload)})
+	require.NoError(t, err)
+}
+func Test_ReportAnalytics_ReportAnalyticsEntryPoint_reportsHttpStatusError(t *testing.T) {
+	// setup
+	logger := log.New(os.Stderr, "test", 0)
+	config := configuration.New()
+	orgId := "orgId"
+
+	config.Set(configuration.ORGANIZATION, orgId)
+
+	requestPayload := testGetScanDonePayloadString()
+
+	// setup mocks
+	ctrl := gomock.NewController(t)
+	networkAccessMock := mocks.NewMockNetworkAccess(ctrl)
+	invocationContextMock := mocks.NewMockInvocationContext(ctrl)
+	testInitReportAnalyticsWorkflow(ctrl)
+
+	mockClient := newTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			// error code!
+			StatusCode: 500,
+			// Send response to be tested
+			Body: ioutil.NopCloser(bytes.NewBufferString(requestPayload)),
+			// Must be set to non-nil value or it panics
+			Header: make(http.Header),
+		}
+	})
+
+	// invocation context mocks
+	invocationContextMock.EXPECT().GetConfiguration().Return(config).AnyTimes()
+	invocationContextMock.EXPECT().GetLogger().Return(logger).AnyTimes()
+	invocationContextMock.EXPECT().GetNetworkAccess().Return(networkAccessMock).AnyTimes()
+	networkAccessMock.EXPECT().GetHttpClient().Return(mockClient).AnyTimes()
+
+	_, err := reportAnalyticsEntrypoint(invocationContextMock, []workflow.Data{testGetScanDonePayload(requestPayload)})
+	require.Error(t, err)
+}
+func Test_ReportAnalytics_ReportAnalyticsEntryPoint_reportsHttpError(t *testing.T) {
+	// setup
+	logger := log.New(os.Stderr, "test", 0)
+	config := configuration.New()
+	orgId := "orgId"
+
+	config.Set(configuration.ORGANIZATION, orgId)
+
+	requestPayload := testGetScanDonePayloadString()
+
+	// setup mocks
+	ctrl := gomock.NewController(t)
+	networkAccessMock := mocks.NewMockNetworkAccess(ctrl)
+	invocationContextMock := mocks.NewMockInvocationContext(ctrl)
+	testInitReportAnalyticsWorkflow(ctrl)
+
+	mockClient := newErrorProducingTestClient(func(req *http.Request) *http.Response { return nil })
+
+	// invocation context mocks
+	invocationContextMock.EXPECT().GetConfiguration().Return(config).AnyTimes()
+	invocationContextMock.EXPECT().GetLogger().Return(logger).AnyTimes()
+	invocationContextMock.EXPECT().GetNetworkAccess().Return(networkAccessMock).AnyTimes()
+	networkAccessMock.EXPECT().GetHttpClient().Return(mockClient).AnyTimes()
+
+	_, err := reportAnalyticsEntrypoint(invocationContextMock, []workflow.Data{testGetScanDonePayload(requestPayload)})
+	require.Error(t, err)
+}
+
+func Test_ReportAnalytics_ReportAnalyticsEntryPoint_validatesInput(t *testing.T) {
+	// setup
+	logger := log.New(os.Stderr, "test", 0)
+	config := configuration.New()
+	orgId := "orgId"
+
+	config.Set(configuration.ORGANIZATION, orgId)
+
+	requestPayload := `{}`
 
 	input := workflow.NewData(workflow.NewTypeIdentifier(WORKFLOWID_REPORT_ANALYTICS, reportAnalyticsWorkflowName), "application/json", []byte(requestPayload))
 
@@ -58,6 +140,7 @@ func Test_ReportAnalytics_ReportAnalyticsEntryPoint_happyPath(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	networkAccessMock := mocks.NewMockNetworkAccess(ctrl)
 	invocationContextMock := mocks.NewMockInvocationContext(ctrl)
+	testInitReportAnalyticsWorkflow(ctrl)
 
 	mockClient := newTestClient(func(req *http.Request) *http.Response {
 		// Test request parameters
@@ -84,68 +167,45 @@ func Test_ReportAnalytics_ReportAnalyticsEntryPoint_happyPath(t *testing.T) {
 	networkAccessMock.EXPECT().GetHttpClient().Return(mockClient).AnyTimes()
 
 	_, err := reportAnalyticsEntrypoint(invocationContextMock, []workflow.Data{input})
-	require.NoError(t, err)
+	require.Error(t, err)
 }
-func Test_ReportAnalytics_ReportAnalyticsEntryPoint_reportsHttpStatusError(t *testing.T) {
-	// setup
-	logger := log.New(os.Stderr, "test", 0)
-	config := configuration.New()
-	orgId := "orgId"
 
-	config.Set(configuration.ORGANIZATION, orgId)
+func testGetScanDonePayload(payload string) workflow.Data {
+	return workflow.NewData(workflow.NewTypeIdentifier(WORKFLOWID_REPORT_ANALYTICS, reportAnalyticsWorkflowName), "application/json", []byte(payload))
+}
 
-	requestPayload := `{}`
-
-	// setup mocks
-	ctrl := gomock.NewController(t)
-	networkAccessMock := mocks.NewMockNetworkAccess(ctrl)
-	invocationContextMock := mocks.NewMockInvocationContext(ctrl)
-	input := workflow.NewData(workflow.NewTypeIdentifier(WORKFLOWID_REPORT_ANALYTICS, reportAnalyticsWorkflowName), "application/json", []byte(requestPayload))
-
-	mockClient := newTestClient(func(req *http.Request) *http.Response {
-		return &http.Response{
-			// error code!
-			StatusCode: 500,
-			// Send response to be tested
-			Body: ioutil.NopCloser(bytes.NewBufferString(requestPayload)),
-			// Must be set to non-nil value or it panics
-			Header: make(http.Header),
+func testGetScanDonePayloadString() string {
+	return `{
+		"data": {
+			"type": "analytics",
+			"attributes": {
+				"deviceId": "unique-uuid",
+				"application": "snyk-cli",
+				"application_version": "1.1233.0",
+				"os": "macOS",
+				"arch": "ARM64",
+							"integration_name": "IntelliJ",
+							"integration_version": "2.5.5",
+							"integration_environment": "Pycharm",
+							"integration_environment_version": "2023.1",
+				"event_type": "Scan done",
+				"status": "Succeeded",
+				"scan_type": "Snyk Open Source",
+				"unique_issue_count": {
+						"critical": 15,
+											"high": 10,
+						"medium": 1,
+						"low": 2
+				},
+				"duration_ms": "1000",
+				"timestamp_finished": "2023-09-01T12:00:00Z"
+			}
 		}
-	})
-
-	// invocation context mocks
-	invocationContextMock.EXPECT().GetConfiguration().Return(config).AnyTimes()
-	invocationContextMock.EXPECT().GetLogger().Return(logger).AnyTimes()
-	invocationContextMock.EXPECT().GetNetworkAccess().Return(networkAccessMock).AnyTimes()
-	networkAccessMock.EXPECT().GetHttpClient().Return(mockClient).AnyTimes()
-
-	_, err := reportAnalyticsEntrypoint(invocationContextMock, []workflow.Data{input})
-	require.Error(t, err)
+	}`
 }
-func Test_ReportAnalytics_ReportAnalyticsEntryPoint_reportsHttpError(t *testing.T) {
-	// setup
-	logger := log.New(os.Stderr, "test", 0)
-	config := configuration.New()
-	orgId := "orgId"
 
-	config.Set(configuration.ORGANIZATION, orgId)
-
-	requestPayload := `{}`
-
-	// setup mocks
-	ctrl := gomock.NewController(t)
-	networkAccessMock := mocks.NewMockNetworkAccess(ctrl)
-	invocationContextMock := mocks.NewMockInvocationContext(ctrl)
-	input := workflow.NewData(workflow.NewTypeIdentifier(WORKFLOWID_REPORT_ANALYTICS, reportAnalyticsWorkflowName), "application/json", []byte(requestPayload))
-
-	mockClient := newErrorProducingTestClient(func(req *http.Request) *http.Response { return nil })
-
-	// invocation context mocks
-	invocationContextMock.EXPECT().GetConfiguration().Return(config).AnyTimes()
-	invocationContextMock.EXPECT().GetLogger().Return(logger).AnyTimes()
-	invocationContextMock.EXPECT().GetNetworkAccess().Return(networkAccessMock).AnyTimes()
-	networkAccessMock.EXPECT().GetHttpClient().Return(mockClient).AnyTimes()
-
-	_, err := reportAnalyticsEntrypoint(invocationContextMock, []workflow.Data{input})
-	require.Error(t, err)
+func testInitReportAnalyticsWorkflow(ctrl *gomock.Controller) {
+	engine := mocks.NewMockEngine(ctrl)
+	engine.EXPECT().Register(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	InitReportAnalyticsWorkflow(engine)
 }

--- a/pkg/local_workflows/report_analytics_workflow_test.go
+++ b/pkg/local_workflows/report_analytics_workflow_test.go
@@ -86,7 +86,7 @@ func Test_ReportAnalytics_ReportAnalyticsEntryPoint_happyPath(t *testing.T) {
 	_, err := reportAnalyticsEntrypoint(invocationContextMock, []workflow.Data{input})
 	require.NoError(t, err)
 }
-func Test_ReportAnalytics_ReportAnalyticsEntryPoint_reportsHttpError(t *testing.T) {
+func Test_ReportAnalytics_ReportAnalyticsEntryPoint_reportsHttpStatusError(t *testing.T) {
 	// setup
 	logger := log.New(os.Stderr, "test", 0)
 	config := configuration.New()
@@ -112,6 +112,33 @@ func Test_ReportAnalytics_ReportAnalyticsEntryPoint_reportsHttpError(t *testing.
 			Header: make(http.Header),
 		}
 	})
+
+	// invocation context mocks
+	invocationContextMock.EXPECT().GetConfiguration().Return(config).AnyTimes()
+	invocationContextMock.EXPECT().GetLogger().Return(logger).AnyTimes()
+	invocationContextMock.EXPECT().GetNetworkAccess().Return(networkAccessMock).AnyTimes()
+	networkAccessMock.EXPECT().GetHttpClient().Return(mockClient).AnyTimes()
+
+	_, err := reportAnalyticsEntrypoint(invocationContextMock, []workflow.Data{input})
+	require.Error(t, err)
+}
+func Test_ReportAnalytics_ReportAnalyticsEntryPoint_reportsHttpError(t *testing.T) {
+	// setup
+	logger := log.New(os.Stderr, "test", 0)
+	config := configuration.New()
+	orgId := "orgId"
+
+	config.Set(configuration.ORGANIZATION, orgId)
+
+	requestPayload := `{}`
+
+	// setup mocks
+	ctrl := gomock.NewController(t)
+	networkAccessMock := mocks.NewMockNetworkAccess(ctrl)
+	invocationContextMock := mocks.NewMockInvocationContext(ctrl)
+	input := workflow.NewData(workflow.NewTypeIdentifier(WORKFLOWID_REPORT_ANALYTICS, reportAnalyticsWorkflowName), "application/json", []byte(requestPayload))
+
+	mockClient := newErrorProducingTestClient(func(req *http.Request) *http.Response { return nil })
 
 	// invocation context mocks
 	invocationContextMock.EXPECT().GetConfiguration().Return(config).AnyTimes()

--- a/pkg/local_workflows/report_analytics_workflow_test.go
+++ b/pkg/local_workflows/report_analytics_workflow_test.go
@@ -1,0 +1,80 @@
+package localworkflows
+
+import (
+	"bytes"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/mocks"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ReportAnalytics_ReportAnalyticsEntryPoint_happyPath(t *testing.T) {
+	// setup
+	logger := log.New(os.Stderr, "test", 0)
+	config := configuration.New()
+	orgId := "orgId"
+
+	config.Set(configuration.ORGANIZATION, orgId)
+
+	requestPayload := `{
+		"data": {
+			"type": "analytics",
+			"attributes": {
+				"deviceId": "unique-uuid",
+				"application": "snyk-cli",
+				"application_version": "1.1233.0",
+				"os": "macOS",
+				"arch": "ARM64",
+							"integration_name": "IntelliJ",
+							"integration_version": "2.5.5",
+							"integration_environment": "Pycharm",
+							"integration_environment_version": "2023.1",
+				"event_type": "Scan done",
+				"status": "Succeeded",
+				"scan_type": "Snyk Open Source",
+				"unique_issue_count": {
+						"critical": 15,
+											"high": 10,
+						"medium": 1,
+						"low": 2
+				},
+				"duration_ms": "1000",
+				"timestamp_finished": "2023-09-01T12:00:00Z"
+			}
+		}
+	}`
+
+	// setup mocks
+	ctrl := gomock.NewController(t)
+	networkAccessMock := mocks.NewMockNetworkAccess(ctrl)
+	invocationContextMock := mocks.NewMockInvocationContext(ctrl)
+
+	mockClient := newTestClient(func(req *http.Request) *http.Response {
+		// Test request parameters
+		assert.Equal(t, "/rest/api/orgs/"+orgId+"/analytics", req.URL.String())
+		assert.Equal(t, "POST", req.Method)
+
+		return &http.Response{
+			StatusCode: 201,
+			// Send response to be tested
+			Body: ioutil.NopCloser(bytes.NewBufferString(requestPayload)),
+			// Must be set to non-nil value or it panics
+			Header: make(http.Header),
+		}
+	})
+
+	// invocation context mocks
+	invocationContextMock.EXPECT().GetConfiguration().Return(config).AnyTimes()
+	invocationContextMock.EXPECT().GetLogger().Return(logger).AnyTimes()
+	invocationContextMock.EXPECT().GetNetworkAccess().Return(networkAccessMock).AnyTimes()
+	networkAccessMock.EXPECT().GetHttpClient().Return(mockClient).AnyTimes()
+
+	reportAnalyticsEntryPoint(invocationContextMock, nil)
+}

--- a/pkg/local_workflows/report_analytics_workflow_test.go
+++ b/pkg/local_workflows/report_analytics_workflow_test.go
@@ -76,5 +76,5 @@ func Test_ReportAnalytics_ReportAnalyticsEntryPoint_happyPath(t *testing.T) {
 	invocationContextMock.EXPECT().GetNetworkAccess().Return(networkAccessMock).AnyTimes()
 	networkAccessMock.EXPECT().GetHttpClient().Return(mockClient).AnyTimes()
 
-	reportAnalyticsEntryPoint(invocationContextMock, nil)
+	reportAnalyticsEntrypoint(invocationContextMock, nil)
 }

--- a/pkg/local_workflows/report_analytics_workflow_test.go
+++ b/pkg/local_workflows/report_analytics_workflow_test.go
@@ -2,6 +2,9 @@ package localworkflows
 
 import (
 	"bytes"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+	"github.com/stretchr/testify/require"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -11,8 +14,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/mocks"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_ReportAnalytics_ReportAnalyticsEntryPoint_happyPath(t *testing.T) {
@@ -51,6 +52,8 @@ func Test_ReportAnalytics_ReportAnalyticsEntryPoint_happyPath(t *testing.T) {
 		}
 	}`
 
+	input := workflow.NewData(workflow.NewTypeIdentifier(WORKFLOWID_REPORT_ANALYTICS, reportAnalyticsWorkflowName), "application/json", []byte(requestPayload))
+
 	// setup mocks
 	ctrl := gomock.NewController(t)
 	networkAccessMock := mocks.NewMockNetworkAccess(ctrl)
@@ -58,8 +61,12 @@ func Test_ReportAnalytics_ReportAnalyticsEntryPoint_happyPath(t *testing.T) {
 
 	mockClient := newTestClient(func(req *http.Request) *http.Response {
 		// Test request parameters
-		assert.Equal(t, "/rest/api/orgs/"+orgId+"/analytics", req.URL.String())
-		assert.Equal(t, "POST", req.Method)
+		require.Equal(t, "/rest/api/orgs/"+orgId+"/analytics", req.URL.String())
+		require.Equal(t, "POST", req.Method)
+		require.Equal(t, "application/json", req.Header.Get("Content-Type"))
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		require.Equal(t, requestPayload, string(body))
 
 		return &http.Response{
 			StatusCode: 201,
@@ -76,5 +83,42 @@ func Test_ReportAnalytics_ReportAnalyticsEntryPoint_happyPath(t *testing.T) {
 	invocationContextMock.EXPECT().GetNetworkAccess().Return(networkAccessMock).AnyTimes()
 	networkAccessMock.EXPECT().GetHttpClient().Return(mockClient).AnyTimes()
 
-	reportAnalyticsEntrypoint(invocationContextMock, nil)
+	_, err := reportAnalyticsEntrypoint(invocationContextMock, []workflow.Data{input})
+	require.NoError(t, err)
+}
+func Test_ReportAnalytics_ReportAnalyticsEntryPoint_reportsHttpError(t *testing.T) {
+	// setup
+	logger := log.New(os.Stderr, "test", 0)
+	config := configuration.New()
+	orgId := "orgId"
+
+	config.Set(configuration.ORGANIZATION, orgId)
+
+	requestPayload := `{}`
+
+	// setup mocks
+	ctrl := gomock.NewController(t)
+	networkAccessMock := mocks.NewMockNetworkAccess(ctrl)
+	invocationContextMock := mocks.NewMockInvocationContext(ctrl)
+	input := workflow.NewData(workflow.NewTypeIdentifier(WORKFLOWID_REPORT_ANALYTICS, reportAnalyticsWorkflowName), "application/json", []byte(requestPayload))
+
+	mockClient := newTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			// error code!
+			StatusCode: 500,
+			// Send response to be tested
+			Body: ioutil.NopCloser(bytes.NewBufferString(requestPayload)),
+			// Must be set to non-nil value or it panics
+			Header: make(http.Header),
+		}
+	})
+
+	// invocation context mocks
+	invocationContextMock.EXPECT().GetConfiguration().Return(config).AnyTimes()
+	invocationContextMock.EXPECT().GetLogger().Return(logger).AnyTimes()
+	invocationContextMock.EXPECT().GetNetworkAccess().Return(networkAccessMock).AnyTimes()
+	networkAccessMock.EXPECT().GetHttpClient().Return(mockClient).AnyTimes()
+
+	_, err := reportAnalyticsEntrypoint(invocationContextMock, []workflow.Data{input})
+	require.Error(t, err)
 }

--- a/pkg/local_workflows/test_utils.go
+++ b/pkg/local_workflows/test_utils.go
@@ -1,0 +1,18 @@
+package localworkflows
+
+import "net/http"
+
+// roundTripFn
+type roundTripFn func(req *http.Request) *http.Response
+
+// RoundTrip
+func (f roundTripFn) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+// return *http.Client with Transport replaced to avoid making real calls
+func newTestClient(fn roundTripFn) *http.Client {
+	return &http.Client{
+		Transport: roundTripFn(fn),
+	}
+}

--- a/pkg/local_workflows/test_utils.go
+++ b/pkg/local_workflows/test_utils.go
@@ -1,18 +1,31 @@
 package localworkflows
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+)
 
 // roundTripFn
 type roundTripFn func(req *http.Request) *http.Response
+type roundTripErrorFn func(req *http.Request) *http.Response
 
-// RoundTrip
 func (f roundTripFn) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req), nil
+}
+
+func (f roundTripErrorFn) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("yay, a test error")
 }
 
 // return *http.Client with Transport replaced to avoid making real calls
 func newTestClient(fn roundTripFn) *http.Client {
 	return &http.Client{
-		Transport: roundTripFn(fn),
+		Transport: fn,
+	}
+}
+
+func newErrorProducingTestClient(fn roundTripErrorFn) *http.Client {
+	return &http.Client{
+		Transport: fn,
 	}
 }

--- a/pkg/local_workflows/whoami_workflow.go
+++ b/pkg/local_workflows/whoami_workflow.go
@@ -14,20 +14,20 @@ import (
 )
 
 const (
-	workflowName     = "whoami"
-	endpoint         = "/user/me"
-	apiVersion       = "/v1"
-	experimentalFlag = "experimental"
-	jsonFlag         = "json"
+	whoAmIworkflowName = "whoami"
+	userMeEndpoint     = "/user/me"
+	apiVersion         = "/v1"
+	experimentalFlag   = "experimental"
+	jsonFlag           = "json"
 )
 
 // define a new workflow identifier for this workflow
-var WORKFLOWID_WHOAMI workflow.Identifier = workflow.NewWorkflowIdentifier(workflowName)
+var WORKFLOWID_WHOAMI workflow.Identifier = workflow.NewWorkflowIdentifier(whoAmIworkflowName)
 
 // InitWhoAmIWorkflow initialises the whoAmI workflow before registering it with the engine.
 func InitWhoAmIWorkflow(engine workflow.Engine) error {
 	// initialise workflow configuration
-	whoAmIConfig := pflag.NewFlagSet(workflowName, pflag.ExitOnError)
+	whoAmIConfig := pflag.NewFlagSet(whoAmIworkflowName, pflag.ExitOnError)
 	// add experimental flag to configuration
 	whoAmIConfig.Bool(experimentalFlag, false, "enable experimental whoAmI command")
 	// add json flag to configuration
@@ -39,7 +39,7 @@ func InitWhoAmIWorkflow(engine workflow.Engine) error {
 }
 
 // whoAmIWorkflowEntryPoint is the entry point for the whoAmI workflow.
-// it calls the `/user/me` endpoint and returns the authenticated user's username
+// it calls the `/user/me` userMeEndpoint and returns the authenticated user's username
 // it can optionally return the full `/user/me` payload response if the json flag is set
 func whoAmIWorkflowEntryPoint(invocationCtx workflow.InvocationContext, _ []workflow.Data) (output []workflow.Data, err error) {
 	// get necessary objects from invocation context
@@ -54,11 +54,11 @@ func whoAmIWorkflowEntryPoint(invocationCtx workflow.InvocationContext, _ []work
 		return nil, fmt.Errorf("set `--experimental` flag to enable whoAmI command")
 	}
 
-	// define userme API endpoint
+	// define userme API userMeEndpoint
 	baseUrl := config.GetString(configuration.API_URL)
-	url := baseUrl + apiVersion + endpoint
+	url := baseUrl + apiVersion + userMeEndpoint
 
-	// call userme API endpoint
+	// call userme API userMeEndpoint
 	userMe, err := fetchUserMe(httpClient, url, logger)
 	if err != nil {
 		return nil, fmt.Errorf("error while fetching user: %w", err)
@@ -83,7 +83,7 @@ func whoAmIWorkflowEntryPoint(invocationCtx workflow.InvocationContext, _ []work
 	return []workflow.Data{userData}, err
 }
 
-// fetchUserMe calls the `/user/me` endpoint and returns the response body
+// fetchUserMe calls the `/user/me` userMeEndpoint and returns the response body
 func fetchUserMe(client *http.Client, url string, logger *log.Logger) (whoAmI []byte, err error) {
 	logger.Printf("Fetching user details (url: %s)", url)
 	res, err := client.Get(url)
@@ -134,7 +134,7 @@ func extractUser(whoAmI []byte, logger *log.Logger) (username string, err error)
 func createWorkflowData(data interface{}, contentType string) workflow.Data {
 	return workflow.NewData(
 		// use new type identifier when creating new data
-		workflow.NewTypeIdentifier(WORKFLOWID_WHOAMI, workflowName),
+		workflow.NewTypeIdentifier(WORKFLOWID_WHOAMI, whoAmIworkflowName),
 		contentType,
 		data,
 	)

--- a/pkg/local_workflows/whoami_workflow_test.go
+++ b/pkg/local_workflows/whoami_workflow_test.go
@@ -17,21 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// roundTripFn
-type roundTripFn func(req *http.Request) *http.Response
-
-// RoundTrip
-func (f roundTripFn) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req), nil
-}
-
-// return *http.Client with Transport replaced to avoid making real calls
-func newTestClient(fn roundTripFn) *http.Client {
-	return &http.Client{
-		Transport: roundTripFn(fn),
-	}
-}
-
 func Test_WhoAmI_whoAmIWorkflowEntryPoint_requireExperimentalFlag(t *testing.T) {
 	// setup
 	logger := log.New(os.Stderr, "test", 0)


### PR DESCRIPTION
We added a new extension that can report analytics data for the "Scan done" event type to the Snyk REST API at `"/rest/api/orgs/"+orgId+"/analytics"`.

Input is validated against the committed JSON Schema which is derived from the Open API spec agreed on between implementing teams.