### PR TITLE
chore: enable golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Lint
+          command: make lint
+      - run:
           name: Build
           command: make build
 
@@ -34,7 +37,7 @@ jobs:
       - prodsec/security_scans:
           mode: auto
 
-  
+
 # Orchestrate our job run sequence
 workflows:
   test_and_release:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -96,42 +96,59 @@ linters:
     - containedctx
     - contextcheck
     - dogsled
-    - dupl
+    # TODO(dupl): revisit
+    #- dupl
     - durationcheck
     - errname
     - errorlint
     - exhaustive
     - exportloopref
-    - forbidigo
+    # TODO(forbidigo): revisit
+    #- forbidigo
     - forcetypeassert
-    - goconst
-    - gocritic
+    # TODO(goconst): revisit
+    #- goconst
+    # TODO(gocritic): revisit
+    #- gocritic
     - gocyclo
-    - godot
-    - gofumpt
-    - goimports
+    # TODO(godot): revisit
+    #- godot
+    # TODO(gofumpt): revisit
+    #- gofumpt
+    # TODO(goimports): revisit
+    #- goimports
     - goprintffuncname
-    - gosec
-    - interfacebloat
-    - ireturn
-    - lll
+    # TODO(gosec): revisit; consequences of revoking non-owner file permissions?
+    #- gosec
+    # TODO(interfacebloat): revisit in a followup; will require a breaking API change
+    #- interfacebloat
+    # TODO(ireturn): revisit in a followup; will require a breaking API change
+    #- ireturn
+    # TODO(lll): revisit in followup; formatting
+    #- lll
     - misspell
     - nakedret
-    - nestif
+    # TODO(nestif): revisit in a followup; refactor will need more careful review
+    #- nestif
     - nilerr
     - nilnil
-    - noctx
+    # TODO(noctx): revisit in a followup; context lifecycle consequences and/or breaking API change
+    #- noctx
     - nolintlint
-    - prealloc
+    # TODO(prealloc): revisit in a followup; some logic around slices are ignoring errors
+    #- prealloc
     - predeclared
     - promlinter
-    - revive
+    # TODO(revive): revisit in a followup; extensive changes, some breaking. godoc requirement would be good to introduce
+    #- revive
     - rowserrcheck
     - sqlclosecheck
-    - stylecheck
-    - tagliatelle
+    # TODO(stylecheck): revisit in a followup; some breaking API changes
+    #- stylecheck
+    # NOTE: removed tagliatelle as it conflicts too much with existing API wireformats
     - tenv
-    - testpackage
+    # TODO(testpackage): improve open vs closed-box testing in a followup
+    #- testpackage
     - thelper
     - tparallel
     - unconvert
@@ -139,7 +156,8 @@ linters:
     - usestdlibvars
     - wastedassign
     - whitespace
-    - wrapcheck
+    # TODO(wrapcheck): wrap errors in a followup
+    #- wrapcheck
 
 issues:
   exclude-rules:
@@ -152,6 +170,10 @@ issues:
     - path: test/
       linters:
         - testpackage
+    - path: \.go
+      linters:
+        # TODO: revisit this one; ignoring errors is BAD
+        - errcheck
   include:
     - EXC0012
     - EXC0014

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,20 @@ LOG_PREFIX = --
 GOOS = $(shell go env GOOS)
 GOARCH = $(shell go env GOARCH)
 
+GO_BIN := $(shell pwd)/.bin
+OVERRIDE_GOCI_LINT_V := v1.55.2
+SHELL := env PATH=$(GO_BIN):$(PATH) $(SHELL)
+
 .PHONY: format
 format:
 	@echo "Formatting..."
 	@gofmt -w -l -e .
 
 .PHONY: lint
-lint:
+lint: $(GO_BIN)/golangci-lint
 	@echo "Linting..."
 	@./scripts/lint.sh
+	$(GO_BIN)/golangci-lint run ./...
 
 .PHONY: build
 build:
@@ -23,18 +28,21 @@ clean:
 	@GOOS=$(GOOS) GOARCH=$(GOARCH) go clean -testcache
 
 .PHONY: test
-test: 
+test:
 	@echo "Testing..."
 	@go test -cover ./...
 
 .PHONY: testv
-testv: 
+testv:
 	@echo "Testing verbosely..."
 	@go test -v ./...
 
 .PHONY: generate
-generate: 
+generate:
 	@go generate ./...
+
+$(GO_BIN)/golangci-lint:
+	curl -sSfL 'https://raw.githubusercontent.com/golangci/golangci-lint/${OVERRIDE_GOCI_LINT_V}/install.sh' | sh -s -- -b ${GO_BIN} ${OVERRIDE_GOCI_LINT_V}
 
 .PHONY: help
 help:

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -29,6 +29,8 @@ func (a *snykApiClient) GetOrgIdFromSlug(slugName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer res.Body.Close()
+
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", err
@@ -55,13 +57,14 @@ func (a *snykApiClient) GetDefaultOrgId() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve org ID: %w", err)
 	}
+	defer res.Body.Close()
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve org ID: %w", err)
 	}
 
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("unable to retrieve org ID (status: %d)", res.StatusCode)
 	}
 

--- a/internal/api/urls.go
+++ b/internal/api/urls.go
@@ -8,11 +8,11 @@ import (
 )
 
 const (
-	API_PREFIX     string = "api"
-	app_pattern    string = "^app\\."
-	api_pattern    string = "^api\\."
-	api_prefix_dot string = API_PREFIX + "."
-	app_prefix     string = "app"
+	API_PREFIX   string = "api"
+	appPattern   string = "^app\\."
+	apiPattern   string = "^api\\."
+	apiPrefixDot string = API_PREFIX + "."
+	appPrefix    string = "app"
 )
 
 func isImmutableHost(host string) bool {
@@ -34,11 +34,7 @@ func isImmutableHost(host string) bool {
 	}
 
 	_, _, err := net.ParseCIDR(portlessHost + "/24")
-	if err == nil {
-		return true
-	}
-
-	return false
+	return err == nil
 }
 
 func GetCanonicalApiUrlFromString(userDefinedUrl string) (string, error) {
@@ -58,12 +54,12 @@ func GetCanonicalApiUrl(url url.URL) (string, error) {
 	if isImmutableHost(url.Host) {
 		url.Path = strings.Replace(url.Path, "/v1", "", 1)
 	} else {
-		appRegexp, _ := regexp.Compile(app_pattern)
-		url.Host = appRegexp.ReplaceAllString(url.Host, api_prefix_dot)
+		appRegexp, _ := regexp.Compile(appPattern)
+		url.Host = appRegexp.ReplaceAllString(url.Host, apiPrefixDot)
 
-		apiRegexp, _ := regexp.Compile(api_pattern)
+		apiRegexp, _ := regexp.Compile(apiPattern)
 		if !apiRegexp.MatchString(url.Host) {
-			url.Host = api_prefix_dot + url.Host
+			url.Host = apiPrefixDot + url.Host
 		}
 
 		// clean path and fragment
@@ -77,7 +73,7 @@ func GetCanonicalApiUrl(url url.URL) (string, error) {
 }
 
 func DeriveAppUrl(canonicalUrl string) (string, error) {
-	return DeriveSubdomainUrl(canonicalUrl, app_prefix)
+	return DeriveSubdomainUrl(canonicalUrl, appPrefix)
 }
 
 func DeriveSubdomainUrl(canonicalUrl string, subdomain string) (string, error) {
@@ -87,7 +83,7 @@ func DeriveSubdomainUrl(canonicalUrl string, subdomain string) (string, error) {
 		return result, err
 	}
 
-	apiRegexp, _ := regexp.Compile(api_pattern)
+	apiRegexp, _ := regexp.Compile(apiPattern)
 	url.Host = apiRegexp.ReplaceAllString(url.Host, subdomain+".")
 
 	result = url.String()

--- a/internal/api/urls_test.go
+++ b/internal/api/urls_test.go
@@ -14,9 +14,7 @@ var instanceList = []string{
 }
 
 func Test_GetCanonicalApiUrlFromString(t *testing.T) {
-
 	for _, instance := range instanceList {
-
 		inputList := []string{
 			"https://" + instance + ".io/api/v1",
 			"https://" + instance + ".io/api",
@@ -37,7 +35,6 @@ func Test_GetCanonicalApiUrlFromString(t *testing.T) {
 			assert.Equal(t, expected, actual)
 		}
 	}
-
 }
 
 func Test_GetCanonicalApiUrlFromString_Edgecases(t *testing.T) {
@@ -88,7 +85,6 @@ func Test_DeriveAppUrl(t *testing.T) {
 		actual, err := DeriveAppUrl("https://api." + instance)
 		assert.Nil(t, err)
 		assert.Equal(t, expected, actual)
-
 	}
 }
 

--- a/internal/utils/temp-dir_test.go
+++ b/internal/utils/temp-dir_test.go
@@ -66,7 +66,7 @@ func Test_systemTempDirectory_handlesWhenTempDirNotExists(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, expectedDir, tempDir)
 	assert.Equal(t, expectedDir, osutil.(*mockTempDirOSUtil).dirPath)
-	assert.Equal(t, os.FileMode(FILEPERM_755), osutil.(*mockTempDirOSUtil).dirPerm)
+	assert.Equal(t, FILEPERM_755, osutil.(*mockTempDirOSUtil).dirPerm)
 }
 
 func Test_systemTempDirectory_handlesTempDirFailure(t *testing.T) {
@@ -107,7 +107,7 @@ func Test_snykTempDirectoryImpl_handlesWhenSnykTempDirNotExists(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, tempDir)
 	assert.Equal(t, expectedResult, osutil.(*mockTempDirOSUtil).dirPath)
-	assert.Equal(t, os.FileMode(FILEPERM_755), osutil.(*mockTempDirOSUtil).dirPerm)
+	assert.Equal(t, FILEPERM_755, osutil.(*mockTempDirOSUtil).dirPerm)
 }
 
 func Test_snykTempDirectoryImpl_handlesSnykTempDirFailure(t *testing.T) {

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -133,8 +133,8 @@ var (
 )
 
 const (
-	sanitize_replacement_string string = "REDACTED"
-	api_endpoint                       = "/v1/analytics/cli"
+	sanitizeReplacementString string = "REDACTED"
+	apiEndpoint               string = "/v1/analytics/cli"
 )
 
 // New creates a new Analytics instance.
@@ -247,7 +247,7 @@ func (a *AnalyticsImpl) GetOutputData() *analyticsOutput {
 	output.Ci = a.IsCiEnvironment()
 	output.IntegrationName = a.integrationName
 	output.IntegrationVersion = a.integrationVersion
-	output.DurationMs = int64(time.Since(a.created).Milliseconds())
+	output.DurationMs = time.Since(a.created).Milliseconds()
 	output.Standalone = true // standalone means binary deployment, which is always true for go applications.
 
 	return output
@@ -265,7 +265,7 @@ func (a *AnalyticsImpl) GetRequest() (*http.Request, error) {
 		return nil, err
 	}
 
-	outputJson, err = SanitizeValuesByKey(sensitiveFieldNames, sanitize_replacement_string, outputJson)
+	outputJson, err = SanitizeValuesByKey(sensitiveFieldNames, sanitizeReplacementString, outputJson)
 	if err != nil {
 		return nil, err
 	}
@@ -274,12 +274,12 @@ func (a *AnalyticsImpl) GetRequest() (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	outputJson, err = SanitizeUsername(user.Username, user.HomeDir, sanitize_replacement_string, outputJson)
+	outputJson, err = SanitizeUsername(user.Username, user.HomeDir, sanitizeReplacementString, outputJson)
 	if err != nil {
 		return nil, err
 	}
 
-	analyticsUrl, _ := url.Parse(a.apiUrl + api_endpoint)
+	analyticsUrl, _ := url.Parse(a.apiUrl + apiEndpoint)
 	if len(a.org) > 0 {
 		query := url.Values{}
 		query.Add("org", a.org)
@@ -320,7 +320,7 @@ func (a *AnalyticsImpl) isEnabled() bool {
 	return !api.IsFedramp(a.apiUrl)
 }
 
-var DisabledInFedrampErr = errors.New("analytics are disabled in FedRAMP environments")
+var DisabledInFedrampErr = errors.New("analytics are disabled in FedRAMP environments") //nolint:errname // breaking API change
 
 // This method sanitizes the given content by searching for key-value mappings. It thereby replaces all keys defined in keysToFilter by the replacement string
 // Supported patterns are:

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"os/user"
 	"strings"
 	"testing"
@@ -14,7 +13,7 @@ import (
 )
 
 func Test_Basic(t *testing.T) {
-	os.Setenv("CIRCLECI", "true")
+	t.Setenv("CIRCLECI", "true")
 	testFields := []string{
 		"tfc-token",
 		"azurerm-account-key",
@@ -64,8 +63,8 @@ func Test_Basic(t *testing.T) {
 			assert.NotNil(t, request)
 			assert.True(t, analytics.IsCiEnvironment())
 
-			expectedAuthHeader, _ := h["Authorization"]
-			actualAuthHeader, _ := request.Header["Authorization"]
+			expectedAuthHeader := h["Authorization"]
+			actualAuthHeader := request.Header["Authorization"]
 			assert.Equal(t, expectedAuthHeader, actualAuthHeader)
 
 			requestUrl := request.URL.String()
@@ -74,7 +73,7 @@ func Test_Basic(t *testing.T) {
 
 			body, err := io.ReadAll(request.Body)
 			assert.Nil(t, err)
-			assert.Equal(t, len(testFields), strings.Count(string(body), sanitize_replacement_string), "Not all sensitive values have been replaced!")
+			assert.Equal(t, len(testFields), strings.Count(string(body), sanitizeReplacementString), "Not all sensitive values have been replaced!")
 
 			var requestBody dataOutput
 			err = json.Unmarshal(body, &requestBody)
@@ -92,7 +91,6 @@ func Test_Basic(t *testing.T) {
 			fmt.Println("Request Body: " + string(body))
 		})
 	}
-
 }
 
 func Test_SanitizeValuesByKey(t *testing.T) {
@@ -121,7 +119,7 @@ func Test_SanitizeValuesByKey(t *testing.T) {
 	// test input
 	filter := sensitiveFieldNames
 	input, _ := json.Marshal(inputStruct)
-	replacement := sanitize_replacement_string
+	replacement := sanitizeReplacementString
 
 	fmt.Println("Before: " + string(input))
 
@@ -226,9 +224,7 @@ func Test_SanitizeUsername(t *testing.T) {
 
 		var outputStruct sanTest
 		json.Unmarshal(output, &outputStruct)
-
 	}
-
 }
 
 func newTestAnalytics(t *testing.T) Analytics {
@@ -239,6 +235,7 @@ func newTestAnalytics(t *testing.T) Analytics {
 }
 
 func testUserCurrent(t *testing.T) func() (*user.User, error) {
+	t.Helper()
 	return func() (*user.User, error) {
 		return &user.User{
 			Uid:      "1000",

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -61,12 +61,13 @@ func initConfiguration(engine workflow.Engine, config configuration.Configuratio
 		client := engine.GetNetworkAccess().GetHttpClient()
 		url := config.GetString(configuration.API_URL)
 		apiClient.Init(url, client)
-		if existingValue != nil && len(existingValue.(string)) > 0 {
-			orgId := existingValue.(string)
+		existingString, ok := existingValue.(string)
+		if existingValue != nil && ok && len(existingString) > 0 {
+			orgId := existingString
 			_, err := uuid.Parse(orgId)
 			isSlugName := err != nil
 			if isSlugName {
-				orgId, err = apiClient.GetOrgIdFromSlug(existingValue.(string))
+				orgId, err = apiClient.GetOrgIdFromSlug(existingString)
 				if err != nil {
 					logger.Print("Failed to determine default value for \"ORGANIZATION\":", err)
 				} else {
@@ -100,7 +101,6 @@ func initConfiguration(engine workflow.Engine, config configuration.Configuratio
 			return existingValue
 		}
 	})
-
 }
 
 // CreateAppEngine creates a new workflow engine.

--- a/pkg/auth/api_tokens.go
+++ b/pkg/auth/api_tokens.go
@@ -8,7 +8,6 @@ import (
 
 // GetAuthHeader returns the authentication header value based on the configuration.
 func GetAuthHeader(config configuration.Configuration) string {
-
 	bearerToken := config.GetString(configuration.AUTHENTICATION_BEARER_TOKEN)
 	if len(bearerToken) > 0 {
 		return fmt.Sprintf("Bearer %s", bearerToken)

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -261,7 +261,10 @@ func (ev *extendedViper) GetString(key string) string {
 	if result == nil {
 		return ""
 	}
-	return result.(string)
+	if s, ok := result.(string); ok {
+		return s
+	}
+	return ""
 }
 
 // GetBool returns a configuration value as bool.
@@ -271,12 +274,11 @@ func (ev *extendedViper) GetBool(key string) bool {
 		return false
 	}
 
-	switch result.(type) {
+	switch v := result.(type) {
 	case bool:
-		return result.(bool)
+		return v
 	case string:
-		stringResult := result.(string)
-		boolResult, _ := strconv.ParseBool(stringResult)
+		boolResult, _ := strconv.ParseBool(v)
 		return boolResult
 	}
 
@@ -290,17 +292,17 @@ func (ev *extendedViper) GetInt(key string) int {
 		return 0
 	}
 
-	switch result.(type) {
+	switch v := result.(type) {
 	case string:
-		stringResult := result.(string)
+		stringResult := v
 		temp, _ := strconv.ParseInt(stringResult, 10, 32)
 		return int(temp)
 	case float32:
-		return int(result.(float32))
+		return int(v)
 	case float64:
-		return int(result.(float64))
+		return int(v)
 	case int:
-		return int(result.(int))
+		return v
 	}
 
 	return 0
@@ -313,17 +315,17 @@ func (ev *extendedViper) GetFloat64(key string) float64 {
 		return 0
 	}
 
-	switch result.(type) {
+	switch v := result.(type) {
 	case string:
-		stringResult := result.(string)
+		stringResult := v
 		temp, _ := strconv.ParseFloat(stringResult, 64)
-		return float64(temp)
+		return temp
 	case float32:
-		return float64(result.(float32))
+		return float64(v)
 	case float64:
-		return float64(result.(float64))
+		return v
 	case int:
-		return float64(result.(int))
+		return float64(v)
 	}
 
 	return 0
@@ -355,9 +357,9 @@ func (ev *extendedViper) GetStringSlice(key string) []string {
 		return output
 	}
 
-	switch result.(type) {
+	switch v := result.(type) {
 	case []string:
-		return result.([]string)
+		return v
 	}
 
 	return output

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -51,7 +51,7 @@ func Test_ConfigurationGet_AUTHENTICATION_TOKEN(t *testing.T) {
 	actualValue := config.GetString(AUTHENTICATION_TOKEN)
 	assert.Equal(t, expectedValue, actualValue)
 
-	os.Setenv("SNYK_TOKEN", expectedValue2)
+	t.Setenv("SNYK_TOKEN", expectedValue2)
 	actualValue = config.GetString(AUTHENTICATION_TOKEN)
 	assert.Equal(t, expectedValue2, actualValue)
 
@@ -67,14 +67,17 @@ func Test_ConfigurationGet_AUTHENTICATION_BEARER_TOKEN(t *testing.T) {
 	config := NewFromFiles(TEST_FILENAME)
 	config.AddAlternativeKeys(AUTHENTICATION_BEARER_TOKEN, []string{"snyk_oauth_token", "snyk_docker_token"})
 
-	os.Setenv("SNYK_OAUTH_TOKEN", expectedValue)
-	actualValue := config.GetString(AUTHENTICATION_BEARER_TOKEN)
-	assert.Equal(t, expectedValue, actualValue)
+	t.Run("oauth token", func(t *testing.T) {
+		t.Setenv("SNYK_OAUTH_TOKEN", expectedValue)
+		actualValue := config.GetString(AUTHENTICATION_BEARER_TOKEN)
+		assert.Equal(t, expectedValue, actualValue)
+	})
 
-	os.Unsetenv("SNYK_OAUTH_TOKEN")
-	os.Setenv("SNYK_DOCKER_TOKEN", expectedValueDocker)
-	actualValue = config.GetString(AUTHENTICATION_BEARER_TOKEN)
-	assert.Equal(t, expectedValueDocker, actualValue)
+	t.Run("docker token", func(t *testing.T) {
+		t.Setenv("SNYK_DOCKER_TOKEN", expectedValueDocker)
+		actualValue := config.GetString(AUTHENTICATION_BEARER_TOKEN)
+		assert.Equal(t, expectedValueDocker, actualValue)
+	})
 
 	cleanupConfigstore()
 	cleanUpEnvVars()
@@ -85,11 +88,11 @@ func Test_ConfigurationGet_ANALYTICS_DISABLED(t *testing.T) {
 
 	config := NewFromFiles(TEST_FILENAME)
 
-	os.Setenv("SNYK_DISABLE_ANALYTICS", "1")
+	t.Setenv("SNYK_DISABLE_ANALYTICS", "1")
 	actualValue := config.GetBool(ANALYTICS_DISABLED)
 	assert.True(t, actualValue)
 
-	os.Setenv("SNYK_DISABLE_ANALYTICS", "0")
+	t.Setenv("SNYK_DISABLE_ANALYTICS", "0")
 	actualValue = config.GetBool(ANALYTICS_DISABLED)
 	assert.False(t, actualValue)
 
@@ -290,7 +293,6 @@ func TestNewInMemory_shouldNotBreakWhenTryingToPersist(t *testing.T) {
 }
 
 func Test_DefaultValuehandling(t *testing.T) {
-
 	t.Run("set value in code", func(t *testing.T) {
 		keyNoDefault := "name"
 		keyWithDefault := "last name"
@@ -355,7 +357,5 @@ func Test_DefaultValuehandling(t *testing.T) {
 		wasSet = config.IsSet(ORGANIZATION)
 		assert.Equal(t, expected, actual)
 		assert.True(t, wasSet)
-
 	})
-
 }

--- a/pkg/configuration/storage_test.go
+++ b/pkg/configuration/storage_test.go
@@ -23,19 +23,23 @@ func Test_JsonStorage_Set_NoConfigFile(t *testing.T) {
 		{
 			setup: "File does not exist",
 			customSetupFunc: func(t *testing.T) string {
+				t.Helper()
 				return filepath.Join(t.TempDir(), "test.json")
 			},
 		},
 		{
 			setup: "Leading folders to the file do not exist",
 			customSetupFunc: func(t *testing.T) string {
+				t.Helper()
 				return filepath.Join(t.TempDir(), "nonexistent", "test.json")
 			},
 		},
 	}
 
-	for _, testCase := range testCases {
+	for i := range testCases {
+		testCase := testCases[i]
 		t.Run(testCase.setup+" - config file is created", func(t *testing.T) {
+			t.Parallel()
 			configFile := testCase.customSetupFunc(t)
 			storage := configuration.NewJsonStorage(configFile)
 
@@ -73,13 +77,16 @@ func Test_JsonStorage_Set_ConfigFileHasValues(t *testing.T) {
 	// Assert
 	storedConfig := readStoredConfigFile(t, configFile)
 	t.Run("File contains key", func(t *testing.T) {
+		t.Parallel()
 		assertConfigContainsKey(t, storedConfig, key, expectedValue)
 	})
 	t.Run("Pre-stored values are not deleted", func(t *testing.T) {
+		t.Parallel()
 		assertConfigContainsKey(t, storedConfig, preExistingKey, preExistingValue)
 	})
 	assertSetCallDoesNotDeleteOtherValues(t, storage, configFile, expectedValue, key)
 	t.Run("Overwrites existing value", func(t *testing.T) {
+		t.Parallel()
 		const newValue = "new value"
 		assert.Contains(t, storedConfig, key)
 		err = storage.Set(key, newValue)
@@ -101,6 +108,7 @@ func Test_JsonStorage_Set_BrokenConfigFile(t *testing.T) {
 
 	// Assert
 	t.Run("Returns an error", func(t *testing.T) {
+		t.Parallel()
 		assert.NotNil(t, err)
 	})
 }
@@ -116,6 +124,7 @@ func Test_JsonStorage_Set_InvalidValue(t *testing.T) {
 
 	// Assert
 	t.Run("Returns an error", func(t *testing.T) {
+		t.Parallel()
 		assert.NotNil(t, err)
 	})
 }
@@ -148,6 +157,7 @@ func assertSetCallDoesNotDeleteOtherValues(
 	preExistingValue string,
 	preExistingValueKey string,
 ) bool {
+	t.Helper()
 	return t.Run("A second call to Set does not delete the first value", func(t *testing.T) {
 		storedConfig := readStoredConfigFile(t, configFile)
 		assert.Equal(t, preExistingValue, storedConfig[preExistingValueKey])
@@ -166,5 +176,6 @@ func assertConfigContainsKey(
 	expectedValueKey string,
 	expectedValue string,
 ) {
+	t.Helper()
 	assert.Equal(t, expectedValue, storedConfig[expectedValueKey])
 }

--- a/pkg/local_workflows/auth_workflow.go
+++ b/pkg/local_workflows/auth_workflow.go
@@ -33,7 +33,7 @@ If you can't wait use this url:
 // define a new workflow identifier for this workflow
 var WORKFLOWID_AUTH workflow.Identifier = workflow.NewWorkflowIdentifier(workflowNameAuth)
 
-// InitAuth initialises the auth workflow before registering it with the engine.
+// InitAuth initializes the auth workflow before registering it with the engine.
 func InitAuth(engine workflow.Engine) error {
 	if !engine.GetConfiguration().GetBool(configuration.FF_OAUTH_AUTH_FLOW_ENABLED) {
 		return nil // Use legacy CLI for authentication for now, until OAuth is ready
@@ -91,7 +91,6 @@ func authEntryPoint(invocationCtx workflow.InvocationContext, _ []workflow.Data)
 		}
 
 		fmt.Println(auth.AUTHENTICATED_MESSAGE)
-
 	} else { // LEGACY flow
 		config.Set(configuration.RAW_CMD_ARGS, os.Args[1:])
 		config.Set(configuration.WORKFLOW_USE_STDIO, true)

--- a/pkg/local_workflows/output_workflow.go
+++ b/pkg/local_workflows/output_workflow.go
@@ -52,10 +52,13 @@ func outputWorkflowEntryPoint(invocation workflow.InvocationContext, input []wor
 		debugLogger.Printf("Processing '%s' based on '%s' of type '%s'\n", input[i].GetIdentifier().String(), contentLocation, mimeType)
 
 		if strings.Contains(mimeType, OUTPUT_CONFIG_KEY_JSON) { // handle application/json
-			singleData := input[i].GetPayload().([]byte)
+			singleData, ok := input[i].GetPayload().([]byte)
+			if !ok {
+				return nil, fmt.Errorf("invalid payload type: %T", input[i].GetPayload())
+			}
 
 			// if json data is processed but non of the json related output configuration is specified, default printJsonToCmd is enabled
-			if printJsonToCmd == false && len(writeJsonToFile) == 0 {
+			if !printJsonToCmd && len(writeJsonToFile) == 0 {
 				printJsonToCmd = true
 			}
 
@@ -76,8 +79,7 @@ func outputWorkflowEntryPoint(invocation workflow.InvocationContext, input []wor
 			if !typeCastSuccessful {
 				singleDataAsString, typeCastSuccessful = input[i].GetPayload().(string)
 				if !typeCastSuccessful {
-					err := fmt.Errorf("Unsupported output type: %s", mimeType)
-					return output, err
+					return output, fmt.Errorf("unsupported output type: %s", mimeType)
 				}
 			} else {
 				singleDataAsString = string(singleData)

--- a/pkg/local_workflows/output_workflow_test.go
+++ b/pkg/local_workflows/output_workflow_test.go
@@ -125,7 +125,7 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 
 	t.Run("should print unsupported mimeTypes that are string convertible", func(t *testing.T) {
 		workflowIdentifier := workflow.NewTypeIdentifier(WORKFLOWID_OUTPUT_WORKFLOW, "output")
-		data := workflow.NewData(workflowIdentifier, "hammer/head", string(payload))
+		data := workflow.NewData(workflowIdentifier, "hammer/head", payload)
 
 		// mock assertions
 		outputDestination.EXPECT().Println(payload).Return(0, nil).Times(1)
@@ -147,6 +147,6 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 
 		// assert
 		assert.Equal(t, []workflow.Data{}, output)
-		assert.Equal(t, "Unsupported output type: hammer/head", err.Error())
+		assert.Equal(t, "unsupported output type: hammer/head", err.Error())
 	})
 }

--- a/pkg/local_workflows/report_analytics_workflow_test.go
+++ b/pkg/local_workflows/report_analytics_workflow_test.go
@@ -64,7 +64,7 @@ func Test_ReportAnalytics_ReportAnalyticsEntryPoint_reportsHttpStatusError(t *te
 	mockClient := newTestClient(func(req *http.Request) *http.Response {
 		return &http.Response{
 			// error code!
-			StatusCode: 500,
+			StatusCode: http.StatusInternalServerError,
 			// Send response to be tested
 			Body: io.NopCloser(bytes.NewBufferString(requestPayload)),
 			// Must be set to non-nil value or it panics
@@ -233,6 +233,7 @@ func testInitReportAnalyticsWorkflow(ctrl *gomock.Controller) error {
 }
 
 func testGetMockHTTPClient(t *testing.T, orgId string, requestPayload string) *http.Client {
+	t.Helper()
 	mockClient := newTestClient(func(req *http.Request) *http.Response {
 		// Test request parameters
 		require.Equal(t, "/hidden/orgs/"+orgId+"/analytics?version=2023-11-09~experimental", req.URL.String())
@@ -243,7 +244,7 @@ func testGetMockHTTPClient(t *testing.T, orgId string, requestPayload string) *h
 		require.Equal(t, requestPayload, string(body))
 
 		return &http.Response{
-			StatusCode: 201,
+			StatusCode: http.StatusCreated,
 			// Send response to be tested
 			Body: io.NopCloser(bytes.NewBufferString(requestPayload)),
 			// Must be set to non-nil value or it panics

--- a/pkg/local_workflows/whoami_workflow.go
+++ b/pkg/local_workflows/whoami_workflow.go
@@ -24,9 +24,9 @@ const (
 // define a new workflow identifier for this workflow
 var WORKFLOWID_WHOAMI workflow.Identifier = workflow.NewWorkflowIdentifier(whoAmIworkflowName)
 
-// InitWhoAmIWorkflow initialises the whoAmI workflow before registering it with the engine.
+// InitWhoAmIWorkflow initializes the whoAmI workflow before registering it with the engine.
 func InitWhoAmIWorkflow(engine workflow.Engine) error {
-	// initialise workflow configuration
+	// initialize workflow configuration
 	whoAmIConfig := pflag.NewFlagSet(whoAmIworkflowName, pflag.ExitOnError)
 	// add experimental flag to configuration
 	whoAmIConfig.Bool(experimentalFlag, false, "enable experimental whoAmI command")

--- a/pkg/local_workflows/whoami_workflow_test.go
+++ b/pkg/local_workflows/whoami_workflow_test.go
@@ -74,7 +74,7 @@ func Test_WhoAmI_whoAmIWorkflowEntryPoint_happyPath(t *testing.T) {
 		assert.Equal(t, "GET", req.Method)
 
 		return &http.Response{
-			StatusCode: 200,
+			StatusCode: http.StatusOK,
 			// Send response to be tested
 			Body: ioutil.NopCloser(bytes.NewBufferString(payload)),
 			// Must be set to non-nil value or it panics
@@ -148,7 +148,7 @@ func Test_WhoAmI_whoAmIWorkflowEntryPoint_fetchUserFailures(t *testing.T) {
 			assert.Equal(t, "GET", req.Method)
 
 			return &http.Response{
-				StatusCode: 401,
+				StatusCode: http.StatusUnauthorized,
 				// Send response to be tested
 				Body: ioutil.NopCloser(bytes.NewBufferString("")),
 				// Must be set to non-nil value or it panics
@@ -175,7 +175,7 @@ func Test_WhoAmI_whoAmIWorkflowEntryPoint_fetchUserFailures(t *testing.T) {
 			assert.Equal(t, "GET", req.Method)
 
 			return &http.Response{
-				StatusCode: 500,
+				StatusCode: http.StatusInternalServerError,
 				// Send response to be tested
 				Body: ioutil.NopCloser(bytes.NewBufferString("")),
 				// Must be set to non-nil value or it panics
@@ -226,7 +226,7 @@ func Test_WhoAmI_whoAmIWorkflowEntryPoint_extractUserFailures(t *testing.T) {
 		assert.Equal(t, "GET", req.Method)
 
 		return &http.Response{
-			StatusCode: 200,
+			StatusCode: http.StatusOK,
 			// Send response to be tested
 			Body: ioutil.NopCloser(bytes.NewBufferString(payloadMissingUserNameProperty)),
 			// Must be set to non-nil value or it panics

--- a/pkg/networking/certs/certs.go
+++ b/pkg/networking/certs/certs.go
@@ -47,8 +47,8 @@ func MakeSelfSignedCert(certName string, dnsNames []string, debugLogger *log.Log
 		debugLogger.Println("MakeSelfSignedCert added ", dnsName)
 	}
 
-	certDERBytes, err_CreateCertificate := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
-	if err_CreateCertificate != nil {
+	certDERBytes, errCreateCertificate := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if errCreateCertificate != nil {
 		return nil, nil, err
 	}
 
@@ -137,7 +137,6 @@ func GetAllCerts(pemData []byte) ([]*x509.Certificate, error) {
 
 // Get global Certificate pool including x509.SystemCertPool() + extraCertificateLocation
 func AddCertificatesToPool(pool *x509.CertPool, extraCertificateLocation string) error {
-
 	_, extracCertList, err := GetExtraCaCert(extraCertificateLocation)
 	if err != nil {
 		return err

--- a/pkg/networking/middleware/auth_header.go
+++ b/pkg/networking/middleware/auth_header.go
@@ -52,8 +52,7 @@ func ShouldRequireAuthentication(
 	subdomainsToCheck := append([]string{""}, additionalSubdomains...)
 	for _, subdomain := range subdomainsToCheck {
 		var matchesPattern bool
-		referenceUrl := ""
-		prefixUrl := ""
+		var prefixUrl, referenceUrl string
 		if len(subdomain) == 0 {
 			prefixUrl = apiUrl
 			referenceUrl, err = api.GetCanonicalApiUrl(*url)
@@ -81,7 +80,6 @@ func ShouldRequireAuthentication(
 	}
 
 	return false, nil
-
 }
 
 func AddAuthenticationHeader(

--- a/pkg/networking/middleware/auth_header_test.go
+++ b/pkg/networking/middleware/auth_header_test.go
@@ -96,5 +96,4 @@ func Test_AddAuthenticationHeader(t *testing.T) {
 
 	err = middleware.AddAuthenticationHeader(authenticator, config, request3)
 	assert.Nil(t, err)
-
 }

--- a/pkg/networking/networking.go
+++ b/pkg/networking/networking.go
@@ -74,7 +74,7 @@ func (rt *defaultHeadersRoundTripper) logRoundTrip(request *http.Request, respon
 
 		// read body for error code
 		if response.StatusCode < 200 || 299 < response.StatusCode {
-			if bodyBytes, err := io.ReadAll(response.Body); err == nil {
+			if bodyBytes, bodyErr := io.ReadAll(response.Body); bodyErr == nil {
 				rt.networkAccess.logger.WithLevel(loglevel).Msgf("< response [%p]: body: %v", request, string(bodyBytes))
 			}
 		}
@@ -142,7 +142,7 @@ func (n *networkImpl) addDefaultHeader(request *http.Request) {
 }
 
 func (n *networkImpl) getUnauthorizedRoundTripper() http.RoundTripper {
-	transport := http.DefaultTransport.(*http.Transport)
+	transport := http.DefaultTransport.(*http.Transport) //nolint:forcetypeassert // panic here is reasonable
 	rt := defaultHeadersRoundTripper{
 		networkAccess:            n,
 		encapsulatedRoundTripper: n.configureRoundTripper(transport),

--- a/pkg/networking/networking_test.go
+++ b/pkg/networking/networking_test.go
@@ -88,7 +88,7 @@ func Test_HttpClient_CallingApiUrl_UsesAuthHeaders_OAuth(t *testing.T) {
 		AccessToken:  accessToken,
 		TokenType:    "b",
 		RefreshToken: "c",
-		Expiry:       time.Now().Add(time.Duration(time.Minute * time.Duration(20))),
+		Expiry:       time.Now().Add(time.Minute * 20),
 	}
 
 	expectedTokenString, _ := json.Marshal(expectedToken)
@@ -228,8 +228,8 @@ func Test_GetHTTPClient_EmptyCAs(t *testing.T) {
 	listen := func() {
 		listenerReady <- struct{}{} // Signal that listener is ready (using empty struct)
 		//nolint:gosec // client timeouts not a concern in tests
-		err := http.ServeTLS(listener, nil, certFile.Name(), keyFile.Name())
-		t.Log("server stopped", err)
+		serveErr := http.ServeTLS(listener, nil, certFile.Name(), keyFile.Name())
+		t.Log("server stopped", serveErr)
 	}
 	go listen()
 
@@ -263,14 +263,9 @@ func Test_AddHeaders_AddsDefaultAndAuthHeaders(t *testing.T) {
 	net := NewNetworkAccess(config)
 	net.AddHeaderField("secret-header", "secret-value")
 
-	request, _ := http.NewRequest("GET", "https://api.snyk.io", nil)
+	request, _ := http.NewRequest(http.MethodGet, "https://api.snyk.io", nil)
 	err := net.AddHeaders(request)
 	assert.Nil(t, err)
-
-	keys := make([]string, 0, len(request.Header))
-	for k := range request.Header {
-		keys = append(keys, k)
-	}
 
 	assert.Equal(t, expectedHeader, request.Header)
 }
@@ -293,7 +288,7 @@ func Test_AddUserAgent_AddsUserAgentHeaderToSnykApiRequests(t *testing.T) {
 
 	config := getConfig()
 	net := NewNetworkAccess(config)
-	request, err := http.NewRequest("GET", "https://api.snyk.io", nil)
+	request, err := http.NewRequest(http.MethodGet, "https://api.snyk.io", nil)
 	assert.Nil(t, err)
 	userAgentInfo := UserAgentInfo{
 		App:                           app,
@@ -326,7 +321,7 @@ func Test_AddUserAgent_MissingIntegrationEnvironment_FormattedCorrectly(t *testi
 
 	config := getConfig()
 	net := NewNetworkAccess(config)
-	request, err := http.NewRequest("GET", "https://api.snyk.io", nil)
+	request, err := http.NewRequest(http.MethodGet, "https://api.snyk.io", nil)
 	assert.Nil(t, err)
 
 	userAgentInfo := UserAgentInfo{
@@ -355,7 +350,7 @@ func Test_AddUserAgent_NoIntegrationInfo_FormattedCorrectly(t *testing.T) {
 
 	config := getConfig()
 	net := NewNetworkAccess(config)
-	request, err := http.NewRequest("GET", "https://api.snyk.io", nil)
+	request, err := http.NewRequest(http.MethodGet, "https://api.snyk.io", nil)
 	assert.Nil(t, err)
 	t.Run("Without integration environment", func(t *testing.T) {
 		userAgentInfo := UserAgentInfo{

--- a/pkg/workflow/dataimpl.go
+++ b/pkg/workflow/dataimpl.go
@@ -67,7 +67,7 @@ func (d *DataImpl) SetMetaData(key string, value string) {
 // GetMetaData returns the value of the given header key.
 func (d *DataImpl) GetMetaData(key string) (string, error) {
 	var value string
-	err := fmt.Errorf("Key '%s' not found!", key)
+	err := fmt.Errorf("key '%s' not found", key)
 	if values, ok := d.header[key]; ok {
 		if len(values) > 0 {
 			value = values[0]

--- a/pkg/workflow/dataimpl_test.go
+++ b/pkg/workflow/dataimpl_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func Test_NewDataFromInput(t *testing.T) {
-
 	expectedContentType := "application/json"
 	expectedContentType2 := "application/binary"
 	expectedContentLocation := "/folder/of/source/file.json"
@@ -33,5 +32,4 @@ func Test_NewDataFromInput(t *testing.T) {
 
 	fmt.Println(input)
 	fmt.Println(output)
-
 }

--- a/pkg/workflow/engineimpl.go
+++ b/pkg/workflow/engineimpl.go
@@ -155,7 +155,7 @@ func (e *EngineImpl) Register(id Identifier, config ConfigurationOptions, entryP
 	}
 
 	if config == nil {
-		return nil, fmt.Errorf("Config must not be nil")
+		return nil, fmt.Errorf("config must not be nil")
 	}
 
 	if id == nil {


### PR DESCRIPTION
Adding golangci-lint to the lint Makefile target, which means it will gate CI.

This PR is a little long, but I've tried to scope it down to a handful of rulesets whose changes are mechanical and generally low-risk (do not introduce significant logic changes, breaking API changes or refactoring).

I've also commented out the rules that I'd like to revisit in followups, especially the ones that will require careful review and possibly some discussion to address.