### PR TITLE
feat: introduce feature flag for code test workflow

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -97,7 +97,7 @@ func (a *snykApiClient) GetFeatureFlag(flagname string) (bool, error) {
 		return defaultResult, fmt.Errorf("unable to retrieve feature flag (status: %d): %w", res.StatusCode, err)
 	}
 
-	if res.StatusCode != http.StatusOK || flag.Code == 401 || flag.Code == 403 {
+	if res.StatusCode != http.StatusOK || flag.Code == "401" || flag.Code == "403" {
 		return defaultResult, nil
 	}
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -16,6 +16,7 @@ type ApiClient interface {
 	GetDefaultOrgId() (orgID string, err error)
 	GetOrgIdFromSlug(slugName string) (string, error)
 	Init(url string, client *http.Client)
+	GetFeatureFlag(flagname string) (bool, error)
 }
 
 type snykApiClient struct {
@@ -74,6 +75,33 @@ func (a *snykApiClient) GetDefaultOrgId() (string, error) {
 	}
 
 	return userInfo.Data.Attributes.DefaultOrgContext, nil
+}
+
+func (a *snykApiClient) GetFeatureFlag(flagname string) (bool, error) {
+	const defaultResult = false
+
+	url := a.url + "/v1/cli-config/feature-flags/" + flagname
+	res, err := a.client.Get(url)
+	if err != nil {
+		return defaultResult, fmt.Errorf("unable to retrieve feature flag: %w", err)
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return defaultResult, fmt.Errorf("unable to retrieve feature flag: %w", err)
+	}
+
+	var flag contract.OrgFeatureFlagResponse
+	if err = json.Unmarshal(body, &flag); err != nil {
+		return defaultResult, fmt.Errorf("unable to retrieve feature flag (status: %d): %w", res.StatusCode, err)
+	}
+
+	if res.StatusCode != http.StatusOK || flag.Code == 401 || flag.Code == 403 {
+		return defaultResult, nil
+	}
+
+	return true, nil
 }
 
 func (a *snykApiClient) Init(url string, client *http.Client) {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -97,8 +97,8 @@ func (a *snykApiClient) GetFeatureFlag(flagname string) (bool, error) {
 		return defaultResult, fmt.Errorf("unable to retrieve feature flag (status: %d): %w", res.StatusCode, err)
 	}
 
-	if res.StatusCode != http.StatusOK || flag.Code == "401" || flag.Code == "403" {
-		return defaultResult, nil
+	if res.StatusCode != http.StatusOK || flag.Code == http.StatusUnauthorized || flag.Code == http.StatusForbidden {
+		return defaultResult, err
 	}
 
 	return true, nil

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -59,7 +59,7 @@ func Test_GetFeatureFlag_false(t *testing.T) {
 
 	featureFlagName := "myFlag"
 	featureFlagResponse := contract.OrgFeatureFlagResponse{
-		Code: "403",
+		Code: http.StatusForbidden,
 	}
 	server := setupSingleReponseServer(t, "/v1/cli-config/feature-flags/"+featureFlagName, featureFlagResponse)
 	api := api.NewApi(server.URL, http.DefaultClient)
@@ -79,7 +79,7 @@ func Test_GetFeatureFlag_true(t *testing.T) {
 
 	featureFlagName := "myFlag"
 	featureFlagResponse := contract.OrgFeatureFlagResponse{
-		Code: "200",
+		Code: http.StatusOK,
 	}
 	server := setupSingleReponseServer(t, "/v1/cli-config/feature-flags/"+featureFlagName, featureFlagResponse)
 	api := api.NewApi(server.URL, http.DefaultClient)

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -133,7 +133,7 @@ func newHttpHandler(t *testing.T, url string, resp []byte) http.HandlerFunc {
 	t.Helper()
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.String() != url {
-			w.WriteHeader(403)
+			w.WriteHeader(http.StatusForbidden)
 			return
 		}
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -59,7 +59,7 @@ func Test_GetFeatureFlag_false(t *testing.T) {
 
 	featureFlagName := "myFlag"
 	featureFlagResponse := contract.OrgFeatureFlagResponse{
-		Code: 403,
+		Code: "403",
 	}
 	server := setupSingleReponseServer(t, "/v1/cli-config/feature-flags/"+featureFlagName, featureFlagResponse)
 	api := api.NewApi(server.URL, http.DefaultClient)
@@ -79,7 +79,7 @@ func Test_GetFeatureFlag_true(t *testing.T) {
 
 	featureFlagName := "myFlag"
 	featureFlagResponse := contract.OrgFeatureFlagResponse{
-		Code: 200,
+		Code: "200",
 	}
 	server := setupSingleReponseServer(t, "/v1/cli-config/feature-flags/"+featureFlagName, featureFlagResponse)
 	api := api.NewApi(server.URL, http.DefaultClient)

--- a/internal/api/contract/OrgFeatureFlagResponse.go
+++ b/internal/api/contract/OrgFeatureFlagResponse.go
@@ -3,6 +3,6 @@ package contract
 type OrgFeatureFlagResponse struct {
 	Ok          bool   `json:"ok,omitempty"`
 	UserMessage string `json:"userMessage,omitempty"`
-	Code        string `json:"code,omitempty"`
+	Code        int    `json:"code,omitempty,string"`
 	Error       string `json:"error,omitempty"`
 }

--- a/internal/api/contract/OrgFeatureFlagResponse.go
+++ b/internal/api/contract/OrgFeatureFlagResponse.go
@@ -1,8 +1,8 @@
 package contract
 
 type OrgFeatureFlagResponse struct {
-	Ok          bool    `json:"ok,omitempty"`
-	UserMessage string  `json:"userMessage,omitempty"`
-	Code        float64 `json:"code,omitempty"`
-	Error       string  `json:"error,omitempty"`
+	Ok          bool   `json:"ok,omitempty"`
+	UserMessage string `json:"userMessage,omitempty"`
+	Code        string `json:"code,omitempty"`
+	Error       string `json:"error,omitempty"`
 }

--- a/internal/api/contract/OrgFeatureFlagResponse.go
+++ b/internal/api/contract/OrgFeatureFlagResponse.go
@@ -1,0 +1,8 @@
+package contract
+
+type OrgFeatureFlagResponse struct {
+	Ok          bool    `json:"ok,omitempty"`
+	UserMessage string  `json:"userMessage,omitempty"`
+	Code        float64 `json:"code,omitempty"`
+	Error       string  `json:"error,omitempty"`
+}

--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -49,6 +49,21 @@ func (mr *MockApiClientMockRecorder) GetDefaultOrgId() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultOrgId", reflect.TypeOf((*MockApiClient)(nil).GetDefaultOrgId))
 }
 
+// GetFeatureFlag mocks base method.
+func (m *MockApiClient) GetFeatureFlag(flagname string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFeatureFlag", flagname)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFeatureFlag indicates an expected call of GetFeatureFlag.
+func (mr *MockApiClientMockRecorder) GetFeatureFlag(flagname interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFeatureFlag", reflect.TypeOf((*MockApiClient)(nil).GetFeatureFlag), flagname)
+}
+
 // GetOrgIdFromSlug mocks base method.
 func (m *MockApiClient) GetOrgIdFromSlug(slugName string) (string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -104,6 +104,22 @@ func initConfiguration(engine workflow.Engine, config configuration.Configuratio
 			return existingValue
 		}
 	})
+
+	config.AddDefaultValue(configuration.FF_CODE_CONSISTENT_IGNORES, func(existingValue interface{}) interface{} {
+		if existingValue == nil {
+			flagname := "snykCodeConsistentIgnores"
+			client := engine.GetNetworkAccess().GetHttpClient()
+			url := config.GetString(configuration.API_URL)
+			apiClient.Init(url, client)
+			result, err := apiClient.GetFeatureFlag(flagname)
+			if err != nil {
+				logger.Printf("Failed to determine feature flag \"%s\": %s", flagname, err)
+			}
+			return result
+		} else {
+			return existingValue
+		}
+	})
 }
 
 // CreateAppEngine creates a new workflow engine.

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -17,6 +17,25 @@ import (
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )
 
+func defaultFunc_FF_CODE_CONSISTENT_IGNORES(engine workflow.Engine, config configuration.Configuration, apiClient api.ApiClient, logger *zerolog.Logger) configuration.DefaultValueFunction {
+	callback := func(existingValue interface{}) interface{} {
+		if existingValue == nil {
+			flagname := "snykCodeConsistentIgnores"
+			client := engine.GetNetworkAccess().GetHttpClient()
+			url := config.GetString(configuration.API_URL)
+			apiClient.Init(url, client)
+			result, err := apiClient.GetFeatureFlag(flagname)
+			if err != nil {
+				logger.Printf("Failed to determine feature flag \"%s\": %s", flagname, err)
+			}
+			return result
+		} else {
+			return existingValue
+		}
+	}
+	return callback
+}
+
 // initConfiguration initializes the configuration with initial values.
 func initConfiguration(engine workflow.Engine, config configuration.Configuration, apiClient api.ApiClient, logger *zerolog.Logger) {
 	if logger == nil {
@@ -105,21 +124,7 @@ func initConfiguration(engine workflow.Engine, config configuration.Configuratio
 		}
 	})
 
-	config.AddDefaultValue(configuration.FF_CODE_CONSISTENT_IGNORES, func(existingValue interface{}) interface{} {
-		if existingValue == nil {
-			flagname := "snykCodeConsistentIgnores"
-			client := engine.GetNetworkAccess().GetHttpClient()
-			url := config.GetString(configuration.API_URL)
-			apiClient.Init(url, client)
-			result, err := apiClient.GetFeatureFlag(flagname)
-			if err != nil {
-				logger.Printf("Failed to determine feature flag \"%s\": %s", flagname, err)
-			}
-			return result
-		} else {
-			return existingValue
-		}
-	})
+	config.AddDefaultValue(configuration.FF_CODE_CONSISTENT_IGNORES, defaultFunc_FF_CODE_CONSISTENT_IGNORES(engine, config, apiClient, logger))
 }
 
 // CreateAppEngine creates a new workflow engine.

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -194,7 +194,6 @@ func Test_initConfiguration_NOT_snykgov(t *testing.T) {
 }
 
 func Test_initConfiguration_FF_CODE_CONSISTENT_IGNORES(t *testing.T) {
-
 	// setup mock
 	ctrl := gomock.NewController(t)
 	mockApiClient := mocks.NewMockApiClient(ctrl)

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -190,4 +191,27 @@ func Test_initConfiguration_NOT_snykgov(t *testing.T) {
 
 	isFedramp := config.GetBool(configuration.IS_FEDRAMP)
 	assert.False(t, isFedramp)
+}
+
+func Test_initConfiguration_FF_CODE_CONSISTENT_IGNORES(t *testing.T) {
+
+	// setup mock
+	ctrl := gomock.NewController(t)
+	mockApiClient := mocks.NewMockApiClient(ctrl)
+	mockApiClient.EXPECT().Init(gomock.Any(), gomock.Any()).AnyTimes()
+	mockApiClient.EXPECT().GetFeatureFlag("snykCodeConsistentIgnores").Return(true, nil).Times(1)
+	mockApiClient.EXPECT().GetFeatureFlag("snykCodeConsistentIgnores").Return(false, nil).Times(1)
+	mockApiClient.EXPECT().GetFeatureFlag("snykCodeConsistentIgnores").Return(false, fmt.Errorf("error")).Times(1)
+
+	config := configuration.NewInMemory()
+	initConfiguration(workflow.NewWorkFlowEngine(config), config, mockApiClient, &zlog.Logger)
+
+	consistentIgnores := config.GetBool(configuration.FF_CODE_CONSISTENT_IGNORES)
+	assert.True(t, consistentIgnores)
+
+	consistentIgnores = config.GetBool(configuration.FF_CODE_CONSISTENT_IGNORES)
+	assert.False(t, consistentIgnores)
+
+	consistentIgnores = config.GetBool(configuration.FF_CODE_CONSISTENT_IGNORES)
+	assert.False(t, consistentIgnores)
 }

--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -31,6 +31,7 @@ const (
 
 	// feature flags
 	FF_OAUTH_AUTH_FLOW_ENABLED string = "internal_snyk_oauth_enabled"
+	FF_CODE_CONSISTENT_IGNORES string = "internal_snyk_code_ignores_enabled"
 
 	// flags
 	FLAG_EXPERIMENTAL string = "experimental"

--- a/pkg/local_workflows/code_workflow.go
+++ b/pkg/local_workflows/code_workflow.go
@@ -3,9 +3,10 @@ package localworkflows
 import (
 	"os"
 
+	"github.com/spf13/pflag"
+
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
-	"github.com/spf13/pflag"
 )
 
 const (
@@ -45,7 +46,7 @@ func InitCodeWorkflow(engine workflow.Engine) error {
 
 // codeWorkflowEntryPoint is the entry point for the code workflow.
 // it provides a wrapper for the legacycli workflow
-func codeWorkflowEntryPoint(invocationCtx workflow.InvocationContext, _ []workflow.Data) (output []workflow.Data, err error) {
+func codeWorkflowEntryPoint(invocationCtx workflow.InvocationContext, _ []workflow.Data) (result []workflow.Data, err error) {
 	// get necessary objects from invocation context
 	config := invocationCtx.GetConfiguration()
 	logger := invocationCtx.GetEnhancedLogger()
@@ -56,11 +57,14 @@ func codeWorkflowEntryPoint(invocationCtx workflow.InvocationContext, _ []workfl
 
 	logger.Debug().Msg("code workflow start")
 
-	// run legacycli
-	legacyCliResponse, legacyCLIError := engine.InvokeWithConfig(workflow.NewWorkflowIdentifier("legacycli"), config)
-	if legacyCLIError != nil {
-		return nil, legacyCLIError
+	if config.GetBool(configuration.FF_CODE_CONSISTENT_IGNORES) {
+		logger.Debug().Msg("Ignores: Consistent")
+	} else {
+		logger.Debug().Msg("Ignores: legacy")
 	}
 
-	return legacyCliResponse, err
+	// run legacycli
+	result, err = engine.InvokeWithConfig(workflow.NewWorkflowIdentifier("legacycli"), config)
+
+	return result, err
 }


### PR DESCRIPTION
This PR adds a generic feature flag mechanism to the existing api client and uses this implementation to determine the value of a feature flag to enable a new code test workflow.
Currently the. feature flag only changes the log message but the test logic is the same.