### PR TITLE
feat: introduce --experimental for code extension

### DIFF
--- a/pkg/local_workflows/code_workflow_test.go
+++ b/pkg/local_workflows/code_workflow_test.go
@@ -46,3 +46,84 @@ func Test_Code_codeWorkflowEntryPoint_happyPath(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, rs)
 }
+
+func Test_Code_codeWorkflowEntryPoint_experimentalFlag(t *testing.T) {
+	// Verify that the experimental flag is not passed to the legacycli workflow
+	// and the legacycli workflow is invoked with the --json arguments
+	mockLegacyWorkFlowFn := func(invocation workflow.InvocationContext, input []workflow.Data) ([]workflow.Data, error) {
+		typeId := workflow.NewTypeIdentifier(invocation.GetWorkflowIdentifier(), "wfl1data")
+		d := workflow.NewData(typeId, "text/plain", nil)
+		assert.Equal(t, []string{"--json", "--severity-threshold=medium"}, invocation.GetConfiguration().Get(configuration.RAW_CMD_ARGS))
+		return []workflow.Data{d}, nil
+	}
+
+	//
+	config := configuration.New()
+	engine := workflow.NewWorkFlowEngine(config)
+
+	err := InitCodeWorkflow(engine)
+	assert.NoError(t, err)
+
+	// Create legacycli workflow
+	mockLegacyCliWorkflowId := workflow.NewWorkflowIdentifier("legacycli")
+	entry1, err := engine.Register(mockLegacyCliWorkflowId, workflow.ConfigurationOptionsFromFlagset(pflag.NewFlagSet("1", pflag.ExitOnError)), mockLegacyWorkFlowFn)
+	assert.Nil(t, err)
+	assert.NotNil(t, entry1)
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	// Method under test
+	wrkflw, ok := engine.GetWorkflow(WORKFLOWID_CODE)
+	assert.True(t, ok)
+	assert.NotNil(t, wrkflw)
+
+	os.Args = []string{"cmd", "--severity-threshold=medium", "--experimental", "--json"}
+
+	config.Set(configuration.FLAG_EXPERIMENTAL, true)
+	config.Set(configuration.RAW_CMD_ARGS, os.Args[1:])
+
+	rs, err := engine.InvokeWithConfig(WORKFLOWID_CODE, config)
+	assert.NoError(t, err)
+	assert.NotNil(t, rs)
+}
+
+func Test_Code_codeWorkflowEntryPoint_experimentalFlagAndReport(t *testing.T) {
+	// Verify that the experimental path is not taken when the --report flag is passed
+	mockLegacyWorkFlowFn := func(invocation workflow.InvocationContext, input []workflow.Data) ([]workflow.Data, error) {
+		typeId := workflow.NewTypeIdentifier(invocation.GetWorkflowIdentifier(), "wfl1data")
+		d := workflow.NewData(typeId, "text/plain", nil)
+		assert.Equal(t, []string{"--severity-threshold=medium", "--report"}, invocation.GetConfiguration().Get(configuration.RAW_CMD_ARGS))
+		return []workflow.Data{d}, nil
+	}
+
+	//
+	config := configuration.New()
+	engine := workflow.NewWorkFlowEngine(config)
+
+	err := InitCodeWorkflow(engine)
+	assert.NoError(t, err)
+
+	// Create legacycli workflow
+	mockLegacyCliWorkflowId := workflow.NewWorkflowIdentifier("legacycli")
+	entry1, err := engine.Register(mockLegacyCliWorkflowId, workflow.ConfigurationOptionsFromFlagset(pflag.NewFlagSet("1", pflag.ExitOnError)), mockLegacyWorkFlowFn)
+	assert.Nil(t, err)
+	assert.NotNil(t, entry1)
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	// Method under test
+	wrkflw, ok := engine.GetWorkflow(WORKFLOWID_CODE)
+	assert.True(t, ok)
+	assert.NotNil(t, wrkflw)
+
+	os.Args = []string{"cmd", "--severity-threshold=medium", "--report"}
+
+	config.Set(configuration.FLAG_EXPERIMENTAL, true)
+	config.Set(configuration.RAW_CMD_ARGS, os.Args[1:])
+
+	rs, err := engine.InvokeWithConfig(WORKFLOWID_CODE, config)
+	assert.NoError(t, err)
+	assert.NotNil(t, rs)
+}


### PR DESCRIPTION
Add a pathway for iterating on a new Go based rendering using --json output of the TypescriptCLI

**Manually check**

* Build a fresh version of the CLI locally and run `./binary-releases/snyk-macos-arm64 code test --experimental`, you will get JSON output that matches `snyk code test --json`