### PR TITLE
feat: support OAuth client credentials grant

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -86,7 +86,11 @@ func initConfiguration(engine workflow.Engine, config configuration.Configuratio
 	})
 
 	config.AddDefaultValue(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, func(existingValue any) any {
-		return true
+		if existingValue == nil {
+			return true
+		} else {
+			return existingValue
+		}
 	})
 
 	config.AddDefaultValue(configuration.IS_FEDRAMP, func(existingValue any) any {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -12,7 +12,6 @@ import (
 	"github.com/snyk/go-application-framework/internal/api"
 	"github.com/snyk/go-application-framework/internal/constants"
 	"github.com/snyk/go-application-framework/internal/utils"
-	"github.com/snyk/go-application-framework/pkg/auth"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
 	"github.com/snyk/go-application-framework/pkg/workflow"
@@ -87,11 +86,7 @@ func initConfiguration(engine workflow.Engine, config configuration.Configuratio
 	})
 
 	config.AddDefaultValue(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, func(existingValue any) any {
-		if existingValue == nil {
-			return auth.IsKnownOAuthEndpoint(config.GetString(configuration.API_URL))
-		} else {
-			return existingValue
-		}
+		return true
 	})
 
 	config.AddDefaultValue(configuration.IS_FEDRAMP, func(existingValue any) any {

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -157,24 +157,6 @@ func Test_CreateAppEngineWithRuntimeInfo(t *testing.T) {
 	assert.Equal(t, ri, engine.GetRuntimeInfo())
 }
 
-func Test_initConfiguration_existingValueOfOAuthFFRespected(t *testing.T) {
-	existingValue := false
-	endpoint := "https://snykgov.io"
-
-	// setup mock
-	ctrl := gomock.NewController(t)
-	mockApiClient := mocks.NewMockApiClient(ctrl)
-
-	config := configuration.NewInMemory()
-	initConfiguration(workflow.NewWorkFlowEngine(config), config, mockApiClient, &zlog.Logger)
-
-	config.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, existingValue)
-	config.Set(configuration.API_URL, endpoint)
-
-	actualOAuthFF := config.GetBool(configuration.FF_OAUTH_AUTH_FLOW_ENABLED)
-	assert.Equal(t, existingValue, actualOAuthFF)
-}
-
 func Test_initConfiguration_snykgov(t *testing.T) {
 	endpoint := "https://snykgov.io"
 
@@ -205,9 +187,6 @@ func Test_initConfiguration_NOT_snykgov(t *testing.T) {
 	initConfiguration(workflow.NewWorkFlowEngine(config), config, mockApiClient, &zlog.Logger)
 
 	config.Set(configuration.API_URL, endpoint)
-
-	actualOAuthFF := config.GetBool(configuration.FF_OAUTH_AUTH_FLOW_ENABLED)
-	assert.False(t, actualOAuthFF)
 
 	isFedramp := config.GetBool(configuration.IS_FEDRAMP)
 	assert.False(t, isFedramp)

--- a/pkg/auth/oauth2authenticator.go
+++ b/pkg/auth/oauth2authenticator.go
@@ -262,10 +262,11 @@ func (o *oAuth2Authenticator) authenticateWithClientCredentialsGrant() error {
 
 	// get token
 	token, err := config.Token(ctx)
-	if err == nil {
-		o.persistToken(token)
+	if err != nil {
+		return err
 	}
 
+	o.persistToken(token)
 	return err
 }
 

--- a/pkg/auth/oauth2authenticator.go
+++ b/pkg/auth/oauth2authenticator.go
@@ -171,11 +171,11 @@ func refreshTokenClientCredentials(ctx context.Context, oauthConfig *oauth2.Conf
 }
 
 func determineGrantType(config configuration.Configuration) GrantType {
-	grandType := AuthorizationCodeGrant
+	grantType := AuthorizationCodeGrant
 	if config.IsSet(PARAMETER_CLIENT_SECRET) && config.IsSet(PARAMETER_CLIENT_ID) {
-		grandType = ClientCredentialsGrant
+		grantType = ClientCredentialsGrant
 	}
-	return grandType
+	return grantType
 }
 
 //goland:noinspection GoUnusedExportedFunction
@@ -243,15 +243,15 @@ func (o *oAuth2Authenticator) Authenticate() error {
 	var err error
 
 	if o.grantType == ClientCredentialsGrant {
-		err = o.grant_client_credentials()
+		err = o.authenticateWithClientCredentialsGrant()
 	} else {
-		err = o.grant_authorization_code()
+		err = o.authenticateWithAuthorizationCode()
 	}
 
 	return err
 }
 
-func (o *oAuth2Authenticator) grant_client_credentials() error {
+func (o *oAuth2Authenticator) authenticateWithClientCredentialsGrant() error {
 	ctx := context.Background()
 	config := getOAuthConfigurationClientCredentials(o.oauthConfig)
 
@@ -269,7 +269,7 @@ func (o *oAuth2Authenticator) grant_client_credentials() error {
 	return err
 }
 
-func (o *oAuth2Authenticator) grant_authorization_code() error {
+func (o *oAuth2Authenticator) authenticateWithAuthorizationCode() error {
 	var responseCode string
 	var responseState string
 	var responseError string

--- a/pkg/auth/oauth2authenticator_test.go
+++ b/pkg/auth/oauth2authenticator_test.go
@@ -207,20 +207,35 @@ func Test_AddAuthenticationHeader_expiredToken_somebodyUpdated(t *testing.T) {
 	assert.Equal(t, *newToken, *authenticator.(*oAuth2Authenticator).token)
 }
 
-func Test_determineGrantType(t *testing.T) {
+func Test_determineGrantType_empty(t *testing.T) {
 	config := configuration.NewInMemory()
 	expected := AuthorizationCodeGrant
 	actual := determineGrantType(config)
 	assert.Equal(t, expected, actual)
+}
 
+func Test_determineGrantType_secret_only(t *testing.T) {
+	config := configuration.NewInMemory()
 	config.Set(PARAMETER_CLIENT_SECRET, "secret")
-	expected = AuthorizationCodeGrant
-	actual = determineGrantType(config)
+	expected := AuthorizationCodeGrant
+	actual := determineGrantType(config)
 	assert.Equal(t, expected, actual)
+}
 
+func Test_determineGrantType_id_only(t *testing.T) {
+	config := configuration.NewInMemory()
 	config.Set(PARAMETER_CLIENT_ID, "id")
-	expected = ClientCredentialsGrant
-	actual = determineGrantType(config)
+	expected := AuthorizationCodeGrant
+	actual := determineGrantType(config)
+	assert.Equal(t, expected, actual)
+}
+
+func Test_determineGrantType_both(t *testing.T) {
+	config := configuration.NewInMemory()
+	config.Set(PARAMETER_CLIENT_ID, "id")
+	config.Set(PARAMETER_CLIENT_SECRET, "secret")
+	expected := ClientCredentialsGrant
+	actual := determineGrantType(config)
 	assert.Equal(t, expected, actual)
 }
 

--- a/pkg/auth/oauth2authenticator_test.go
+++ b/pkg/auth/oauth2authenticator_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
 )
 
 func Test_GetVerifier(t *testing.T) {
@@ -204,4 +205,63 @@ func Test_AddAuthenticationHeader_expiredToken_somebodyUpdated(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, *newToken, *actualToken)
 	assert.Equal(t, *newToken, *authenticator.(*oAuth2Authenticator).token)
+}
+
+func Test_determineGrantType(t *testing.T) {
+	config := configuration.NewInMemory()
+	expected := AuthorizationCodeGrant
+	actual := determineGrantType(config)
+	assert.Equal(t, expected, actual)
+
+	config.Set(PARAMETER_CLIENT_SECRET, "secret")
+	expected = AuthorizationCodeGrant
+	actual = determineGrantType(config)
+	assert.Equal(t, expected, actual)
+
+	config.Set(PARAMETER_CLIENT_ID, "id")
+	expected = ClientCredentialsGrant
+	actual = determineGrantType(config)
+	assert.Equal(t, expected, actual)
+}
+
+func Test_Authenticate_CredentialsGrant(t *testing.T) {
+	go func() {
+		mux := http.NewServeMux()
+		srv := &http.Server{
+			Handler: mux,
+			Addr:    "localhost:3221",
+		}
+		mux.HandleFunc("/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+			newToken := &oauth2.Token{
+				AccessToken: "a",
+				TokenType:   "b",
+				Expiry:      time.Now().Add(60 * time.Second).UTC(),
+			}
+			data, err := json.Marshal(newToken)
+			assert.Nil(t, err)
+
+			w.Header().Set("Content-Type", "application/json;charset=UTF-8")
+			_, err = w.Write(data)
+			assert.Nil(t, err)
+		})
+
+		timer := time.AfterFunc(3*time.Second, func() {
+			srv.Shutdown(context.Background())
+		})
+
+		srv.ListenAndServe()
+		timer.Stop()
+	}()
+
+	config := configuration.NewInMemory()
+	config.Set(PARAMETER_CLIENT_SECRET, "secret")
+	config.Set(PARAMETER_CLIENT_ID, "id")
+	config.Set(configuration.API_URL, "http://localhost:3221")
+
+	authenticator := NewOAuth2AuthenticatorWithOpts(config, WithHttpClient(http.DefaultClient))
+	err := authenticator.Authenticate()
+	assert.Nil(t, err)
+
+	token := config.GetString(CONFIG_KEY_OAUTH_TOKEN)
+	assert.NotEmpty(t, token)
 }

--- a/pkg/local_workflows/auth_workflow.go
+++ b/pkg/local_workflows/auth_workflow.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/pflag"
+
 	"github.com/snyk/go-application-framework/pkg/auth"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
-	"github.com/spf13/pflag"
 )
 
 const (
@@ -40,6 +41,8 @@ func InitAuth(engine workflow.Engine) error {
 	config := pflag.NewFlagSet(workflowNameAuth, pflag.ExitOnError)
 	config.String(authTypeParameter, "", authTypeDescription)
 	config.Bool(headlessFlag, false, "Enable headless OAuth authentication")
+	config.String(auth.PARAMETER_CLIENT_SECRET, "", "Client Credential Grant, client secret")
+	config.String(auth.PARAMETER_CLIENT_ID, "", "Client Credential Grant, client id")
 
 	_, err := engine.Register(WORKFLOWID_AUTH, workflow.ConfigurationOptionsFromFlagset(config), authEntryPoint)
 	return err


### PR DESCRIPTION
This PR adds OAuth [Client Credentials Grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4) to the OAuth2Authenticator, in addition to the existing Authorization Code Grant. It therefore switches between these types, per default it'll continue to use Authorization Code Grant and if Client ID and Client Secret are configured, it'll use the Client Credentials Grant.