### PR TITLE
chore: golangci-lint fixes, gosec

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -2,6 +2,7 @@ package analytics
 
 import (
 	"bytes"
+	//nolint:gosec // insecure sha1 used for legacy identifier
 	"crypto/sha1"
 	"encoding/json"
 	"errors"
@@ -225,6 +226,7 @@ func (a *AnalyticsImpl) GetOutputData() *analyticsOutput {
 	}
 
 	// deepcode ignore InsecureHash: It is just being used to generate an id, without any security concerns
+	//nolint:gosec // sha1 only used to generate an id
 	shasum := sha1.New()
 	uuid, _ := uuid.GenerateUUID()
 	io.WriteString(shasum, uuid)

--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -1,10 +1,11 @@
 package configuration
 
 const (
-	API_URL                         string = "snyk_api"                      // AKA "endpoint" in the config file
-	AUTHENTICATION_SUBDOMAINS       string = "internal_auth_subdomain"       // array of additional subdomains to add authentication for
-	AUTHENTICATION_ADDITIONAL_URLS  string = "internal_additional_auth_urls" // array of additional urls to add authentication for
-	AUTHENTICATION_TOKEN            string = "snyk_token"
+	API_URL                        string = "snyk_api"                      // AKA "endpoint" in the config file
+	AUTHENTICATION_SUBDOMAINS      string = "internal_auth_subdomain"       // array of additional subdomains to add authentication for
+	AUTHENTICATION_ADDITIONAL_URLS string = "internal_additional_auth_urls" // array of additional urls to add authentication for
+	AUTHENTICATION_TOKEN           string = "snyk_token"
+	//nolint:gosec // not a token value, a configuration key
 	AUTHENTICATION_BEARER_TOKEN     string = "snyk_oauth_token"
 	INTEGRATION_NAME                string = "snyk_integration_name"
 	INTEGRATION_VERSION             string = "snyk_integration_version"


### PR DESCRIPTION
Several gosec linter fixes:

- Use secure random source for creating oauth2 verifer.
  https://www.rfc-editor.org/rfc/rfc7636#section-4.1 prescribes a "high-entropy
  cryptographic random [string]".
- nolint comments for sha1 usage, which is not ideal, but should not be a
  security issue. Could be a future FedRAMP issue though...
- TLS listener test uses randomly assigned port and listens only on localhost.
  This should avoid an annoying security pop-up on macOS. Also makes the test
  more reproducible, in the event the dev machine has something listening on
  8443.
- Satisfy slowloris warnings on http.Server setup without read timeouts.

Stacked on #119. PTAL at 39faa9faf90bf3bdf948952a47a1868ab6055258 if you want to review just the new changes introduced here.

CLI-49