### PR TITLE
feat: accept cli input for report analytics [HEAD-921]

### DIFF
--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -34,7 +34,10 @@ func InitReportAnalyticsWorkflow(engine workflow.Engine) error {
 	scanDoneSchemaLoader = gojsonschema.NewStringLoader(json_schemas.ScanDoneEventSchema)
 
 	// register workflow with engine
-	_, err := engine.Register(WORKFLOWID_REPORT_ANALYTICS, workflow.ConfigurationOptionsFromFlagset(params), reportAnalyticsEntrypoint)
+	result, err := engine.Register(WORKFLOWID_REPORT_ANALYTICS, workflow.ConfigurationOptionsFromFlagset(params), reportAnalyticsEntrypoint)
+
+	// don't display in help
+	result.SetVisibility(false)
 	return err
 }
 

--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -52,7 +52,7 @@ func reportAnalyticsEntrypoint(invocationCtx workflow.InvocationContext, inputDa
 
 	commandLineInput := config.GetString(reportAnalyticsInputDataFlagName)
 	if commandLineInput != "" {
-		logger.Printf(fmt.Sprintf("%s: adding command line input", reportAnalyticsWorkflowName))
+		logger.Printf("adding command line input")
 		data := workflow.NewData(
 			workflow.NewTypeIdentifier(WORKFLOWID_REPORT_ANALYTICS, reportAnalyticsWorkflowName),
 			"application/json",
@@ -62,7 +62,7 @@ func reportAnalyticsEntrypoint(invocationCtx workflow.InvocationContext, inputDa
 	}
 
 	for i, input := range inputData {
-		logger.Printf(fmt.Sprintf("%s: processing element %d", reportAnalyticsWorkflowName, i))
+		logger.Printf(fmt.Sprintf("processing element %d", i))
 		documentLoader := gojsonschema.NewBytesLoader(input.GetPayload().([]byte))
 		result, validationErr := gojsonschema.Validate(scanDoneSchemaLoader, documentLoader)
 

--- a/pkg/local_workflows/report_analytics_workflow_test.go
+++ b/pkg/local_workflows/report_analytics_workflow_test.go
@@ -226,7 +226,7 @@ func testGetScanDonePayloadString() string {
 
 func testInitReportAnalyticsWorkflow(ctrl *gomock.Controller) error {
 	engine := mocks.NewMockEngine(ctrl)
-	engine.EXPECT().Register(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	engine.EXPECT().Register(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes().Return(&workflow.EntryImpl{}, nil)
 	return InitReportAnalyticsWorkflow(engine)
 }
 


### PR DESCRIPTION
This enables `snyk reportAnalytics -i '<json-data>'`. This extension is not meant for public consumption.