### PR TITLE
fix: alternate key usage

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -219,10 +219,14 @@ func (ev *extendedViper) get(key string) interface{} {
 	isSet := ev.viper.IsSet(key)
 
 	// try to lookup alternative keys if available
-	if !isSet {
-		for _, altKey := range ev.alternativeKeys[key] {
-			result = ev.viper.Get(altKey)
-		}
+	index := 0
+	alternativeKeys := ev.alternativeKeys[key]
+	alternativeKeysSize := len(alternativeKeys)
+	for !isSet && index < alternativeKeysSize {
+		altKey := alternativeKeys[index]
+		result = ev.viper.Get(altKey)
+		isSet = ev.viper.IsSet(altKey)
+		index++
 	}
 
 	return result

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -98,13 +98,20 @@ func Test_ConfigurationGet_ANALYTICS_DISABLED(t *testing.T) {
 }
 
 func Test_ConfigurationGet_ALTERNATE_KEYS(t *testing.T) {
+	key := "snyk_cfg_api"
+	expected := "value"
 	alternateKeys := []string{"snyk_token", "snyk_cfg_api", "api"}
 
-	config := NewFromFiles(TEST_FILENAME)
+	config := NewInMemory()
 	config.AddAlternativeKeys(AUTHENTICATION_TOKEN, alternateKeys)
+
+	config.Set(key, expected)
 
 	actualValue := config.GetAlternativeKeys(AUTHENTICATION_TOKEN)
 	assert.Equal(t, alternateKeys, actualValue)
+
+	actual := config.GetString(AUTHENTICATION_TOKEN)
+	assert.Equal(t, expected, actual)
 }
 
 func Test_ConfigurationGet_unset(t *testing.T) {


### PR DESCRIPTION
Fix previously introduced error when looking up configuration values via alternative keys. when there where multiple alternative keys, a successful lookup could get overridden by a later alternative key.