### PR TITLE
feat: adds log scrubbing tool

### DIFF
--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -1,0 +1,51 @@
+/*
+ * © 2023 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logging
+
+import (
+	"strings"
+
+	"github.com/rs/zerolog"
+)
+
+type scrubbingWriter struct {
+	writer    zerolog.LevelWriter
+	scrubDict map[string]bool
+}
+
+func (w *scrubbingWriter) WriteLevel(level zerolog.Level, p []byte) (n int, err error) {
+	return w.writer.WriteLevel(level, w.scrub(p))
+}
+
+func NewScrubbingWriter(writer zerolog.LevelWriter, scrubDict map[string]bool) zerolog.LevelWriter {
+	return &scrubbingWriter{
+		writer:    writer,
+		scrubDict: scrubDict,
+	}
+}
+
+func (w *scrubbingWriter) Write(p []byte) (n int, err error) {
+	return w.writer.Write(w.scrub(p))
+}
+
+func (w *scrubbingWriter) scrub(p []byte) []byte {
+	s := string(p)
+	for term := range w.scrubDict {
+		s = strings.Replace(s, term, "***", -1)
+	}
+	return []byte(s)
+}

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -66,5 +66,12 @@ func NewScrubbingIoWriter(writer io.Writer, scrubDict map[string]bool) io.Writer
 }
 
 func (w *scrubbingIoWriter) Write(p []byte) (n int, err error) {
-	return w.writer.Write(scrub(p, w.scrubDict))
+	_, err = w.writer.Write(scrub(p, w.scrubDict))
+	if err != nil {
+		// in case of an error of the underlying writer, we return zero bytes written,
+		// since it is difficult to map back to the unredacted length.
+		return 0, err
+	}
+
+	return len(p), err
 }

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -23,6 +23,8 @@ import (
 	"github.com/rs/zerolog"
 )
 
+const redactMask string = "***"
+
 type scrubbingLevelWriter struct {
 	writer    zerolog.LevelWriter
 	scrubDict map[string]bool
@@ -51,7 +53,7 @@ func (w *scrubbingLevelWriter) Write(p []byte) (n int, err error) {
 func scrub(p []byte, scrubDict map[string]bool) []byte {
 	s := string(p)
 	for term := range scrubDict {
-		s = strings.Replace(s, term, "***", -1)
+		s = strings.Replace(s, term, redactMask, -1)
 	}
 	return []byte(s)
 }

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -36,7 +36,8 @@ type scrubbingIoWriter struct {
 }
 
 func (w *scrubbingLevelWriter) WriteLevel(level zerolog.Level, p []byte) (n int, err error) {
-	return w.writer.WriteLevel(level, scrub(p, w.scrubDict))
+	n, err = w.writer.WriteLevel(level, scrub(p, w.scrubDict))
+	return len(p), err // we return the original length, since we don't know the length of the redacted string
 }
 
 func NewScrubbingWriter(writer zerolog.LevelWriter, scrubDict map[string]bool) zerolog.LevelWriter {
@@ -47,7 +48,8 @@ func NewScrubbingWriter(writer zerolog.LevelWriter, scrubDict map[string]bool) z
 }
 
 func (w *scrubbingLevelWriter) Write(p []byte) (n int, err error) {
-	return w.writer.Write(scrub(p, w.scrubDict))
+	n, err = w.writer.Write(scrub(p, w.scrubDict))
+	return len(p), err // we return the original length, since we don't know the length of the redacted string
 }
 
 func scrub(p []byte, scrubDict map[string]bool) []byte {

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -1,0 +1,66 @@
+/*
+ * © 2023 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logging
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+type mockWriter struct {
+	written []byte
+}
+
+func (m *mockWriter) Write(p []byte) (n int, err error) {
+	m.written = p
+	return len(p), nil
+}
+
+func (m *mockWriter) WriteLevel(_ zerolog.Level, p []byte) (n int, err error) {
+	m.written = p
+	return len(p), nil
+}
+
+func TestScrubbingWriter_Write(t *testing.T) {
+	scrubDict := map[string]bool{
+		"password": true,
+	}
+
+	mockWriter := &mockWriter{}
+
+	writer := NewScrubbingWriter(mockWriter, scrubDict)
+
+	_, _ = writer.Write([]byte("password"))
+
+	require.NotContainsf(t, mockWriter.written, "password", "password should be scrubbed")
+}
+
+func TestScrubbingWriter_WriteLevel(t *testing.T) {
+	scrubDict := map[string]bool{
+		"password": true,
+	}
+
+	mockWriter := &mockWriter{}
+
+	writer := NewScrubbingWriter(mockWriter, scrubDict)
+
+	_, _ = writer.WriteLevel(zerolog.InfoLevel, []byte("password"))
+
+	require.NotContainsf(t, mockWriter.written, "password", "password should be scrubbed")
+}

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -49,12 +49,17 @@ func TestScrubbingWriter_Write(t *testing.T) {
 
 	writer := NewScrubbingWriter(mockWriter, scrubDict)
 
-	_, _ = writer.Write([]byte("password"))
+	n, err := writer.Write([]byte("password"))
 
-	require.NotContainsf(t, mockWriter.written, "password", "password should be scrubbed")
+	assert.Nil(t, err)
+	assert.Equal(t, len("password"), n)
+
+	require.Equal(t, "***", string(mockWriter.written), "password should be scrubbed")
 }
 
 func TestScrubbingWriter_WriteLevel(t *testing.T) {
+	s := []byte("password")
+
 	scrubDict := map[string]bool{
 		"password": true,
 	}
@@ -63,7 +68,9 @@ func TestScrubbingWriter_WriteLevel(t *testing.T) {
 
 	writer := NewScrubbingWriter(mockWriter, scrubDict)
 
-	_, _ = writer.WriteLevel(zerolog.InfoLevel, []byte("password"))
+	n, err := writer.WriteLevel(zerolog.InfoLevel, s)
+	assert.Nil(t, err)
+	assert.Equal(t, len(s), n)
 
 	require.NotContainsf(t, mockWriter.written, "password", "password should be scrubbed")
 }

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -17,6 +17,7 @@
 package logging
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -63,4 +64,16 @@ func TestScrubbingWriter_WriteLevel(t *testing.T) {
 	_, _ = writer.WriteLevel(zerolog.InfoLevel, []byte("password"))
 
 	require.NotContainsf(t, mockWriter.written, "password", "password should be scrubbed")
+}
+
+func TestScrubbingIOWriter(t *testing.T) {
+	scrubDict := map[string]bool{
+		"password": true,
+	}
+
+	s := string("abc")
+	bufioWriter := bytes.NewBufferString(s)
+
+	writer := NewScrubbingIOWriter(bufioWriter, scrubDict)
+
 }

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -81,8 +81,9 @@ func TestScrubbingIoWriter(t *testing.T) {
 	bufioWriter := bytes.NewBufferString("")
 	writer := NewScrubbingIoWriter(bufioWriter, scrubDict)
 	// invoke method under test
-	_, err := writer.Write([]byte(patternWithSecret))
+	n, err := writer.Write([]byte(patternWithSecret))
 	assert.Nil(t, err)
+	assert.Equal(t, len(patternWithSecret), n)
 
 	require.Equal(t, patternWithMaskedSecret, bufioWriter.String(), "password should be scrubbed")
 }

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -66,14 +66,17 @@ func TestScrubbingWriter_WriteLevel(t *testing.T) {
 	require.NotContainsf(t, mockWriter.written, "password", "password should be scrubbed")
 }
 
-func TestScrubbingIOWriter(t *testing.T) {
+func TestScrubbingIoWriter(t *testing.T) {
 	scrubDict := map[string]bool{
 		"password": true,
 	}
 
-	s := string("abc")
-	bufioWriter := bytes.NewBufferString(s)
+	bufioWriter := bytes.NewBufferString("")
 
-	writer := NewScrubbingIOWriter(bufioWriter, scrubDict)
+	writer := NewScrubbingIoWriter(bufioWriter, scrubDict)
 
+	// invoke method under test
+	_, _ = writer.Write([]byte("password"))
+
+	require.Equal(t, "***", bufioWriter.String(), "password should be scrubbed")
 }

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -46,7 +46,6 @@ func TestScrubbingWriter_Write(t *testing.T) {
 	}
 
 	mockWriter := &mockWriter{}
-
 	writer := NewScrubbingWriter(mockWriter, scrubDict)
 
 	n, err := writer.Write([]byte("password"))
@@ -65,14 +64,13 @@ func TestScrubbingWriter_WriteLevel(t *testing.T) {
 	}
 
 	mockWriter := &mockWriter{}
-
 	writer := NewScrubbingWriter(mockWriter, scrubDict)
 
 	n, err := writer.WriteLevel(zerolog.InfoLevel, s)
 	assert.Nil(t, err)
 	assert.Equal(t, len(s), n)
 
-	require.NotContainsf(t, mockWriter.written, "password", "password should be scrubbed")
+	require.Equal(t, "***", string(mockWriter.written), "password should be scrubbed")
 }
 
 func TestScrubbingIoWriter(t *testing.T) {
@@ -87,10 +85,10 @@ func TestScrubbingIoWriter(t *testing.T) {
 
 	bufioWriter := bytes.NewBufferString("")
 	writer := NewScrubbingIoWriter(bufioWriter, scrubDict)
+
 	// invoke method under test
 	n, err := writer.Write([]byte(patternWithSecret))
 	assert.Nil(t, err)
 	assert.Equal(t, len(patternWithSecret), n)
-
 	require.Equal(t, patternWithMaskedSecret, bufioWriter.String(), "password should be scrubbed")
 }


### PR DESCRIPTION
Moves the log scrubbing behaviour available in snyk-ls to the shared library. This is preparatory work for adopting this behaviour in the CLI. 
Original implementation: https://github.com/snyk/snyk-ls/blob/main/internal/logging/scrubbingLogWriter.go

Once this has been merged we can update https://github.com/snyk/snyk-ls/pull/424