### PR TITLE
fix: Authentication when using an invalid pre-existing token [HEAD-1197]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   linux:
     machine:
-      image: ubuntu-2024.01-20.04
+      image: ubuntu-2204:2023.10.1
 
 # Define the jobs we want to run for this project
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   linux:
     machine:
-      image: ubuntu-2004:2022.07.1
+      image: ubuntu-2024.01-20.04
 
 # Define the jobs we want to run for this project
 jobs:

--- a/pkg/local_workflows/auth_workflow.go
+++ b/pkg/local_workflows/auth_workflow.go
@@ -95,7 +95,7 @@ func authEntryPoint(invocationCtx workflow.InvocationContext, _ []workflow.Data)
 	} else { // LEGACY flow
 		config.Set(configuration.RAW_CMD_ARGS, os.Args[1:])
 		config.Set(configuration.WORKFLOW_USE_STDIO, true)
-		config.Set(configuration.AUTHENTICATION_TOKEN, "")
+		config.Set(configuration.AUTHENTICATION_TOKEN, "") // unset token to avoid using it during authentication
 
 		_, legacyCLIError := engine.InvokeWithConfig(workflow.NewWorkflowIdentifier("legacycli"), config)
 		if legacyCLIError != nil {

--- a/pkg/local_workflows/auth_workflow.go
+++ b/pkg/local_workflows/auth_workflow.go
@@ -95,6 +95,8 @@ func authEntryPoint(invocationCtx workflow.InvocationContext, _ []workflow.Data)
 	} else { // LEGACY flow
 		config.Set(configuration.RAW_CMD_ARGS, os.Args[1:])
 		config.Set(configuration.WORKFLOW_USE_STDIO, true)
+		config.Set(configuration.AUTHENTICATION_TOKEN, "")
+
 		_, legacyCLIError := engine.InvokeWithConfig(workflow.NewWorkflowIdentifier("legacycli"), config)
 		if legacyCLIError != nil {
 			return nil, legacyCLIError

--- a/pkg/mocks/networking.go
+++ b/pkg/mocks/networking.go
@@ -12,6 +12,7 @@ import (
 	zerolog "github.com/rs/zerolog"
 	auth "github.com/snyk/go-application-framework/pkg/auth"
 	configuration "github.com/snyk/go-application-framework/pkg/configuration"
+	networking "github.com/snyk/go-application-framework/pkg/networking"
 )
 
 // MockNetworkAccess is a mock of NetworkAccess interface.
@@ -75,6 +76,20 @@ func (m *MockNetworkAccess) AddRootCAs(pemFileLocation string) error {
 func (mr *MockNetworkAccessMockRecorder) AddRootCAs(pemFileLocation interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRootCAs", reflect.TypeOf((*MockNetworkAccess)(nil).AddRootCAs), pemFileLocation)
+}
+
+// Clone mocks base method.
+func (m *MockNetworkAccess) Clone() networking.NetworkAccess {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Clone")
+	ret0, _ := ret[0].(networking.NetworkAccess)
+	return ret0
+}
+
+// Clone indicates an expected call of Clone.
+func (mr *MockNetworkAccessMockRecorder) Clone() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockNetworkAccess)(nil).Clone))
 }
 
 // GetAuthenticator mocks base method.

--- a/pkg/networking/networking.go
+++ b/pkg/networking/networking.go
@@ -39,6 +39,8 @@ type NetworkAccess interface {
 	SetConfiguration(configuration configuration.Configuration)
 	GetLogger() *zerolog.Logger
 	GetConfiguration() configuration.Configuration
+
+	Clone() NetworkAccess
 }
 
 // networkImpl is the default implementation of the NetworkAccess interface.
@@ -210,4 +212,19 @@ func (n *networkImpl) GetLogger() *zerolog.Logger {
 
 func (n *networkImpl) GetConfiguration() configuration.Configuration {
 	return n.config
+}
+
+func (n *networkImpl) Clone() NetworkAccess {
+	clone := &networkImpl{
+		config:       n.config.Clone(),
+		logger:       n.logger,
+		staticHeader: n.staticHeader.Clone(),
+		proxy:        n.proxy,
+	}
+
+	if n.caPool != nil {
+		clone.caPool = n.caPool.Clone()
+	}
+
+	return clone
 }

--- a/pkg/networking/networking_test.go
+++ b/pkg/networking/networking_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -412,4 +413,30 @@ func Test_UserAgentInfo_Complete(t *testing.T) {
 	assert.Equal(t, expectedIntVersion, ua.IntegrationVersion)
 	assert.Equal(t, expectedIntEnvName, ua.IntegrationEnvironment)
 	assert.Equal(t, expectedIntEnvVersion, ua.IntegrationEnvironmentVersion)
+}
+
+func TestNetworkImpl_Clone(t *testing.T) {
+	config := configuration.NewInMemory()
+	network := NewNetworkAccess(config)
+
+	config2 := configuration.NewInMemory()
+	config2.Set(configuration.AUTHENTICATION_TOKEN, "test")
+	clonedNetwork := network.Clone()
+	clonedNetwork.SetConfiguration(config2)
+
+	url1, _ := url.Parse("")
+	req1 := &http.Request{
+		Header: http.Header{},
+		URL:    url1,
+	}
+	req2 := &http.Request{
+		Header: http.Header{},
+		URL:    url1,
+	}
+
+	network.AddHeaders(req1)
+	clonedNetwork.AddHeaders(req2)
+
+	assert.NotEqual(t, req1, req2)
+	assert.NotEqual(t, network.GetConfiguration(), clonedNetwork.GetConfiguration())
 }

--- a/pkg/workflow/engine_test.go
+++ b/pkg/workflow/engine_test.go
@@ -178,17 +178,25 @@ func Test_Engine_ClonedNetworkAccess(t *testing.T) {
 
 	workflowId := NewWorkflowIdentifier("cmd")
 	_, err := engine.Register(workflowId, ConfigurationOptionsFromFlagset(pflag.NewFlagSet("1", pflag.ExitOnError)), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		assert.Equal(t, expected, invocation.GetNetworkAccess().GetConfiguration().GetInt(valueName))
+		assert.Equal(t, expected, invocation.GetConfiguration().GetInt(valueName))
+
+		newValue := 1
+
 		// changing the network configuration inside a callback
-		invocation.GetNetworkAccess().GetConfiguration().Set(valueName, 1)
+		invocation.GetNetworkAccess().GetConfiguration().Set(valueName, newValue)
+
+		assert.Equal(t, newValue, invocation.GetNetworkAccess().GetConfiguration().GetInt(valueName))
+		assert.Equal(t, newValue, invocation.GetConfiguration().GetInt(valueName))
 		return []Data{}, nil
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = engine.Init()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	_, err = engine.Invoke(workflowId)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// ensure that the config value in the original config wasn't changed
 	actual := config.GetInt(valueName)

--- a/pkg/workflow/engine_test.go
+++ b/pkg/workflow/engine_test.go
@@ -167,3 +167,30 @@ func Test_Engine_SetterRuntimeInfo(t *testing.T) {
 
 	assert.Equal(t, ri, engine.GetRuntimeInfo())
 }
+
+func Test_Engine_ClonedNetworkAccess(t *testing.T) {
+	valueName := "randomValue"
+	expected := 815
+	config := configuration.NewInMemory()
+	config.Set(valueName, expected)
+
+	engine := NewWorkFlowEngine(config)
+
+	workflowId := NewWorkflowIdentifier("cmd")
+	_, err := engine.Register(workflowId, ConfigurationOptionsFromFlagset(pflag.NewFlagSet("1", pflag.ExitOnError)), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		// changing the network configuration inside a callback
+		invocation.GetNetworkAccess().GetConfiguration().Set(valueName, 1)
+		return []Data{}, nil
+	})
+	assert.Nil(t, err)
+
+	err = engine.Init()
+	assert.Nil(t, err)
+
+	_, err = engine.Invoke(workflowId)
+	assert.Nil(t, err)
+
+	// ensure that the config value in the original config wasn't changed
+	actual := config.GetInt(valueName)
+	assert.Equal(t, expected, actual)
+}

--- a/pkg/workflow/engineimpl.go
+++ b/pkg/workflow/engineimpl.go
@@ -243,8 +243,12 @@ func (e *EngineImpl) InvokeWithInputAndConfig(
 				config = e.config.Clone()
 			}
 
+			// prepare networkAccess
+			networkAccess := e.networkAccess.Clone()
+			networkAccess.SetConfiguration(config)
+
 			// create a context object for the invocation
-			context := NewInvocationContext(id, config, e, e.networkAccess, zlogger, e.analytics, e.ui)
+			context := NewInvocationContext(id, config, e, networkAccess, zlogger, e.analytics, e.ui)
 
 			// invoke workflow through its callback
 			output, err = callback(context, input)


### PR DESCRIPTION
This PR ensures to unset any available token when executing token authentication in auth_workflow.go
Therefore it adds cloning of the global NetworkAccess object before invoking an extension to avoid side effects between Extensions. This means that an Extension is even more sandboxed and will not affect global states or other Extension states.

To enable the CI/CD pipeline, I updated the runner image used to have a more recent golang version available.