### PR TITLE
chore: satisfy lint errcheck rule

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -170,10 +170,6 @@ issues:
     - path: test/
       linters:
         - testpackage
-    - path: \.go
-      linters:
-        # TODO: revisit this one; ignoring errors is BAD
-        - errcheck
   include:
     - EXC0012
     - EXC0014

--- a/internal/api/urls.go
+++ b/internal/api/urls.go
@@ -15,6 +15,11 @@ const (
 	appPrefix    string = "app"
 )
 
+var (
+	apiRegexp = regexp.MustCompile(apiPattern)
+	appRegexp = regexp.MustCompile(appPattern)
+)
+
 func isImmutableHost(host string) bool {
 	knownHostNames := map[string]bool{
 		"localhost": true,
@@ -54,10 +59,8 @@ func GetCanonicalApiUrl(url url.URL) (string, error) {
 	if isImmutableHost(url.Host) {
 		url.Path = strings.Replace(url.Path, "/v1", "", 1)
 	} else {
-		appRegexp, _ := regexp.Compile(appPattern)
 		url.Host = appRegexp.ReplaceAllString(url.Host, apiPrefixDot)
 
-		apiRegexp, _ := regexp.Compile(apiPattern)
 		if !apiRegexp.MatchString(url.Host) {
 			url.Host = apiPrefixDot + url.Host
 		}
@@ -83,7 +86,6 @@ func DeriveSubdomainUrl(canonicalUrl string, subdomain string) (string, error) {
 		return result, err
 	}
 
-	apiRegexp, _ := regexp.Compile(apiPattern)
 	url.Host = apiRegexp.ReplaceAllString(url.Host, subdomain+".")
 
 	result = url.String()

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -228,7 +228,9 @@ func (a *AnalyticsImpl) GetOutputData() *analyticsOutput {
 	// deepcode ignore InsecureHash: It is just being used to generate an id, without any security concerns
 	//nolint:gosec // sha1 only used to generate an id
 	shasum := sha1.New()
+	//nolint:errcheck // breaking api change needed to fix this
 	uuid, _ := uuid.GenerateUUID()
+	//nolint:errcheck // breaking api change needed to fix this
 	io.WriteString(shasum, uuid)
 	output.Id = fmt.Sprintf("%x", shasum.Sum(nil))
 
@@ -279,7 +281,10 @@ func (a *AnalyticsImpl) GetRequest() (*http.Request, error) {
 		return nil, err
 	}
 
-	analyticsUrl, _ := url.Parse(a.apiUrl + apiEndpoint)
+	analyticsUrl, err := url.Parse(a.apiUrl + apiEndpoint)
+	if err != nil {
+		return nil, err
+	}
 	if len(a.org) > 0 {
 		query := url.Values{}
 		query.Add("org", a.org)

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -118,23 +118,26 @@ func Test_SanitizeValuesByKey(t *testing.T) {
 
 	// test input
 	filter := sensitiveFieldNames
-	input, _ := json.Marshal(inputStruct)
+	input, err := json.Marshal(inputStruct)
+	assert.NoError(t, err)
+
 	replacement := sanitizeReplacementString
 
 	fmt.Println("Before: " + string(input))
 
 	// invoke method under test
 	output, err := SanitizeValuesByKey(filter, replacement, input)
+	assert.NoError(t, err)
 
 	fmt.Println("After: " + string(output))
 
-	assert.Nil(t, err, "Failed to santize!")
+	assert.NoError(t, err, "Failed to santize!")
 	actualNumberOfRedacted := strings.Count(string(output), replacement)
 	assert.Equal(t, expectedNumberOfRedacted, actualNumberOfRedacted)
 
 	var outputStruct sanTest
 	err = json.Unmarshal(output, &outputStruct)
-	assert.Nil(t, err, "Failed to decode json object!")
+	assert.NoError(t, err, "Failed to decode json object!")
 
 	// count how often the known secrets are being found in the input and the output
 	secretsCountAfter := 0
@@ -201,14 +204,15 @@ func Test_SanitizeUsername(t *testing.T) {
 			Other:    fmt.Sprintf("some other value where %s is contained", rawUserName),
 		}
 
-		input, _ := json.Marshal(inputStruct)
+		input, err := json.Marshal(inputStruct)
+		assert.NoError(t, err)
 		fmt.Printf("%d - Before: %s\n", i, string(input))
 
 		// invoke method under test
 		output, err := SanitizeUsername(rawUserName, homeDir, replacement, input)
 
 		fmt.Printf("%d - After: %s\n", i, string(output))
-		assert.Nil(t, err, "Failed to santize static values!")
+		assert.NoError(t, err, "Failed to santize static values!")
 
 		numRedacted := strings.Count(string(output), replacement)
 		assert.Equal(t, 2, numRedacted)
@@ -223,7 +227,8 @@ func Test_SanitizeUsername(t *testing.T) {
 		assert.Equal(t, 0, numHomeDirInstances)
 
 		var outputStruct sanTest
-		json.Unmarshal(output, &outputStruct)
+		err = json.Unmarshal(output, &outputStruct)
+		assert.NoError(t, err)
 	}
 }
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -43,7 +43,10 @@ func initConfiguration(engine workflow.Engine, config configuration.Configuratio
 			}
 		}
 
-		apiString, _ := api.GetCanonicalApiUrlFromString(urlString)
+		apiString, err := api.GetCanonicalApiUrlFromString(urlString)
+		if err != nil {
+			logger.Warn().Err(err).Str(configuration.API_URL, urlString).Msg("failed to get api url")
+		}
 		return apiString
 	})
 

--- a/pkg/auth/authenticator_test.go
+++ b/pkg/auth/authenticator_test.go
@@ -11,7 +11,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func getTestOauthTokenStorageType() string {
+func getTestOauthTokenStorageType(t *testing.T) string {
+	t.Helper()
 	expectedToken := &oauth2.Token{
 		AccessToken:  "a",
 		TokenType:    "b",
@@ -19,7 +20,8 @@ func getTestOauthTokenStorageType() string {
 		Expiry:       time.Now(),
 	}
 
-	expectedTokenString, _ := json.Marshal(expectedToken)
+	expectedTokenString, err := json.Marshal(expectedToken)
+	assert.NoError(t, err)
 	return string(expectedTokenString)
 }
 
@@ -32,7 +34,7 @@ func Test_CreateAuthenticator_token(t *testing.T) {
 
 func Test_CreateAuthenticator_token_oauthDisabled(t *testing.T) {
 	config := configuration.NewFromFiles("")
-	config.Set(CONFIG_KEY_OAUTH_TOKEN, getTestOauthTokenStorageType())
+	config.Set(CONFIG_KEY_OAUTH_TOKEN, getTestOauthTokenStorageType(t))
 	config.Set(configuration.AUTHENTICATION_TOKEN, "api token")
 	config.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, false)
 
@@ -43,7 +45,7 @@ func Test_CreateAuthenticator_token_oauthDisabled(t *testing.T) {
 
 func Test_CreateAuthenticator_oauth_oauthEnabled(t *testing.T) {
 	config := configuration.NewFromFiles("")
-	config.Set(CONFIG_KEY_OAUTH_TOKEN, getTestOauthTokenStorageType())
+	config.Set(CONFIG_KEY_OAUTH_TOKEN, getTestOauthTokenStorageType(t))
 	config.Set(configuration.AUTHENTICATION_TOKEN, "api token")
 	config.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, true)
 

--- a/pkg/auth/oauth2authenticator.go
+++ b/pkg/auth/oauth2authenticator.go
@@ -372,10 +372,8 @@ func (o *oAuth2Authenticator) authenticateWithAuthorizationCode() error {
 		return err
 	}
 
-	if err = o.persistToken(token); err != nil {
-		return err
-	}
-	return nil
+	err = o.persistToken(token)
+	return err
 }
 
 func (o *oAuth2Authenticator) AddAuthenticationHeader(request *http.Request) error {

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -156,6 +156,7 @@ func readConfigFilesIntoViper(files []string, config *extendedViper) {
 	config.viper.AddConfigPath(".")
 
 	// read config files
+	//nolint:errcheck // breaking api change needed to fix this
 	_ = config.viper.ReadInConfig()
 }
 
@@ -191,6 +192,7 @@ func (ev *extendedViper) Clone() Configuration {
 	}
 
 	for _, v := range ev.flagsets {
+		//nolint:errcheck // breaking api change needed to fix this
 		clone.AddFlagSet(v)
 	}
 
@@ -206,6 +208,7 @@ func (ev *extendedViper) Set(key string, value interface{}) {
 	ev.mutex.Unlock()
 
 	if ev.storage != nil && ev.persistedKeys[key] {
+		//nolint:errcheck // breaking api change needed to fix this
 		_ = ev.storage.Set(key, value)
 	}
 }
@@ -278,7 +281,10 @@ func (ev *extendedViper) GetBool(key string) bool {
 	case bool:
 		return v
 	case string:
-		boolResult, _ := strconv.ParseBool(v)
+		boolResult, err := strconv.ParseBool(v)
+		if err != nil {
+			return false
+		}
 		return boolResult
 	}
 
@@ -295,8 +301,11 @@ func (ev *extendedViper) GetInt(key string) int {
 	switch v := result.(type) {
 	case string:
 		stringResult := v
-		temp, _ := strconv.ParseInt(stringResult, 10, 32)
-		return int(temp)
+		i, err := strconv.ParseInt(stringResult, 10, 32)
+		if err != nil {
+			return 0
+		}
+		return int(i)
 	case float32:
 		return int(v)
 	case float64:
@@ -318,8 +327,11 @@ func (ev *extendedViper) GetFloat64(key string) float64 {
 	switch v := result.(type) {
 	case string:
 		stringResult := v
-		temp, _ := strconv.ParseFloat(stringResult, 64)
-		return temp
+		f, err := strconv.ParseFloat(stringResult, 64)
+		if err != nil {
+			return 0
+		}
+		return f
 	case float32:
 		return float64(v)
 	case float64:

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -163,6 +163,14 @@ func Test_ConfigurationSet_differentCases(t *testing.T) {
 	actualValueFloat = config.GetFloat64("number")
 	assert.Equal(t, 798.36, actualValueFloat)
 
+	// assert existing behavior: invalid float is 0
+	actualValueFloat = config.GetFloat64("api")
+	assert.Equal(t, 0.0, actualValueFloat)
+
+	// assert existing behavior: invalid int is 0
+	actualValueInt = config.GetInt("api")
+	assert.Equal(t, 0, actualValueInt)
+
 	cleanupConfigstore(t)
 }
 

--- a/pkg/configuration/storage_test.go
+++ b/pkg/configuration/storage_test.go
@@ -6,8 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
 )
 
 const key = "someKey"
@@ -64,15 +65,16 @@ func Test_JsonStorage_Set_ConfigFileHasValues(t *testing.T) {
 		preExistingKey: preExistingValue,
 	}
 
-	unknownJson, _ := json.Marshal(preExistingConfig)
+	unknownJson, err := json.Marshal(preExistingConfig)
+	assert.NoError(t, err)
 	configFile := filepath.Join(t.TempDir(), "test.json")
-	err := os.WriteFile(configFile, unknownJson, 0666)
-	assert.Nil(t, err)
+	err = os.WriteFile(configFile, unknownJson, 0666)
+	assert.NoError(t, err)
 	storage := configuration.NewJsonStorage(configFile)
 
 	// Act
 	err = storage.Set(key, expectedValue)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Assert
 	storedConfig := readStoredConfigFile(t, configFile)
@@ -90,9 +92,9 @@ func Test_JsonStorage_Set_ConfigFileHasValues(t *testing.T) {
 		const newValue = "new value"
 		assert.Contains(t, storedConfig, key)
 		err = storage.Set(key, newValue)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		storedConfig = readStoredConfigFile(t, configFile)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, newValue, storedConfig[key])
 	})
 }

--- a/pkg/networking/certs/certs_test.go
+++ b/pkg/networking/certs/certs_test.go
@@ -24,8 +24,10 @@ func Test_GetExtraCaCert_InvalidPathSpecified(t *testing.T) {
 }
 
 func Test_GetExtraCaCert_InvalidCertSpecified(t *testing.T) {
-	file, _ := os.CreateTemp("", "")
-	file.Write([]byte{'h', 'e', 'l', 'l', 'o'})
+	file, err := os.CreateTemp("", "")
+	assert.NoError(t, err)
+	_, err = file.Write([]byte{'h', 'e', 'l', 'l', 'o'})
+	assert.NoError(t, err)
 
 	extraCertificateBytes, extraCertificateList, extraCertificateError := GetExtraCaCert(file.Name())
 	fmt.Println(string(extraCertificateBytes))
@@ -34,54 +36,68 @@ func Test_GetExtraCaCert_InvalidCertSpecified(t *testing.T) {
 	assert.NotNil(t, extraCertificateError)
 
 	// cleanup
-	os.Remove(file.Name())
+	err = os.Remove(file.Name())
+	assert.NoError(t, err)
 }
 
 func Test_GetExtraCaCert_CertSpecified(t *testing.T) {
 	logger := log.Default()
-	certPem, _, _ := MakeSelfSignedCert("mycert", []string{"dns"}, logger)
-	file, _ := os.CreateTemp("", "")
-	file.Write(certPem)
+	certPem, _, err := MakeSelfSignedCert("mycert", []string{"dns"}, logger)
+	assert.NoError(t, err)
+	file, err := os.CreateTemp("", "")
+	assert.NoError(t, err)
+	_, err = file.Write(certPem)
+	assert.NoError(t, err)
 
 	extraCertificateBytes, extraCertificateList, extraCertificateError := GetExtraCaCert(file.Name())
 	assert.Len(t, extraCertificateList, 1)
 	assert.NotEmpty(t, extraCertificateBytes)
-	assert.Nil(t, extraCertificateError)
+	assert.NoError(t, extraCertificateError)
 
 	// cleanup
-	os.Remove(file.Name())
+	err = os.Remove(file.Name())
+	assert.NoError(t, err)
 }
 
 func Test_AppendExtraCaCert_AddOneCert(t *testing.T) {
 	logger := log.Default()
-	extraCertPem, _, _ := MakeSelfSignedCert("mycert", []string{"dns"}, logger)
-	certPem, _, _ := MakeSelfSignedCert("mycert", []string{"dns"}, logger)
-	file, _ := os.CreateTemp("", "")
-	file.Write(extraCertPem)
+	extraCertPem, _, err := MakeSelfSignedCert("mycert", []string{"dns"}, logger)
+	assert.NoError(t, err)
+	certPem, _, err := MakeSelfSignedCert("mycert", []string{"dns"}, logger)
+	assert.NoError(t, err)
+	file, err := os.CreateTemp("", "")
+	assert.NoError(t, err)
+	_, err = file.Write(extraCertPem)
+	assert.NoError(t, err)
 
 	certPem = AppendExtraCaCert(file.Name(), certPem)
 
 	certList, err := GetAllCerts(certPem)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, len(certList))
 
 	// cleanup
-	os.Remove(file.Name())
+	err = os.Remove(file.Name())
+	assert.NoError(t, err)
 }
 
 func Test_AppendExtraCaCert_AddNoCert(t *testing.T) {
 	logger := log.Default()
 	extraCertPem := "djalks"
-	certPem, _, _ := MakeSelfSignedCert("mycert", []string{"dns"}, logger)
-	file, _ := os.CreateTemp("", "")
-	file.Write([]byte(extraCertPem))
+	certPem, _, err := MakeSelfSignedCert("mycert", []string{"dns"}, logger)
+	assert.NoError(t, err)
+	file, err := os.CreateTemp("", "")
+	assert.NoError(t, err)
+	_, err = file.Write([]byte(extraCertPem))
+	assert.NoError(t, err)
 
 	certPem = AppendExtraCaCert(file.Name(), certPem)
 
 	certList, err := GetAllCerts(certPem)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(certList))
 
 	// cleanup
-	os.Remove(file.Name())
+	err = os.Remove(file.Name())
+	assert.NoError(t, err)
 }

--- a/pkg/networking/middleware/auth_header_test.go
+++ b/pkg/networking/middleware/auth_header_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 func Test_ShouldRequireAuthentication(t *testing.T) {
-	apiUrl, _ := api.GetCanonicalApiUrlFromString("https://api.au.snyk.io")
+	apiUrl, err := api.GetCanonicalApiUrlFromString("https://api.au.snyk.io")
+	assert.NoError(t, err)
 
 	cases := map[string]bool{
 		"https://app.au.snyk.io":                 true,
@@ -28,7 +29,8 @@ func Test_ShouldRequireAuthentication(t *testing.T) {
 	additionalSubdomains := []string{}
 
 	for u, expected := range cases {
-		requestUrl, _ := url.Parse(u)
+		requestUrl, err := url.Parse(u)
+		assert.NoError(t, err)
 		actual, err := middleware.ShouldRequireAuthentication(apiUrl, requestUrl, additionalSubdomains, additionalSubdomains)
 		assert.Nil(t, err)
 		assert.Equal(t, expected, actual)
@@ -36,7 +38,8 @@ func Test_ShouldRequireAuthentication(t *testing.T) {
 }
 
 func Test_ShouldRequireAuthentication_subdomains(t *testing.T) {
-	apiUrl, _ := api.GetCanonicalApiUrlFromString("https://api.eu.snyk.io")
+	apiUrl, err := api.GetCanonicalApiUrlFromString("https://api.eu.snyk.io")
+	assert.NoError(t, err)
 
 	cases := map[string]bool{
 		"https://mydomain.eu.snyk.io:443": true,
@@ -51,7 +54,8 @@ func Test_ShouldRequireAuthentication_subdomains(t *testing.T) {
 
 	for u, expected := range cases {
 		t.Run(u, func(t *testing.T) {
-			requestUrl, _ := url.Parse(u)
+			requestUrl, err := url.Parse(u)
+			assert.NoError(t, err)
 			actual, err := middleware.ShouldRequireAuthentication(apiUrl, requestUrl, additionalSubdomains, additionalUrls)
 			assert.Nil(t, err)
 			assert.Equal(t, expected, actual)
@@ -67,18 +71,20 @@ func Test_AddAuthenticationHeader(t *testing.T) {
 	config.Set(configuration.AUTHENTICATION_SUBDOMAINS, []string{"deeproxy"})
 
 	// case: headers added (api)
-	url, _ := url.Parse("https://app.snyk.io/rest/endpoint1")
+	url, err := url.Parse("https://app.snyk.io/rest/endpoint1")
+	assert.NoError(t, err)
 	request := &http.Request{
 		URL: url,
 	}
 
 	authenticator.EXPECT().AddAuthenticationHeader(request).Times(1)
 
-	err := middleware.AddAuthenticationHeader(authenticator, config, request)
-	assert.Nil(t, err)
+	err = middleware.AddAuthenticationHeader(authenticator, config, request)
+	assert.NoError(t, err)
 
 	// case: headers added (deeproxy)
-	url2, _ := url.Parse("https://deeproxy.snyk.io/rest/endpoint23")
+	url2, err := url.Parse("https://deeproxy.snyk.io/rest/endpoint23")
+	assert.NoError(t, err)
 	request2 := &http.Request{
 		URL: url2,
 	}
@@ -86,14 +92,15 @@ func Test_AddAuthenticationHeader(t *testing.T) {
 	authenticator.EXPECT().AddAuthenticationHeader(request2).Times(1)
 
 	err = middleware.AddAuthenticationHeader(authenticator, config, request2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// case: no headers added
-	url3, _ := url.Parse("https://app.au.snyk.io/rest/endpoint1")
+	url3, err := url.Parse("https://app.au.snyk.io/rest/endpoint1")
+	assert.NoError(t, err)
 	request3 := &http.Request{
 		URL: url3,
 	}
 
 	err = middleware.AddAuthenticationHeader(authenticator, config, request3)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }

--- a/pkg/networking/networking.go
+++ b/pkg/networking/networking.go
@@ -142,6 +142,7 @@ func (n *networkImpl) addDefaultHeader(request *http.Request) {
 }
 
 func (n *networkImpl) getUnauthorizedRoundTripper() http.RoundTripper {
+	//nolint:errcheck // breaking api change needed to fix this
 	transport := http.DefaultTransport.(*http.Transport) //nolint:forcetypeassert // panic here is reasonable
 	rt := defaultHeadersRoundTripper{
 		networkAccess:            n,

--- a/pkg/workflow/dataimpl.go
+++ b/pkg/workflow/dataimpl.go
@@ -94,12 +94,14 @@ func (d *DataImpl) GetIdentifier() Identifier {
 
 // GetContentType returns the Content-Type header of the given data instance.
 func (d *DataImpl) GetContentType() string {
+	//nolint:errcheck // breaking api change required to fix this
 	result, _ := d.GetMetaData(Content_type_key)
 	return result
 }
 
 // GetContentLocation returns the Content-Location header of the given data instance.
 func (d *DataImpl) GetContentLocation() string {
+	//nolint:errcheck // breaking api change required to fix this
 	result, _ := d.GetMetaData(Content_location_key)
 	return result
 }

--- a/pkg/workflow/engineimpl.go
+++ b/pkg/workflow/engineimpl.go
@@ -187,8 +187,12 @@ func (e *EngineImpl) GetWorkflows() []Identifier {
 	var result []Identifier
 
 	for k := range e.workflows {
-		tmp, _ := url.Parse(k)
-		result = append(result, tmp)
+		u, err := url.Parse(k)
+		if err != nil {
+			// a panic here is reasonable; how did we register an invalid URL in the first place?
+			panic(fmt.Sprintf("invalid workflow url: %q", k))
+		}
+		result = append(result, u)
 	}
 
 	return result


### PR DESCRIPTION
Handle error return values to the greatest extent possible.

Ignore errcheck in areas where a breaking API change would be required, to be addressed in followups.