### PR TITLE
fix: expose TestSummaryResult struct

### DIFF
--- a/pkg/workflow/json_schemas/data_test_summary.go
+++ b/pkg/workflow/json_schemas/data_test_summary.go
@@ -40,12 +40,14 @@ const TestSummarySchema = `{
 	}
   }`
 
+type TestSummaryResult struct {
+	Severity string `json:"severity"`
+	Total    int    `json:"total"`
+	Open     int    `json:"open"`
+	Ignored  int    `json:"ignored"`
+}
+
 type TestSummary struct {
-	Results []struct {
-		Severity string `json:"severity"`
-		Total    int    `json:"total"`
-		Open     int    `json:"open"`
-		Ignored  int    `json:"ignored"`
-	} `json:"results"`
-	Type string `json:"type"`
+	Results []TestSummaryResult `json:"results"`
+	Type    string              `json:"type"`
 }


### PR DESCRIPTION
Make it easier for consumers to work with this struct by introducing a named type for the Results data. 

```go 
// Define some sample TestSummaryResult structs
critical := TestSummaryResult{
  Severity: "Critical",
  Total:    10,
  Open:     10,
  Ignored:  0,
}

high := TestSummaryResult{
  Severity: "High",
  Total:    20,
  Open:     17,
  Ignored:  3,
}

// Instantiate the TestSummary struct
summary := TestSummary{
  Type: "sbomz",
  Results: [] TestSummaryResult{critical, high},
}
```