### PR TITLE
chore: golangci-lint fixes, wastedassign

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,157 @@
+run:
+  build-tags:
+    - integration
+  concurrency: 4
+  issues-exit-code: 1
+  skip-dirs: []
+  tests: true
+  timeout: 5m
+
+linters-settings:
+  errcheck:
+    check-blank: true
+    check-type-assertions: true
+  exhaustive:
+    default-signifies-exhaustive: true
+  goconst:
+    ignore-calls: false
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+  gocyclo:
+    min-complexity: 15
+  gofumpt:
+    module-path: github.com/snyk/go-application-framework
+    extra-rules: true
+  goimports:
+    local-prefixes: github.com/snyk/go-application-framework
+  gosimple:
+    checks: ['all']
+  govet:
+    check-shadowing: true
+    enable-all: true
+    disable:
+      - fieldalignment
+  lll:
+    line-length: 160
+  misspell:
+    locale: US
+  nolintlint:
+    allow-unused: false
+    require-explanation: true
+    require-specific: true
+  prealloc:
+    simple: true
+    range-loops: true
+    for-loops: true
+  promlinter:
+    strict: true
+  revive:
+    rules:
+      - name: blank-imports
+        disabled: true
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+        disable-stuttering-check: true
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+        disabled: true
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
+  staticcheck:
+    checks: ['all']
+  stylecheck:
+    checks: ['all']
+    http-status-code-whitelist: []
+  varcheck:
+    exported-fields: true
+
+linters:
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - containedctx
+    - contextcheck
+    - dogsled
+    - dupl
+    - durationcheck
+    - errname
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - forbidigo
+    - forcetypeassert
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - gofumpt
+    - goimports
+    - goprintffuncname
+    - gosec
+    - interfacebloat
+    - ireturn
+    - lll
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnil
+    - noctx
+    - nolintlint
+    - prealloc
+    - predeclared
+    - promlinter
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
+    - stylecheck
+    - tagliatelle
+    - tenv
+    - testpackage
+    - thelper
+    - tparallel
+    - unconvert
+    - unparam
+    - usestdlibvars
+    - wastedassign
+    - whitespace
+    - wrapcheck
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - bodyclose
+        - forcetypeassert
+        - goconst
+        - ireturn
+    - path: test/
+      linters:
+        - testpackage
+  include:
+    - EXC0012
+    - EXC0014

--- a/internal/api/urls.go
+++ b/internal/api/urls.go
@@ -52,7 +52,7 @@ func GetCanonicalApiUrlFromString(userDefinedUrl string) (string, error) {
 }
 
 func GetCanonicalApiUrl(url url.URL) (string, error) {
-	result := ""
+	var result string
 
 	// for localhost we don't change the host, since there are no subdomains
 	if isImmutableHost(url.Host) {

--- a/pkg/local_workflows/output_workflow.go
+++ b/pkg/local_workflows/output_workflow.go
@@ -71,7 +71,7 @@ func outputWorkflowEntryPoint(invocation workflow.InvocationContext, input []wor
 			}
 		} else { // handle text/pain and unknown the same way
 			// try to convert payload to a string
-			singleDataAsString := ""
+			var singleDataAsString string
 			singleData, typeCastSuccessful := input[i].GetPayload().([]byte)
 			if !typeCastSuccessful {
 				singleDataAsString, typeCastSuccessful = input[i].GetPayload().(string)

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -47,8 +47,8 @@ func GetScrubDictFromConfig(config configuration.Configuration) ScrubbingDict {
 	return dict
 }
 
-func (w *scrubbingLevelWriter) WriteLevel(level zerolog.Level, p []byte) (n int, err error) {
-	n, err = w.writer.WriteLevel(level, scrub(p, w.scrubDict))
+func (w *scrubbingLevelWriter) WriteLevel(level zerolog.Level, p []byte) (int, error) {
+	_, err := w.writer.WriteLevel(level, scrub(p, w.scrubDict))
 	return len(p), err // we return the original length, since we don't know the length of the redacted string
 }
 
@@ -59,9 +59,8 @@ func NewScrubbingWriter(writer zerolog.LevelWriter, scrubDict ScrubbingDict) zer
 	}
 }
 
-func (w *scrubbingLevelWriter) Write(p []byte) (n int, err error) {
-	n, err = w.writer.Write(scrub(p, w.scrubDict))
-
+func (w *scrubbingLevelWriter) Write(p []byte) (int, error) {
+	_, err := w.writer.Write(scrub(p, w.scrubDict))
 	return len(p), err // we return the original length, since we don't know the length of the redacted string
 }
 

--- a/pkg/networking/middleware/auth_header.go
+++ b/pkg/networking/middleware/auth_header.go
@@ -51,7 +51,7 @@ func ShouldRequireAuthentication(
 ) (matchesPattern bool, err error) {
 	subdomainsToCheck := append([]string{""}, additionalSubdomains...)
 	for _, subdomain := range subdomainsToCheck {
-		matchesPattern := false
+		var matchesPattern bool
 		referenceUrl := ""
 		prefixUrl := ""
 		if len(subdomain) == 0 {

--- a/pkg/utils/array.go
+++ b/pkg/utils/array.go
@@ -127,7 +127,7 @@ func ToSlice(input map[string]string, combineBy string) []string {
 //	key := "A"
 //	map = Remove(map, key)  // map is {"c": "d"}
 func Remove(input map[string]string, key string) map[string]string {
-	found := false
+	var found bool
 	key, found = FindKeyCaseInsensitive(input, key)
 	if found {
 		delete(input, key)
@@ -149,11 +149,8 @@ func Remove(input map[string]string, key string) map[string]string {
 //	key := "A"
 //	key, found = FindKeyCaseInsensitive(map, key)  // key is "a" and found is true
 func FindKeyCaseInsensitive(input map[string]string, key string) (string, bool) {
-
-	found := false
-
 	// look for exact match
-	_, found = input[key]
+	_, found := input[key]
 
 	// look for lower case match
 	if !found {


### PR DESCRIPTION
Fix issues flagged by the wastedassign rule.

Add a baseline golangci-lint configuration file. Not switching our build to use it yet though, because there are a lot of other rule violations to get through.

Planning to address each rule one-by-one, which will make for a more coherent, easy to read (and bisect) git commit history.