### PR TITLE
fix: support additional URLs for authentication [HEAD-1017]

### DIFF
--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -1,8 +1,9 @@
 package configuration
 
 const (
-	API_URL                         string = "snyk_api"                // AKA "endpoint" in the config file
-	AUTHENTICATION_SUBDOMAINS       string = "internal_auth_subdomain" // array of additional subdomains to add authentication for
+	API_URL                         string = "snyk_api"                      // AKA "endpoint" in the config file
+	AUTHENTICATION_SUBDOMAINS       string = "internal_auth_subdomain"       // array of additional subdomains to add authentication for
+	AUTHENTICATION_ADDITIONAL_URLS  string = "internal_additional_auth_urls" // array of additional urls to add authentication for
 	AUTHENTICATION_TOKEN            string = "snyk_token"
 	AUTHENTICATION_BEARER_TOKEN     string = "snyk_oauth_token"
 	INTEGRATION_NAME                string = "snyk_integration_name"

--- a/pkg/networking/middleware/auth_header.go
+++ b/pkg/networking/middleware/auth_header.go
@@ -47,6 +47,7 @@ func ShouldRequireAuthentication(
 	apiUrl string,
 	url *url.URL,
 	additionalSubdomains []string,
+	additionalUrls []string,
 ) (matchesPattern bool, err error) {
 	subdomainsToCheck := append([]string{""}, additionalSubdomains...)
 	for _, subdomain := range subdomainsToCheck {
@@ -71,6 +72,14 @@ func ShouldRequireAuthentication(
 		}
 	}
 
+	// if the default check for an api didn't succeed, check additional Urls if available
+	requestUrl := url.String()
+	for _, v := range additionalUrls {
+		if strings.HasPrefix(requestUrl, v) {
+			return true, nil
+		}
+	}
+
 	return false, nil
 
 }
@@ -82,7 +91,8 @@ func AddAuthenticationHeader(
 ) error {
 	apiUrl := config.GetString(configuration.API_URL)
 	additionalSubdomains := config.GetStringSlice(configuration.AUTHENTICATION_SUBDOMAINS)
-	isSnykApi, err := ShouldRequireAuthentication(apiUrl, request.URL, additionalSubdomains)
+	additionalUrls := config.GetStringSlice(configuration.AUTHENTICATION_ADDITIONAL_URLS)
+	isSnykApi, err := ShouldRequireAuthentication(apiUrl, request.URL, additionalSubdomains, additionalUrls)
 
 	// requests to the api automatically get an authentication token attached
 	if !isSnykApi {

--- a/pkg/networking/middleware/auth_header_test.go
+++ b/pkg/networking/middleware/auth_header_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/snyk/go-application-framework/internal/api"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/mocks"
 	"github.com/snyk/go-application-framework/pkg/networking/middleware"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_ShouldRequireAuthentication(t *testing.T) {
@@ -28,11 +29,10 @@ func Test_ShouldRequireAuthentication(t *testing.T) {
 
 	for u, expected := range cases {
 		requestUrl, _ := url.Parse(u)
-		actual, err := middleware.ShouldRequireAuthentication(apiUrl, requestUrl, additionalSubdomains)
+		actual, err := middleware.ShouldRequireAuthentication(apiUrl, requestUrl, additionalSubdomains, additionalSubdomains)
 		assert.Nil(t, err)
 		assert.Equal(t, expected, actual)
 	}
-
 }
 
 func Test_ShouldRequireAuthentication_subdomains(t *testing.T) {
@@ -42,19 +42,21 @@ func Test_ShouldRequireAuthentication_subdomains(t *testing.T) {
 		"https://mydomain.eu.snyk.io:443": true,
 		"https://whatever.eu.snyk.io":     false,
 		"https://deeproxy.eu.snyk.io":     true,
+		"https://somethingelse.com/":      true,
+		"https://definitelynot.com/":      false,
 	}
 
 	additionalSubdomains := []string{"deeproxy", "mydomain"}
+	additionalUrls := []string{"https://somethingelse.com/"}
 
 	for u, expected := range cases {
 		t.Run(u, func(t *testing.T) {
 			requestUrl, _ := url.Parse(u)
-			actual, err := middleware.ShouldRequireAuthentication(apiUrl, requestUrl, additionalSubdomains)
+			actual, err := middleware.ShouldRequireAuthentication(apiUrl, requestUrl, additionalSubdomains, additionalUrls)
 			assert.Nil(t, err)
 			assert.Equal(t, expected, actual)
 		})
 	}
-
 }
 
 func Test_AddAuthenticationHeader(t *testing.T) {


### PR DESCRIPTION
Introduce on optional configuration to specify additional URLs for which authentication header are being added.