### PR TITLE
feat: skip test summary mime type

### DIFF
--- a/pkg/local_workflows/output_workflow.go
+++ b/pkg/local_workflows/output_workflow.go
@@ -44,6 +44,11 @@ func outputWorkflowEntryPoint(invocation workflow.InvocationContext, input []wor
 
 	for i := range input {
 		mimeType := input[i].GetContentType()
+
+		if strings.HasPrefix(mimeType, workflow.CONTENT_TYPE_TEST_SUMMARY) {
+			continue
+		}
+
 		contentLocation := input[i].GetContentLocation()
 		if len(contentLocation) == 0 {
 			contentLocation = "unknown"

--- a/pkg/local_workflows/output_workflow_test.go
+++ b/pkg/local_workflows/output_workflow_test.go
@@ -170,4 +170,51 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 		assert.Equal(t, []workflow.Data{}, output)
 		assert.Equal(t, "unsupported output type: hammer/head", err.Error())
 	})
+
+	t.Run("should reject test summary mimeType", func(t *testing.T) {
+		workflowIdentifier := workflow.NewTypeIdentifier(WORKFLOWID_OUTPUT_WORKFLOW, "output")
+		data := workflow.NewData(workflowIdentifier, workflow.CONTENT_TYPE_TEST_SUMMARY, []byte(payload))
+
+		// mock assertions
+		outputDestination.EXPECT().Println(payload).Return(0, nil).Times(0)
+
+		// execute
+		output, err := outputWorkflowEntryPoint(invocationContextMock, []workflow.Data{data}, outputDestination)
+
+		// assert
+		assert.Nil(t, err)
+		assert.Equal(t, []workflow.Data{}, output)
+	})
+
+	t.Run("should reject versioned test summary mimeType", func(t *testing.T) {
+		versionedTestSummaryContentType := workflow.CONTENT_TYPE_TEST_SUMMARY + "; version=2024-04-10"
+		workflowIdentifier := workflow.NewTypeIdentifier(WORKFLOWID_OUTPUT_WORKFLOW, "output")
+		data := workflow.NewData(workflowIdentifier, versionedTestSummaryContentType, []byte(payload))
+
+		// mock assertions
+		outputDestination.EXPECT().Println(payload).Return(0, nil).Times(0)
+
+		// execute
+		output, err := outputWorkflowEntryPoint(invocationContextMock, []workflow.Data{data}, outputDestination)
+
+		// assert
+		assert.Nil(t, err)
+		assert.Equal(t, []workflow.Data{}, output)
+	})
+
+	t.Run("should reject test summary mimeType and display known mimeType", func(t *testing.T) {
+		workflowIdentifier := workflow.NewTypeIdentifier(WORKFLOWID_OUTPUT_WORKFLOW, "output")
+		testSummaryData := workflow.NewData(workflowIdentifier, workflow.CONTENT_TYPE_TEST_SUMMARY, []byte(payload))
+		textData := workflow.NewData(workflowIdentifier, "text/plain", []byte(payload))
+
+		// mock assertions
+		outputDestination.EXPECT().Println(payload).Return(0, nil).Times(1)
+
+		// execute
+		output, err := outputWorkflowEntryPoint(invocationContextMock, []workflow.Data{testSummaryData, textData}, outputDestination)
+
+		// assert
+		assert.Nil(t, err)
+		assert.Equal(t, []workflow.Data{}, output)
+	})
 }


### PR DESCRIPTION
This will skip any inputs where the content type starts with the constant `CONTENT_TYPE_TEST_SUMMARY`. This will support potential future versioned test summary content types.