### PR TITLE
feat: snyk_timeout_secs configuration key

### DIFF
--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -26,6 +26,7 @@ const (
 	WORKING_DIRECTORY               string = "internal_working_dir"
 	IS_FEDRAMP                      string = "internal_is_fedramp"
 	UNKNOWN_ARGS                    string = "internal_unknown_arguments" // arguments unknown to the current application but maybe relevant for delegated application calls
+	TIMEOUT                         string = "snyk_timeout_secs"
 
 	// feature flags
 	FF_OAUTH_AUTH_FLOW_ENABLED string = "internal_snyk_oauth_enabled"


### PR DESCRIPTION
Adding a configuration key for setting a maximum timeout the user is willing to wait for a snyk command to execute.