### PR TITLE
chore: update gitleaks ignore

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,4 +1,4 @@
 # add false positives here
-d79fad3ae8f466378405aa61c2e273d1d478fa41:pkg/ui/testdata/4-high-5-medium.json:generic-api-key:1085
-d79fad3ae8f466378405aa61c2e273d1d478fa41:pkg/ui/testdata/4-high-5-medium.json:generic-api-key:1090
-d79fad3ae8f466378405aa61c2e273d1d478fa41:pkg/ui/testdata/4-high-5-medium.json:generic-api-key:1110
+52e404525dab2a3620df22892e4a11faa565fbf2:internal/presenters/testdata/4-high-5-medium.json:generic-api-key:1085
+52e404525dab2a3620df22892e4a11faa565fbf2:internal/presenters/testdata/4-high-5-medium.json:generic-api-key:1090
+52e404525dab2a3620df22892e4a11faa565fbf2:internal/presenters/testdata/4-high-5-medium.json:generic-api-key:1110


### PR DESCRIPTION
Looks like the path was wrong for these ignores, not sure how it ever worked. 