### PR TITLE
chore: improve reproducibility of username sanitize tests

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -55,6 +55,8 @@ type AnalyticsImpl struct {
 	integrationVersion string
 	os                 string
 	command            string
+
+	userCurrent func() (*user.User, error)
 }
 
 // metadataOutput defines the metadataOutput payload.
@@ -136,7 +138,9 @@ const (
 
 // New creates a new Analytics instance.
 func New() Analytics {
-	a := &AnalyticsImpl{}
+	a := &AnalyticsImpl{
+		userCurrent: user.Current,
+	}
 	a.headerFunc = func() http.Header { return http.Header{} }
 	a.created = time.Now()
 	a.clientFunc = func() *http.Client { return &http.Client{} }
@@ -264,7 +268,7 @@ func (a *AnalyticsImpl) GetRequest() (*http.Request, error) {
 		return nil, err
 	}
 
-	user, err := user.Current()
+	user, err := a.userCurrent()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func Test_Basic(t *testing.T) {
-
 	os.Setenv("CIRCLECI", "true")
 	testFields := []string{
 		"tfc-token",
@@ -44,8 +43,7 @@ func Test_Basic(t *testing.T) {
 	commandList := []string{"", "iac capture"}
 	for _, cmd := range commandList {
 		t.Run(cmd, func(t *testing.T) {
-
-			analytics := New()
+			analytics := newTestAnalytics(t)
 			analytics.SetCmdArguments(args)
 			analytics.AddError(fmt.Errorf("Something went terrible wrong."))
 			analytics.SetVersion("1234567")
@@ -163,7 +161,7 @@ func Test_SanitizeUsername(t *testing.T) {
 		homeDir      string
 	}
 
-	user, err := user.Current()
+	user, err := testUserCurrent(t)()
 	assert.Nil(t, err)
 
 	// runs 3 cases
@@ -231,4 +229,23 @@ func Test_SanitizeUsername(t *testing.T) {
 
 	}
 
+}
+
+func newTestAnalytics(t *testing.T) Analytics {
+	t.Helper()
+	a := New()
+	a.(*AnalyticsImpl).userCurrent = testUserCurrent(t)
+	return a
+}
+
+func testUserCurrent(t *testing.T) func() (*user.User, error) {
+	return func() (*user.User, error) {
+		return &user.User{
+			Uid:      "1000",
+			Gid:      "1000",
+			Username: "test-runner-user",
+			Name:     "Test Runner User",
+			HomeDir:  t.TempDir(),
+		}, nil
+	}
 }


### PR DESCRIPTION
Using the actual user.Current() during tests makes them more difficult to reproduce.

My username is `c`, which causes a lot of false positives; because each "c" substring gets replaced with "REDACTED", I can't run the tests locally as a result.

This makes `user.Current()` patchable, so that test scenarios can use a normalized, consistent "username".