### PR TITLE
fix: write error output to stderr

### DIFF
--- a/pkg/ui/builder.go
+++ b/pkg/ui/builder.go
@@ -70,7 +70,7 @@ func (b *ConsoleUiBuilder) Build() (UserInterface, error) {
 func NewConsoleUiBuilder() *ConsoleUiBuilder {
 	return &ConsoleUiBuilder{
 		outputWriter:       os.Stdout,
-		errorOutputWriter:  newColoredWriter(os.Stdout, red),
+		errorOutputWriter:  newColoredWriter(os.Stderr, red),
 		progressBarFactory: func() ProgressBar { return newProgressBar(os.Stderr) },
 		inputReader:        bufio.NewReader(os.Stdin),
 	}


### PR DESCRIPTION
Since this repo does not have Issues enabled, I'm using a PR to raise the topic. I noticed that in the UI package, `Stdout` is being used for both output as well as error messages. This changes the default error writer to `os.Stderr`. Happy to hear your thoughts on this.