### PR TITLE
fix: path to the experimental analytics endpoint

### DIFF
--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -53,7 +53,7 @@ func reportAnalyticsEntrypoint(invocationCtx workflow.InvocationContext, inputDa
 		return nil, fmt.Errorf("set `--experimental` flag to enable analytics report command")
 	}
 
-	url := fmt.Sprintf("%s/rest/api/orgs/%s/analytics", config.GetString(configuration.API_URL), config.Get(configuration.ORGANIZATION))
+	url := fmt.Sprintf("%s/hidden/orgs/%s/analytics?version=2023-11-09~experimental", config.GetString(configuration.API_URL), config.Get(configuration.ORGANIZATION))
 
 	commandLineInput := config.GetString(reportAnalyticsInputDataFlagName)
 	if commandLineInput != "" {

--- a/pkg/local_workflows/report_analytics_workflow_test.go
+++ b/pkg/local_workflows/report_analytics_workflow_test.go
@@ -235,7 +235,7 @@ func testInitReportAnalyticsWorkflow(ctrl *gomock.Controller) error {
 func testGetMockHTTPClient(t *testing.T, orgId string, requestPayload string) *http.Client {
 	mockClient := newTestClient(func(req *http.Request) *http.Response {
 		// Test request parameters
-		require.Equal(t, "/rest/api/orgs/"+orgId+"/analytics", req.URL.String())
+		require.Equal(t, "/hidden/orgs/"+orgId+"/analytics?version=2023-11-09~experimental", req.URL.String())
 		require.Equal(t, "POST", req.Method)
 		require.Equal(t, "application/json", req.Header.Get("Content-Type"))
 		body, err := io.ReadAll(req.Body)


### PR DESCRIPTION
I'm assuming when we were writing this the endpoint wasn't functional yet and we couldn't test it against a real endpoint. The path to it has slightly changed, which this PR fixes.