### PR TITLE
feat: support --include-ignores flag

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -2,3 +2,7 @@
 52e404525dab2a3620df22892e4a11faa565fbf2:internal/presenters/testdata/4-high-5-medium.json:generic-api-key:1085
 52e404525dab2a3620df22892e4a11faa565fbf2:internal/presenters/testdata/4-high-5-medium.json:generic-api-key:1090
 52e404525dab2a3620df22892e4a11faa565fbf2:internal/presenters/testdata/4-high-5-medium.json:generic-api-key:1110
+9cab824f0ff3d537545ff7705817fe05ff0cad54:internal/presenters/testdata/with-ignores.json:generic-api-key:159
+9cab824f0ff3d537545ff7705817fe05ff0cad54:internal/presenters/testdata/with-ignores.json:generic-api-key:224
+9cab824f0ff3d537545ff7705817fe05ff0cad54:internal/presenters/testdata/with-ignores.json:generic-api-key:474
+9cab824f0ff3d537545ff7705817fe05ff0cad54:internal/presenters/testdata/with-ignores.json:generic-api-key:539

--- a/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
+++ b/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
@@ -261,3 +261,62 @@ To edit or remove the ignore please go to: https://app.snyk.io/
 To view ignored and open issues, use the --include-ignores option.
 
 ---
+
+[TestPresenterSarifResultsPretty_IncludeIgnored - 1]
+
+Testing /path/to/project ...
+
+Open Issues
+
+ ✗ [LOW] Hardcoded Secret
+   Path: test/service-tests/service-utils/knex.service-spec.ts, line 72
+   Info: Avoid hardcoding values that are meant to be secret. Found a hardcoded string used in here.
+
+ ✗ [LOW] Hardcoded Secret
+   Path: test/service-tests/service-utils/knex.service-spec.ts, line 76
+   Info: Avoid hardcoding values that are meant to be secret. Found a hardcoded string used in here.
+
+ ✗ [MEDIUM] Cleartext Transmission of Sensitive Information
+   Path: src/main.ts, line 59
+   Info: http.createServer uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.
+
+ ✗ [HIGH] Hardcoded Secret
+   Path: scripts/db/migrations/20230811153738_add_generated_grouping_columns_to_collections_table.ts, line 4
+   Info: Avoid hardcoding values that are meant to be secret. Found a hardcoded string used in here.
+
+─────────────────────────────────────────────────────
+
+Ignored Issues
+
+ ! [ IGNORED ] [MEDIUM] Cleartext Transmission of Sensitive Information
+   Path: src/main.ts, line 58
+   Info: http.createServer uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.
+
+  Expiration: 15 days
+  Category:   Won't fix
+  Ignored on: February 23, 2024
+  Ignored by: Neil M
+  Reason:     False positive
+
+
+💡 Tip
+
+Ignores are currently managed in the Snyk Web UI.
+To edit or remove the ignore please go to: https://app.snyk.io/
+╭─────────────────────────────────────────────────────╮
+│ Test Summary                                        │
+│                                                     │
+│   Organization:      test-org                       │
+│   Test type:         Static code analysis           │
+│   Project path:      /path/to/project               │
+│                                                     │
+│   Total issues:   5                                 │
+│   Ignored issues: 1 [ 0 HIGH  1 MEDIUM  0 LOW ]     │
+│   Open issues:    4 [ 1 HIGH  1 MEDIUM  2 LOW ]     │
+╰─────────────────────────────────────────────────────╯
+
+💡 Tip
+
+To view ignored issues only, use the --only-ignores option.
+
+---

--- a/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
+++ b/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
@@ -233,12 +233,11 @@ Ignored Issues
    Path: src/main.ts, line 58
    Info: http.createServer uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.
 
-  Expiration: 15 days
-  Category:   Won't fix
-  Ignored on: February 23, 2024
-  Ignored by: Neil M
-  Reason:     False positive
-
+   Expiration: 15 days
+   Category:   Won't fix
+   Ignored on: February 23, 2024
+   Ignored by: Neil M
+   Reason:     False positive
 
 💡 Tip
 
@@ -292,12 +291,11 @@ Ignored Issues
    Path: src/main.ts, line 58
    Info: http.createServer uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.
 
-  Expiration: 15 days
-  Category:   Won't fix
-  Ignored on: February 23, 2024
-  Ignored by: Neil M
-  Reason:     False positive
-
+   Expiration: 15 days
+   Category:   Won't fix
+   Ignored on: February 23, 2024
+   Ignored by: Neil M
+   Reason:     False positive
 
 💡 Tip
 

--- a/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
+++ b/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
@@ -233,12 +233,12 @@ Ignored Issues
    Path: src/main.ts, line 58
    Info: http.createServer uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.
 
-      Expiration: 15 days
-   Category: Won't fix
+  Expiration: 15 days
+  Category:   Won't fix
+  Ignored on: February 23, 2024
+  Ignored by: Neil M
+  Reason:     False positive
 
-   Ignored on: February 23, 2024
-   Ignored by: Neil M 
-   Reason:     False positive
 
 💡 Tip
 

--- a/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
+++ b/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
@@ -222,3 +222,42 @@ Open Issues
 To view ignored issues, use the --include-ignores option. To view ignored issues only, use the --only-ignores option.
 
 ---
+
+[TestPresenterSarifResultsPretty_OnlyIgnored - 1]
+
+Testing /path/to/project ...
+
+Ignored Issues
+
+ ! [ IGNORED ] [MEDIUM] Cleartext Transmission of Sensitive Information
+   Path: src/main.ts, line 58
+   Info: http.createServer uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.
+
+      Expiration: 15 days
+   Category: Won't fix
+
+   Ignored on: February 23, 2024
+   Ignored by: Neil M 
+   Reason:     False positive
+
+💡 Tip
+
+Ignores are currently managed in the Snyk Web UI.
+To edit or remove the ignore please go to: https://app.snyk.io/
+╭─────────────────────────────────────────────────────╮
+│ Test Summary                                        │
+│                                                     │
+│   Organization:      test-org                       │
+│   Test type:         Static code analysis           │
+│   Project path:      /path/to/project               │
+│                                                     │
+│   Total issues:   5                                 │
+│   Ignored issues: 1 [ 0 HIGH  1 MEDIUM  0 LOW ]     │
+│   Open issues:    4 [ 1 HIGH  1 MEDIUM  2 LOW ]     │
+╰─────────────────────────────────────────────────────╯
+
+💡 Tip
+
+To view ignored and open issues, use the --include-ignores option.
+
+---

--- a/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
+++ b/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
@@ -177,3 +177,48 @@ Open Issues
 To view ignored issues, use the --include-ignores option. To view ignored issues only, use the --only-ignores option.
 
 ---
+
+[TestPresenterSarifResultsPretty_WithIgnored - 1]
+
+Testing /path/to/project ...
+
+Open Issues
+
+ ✗ [LOW] Hardcoded Secret
+   Path: test/service-tests/service-utils/knex.service-spec.ts, line 72
+   Info: Avoid hardcoding values that are meant to be secret. Found a hardcoded string used in here.
+
+ ✗ [LOW] Hardcoded Secret
+   Path: test/service-tests/service-utils/knex.service-spec.ts, line 76
+   Info: Avoid hardcoding values that are meant to be secret. Found a hardcoded string used in here.
+
+ ✗ [MEDIUM] Cleartext Transmission of Sensitive Information
+   Path: src/main.ts, line 58
+   Info: http.createServer uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.
+
+ ✗ [MEDIUM] Cleartext Transmission of Sensitive Information
+   Path: src/main.ts, line 59
+   Info: http.createServer uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.
+
+ ✗ [HIGH] Hardcoded Secret
+   Path: scripts/db/migrations/20230811153738_add_generated_grouping_columns_to_collections_table.ts, line 4
+   Info: Avoid hardcoding values that are meant to be secret. Found a hardcoded string used in here.
+
+
+╭─────────────────────────────────────────────────────╮
+│ Test Summary                                        │
+│                                                     │
+│   Organization:      test-org                       │
+│   Test type:         Static code analysis           │
+│   Project path:      /path/to/project               │
+│                                                     │
+│   Total issues:   5                                 │
+│   Ignored issues: 1 [ 0 HIGH  1 MEDIUM  0 LOW ]     │
+│   Open issues:    4 [ 1 HIGH  1 MEDIUM  2 LOW ]     │
+╰─────────────────────────────────────────────────────╯
+
+💡 Tip
+
+To view ignored issues, use the --include-ignores option. To view ignored issues only, use the --only-ignores option.
+
+---

--- a/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
+++ b/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
@@ -119,9 +119,9 @@ To view ignored issues, use the --include-ignores option. To view ignored issues
 
 [TestPresenterSarifResultsPretty_MediumHighIssuesWithColor - 1]
 
-Testing /path/to/project ...
+[1mTesting /path/to/project ...[0m
 
-Open Issues
+[1mOpen Issues[0m
 
  [33m✗ [MEDIUM][0m [1mCleartext Transmission of Sensitive Information[0m
    Path: app.js, line 63

--- a/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
+++ b/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
@@ -243,6 +243,7 @@ Ignored Issues
 
 Ignores are currently managed in the Snyk Web UI.
 To edit or remove the ignore please go to: https://app.snyk.io/
+
 ╭─────────────────────────────────────────────────────╮
 │ Test Summary                                        │
 │                                                     │
@@ -301,6 +302,7 @@ Ignored Issues
 
 Ignores are currently managed in the Snyk Web UI.
 To edit or remove the ignore please go to: https://app.snyk.io/
+
 ╭─────────────────────────────────────────────────────╮
 │ Test Summary                                        │
 │                                                     │

--- a/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
+++ b/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
@@ -230,8 +230,8 @@ Testing /path/to/project ...
 Ignored Issues
 
  ! [ IGNORED ] [MEDIUM] Cleartext Transmission of Sensitive Information
-   Path: src/main.ts, line 58
-   Info: http.createServer uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.
+   Path:       src/main.ts, line 58
+   Info:       http.createServer uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.
 
    Expiration: 15 days
    Category:   Won't fix
@@ -289,8 +289,8 @@ Open Issues
 Ignored Issues
 
  ! [ IGNORED ] [MEDIUM] Cleartext Transmission of Sensitive Information
-   Path: src/main.ts, line 58
-   Info: http.createServer uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.
+   Path:       src/main.ts, line 58
+   Info:       http.createServer uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.
 
    Expiration: 15 days
    Category:   Won't fix

--- a/internal/presenters/components.go
+++ b/internal/presenters/components.go
@@ -50,24 +50,21 @@ func RenderFindings(findings []Finding, showIgnored bool, showOpen bool) string 
 }
 
 func RenderFinding(finding Finding) string {
-	ignoredProperties := "\n"
+	properties := "\n"
 	titlePrefix := "✗ "
 
 	if finding.Ignored {
 		titlePrefix = "! [ IGNORED ] "
-		ignoredProperties = getIgnoredProperties(finding, ignoredProperties)
-	} else {
-
 	}
+
+	properties = getFormattedProperties(finding.Properties)
 
 	return strings.Join([]string{
 		fmt.Sprintf(" %s %s",
 			renderInSeverityColor(finding.Severity, fmt.Sprintf("%s[%s]", titlePrefix, strings.ToUpper(finding.Severity))),
 			renderBold(finding.Title),
 		),
-		fmt.Sprintf("   Path: %s, line %d", finding.Path, finding.Line),
-		fmt.Sprintf("   Info: %s", finding.Message),
-		ignoredProperties,
+		properties,
 	}, "\n")
 }
 
@@ -77,6 +74,29 @@ func RenderDivider() string {
 
 func RenderTitle(str string) string {
 	return fmt.Sprintf("\n%s\n\n", renderBold(str))
+}
+
+func getFormattedProperties(properties []FindingProperty) string {
+	formattedProperties := ""
+	labelLength := 0
+
+	for _, property := range properties {
+		if len(property.Label) > labelLength {
+			labelLength = len(property.Label) + 1
+		}
+	}
+
+	labelAndPropertyFormat := "   %-" + fmt.Sprintf("%d", labelLength) + "s %s\n"
+
+	for _, property := range properties {
+		if property.Label == "" {
+			formattedProperties += "\n"
+			continue
+		}
+		formattedProperties += fmt.Sprintf(labelAndPropertyFormat, property.Label+":", property.Value)
+	}
+
+	return formattedProperties
 }
 
 func RenderTip(str string) string {

--- a/internal/presenters/components.go
+++ b/internal/presenters/components.go
@@ -102,7 +102,7 @@ func RenderTip(str string) string {
 	return fmt.Sprintf("\n💡 Tip\n\n%s", str)
 }
 
-func RenderSummary(summary *json_schemas.TestSummary, orgName string, testPath string) string {
+func RenderSummary(summary *json_schemas.TestSummary, orgName string, testPath string) (string, error) {
 	var buff bytes.Buffer
 	var summaryTemplate = template.Must(template.New("summary").Parse(`Test Summary
 
@@ -159,8 +159,8 @@ func RenderSummary(summary *json_schemas.TestSummary, orgName string, testPath s
 		IgnoredIssueCountWithSeverities: ignoredIssueCountWithSeverities,
 	})
 	if err != nil {
-		return fmt.Sprintf("failed to execute summary template: %v", err)
+		return "", fmt.Errorf("failed to generete test summary from template: %w", err)
 	}
 
-	return boxStyle.Render(buff.String())
+	return boxStyle.Render(buff.String()), nil
 }

--- a/internal/presenters/components.go
+++ b/internal/presenters/components.go
@@ -1,0 +1,145 @@
+package presenters
+
+import (
+	"bytes"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"text/template"
+
+	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
+)
+
+func RenderFindings(findings []Finding, showIgnored bool, showOpen bool) string {
+	if len(findings) == 0 {
+		return ""
+	}
+
+	response := ""
+
+	if showOpen {
+		response += RenderTitle("Open Issues")
+
+		for _, finding := range findings {
+			if finding.Ignored {
+				continue
+			}
+			response += RenderFinding(finding)
+		}
+	}
+
+	if showOpen && showIgnored {
+		response += RenderDivider()
+	}
+
+	if showIgnored {
+		response += RenderTitle("Ignored Issues")
+
+		for _, finding := range findings {
+			if !finding.Ignored {
+				continue
+			}
+			response += RenderFinding(finding)
+		}
+
+		response += RenderTip("Ignores are currently managed in the Snyk Web UI.\nTo edit or remove the ignore please go to: https://app.snyk.io/") + "\n"
+	}
+
+	return response
+}
+
+func RenderFinding(finding Finding) string {
+	ignoredProperties := "\n"
+	titlePrefix := "✗ "
+
+	if finding.Ignored {
+		titlePrefix = "! [ IGNORED ] "
+		ignoredProperties = getIgnoredProperties(finding, ignoredProperties)
+	}
+
+	return strings.Join([]string{
+		fmt.Sprintf(" %s %s",
+			renderInSeverityColor(finding.Severity, fmt.Sprintf("%s[%s]", titlePrefix, strings.ToUpper(finding.Severity))),
+			renderBold(finding.Title),
+		),
+		fmt.Sprintf("   Path: %s, line %d", finding.Path, finding.Line),
+		fmt.Sprintf("   Info: %s", finding.Message),
+		ignoredProperties,
+	}, "\n")
+}
+
+func RenderDivider() string {
+	return "─────────────────────────────────────────────────────\n"
+}
+
+func RenderTitle(str string) string {
+	return fmt.Sprintf("\n%s\n\n", renderBold(str))
+}
+
+func RenderTip(str string) string {
+	return fmt.Sprintf("\n💡 Tip\n\n%s", str)
+}
+
+func RenderSummary(summary *json_schemas.TestSummary, meta TestMeta) string {
+	var buff bytes.Buffer
+	var summaryTemplate = template.Must(template.New("summary").Parse(`Test Summary
+
+  Organization:      {{ .Org }}
+  Test type:         {{ .Type }}
+  Project path:      {{ .TestPath }}
+
+  Total issues:   {{ .TotalIssueCount }}{{ if .TotalIssueCount }}
+  Ignored issues: {{ .IgnoredIssueCountWithSeverities }} 
+  Open issues:    {{ .OpenIssueCountWithSeverities }}{{ end }}`))
+
+	totalIssueCount := 0
+	openIssueCount := 0
+	ignoredIssueCount := 0
+	openIssueLabelledCount := ""
+	ignoredIssueLabelledCount := ""
+
+	slices.Reverse(summary.SeverityOrderAsc)
+
+	for _, severity := range summary.SeverityOrderAsc {
+		for _, result := range summary.Results {
+			if result.Severity == severity {
+				totalIssueCount += result.Total
+				openIssueCount += result.Open
+				ignoredIssueCount += result.Ignored
+				openIssueLabelledCount += renderInSeverityColor(severity, fmt.Sprintf(" %d %s ", result.Open, strings.ToUpper(severity)))
+				ignoredIssueLabelledCount += renderInSeverityColor(severity, fmt.Sprintf(" %d %s ", result.Ignored, strings.ToUpper(severity)))
+			}
+		}
+	}
+
+	openIssueCountWithSeverities := fmt.Sprintf("%s [%s]", renderBold(strconv.Itoa(openIssueCount)), openIssueLabelledCount)
+	ignoredIssueCountWithSeverities := fmt.Sprintf("%s [%s]", renderBold(strconv.Itoa(ignoredIssueCount)), ignoredIssueLabelledCount)
+	testType := summary.Type
+	if testType == "sast" {
+		testType = "Static code analysis"
+	}
+
+	err := summaryTemplate.Execute(&buff, struct {
+		Org                             string
+		TestPath                        string
+		Type                            string
+		TotalIssueCount                 int
+		IgnoreIssueCount                int
+		OpenIssueCountWithSeverities    string
+		IgnoredIssueCountWithSeverities string
+	}{
+		Org:                             meta.OrgName,
+		TestPath:                        meta.TestPath,
+		Type:                            testType,
+		TotalIssueCount:                 totalIssueCount,
+		IgnoreIssueCount:                ignoredIssueCount,
+		OpenIssueCountWithSeverities:    openIssueCountWithSeverities,
+		IgnoredIssueCountWithSeverities: ignoredIssueCountWithSeverities,
+	})
+	if err != nil {
+		return fmt.Sprintf("failed to execute summary template: %v", err)
+	}
+
+	return boxStyle.Render(buff.String())
+}

--- a/internal/presenters/components.go
+++ b/internal/presenters/components.go
@@ -56,6 +56,8 @@ func RenderFinding(finding Finding) string {
 	if finding.Ignored {
 		titlePrefix = "! [ IGNORED ] "
 		ignoredProperties = getIgnoredProperties(finding, ignoredProperties)
+	} else {
+
 	}
 
 	return strings.Join([]string{
@@ -81,7 +83,7 @@ func RenderTip(str string) string {
 	return fmt.Sprintf("\n💡 Tip\n\n%s", str)
 }
 
-func RenderSummary(summary *json_schemas.TestSummary, meta TestMeta) string {
+func RenderSummary(summary *json_schemas.TestSummary, orgName string, testPath string) string {
 	var buff bytes.Buffer
 	var summaryTemplate = template.Must(template.New("summary").Parse(`Test Summary
 
@@ -129,8 +131,8 @@ func RenderSummary(summary *json_schemas.TestSummary, meta TestMeta) string {
 		OpenIssueCountWithSeverities    string
 		IgnoredIssueCountWithSeverities string
 	}{
-		Org:                             meta.OrgName,
-		TestPath:                        meta.TestPath,
+		Org:                             orgName,
+		TestPath:                        testPath,
 		Type:                            testType,
 		TotalIssueCount:                 totalIssueCount,
 		IgnoreIssueCount:                ignoredIssueCount,

--- a/internal/presenters/components.go
+++ b/internal/presenters/components.go
@@ -50,14 +50,13 @@ func RenderFindings(findings []Finding, showIgnored bool, showOpen bool) string 
 }
 
 func RenderFinding(finding Finding) string {
-	properties := "\n"
 	titlePrefix := "✗ "
 
 	if finding.Ignored {
 		titlePrefix = "! [ IGNORED ] "
 	}
 
-	properties = getFormattedProperties(finding.Properties)
+	properties := getFormattedProperties(finding.Properties)
 
 	return strings.Join([]string{
 		fmt.Sprintf(" %s %s",

--- a/internal/presenters/presenter_sarif_results_pretty.go
+++ b/internal/presenters/presenter_sarif_results_pretty.go
@@ -117,9 +117,9 @@ func convertSarifToFindingsList(input sarif.SarifDocument) []Finding {
 
 			isIgnored := len(result.Suppressions) > 0
 
-			var ignoreProperties []FindingProperty
+			var findingProperties []FindingProperty
 
-			ignoreProperties = append(ignoreProperties, FindingProperty{
+			findingProperties = append(findingProperties, FindingProperty{
 				Label: "Path",
 				Value: fmt.Sprintf("%s, line %d",
 					location.PhysicalLocation.ArtifactLocation.URI,
@@ -127,12 +127,12 @@ func convertSarifToFindingsList(input sarif.SarifDocument) []Finding {
 				),
 			})
 
-			ignoreProperties = append(ignoreProperties, FindingProperty{
+			findingProperties = append(findingProperties, FindingProperty{
 				Label: "Info",
 				Value: result.Message.Text,
 			})
 
-			ignoreProperties = append(ignoreProperties, FindingProperty{
+			findingProperties = append(findingProperties, FindingProperty{
 				Label: "",
 				Value: "",
 			})
@@ -143,12 +143,12 @@ func convertSarifToFindingsList(input sarif.SarifDocument) []Finding {
 					expiration = *suppression.Properties.Expiration
 				}
 
-				ignoreProperties = append(ignoreProperties, FindingProperty{
+				findingProperties = append(findingProperties, FindingProperty{
 					Label: "Expiration",
 					Value: expiration,
 				})
 
-				ignoreProperties = append(ignoreProperties, FindingProperty{
+				findingProperties = append(findingProperties, FindingProperty{
 					Label: "Category",
 					Value: strings.Replace(string(suppression.Properties.Category), "wont-fix", "Won't fix", 1),
 				})
@@ -157,18 +157,18 @@ func convertSarifToFindingsList(input sarif.SarifDocument) []Finding {
 				s, err := time.Parse(time.RFC3339, suppression.Properties.IgnoredOn)
 
 				if err == nil {
-					ignoreProperties = append(ignoreProperties, FindingProperty{
+					findingProperties = append(findingProperties, FindingProperty{
 						Label: "Ignored on",
 						Value: s.Format("January 02, 2006"),
 					})
 				}
 
-				ignoreProperties = append(ignoreProperties, FindingProperty{
+				findingProperties = append(findingProperties, FindingProperty{
 					Label: "Ignored by",
 					Value: suppression.Properties.IgnoredBy.Name,
 				})
 
-				ignoreProperties = append(ignoreProperties, FindingProperty{
+				findingProperties = append(findingProperties, FindingProperty{
 					Label: "Reason",
 					Value: suppression.Justification,
 				})
@@ -179,7 +179,7 @@ func convertSarifToFindingsList(input sarif.SarifDocument) []Finding {
 				Severity:   severity,
 				Title:      title,
 				Ignored:    isIgnored,
-				Properties: ignoreProperties,
+				Properties: findingProperties,
 			})
 		}
 	}

--- a/internal/presenters/presenter_sarif_results_pretty.go
+++ b/internal/presenters/presenter_sarif_results_pretty.go
@@ -77,7 +77,7 @@ type TestMeta struct {
 	TestPath string
 }
 
-func PresenterSarifResultsPretty(input sarif.SarifDocument, meta TestMeta, showIgnored bool) (string, error) {
+func PresenterSarifResultsPretty(input sarif.SarifDocument, meta TestMeta, showIgnored bool, showOpen bool) (string, error) {
 	findings := convertSarifToFindingsList(input)
 	summary := sarif_utils.CreateCodeSummary(&input)
 
@@ -88,7 +88,7 @@ Testing %s ...
 %s
 `,
 		meta.TestPath,
-		renderFindings(SortFindings(findings, summary.SeverityOrderAsc), showIgnored),
+		renderFindings(SortFindings(findings, summary.SeverityOrderAsc), showIgnored, showOpen),
 		renderSummary(summary, meta),
 		getTip(),
 	)
@@ -96,7 +96,7 @@ Testing %s ...
 	return str, nil
 }
 
-func renderFindings(findings []Finding, showIgnored bool) string {
+func renderFindings(findings []Finding, showIgnored bool, showOpen bool) string {
 	if len(findings) == 0 {
 		return ""
 	}
@@ -107,6 +107,11 @@ func renderFindings(findings []Finding, showIgnored bool) string {
 		if finding.Ignored && !showIgnored {
 			continue
 		}
+
+		if !showOpen && !finding.Ignored {
+			continue
+		}
+
 		response += fmt.Sprintf(` %s %s
    Path: %s, line %d
    Info: %s

--- a/internal/presenters/presenter_sarif_results_pretty.go
+++ b/internal/presenters/presenter_sarif_results_pretty.go
@@ -111,10 +111,6 @@ func renderFindings(findings []Finding, showIgnored bool, showOpen bool) string 
 				continue
 			}
 
-			if !showOpen && !finding.Ignored {
-				continue
-			}
-
 			response += fmt.Sprintf(` %s %s
    Path: %s, line %d
    Info: %s

--- a/internal/presenters/presenter_sarif_results_pretty.go
+++ b/internal/presenters/presenter_sarif_results_pretty.go
@@ -1,18 +1,13 @@
 package presenters
 
 import (
-	"bytes"
 	"fmt"
 	"slices"
-	"strconv"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/snyk/code-client-go/sarif"
 	sarif_utils "github.com/snyk/go-application-framework/internal/utils/sarif"
-
-	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
 )
 
 type Finding struct {
@@ -128,71 +123,13 @@ func PresenterSarifResultsPretty(input sarif.SarifDocument, meta TestMeta, showI
 	str := strings.Join([]string{
 		"",
 		renderBold(fmt.Sprintf("Testing %s ...", meta.TestPath)),
-		renderFindings(SortFindings(findings, summary.SeverityOrderAsc), showIgnored, showOpen),
-		renderSummary(summary, meta),
+		RenderFindings(SortFindings(findings, summary.SeverityOrderAsc), showIgnored, showOpen),
+		RenderSummary(summary, meta),
 		getFinalTip(showIgnored, showOpen),
 		"",
 	}, "\n")
 
 	return str, nil
-}
-
-func renderFindings(findings []Finding, showIgnored bool, showOpen bool) string {
-	if len(findings) == 0 {
-		return ""
-	}
-
-	response := ""
-
-	if showOpen {
-		response += renderTitle("Open Issues")
-
-		for _, finding := range findings {
-			if finding.Ignored {
-				continue
-			}
-			response += renderFinding(finding)
-		}
-	}
-
-	if showOpen && showIgnored {
-		response += renderDivider()
-	}
-
-	if showIgnored {
-		response += renderTitle("Ignored Issues")
-
-		for _, finding := range findings {
-			if !finding.Ignored {
-				continue
-			}
-			response += renderFinding(finding)
-		}
-
-		response += renderTip("Ignores are currently managed in the Snyk Web UI.\nTo edit or remove the ignore please go to: https://app.snyk.io/") + "\n"
-	}
-
-	return response
-}
-
-func renderFinding(finding Finding) string {
-	ignoredProperties := "\n"
-	titlePrefix := "✗ "
-
-	if finding.Ignored {
-		titlePrefix = "! [ IGNORED ] "
-		ignoredProperties = getIgnoredProperties(finding, ignoredProperties)
-	}
-
-	return strings.Join([]string{
-		fmt.Sprintf(" %s %s",
-			renderInSeverityColor(finding.Severity, fmt.Sprintf("%s[%s]", titlePrefix, strings.ToUpper(finding.Severity))),
-			renderBold(finding.Title),
-		),
-		fmt.Sprintf("   Path: %s, line %d", finding.Path, finding.Line),
-		fmt.Sprintf("   Info: %s", finding.Message),
-		ignoredProperties,
-	}, "\n")
 }
 
 func getIgnoredProperties(finding Finding, ignoredProperties string) string {
@@ -223,82 +160,7 @@ func getFinalTip(showIgnored bool, showOpen bool) string {
 		tip = `To view ignored and open issues, use the --include-ignores option.`
 	}
 
-	return renderTip(tip)
-}
-
-func renderDivider() string {
-	return "─────────────────────────────────────────────────────\n"
-}
-
-func renderTitle(str string) string {
-	return fmt.Sprintf("\n%s\n\n", renderBold(str))
-}
-
-func renderTip(str string) string {
-	return fmt.Sprintf("\n💡 Tip\n\n%s", str)
-}
-
-func renderSummary(summary *json_schemas.TestSummary, meta TestMeta) string {
-	var buff bytes.Buffer
-	var summaryTemplate = template.Must(template.New("summary").Parse(`Test Summary
-
-  Organization:      {{ .Org }}
-  Test type:         {{ .Type }}
-  Project path:      {{ .TestPath }}
-
-  Total issues:   {{ .TotalIssueCount }}{{ if .TotalIssueCount }}
-  Ignored issues: {{ .IgnoredIssueCountWithSeverities }} 
-  Open issues:    {{ .OpenIssueCountWithSeverities }}{{ end }}`))
-
-	totalIssueCount := 0
-	openIssueCount := 0
-	ignoredIssueCount := 0
-	openIssueLabelledCount := ""
-	ignoredIssueLabelledCount := ""
-
-	slices.Reverse(summary.SeverityOrderAsc)
-
-	for _, severity := range summary.SeverityOrderAsc {
-		for _, result := range summary.Results {
-			if result.Severity == severity {
-				totalIssueCount += result.Total
-				openIssueCount += result.Open
-				ignoredIssueCount += result.Ignored
-				openIssueLabelledCount += renderInSeverityColor(severity, fmt.Sprintf(" %d %s ", result.Open, strings.ToUpper(severity)))
-				ignoredIssueLabelledCount += renderInSeverityColor(severity, fmt.Sprintf(" %d %s ", result.Ignored, strings.ToUpper(severity)))
-			}
-		}
-	}
-
-	openIssueCountWithSeverities := fmt.Sprintf("%s [%s]", renderBold(strconv.Itoa(openIssueCount)), openIssueLabelledCount)
-	ignoredIssueCountWithSeverities := fmt.Sprintf("%s [%s]", renderBold(strconv.Itoa(ignoredIssueCount)), ignoredIssueLabelledCount)
-	testType := summary.Type
-	if testType == "sast" {
-		testType = "Static code analysis"
-	}
-
-	err := summaryTemplate.Execute(&buff, struct {
-		Org                             string
-		TestPath                        string
-		Type                            string
-		TotalIssueCount                 int
-		IgnoreIssueCount                int
-		OpenIssueCountWithSeverities    string
-		IgnoredIssueCountWithSeverities string
-	}{
-		Org:                             meta.OrgName,
-		TestPath:                        meta.TestPath,
-		Type:                            testType,
-		TotalIssueCount:                 totalIssueCount,
-		IgnoreIssueCount:                ignoredIssueCount,
-		OpenIssueCountWithSeverities:    openIssueCountWithSeverities,
-		IgnoredIssueCountWithSeverities: ignoredIssueCountWithSeverities,
-	})
-	if err != nil {
-		return fmt.Sprintf("failed to execute summary template: %v", err)
-	}
-
-	return boxStyle.Render(buff.String())
+	return RenderTip(tip)
 }
 
 func SortFindings(findings []Finding, order []string) []Finding {

--- a/internal/presenters/presenter_sarif_results_pretty.go
+++ b/internal/presenters/presenter_sarif_results_pretty.go
@@ -169,7 +169,7 @@ func renderFindings(findings []Finding, showIgnored bool, showOpen bool) string 
 			response += renderFinding(finding)
 		}
 
-		response += renderTip("Ignores are currently managed in the Snyk Web UI.\nTo edit or remove the ignore please go to: https://app.snyk.io/")
+		response += renderTip("Ignores are currently managed in the Snyk Web UI.\nTo edit or remove the ignore please go to: https://app.snyk.io/") + "\n"
 	}
 
 	return response

--- a/internal/presenters/presenter_sarif_results_pretty.go
+++ b/internal/presenters/presenter_sarif_results_pretty.go
@@ -63,9 +63,15 @@ func convertSarifToFindingsList(input sarif.SarifDocument) []Finding {
 			var ignoreProperties []IgnoreProperty
 
 			for _, suppression := range result.Suppressions {
+
+				expiration := ""
+				if suppression.Properties.Expiration != nil {
+					expiration = *suppression.Properties.Expiration
+				}
+
 				ignoreProperties = append(ignoreProperties, IgnoreProperty{
 					Label: "Expiration",
-					Value: fmt.Sprintf("%s", *suppression.Properties.Expiration),
+					Value: fmt.Sprintf("%s", expiration),
 				})
 
 				ignoreProperties = append(ignoreProperties, IgnoreProperty{
@@ -81,8 +87,6 @@ func convertSarifToFindingsList(input sarif.SarifDocument) []Finding {
 						Label: "Ignored on",
 						Value: s.Format("January 02, 2006"),
 					})
-				} else {
-					panic(err)
 				}
 
 				ignoreProperties = append(ignoreProperties, IgnoreProperty{

--- a/internal/presenters/presenter_sarif_results_pretty.go
+++ b/internal/presenters/presenter_sarif_results_pretty.go
@@ -163,6 +163,10 @@ func renderFindings(findings []Finding, showIgnored bool, showOpen bool) string 
 		}
 	}
 
+	if showOpen && showIgnored {
+		response += renderDivider()
+	}
+
 	if showIgnored {
 		response += "\nIgnored Issues\n\n"
 
@@ -211,6 +215,10 @@ func getFinalTip(showIgnored bool, showOpen bool) string {
 	}
 
 	return renderTip(tip)
+}
+
+func renderDivider() string {
+	return "─────────────────────────────────────────────────────\n"
 }
 
 func renderTip(str string) string {

--- a/internal/presenters/presenter_sarif_results_pretty.go
+++ b/internal/presenters/presenter_sarif_results_pretty.go
@@ -125,17 +125,14 @@ func PresenterSarifResultsPretty(input sarif.SarifDocument, meta TestMeta, showI
 	findings := convertSarifToFindingsList(input)
 	summary := sarif_utils.CreateCodeSummary(&input)
 
-	str := fmt.Sprintf(`
-Testing %s ...
-%s
-%s
-%s
-`,
-		meta.TestPath,
+	str := strings.Join([]string{
+		"",
+		renderBold(fmt.Sprintf("Testing %s ...", meta.TestPath)),
 		renderFindings(SortFindings(findings, summary.SeverityOrderAsc), showIgnored, showOpen),
 		renderSummary(summary, meta),
 		getFinalTip(showIgnored, showOpen),
-	)
+		"",
+	}, "\n")
 
 	return str, nil
 }
@@ -148,7 +145,7 @@ func renderFindings(findings []Finding, showIgnored bool, showOpen bool) string 
 	response := ""
 
 	if showOpen {
-		response += "\nOpen Issues\n\n"
+		response += renderTitle("Open Issues")
 
 		for _, finding := range findings {
 			if finding.Ignored {
@@ -168,7 +165,7 @@ func renderFindings(findings []Finding, showIgnored bool, showOpen bool) string 
 	}
 
 	if showIgnored {
-		response += "\nIgnored Issues\n\n"
+		response += renderTitle("Ignored Issues")
 
 		for _, finding := range findings {
 			if !finding.Ignored {
@@ -219,6 +216,10 @@ func getFinalTip(showIgnored bool, showOpen bool) string {
 
 func renderDivider() string {
 	return "─────────────────────────────────────────────────────\n"
+}
+
+func renderTitle(str string) string {
+	return fmt.Sprintf("\n%s\n\n", renderBold(str))
 }
 
 func renderTip(str string) string {

--- a/internal/presenters/presenter_sarif_results_pretty.go
+++ b/internal/presenters/presenter_sarif_results_pretty.go
@@ -138,7 +138,6 @@ func convertSarifToFindingsList(input sarif.SarifDocument) []Finding {
 			})
 
 			for _, suppression := range result.Suppressions {
-
 				expiration := ""
 				if suppression.Properties.Expiration != nil {
 					expiration = *suppression.Properties.Expiration
@@ -146,7 +145,7 @@ func convertSarifToFindingsList(input sarif.SarifDocument) []Finding {
 
 				ignoreProperties = append(ignoreProperties, FindingProperty{
 					Label: "Expiration",
-					Value: fmt.Sprintf("%s", expiration),
+					Value: expiration,
 				})
 
 				ignoreProperties = append(ignoreProperties, FindingProperty{

--- a/internal/presenters/presenter_sarif_results_pretty_test.go
+++ b/internal/presenters/presenter_sarif_results_pretty_test.go
@@ -13,11 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testMeta = presenters.TestMeta{
-	OrgName:  "test-org",
-	TestPath: "/path/to/project",
-}
-
 func TestPresenterSarifResultsPretty_NoIssues(t *testing.T) {
 	fd, err := os.Open("testdata/no-issues.json")
 	require.Nil(t, err)
@@ -125,7 +120,7 @@ func TestPresenterSarifResultsPretty_DefaultHideIgnored(t *testing.T) {
 	result, err := p.Render()
 
 	require.Nil(t, err)
-	require.NotContains(t, result, "Path: src/main.ts, line 58")
+	require.NotContains(t, result, "src/main.ts, line 58")
 }
 
 func TestPresenterSarifResultsPretty_IncludeIgnored(t *testing.T) {
@@ -149,7 +144,7 @@ func TestPresenterSarifResultsPretty_IncludeIgnored(t *testing.T) {
 
 	require.Nil(t, err)
 	require.Contains(t, result, "[ IGNORED ] [MEDIUM]")
-	require.Contains(t, result, "Path: src/main.ts, line 58")
+	require.Contains(t, result, "src/main.ts, line 58")
 	require.Contains(t, result, "Ignored Issues")
 	require.Contains(t, result, "Ignores are currently managed in the Snyk Web UI.")
 	require.Contains(t, result, "To view ignored issues only, use the --only-ignores option.")
@@ -180,7 +175,7 @@ func TestPresenterSarifResultsPretty_OnlyIgnored(t *testing.T) {
 	require.Nil(t, err)
 	require.Contains(t, result, "Ignored Issues")
 	require.Contains(t, result, "! [ IGNORED ] [MEDIUM]")
-	require.Contains(t, result, "Path: src/main.ts, line 58")
+	require.Contains(t, result, "Path:       src/main.ts, line 58")
 	require.Contains(t, result, "Category:   Won't fix")
 	require.Contains(t, result, "Expiration: 15 days")
 	require.Contains(t, result, "Ignored on: February 23, 2024")

--- a/internal/presenters/presenter_sarif_results_pretty_test.go
+++ b/internal/presenters/presenter_sarif_results_pretty_test.go
@@ -28,7 +28,7 @@ func TestPresenterSarifResultsPretty_NoIssues(t *testing.T) {
 	require.Nil(t, err)
 
 	lipgloss.SetColorProfile(termenv.Ascii)
-	result, err := presenters.PresenterSarifResultsPretty(input, testMeta)
+	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false)
 
 	require.Nil(t, err)
 	snaps.MatchSnapshot(t, result)
@@ -44,7 +44,7 @@ func TestPresenterSarifResultsPretty_LowIssues(t *testing.T) {
 	require.Nil(t, err)
 
 	lipgloss.SetColorProfile(termenv.Ascii)
-	result, err := presenters.PresenterSarifResultsPretty(input, testMeta)
+	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false)
 
 	require.Nil(t, err)
 	snaps.MatchSnapshot(t, result)
@@ -60,7 +60,7 @@ func TestPresenterSarifResultsPretty_MediumHighIssues(t *testing.T) {
 	require.Nil(t, err)
 
 	lipgloss.SetColorProfile(termenv.Ascii)
-	result, err := presenters.PresenterSarifResultsPretty(input, testMeta)
+	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false)
 
 	require.Nil(t, err)
 	snaps.MatchSnapshot(t, result)
@@ -76,8 +76,40 @@ func TestPresenterSarifResultsPretty_MediumHighIssuesWithColor(t *testing.T) {
 	require.Nil(t, err)
 
 	lipgloss.SetColorProfile(termenv.TrueColor)
-	result, err := presenters.PresenterSarifResultsPretty(input, testMeta)
+	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false)
 
 	require.Nil(t, err)
 	snaps.MatchSnapshot(t, result)
+}
+
+func TestPresenterSarifResultsPretty_DefaultHideIgnored(t *testing.T) {
+	fd, err := os.Open("testdata/with-ignores.json")
+	require.Nil(t, err)
+
+	var input sarif.SarifDocument
+
+	err = json.NewDecoder(fd).Decode(&input)
+	require.Nil(t, err)
+
+	lipgloss.SetColorProfile(termenv.Ascii)
+	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false)
+
+	require.Nil(t, err)
+	require.NotContains(t, result, "Path: src/main.ts, line 58")
+}
+
+func TestPresenterSarifResultsPretty_IncludeIgnored(t *testing.T) {
+	fd, err := os.Open("testdata/with-ignores.json")
+	require.Nil(t, err)
+
+	var input sarif.SarifDocument
+
+	err = json.NewDecoder(fd).Decode(&input)
+	require.Nil(t, err)
+
+	lipgloss.SetColorProfile(termenv.Ascii)
+	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, true)
+
+	require.Nil(t, err)
+	require.Contains(t, result, "Path: src/main.ts, line 58")
 }

--- a/internal/presenters/presenter_sarif_results_pretty_test.go
+++ b/internal/presenters/presenter_sarif_results_pretty_test.go
@@ -134,7 +134,14 @@ func TestPresenterSarifResultsPretty_OnlyIgnored(t *testing.T) {
 	require.Contains(t, result, "Ignored Issues")
 	require.Contains(t, result, "! [ IGNORED ] [MEDIUM]")
 	require.Contains(t, result, "Path: src/main.ts, line 58")
-	
+	require.Contains(t, result, "Category: Won't fix")
+	require.Contains(t, result, "Expiration: 15 days")
+	require.Contains(t, result, "Ignored on: February 23, 2024")
+	require.Contains(t, result, "Ignored by: Neil M")
+	require.Contains(t, result, "Reason:     False positive")
+
 	require.Contains(t, result, "Ignores are currently managed in the Snyk Web UI.")
 	require.Contains(t, result, "To view ignored and open issues, use the --include-ignores option.")
+
+	snaps.MatchSnapshot(t, result)
 }

--- a/internal/presenters/presenter_sarif_results_pretty_test.go
+++ b/internal/presenters/presenter_sarif_results_pretty_test.go
@@ -116,6 +116,8 @@ func TestPresenterSarifResultsPretty_IncludeIgnored(t *testing.T) {
 	require.Contains(t, result, "Ignored Issues")
 	require.Contains(t, result, "Ignores are currently managed in the Snyk Web UI.")
 	require.Contains(t, result, "To view ignored issues only, use the --only-ignores option.")
+
+	snaps.MatchSnapshot(t, result)
 }
 
 func TestPresenterSarifResultsPretty_OnlyIgnored(t *testing.T) {

--- a/internal/presenters/presenter_sarif_results_pretty_test.go
+++ b/internal/presenters/presenter_sarif_results_pretty_test.go
@@ -131,9 +131,10 @@ func TestPresenterSarifResultsPretty_OnlyIgnored(t *testing.T) {
 	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, true, false)
 
 	require.Nil(t, err)
-	require.Contains(t, result, "[ IGNORED ] [MEDIUM]")
-	require.Contains(t, result, "Path: src/main.ts, line 58")
 	require.Contains(t, result, "Ignored Issues")
+	require.Contains(t, result, "! [ IGNORED ] [MEDIUM]")
+	require.Contains(t, result, "Path: src/main.ts, line 58")
+	
 	require.Contains(t, result, "Ignores are currently managed in the Snyk Web UI.")
 	require.Contains(t, result, "To view ignored and open issues, use the --include-ignores option.")
 }

--- a/internal/presenters/presenter_sarif_results_pretty_test.go
+++ b/internal/presenters/presenter_sarif_results_pretty_test.go
@@ -111,5 +111,29 @@ func TestPresenterSarifResultsPretty_IncludeIgnored(t *testing.T) {
 	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, true, true)
 
 	require.Nil(t, err)
+	require.Contains(t, result, "[ IGNORED ] [MEDIUM]")
 	require.Contains(t, result, "Path: src/main.ts, line 58")
+	require.Contains(t, result, "Ignored Issues")
+	require.Contains(t, result, "Ignores are currently managed in the Snyk Web UI.")
+	require.Contains(t, result, "To view ignored issues only, use the --only-ignores option.")
+}
+
+func TestPresenterSarifResultsPretty_OnlyIgnored(t *testing.T) {
+	fd, err := os.Open("testdata/with-ignores.json")
+	require.Nil(t, err)
+
+	var input sarif.SarifDocument
+
+	err = json.NewDecoder(fd).Decode(&input)
+	require.Nil(t, err)
+
+	lipgloss.SetColorProfile(termenv.Ascii)
+	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, true, false)
+
+	require.Nil(t, err)
+	require.Contains(t, result, "[ IGNORED ] [MEDIUM]")
+	require.Contains(t, result, "Path: src/main.ts, line 58")
+	require.Contains(t, result, "Ignored Issues")
+	require.Contains(t, result, "Ignores are currently managed in the Snyk Web UI.")
+	require.Contains(t, result, "To view ignored and open issues, use the --include-ignores option.")
 }

--- a/internal/presenters/presenter_sarif_results_pretty_test.go
+++ b/internal/presenters/presenter_sarif_results_pretty_test.go
@@ -22,13 +22,19 @@ func TestPresenterSarifResultsPretty_NoIssues(t *testing.T) {
 	fd, err := os.Open("testdata/no-issues.json")
 	require.Nil(t, err)
 
-	var input sarif.SarifDocument
+	var sarifDocument sarif.SarifDocument
 
-	err = json.NewDecoder(fd).Decode(&input)
+	err = json.NewDecoder(fd).Decode(&sarifDocument)
 	require.Nil(t, err)
 
 	lipgloss.SetColorProfile(termenv.Ascii)
-	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false, true)
+	p := presenters.SarifTestResults(
+		sarifDocument,
+		presenters.WithOrgName("test-org"),
+		presenters.WithTestPath("/path/to/project"),
+	)
+
+	result, err := p.Render()
 
 	require.Nil(t, err)
 	snaps.MatchSnapshot(t, result)
@@ -44,7 +50,13 @@ func TestPresenterSarifResultsPretty_LowIssues(t *testing.T) {
 	require.Nil(t, err)
 
 	lipgloss.SetColorProfile(termenv.Ascii)
-	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false, true)
+	p := presenters.SarifTestResults(
+		input,
+		presenters.WithOrgName("test-org"),
+		presenters.WithTestPath("/path/to/project"),
+	)
+
+	result, err := p.Render()
 
 	require.Nil(t, err)
 	snaps.MatchSnapshot(t, result)
@@ -60,7 +72,13 @@ func TestPresenterSarifResultsPretty_MediumHighIssues(t *testing.T) {
 	require.Nil(t, err)
 
 	lipgloss.SetColorProfile(termenv.Ascii)
-	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false, true)
+	p := presenters.SarifTestResults(
+		input,
+		presenters.WithOrgName("test-org"),
+		presenters.WithTestPath("/path/to/project"),
+	)
+
+	result, err := p.Render()
 
 	require.Nil(t, err)
 	snaps.MatchSnapshot(t, result)
@@ -76,7 +94,13 @@ func TestPresenterSarifResultsPretty_MediumHighIssuesWithColor(t *testing.T) {
 	require.Nil(t, err)
 
 	lipgloss.SetColorProfile(termenv.TrueColor)
-	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false, true)
+	p := presenters.SarifTestResults(
+		input,
+		presenters.WithOrgName("test-org"),
+		presenters.WithTestPath("/path/to/project"),
+	)
+
+	result, err := p.Render()
 
 	require.Nil(t, err)
 	snaps.MatchSnapshot(t, result)
@@ -92,7 +116,13 @@ func TestPresenterSarifResultsPretty_DefaultHideIgnored(t *testing.T) {
 	require.Nil(t, err)
 
 	lipgloss.SetColorProfile(termenv.Ascii)
-	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false, true)
+	p := presenters.SarifTestResults(
+		input,
+		presenters.WithOrgName("test-org"),
+		presenters.WithTestPath("/path/to/project"),
+	)
+
+	result, err := p.Render()
 
 	require.Nil(t, err)
 	require.NotContains(t, result, "Path: src/main.ts, line 58")
@@ -108,7 +138,14 @@ func TestPresenterSarifResultsPretty_IncludeIgnored(t *testing.T) {
 	require.Nil(t, err)
 
 	lipgloss.SetColorProfile(termenv.Ascii)
-	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, true, true)
+	p := presenters.SarifTestResults(
+		input,
+		presenters.WithOrgName("test-org"),
+		presenters.WithTestPath("/path/to/project"),
+		presenters.WithIgnored(true),
+	)
+
+	result, err := p.Render()
 
 	require.Nil(t, err)
 	require.Contains(t, result, "[ IGNORED ] [MEDIUM]")
@@ -130,7 +167,15 @@ func TestPresenterSarifResultsPretty_OnlyIgnored(t *testing.T) {
 	require.Nil(t, err)
 
 	lipgloss.SetColorProfile(termenv.Ascii)
-	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, true, false)
+	p := presenters.SarifTestResults(
+		input,
+		presenters.WithOrgName("test-org"),
+		presenters.WithTestPath("/path/to/project"),
+		presenters.WithIgnored(true),
+		presenters.WithOpen(false),
+	)
+
+	result, err := p.Render()
 
 	require.Nil(t, err)
 	require.Contains(t, result, "Ignored Issues")

--- a/internal/presenters/presenter_sarif_results_pretty_test.go
+++ b/internal/presenters/presenter_sarif_results_pretty_test.go
@@ -134,7 +134,7 @@ func TestPresenterSarifResultsPretty_OnlyIgnored(t *testing.T) {
 	require.Contains(t, result, "Ignored Issues")
 	require.Contains(t, result, "! [ IGNORED ] [MEDIUM]")
 	require.Contains(t, result, "Path: src/main.ts, line 58")
-	require.Contains(t, result, "Category: Won't fix")
+	require.Contains(t, result, "Category:   Won't fix")
 	require.Contains(t, result, "Expiration: 15 days")
 	require.Contains(t, result, "Ignored on: February 23, 2024")
 	require.Contains(t, result, "Ignored by: Neil M")

--- a/internal/presenters/presenter_sarif_results_pretty_test.go
+++ b/internal/presenters/presenter_sarif_results_pretty_test.go
@@ -28,7 +28,7 @@ func TestPresenterSarifResultsPretty_NoIssues(t *testing.T) {
 	require.Nil(t, err)
 
 	lipgloss.SetColorProfile(termenv.Ascii)
-	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false)
+	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false, true)
 
 	require.Nil(t, err)
 	snaps.MatchSnapshot(t, result)
@@ -44,7 +44,7 @@ func TestPresenterSarifResultsPretty_LowIssues(t *testing.T) {
 	require.Nil(t, err)
 
 	lipgloss.SetColorProfile(termenv.Ascii)
-	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false)
+	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false, true)
 
 	require.Nil(t, err)
 	snaps.MatchSnapshot(t, result)
@@ -60,7 +60,7 @@ func TestPresenterSarifResultsPretty_MediumHighIssues(t *testing.T) {
 	require.Nil(t, err)
 
 	lipgloss.SetColorProfile(termenv.Ascii)
-	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false)
+	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false, true)
 
 	require.Nil(t, err)
 	snaps.MatchSnapshot(t, result)
@@ -76,7 +76,7 @@ func TestPresenterSarifResultsPretty_MediumHighIssuesWithColor(t *testing.T) {
 	require.Nil(t, err)
 
 	lipgloss.SetColorProfile(termenv.TrueColor)
-	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false)
+	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false, true)
 
 	require.Nil(t, err)
 	snaps.MatchSnapshot(t, result)
@@ -92,7 +92,7 @@ func TestPresenterSarifResultsPretty_DefaultHideIgnored(t *testing.T) {
 	require.Nil(t, err)
 
 	lipgloss.SetColorProfile(termenv.Ascii)
-	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false)
+	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, false, true)
 
 	require.Nil(t, err)
 	require.NotContains(t, result, "Path: src/main.ts, line 58")
@@ -108,7 +108,7 @@ func TestPresenterSarifResultsPretty_IncludeIgnored(t *testing.T) {
 	require.Nil(t, err)
 
 	lipgloss.SetColorProfile(termenv.Ascii)
-	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, true)
+	result, err := presenters.PresenterSarifResultsPretty(input, testMeta, true, true)
 
 	require.Nil(t, err)
 	require.Contains(t, result, "Path: src/main.ts, line 58")

--- a/internal/presenters/testdata/with-ignores.json
+++ b/internal/presenters/testdata/with-ignores.json
@@ -1,0 +1,1043 @@
+{
+    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+    "version": "2.1.0",
+    "runs": [
+      {
+        "tool": {
+          "driver": {
+            "name": "SnykCode",
+            "semanticVersion": "1.0.0",
+            "version": "1.0.0",
+            "rules": [
+              {
+                "id": "javascript/HardcodedNonCryptoSecret",
+                "name": "HardcodedNonCryptoSecret",
+                "shortDescription": {
+                  "text": "Hardcoded Secret"
+                },
+                "defaultConfiguration": {
+                  "level": "error"
+                },
+                "help": {
+                  "markdown": "## Details\n\nWhen constants are hardcoded into applications, this information could easily be reverse-engineered and become known to attackers. For example, if a breached authentication token is hardcoded in multiple places in the application, it may lead to components of the application remaining vulnerable if not all instances are changed.\nAnother negative effect of hard-coding constants is potential unpredictability in the application's performance if the development team fails to update every single instance of the hardcoded constant throughout the code. For these reasons, hard-coding security-relevant constants is considered bad coding practice and should be remedied if present and avoided in future.\n\n## Best practices for prevention\n- Never hard code security-related constants; use symbolic names or configuration lookup files.\n- As hard coding is often done by coders working alone on a small scale, examine all legacy code components and test carefully when scaling.\n- Adopt a \"future-proof code\" mindset: While use of constants may save a little time now and make development simpler in the short term, it could cost time and money adapting to scale or other unforeseen circumstances (such as new hardware) in the future.",
+                  "text": ""
+                },
+                "properties": {
+                  "tags": [
+                    "javascript",
+                    "HardcodedNonCryptoSecret",
+                    "Security"
+                  ],
+                  "categories": [
+                    "Security"
+                  ],
+                  "exampleCommitFixes": [
+                    {
+                      "commitURL": "https://github.com/DanielMil/Authentication-Server/commit/310ce5500e9e751ee2fd9f3018bf772e9aae8364?diff=split#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122L-1",
+                      "lines": [
+                        {
+                          "line": "// Set environment variables\n",
+                          "lineNumber": 14,
+                          "lineChange": "added"
+                        },
+                        {
+                          "line": "const sessionSecret: any = process.env.SESSION_SECRET;\n",
+                          "lineNumber": 15,
+                          "lineChange": "added"
+                        },
+                        {
+                          "line": "const dbConnection: any = process.env.MONGO_URI; \n",
+                          "lineNumber": 16,
+                          "lineChange": "added"
+                        },
+                        {
+                          "line": "\n",
+                          "lineNumber": 17,
+                          "lineChange": "added"
+                        },
+                        {
+                          "line": "// Mongo config\n",
+                          "lineNumber": 18,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "const DB_CONNECTION: any = process.env.MONGO_URI; \n",
+                          "lineNumber": 15,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "mongoose.connect(DB_CONNECTION, { useNewUrlParser: true })\n",
+                          "lineNumber": 16,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": " .then(() => console.log(\"Succesfully connected to MongoDB.\"))\n",
+                          "lineNumber": 20,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": " .catch((err: mongoose.Error) => console.error(err));\n",
+                          "lineNumber": 21,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "const MongoStore = mongoStore(session); \n",
+                          "lineNumber": 22,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "const db: any  = mongoose.connection;\n",
+                          "lineNumber": 23,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": " \n",
+                          "lineNumber": 24,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "// Fix mongo deprecation warnings\n",
+                          "lineNumber": 25,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "mongoose.set('useNewUrlParser', true);\n",
+                          "lineNumber": 26,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "mongoose.set('useFindAndModify', false);\n",
+                          "lineNumber": 27,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "mongoose.set('useCreateIndex', true);\n",
+                          "lineNumber": 28,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "\n",
+                          "lineNumber": 29,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "// Configure express session\n",
+                          "lineNumber": 30,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "app.use(cookieParser());\n",
+                          "lineNumber": 31,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "app.use(session({\n",
+                          "lineNumber": 32,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "    secret: \"secret\",\n",
+                          "lineNumber": 30,
+                          "lineChange": "removed"
+                        },
+                        {
+                          "line": "    secret: sessionSecret,\n",
+                          "lineNumber": 33,
+                          "lineChange": "added"
+                        }
+                      ]
+                    },
+                    {
+                      "commitURL": "https://github.com/virena-app/virena/commit/8058527e8ef71bfa81f0cb0fb35eb80d00e08fdb?diff=split#diff-186488e26aa960d29fec244ac086f15e024c5a84df47eeba233d9b8d2525de2dL-1",
+                      "lines": [
+                        {
+                          "line": "client_id: '8fcf3e5c2d3d5dd78188',\n",
+                          "lineNumber": 36,
+                          "lineChange": "removed"
+                        },
+                        {
+                          "line": "client_secret: '0e102c56021e1aa28005b469b3c83ef7cb7e5b0e'\n",
+                          "lineNumber": 37,
+                          "lineChange": "removed"
+                        },
+                        {
+                          "line": "client_id: process.env.GITINIT,\n",
+                          "lineNumber": 36,
+                          "lineChange": "added"
+                        },
+                        {
+                          "line": "client_secret: process.env.GITSEE\n",
+                          "lineNumber": 37,
+                          "lineChange": "added"
+                        }
+                      ]
+                    },
+                    {
+                      "commitURL": "https://github.com/nemtech/nem2-library-js/commit/dd101718759035849eeb9d4a388656acdb5bf6d9?diff=split#diff-59ccc41578f07869060f7aea9ceca193a407696cce3de9f7219f98187f65c5b7L-1",
+                      "lines": [
+                        {
+                          "line": "const hash = sha3_512.create();\n",
+                          "lineNumber": 29,
+                          "lineChange": "removed"
+                        },
+                        {
+                          "line": "hash.update('secret');\n",
+                          "lineNumber": 30,
+                          "lineChange": "removed"
+                        },
+                        {
+                          "line": "const hash = new Ripemd160().update(Buffer.from('Test Hash 160')).digest('Hex');\t\t\n",
+                          "lineNumber": 31,
+                          "lineChange": "added"
+                        },
+                        {
+                          "line": "const secretLockTransaction = {\n",
+                          "lineNumber": 32,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "\tdeadline: deadline(),\n",
+                          "lineNumber": 33,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "\tmosaicId: [3646934825, 3576016193],\n",
+                          "lineNumber": 34,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "\tmosaicAmount: uint64.fromUint(10000000),\n",
+                          "lineNumber": 35,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "\tduration: uint64.fromUint(100),\n",
+                          "lineNumber": 36,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "\thashAlgorithm: 0,\n",
+                          "lineNumber": 36,
+                          "lineChange": "removed"
+                        },
+                        {
+                          "line": "\tsecret: '225fe6d12b73a7d51f2992ce82951dbf8c173fa4',\n",
+                          "lineNumber": 37,
+                          "lineChange": "removed"
+                        },
+                        {
+                          "line": "\thashAlgorithm: HashAlgorithm.RIPEMD_160,\n",
+                          "lineNumber": 37,
+                          "lineChange": "added"
+                        },
+                        {
+                          "line": "\tsecret: hash,\n",
+                          "lineNumber": 38,
+                          "lineChange": "added"
+                        }
+                      ]
+                    }
+                  ],
+                  "exampleCommitDescriptions": [],
+                  "precision": "very-high",
+                  "repoDatasetSize": 68,
+                  "cwe": [
+                    "CWE-547"
+                  ]
+                }
+              },
+              {
+                "id": "javascript/HttpToHttps",
+                "name": "HttpToHttps",
+                "shortDescription": {
+                  "text": "Cleartext Transmission of Sensitive Information"
+                },
+                "defaultConfiguration": {
+                  "level": "warning"
+                },
+                "help": {
+                  "markdown": "\n## Details\nThis weakness occurs when software transmits sensitive information, such as passwords or credit card numbers, in unencrypted form. This information may then be intercepted by threat actors using sniffer tools or interception techniques such as man-in-the-middle (MITM) attacks (often involving social engineering). Attackers can then use information gleaned to perform a variety of actions, depending on the information type. Possible actions include gaining unauthorized access, impersonating a user, moving laterally within the organization's network, or retrieving and potentially modifying files. This weakness is almost completely avoidable through intelligent architecture and design.\n\n## Best practices for prevention\n* Build web applications around a security mindset and the awareness that sniffers may be present at any time.\n* Ensure that all sensitive data transmission uses reliable encryption.\n* Implement security measures so that sensitive results are never returned in plain text.\n* Implement multiple-factor authentication methods to validate remote instances.\n* Use SSL not only at logon but throughout communications.",
+                  "text": ""
+                },
+                "properties": {
+                  "tags": [
+                    "javascript",
+                    "HttpToHttps",
+                    "Security"
+                  ],
+                  "categories": [
+                    "Security"
+                  ],
+                  "exampleCommitFixes": [
+                    {
+                      "commitURL": "https://github.com/medic/couch2pg/commit/062eaa0f53d2cd2327232a695c60bf4c9fd589f6?diff=split#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L-1",
+                      "lines": [
+                        {
+                          "line": "var httplib = require('http');\n",
+                          "lineNumber": 1,
+                          "lineChange": "removed"
+                        },
+                        {
+                          "line": "var httplib = require('https');\n",
+                          "lineNumber": 1,
+                          "lineChange": "added"
+                        }
+                      ]
+                    },
+                    {
+                      "commitURL": "https://github.com/dondi/GRNsight/commit/01e7d39d55ea9c18348a48aac5954183d825e834?diff=split#diff-65890f102baa526da3cc5d65e0528ea728fa9fa63659a7f2e1d523686240359cL-1",
+                      "lines": [
+                        {
+                          "line": "var https = require(\"http\");\n",
+                          "lineNumber": 2,
+                          "lineChange": "removed"
+                        },
+                        {
+                          "line": "var https = require(\"https\");\n",
+                          "lineNumber": 2,
+                          "lineChange": "added"
+                        }
+                      ]
+                    },
+                    {
+                      "commitURL": "https://github.com/watilde/npmbrew/commit/968a0cd04e732ede4552e60e86762ce77f7f0a5c?diff=split#diff-94469ba7812da76fe341041375403897426443f146321489331bb46bb45faf5bL-1",
+                      "lines": [
+                        {
+                          "line": "var http = require(\"http\")\n",
+                          "lineNumber": 2,
+                          "lineChange": "removed"
+                        },
+                        {
+                          "line": "var http = require(\"https\")\n",
+                          "lineNumber": 2,
+                          "lineChange": "added"
+                        }
+                      ]
+                    }
+                  ],
+                  "exampleCommitDescriptions": [],
+                  "precision": "very-high",
+                  "repoDatasetSize": 4,
+                  "cwe": [
+                    "CWE-319"
+                  ]
+                }
+              },
+              {
+                "id": "javascript/HardcodedNonCryptoSecret/test",
+                "name": "HardcodedNonCryptoSecret/test",
+                "shortDescription": {
+                  "text": "Hardcoded Secret"
+                },
+                "defaultConfiguration": {
+                  "level": "note"
+                },
+                "help": {
+                  "markdown": "## Details\n\nWhen constants are hardcoded into applications, this information could easily be reverse-engineered and become known to attackers. For example, if a breached authentication token is hardcoded in multiple places in the application, it may lead to components of the application remaining vulnerable if not all instances are changed.\nAnother negative effect of hard-coding constants is potential unpredictability in the application's performance if the development team fails to update every single instance of the hardcoded constant throughout the code. For these reasons, hard-coding security-relevant constants is considered bad coding practice and should be remedied if present and avoided in future.\n\n## Best practices for prevention\n- Never hard code security-related constants; use symbolic names or configuration lookup files.\n- As hard coding is often done by coders working alone on a small scale, examine all legacy code components and test carefully when scaling.\n- Adopt a \"future-proof code\" mindset: While use of constants may save a little time now and make development simpler in the short term, it could cost time and money adapting to scale or other unforeseen circumstances (such as new hardware) in the future.",
+                  "text": ""
+                },
+                "properties": {
+                  "tags": [
+                    "javascript",
+                    "HardcodedNonCryptoSecret",
+                    "Security",
+                    "InTest"
+                  ],
+                  "categories": [
+                    "InTest"
+                  ],
+                  "exampleCommitFixes": [
+                    {
+                      "commitURL": "https://github.com/DanielMil/Authentication-Server/commit/310ce5500e9e751ee2fd9f3018bf772e9aae8364?diff=split#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122L-1",
+                      "lines": [
+                        {
+                          "line": "// Set environment variables\n",
+                          "lineNumber": 14,
+                          "lineChange": "added"
+                        },
+                        {
+                          "line": "const sessionSecret: any = process.env.SESSION_SECRET;\n",
+                          "lineNumber": 15,
+                          "lineChange": "added"
+                        },
+                        {
+                          "line": "const dbConnection: any = process.env.MONGO_URI; \n",
+                          "lineNumber": 16,
+                          "lineChange": "added"
+                        },
+                        {
+                          "line": "\n",
+                          "lineNumber": 17,
+                          "lineChange": "added"
+                        },
+                        {
+                          "line": "// Mongo config\n",
+                          "lineNumber": 18,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "const DB_CONNECTION: any = process.env.MONGO_URI; \n",
+                          "lineNumber": 15,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "mongoose.connect(DB_CONNECTION, { useNewUrlParser: true })\n",
+                          "lineNumber": 16,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": " .then(() => console.log(\"Succesfully connected to MongoDB.\"))\n",
+                          "lineNumber": 20,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": " .catch((err: mongoose.Error) => console.error(err));\n",
+                          "lineNumber": 21,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "const MongoStore = mongoStore(session); \n",
+                          "lineNumber": 22,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "const db: any  = mongoose.connection;\n",
+                          "lineNumber": 23,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": " \n",
+                          "lineNumber": 24,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "// Fix mongo deprecation warnings\n",
+                          "lineNumber": 25,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "mongoose.set('useNewUrlParser', true);\n",
+                          "lineNumber": 26,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "mongoose.set('useFindAndModify', false);\n",
+                          "lineNumber": 27,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "mongoose.set('useCreateIndex', true);\n",
+                          "lineNumber": 28,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "\n",
+                          "lineNumber": 29,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "// Configure express session\n",
+                          "lineNumber": 30,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "app.use(cookieParser());\n",
+                          "lineNumber": 31,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "app.use(session({\n",
+                          "lineNumber": 32,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "    secret: \"secret\",\n",
+                          "lineNumber": 30,
+                          "lineChange": "removed"
+                        },
+                        {
+                          "line": "    secret: sessionSecret,\n",
+                          "lineNumber": 33,
+                          "lineChange": "added"
+                        }
+                      ]
+                    },
+                    {
+                      "commitURL": "https://github.com/virena-app/virena/commit/8058527e8ef71bfa81f0cb0fb35eb80d00e08fdb?diff=split#diff-186488e26aa960d29fec244ac086f15e024c5a84df47eeba233d9b8d2525de2dL-1",
+                      "lines": [
+                        {
+                          "line": "client_id: '8fcf3e5c2d3d5dd78188',\n",
+                          "lineNumber": 36,
+                          "lineChange": "removed"
+                        },
+                        {
+                          "line": "client_secret: '0e102c56021e1aa28005b469b3c83ef7cb7e5b0e'\n",
+                          "lineNumber": 37,
+                          "lineChange": "removed"
+                        },
+                        {
+                          "line": "client_id: process.env.GITINIT,\n",
+                          "lineNumber": 36,
+                          "lineChange": "added"
+                        },
+                        {
+                          "line": "client_secret: process.env.GITSEE\n",
+                          "lineNumber": 37,
+                          "lineChange": "added"
+                        }
+                      ]
+                    },
+                    {
+                      "commitURL": "https://github.com/nemtech/nem2-library-js/commit/dd101718759035849eeb9d4a388656acdb5bf6d9?diff=split#diff-59ccc41578f07869060f7aea9ceca193a407696cce3de9f7219f98187f65c5b7L-1",
+                      "lines": [
+                        {
+                          "line": "const hash = sha3_512.create();\n",
+                          "lineNumber": 29,
+                          "lineChange": "removed"
+                        },
+                        {
+                          "line": "hash.update('secret');\n",
+                          "lineNumber": 30,
+                          "lineChange": "removed"
+                        },
+                        {
+                          "line": "const hash = new Ripemd160().update(Buffer.from('Test Hash 160')).digest('Hex');\t\t\n",
+                          "lineNumber": 31,
+                          "lineChange": "added"
+                        },
+                        {
+                          "line": "const secretLockTransaction = {\n",
+                          "lineNumber": 32,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "\tdeadline: deadline(),\n",
+                          "lineNumber": 33,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "\tmosaicId: [3646934825, 3576016193],\n",
+                          "lineNumber": 34,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "\tmosaicAmount: uint64.fromUint(10000000),\n",
+                          "lineNumber": 35,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "\tduration: uint64.fromUint(100),\n",
+                          "lineNumber": 36,
+                          "lineChange": "none"
+                        },
+                        {
+                          "line": "\thashAlgorithm: 0,\n",
+                          "lineNumber": 36,
+                          "lineChange": "removed"
+                        },
+                        {
+                          "line": "\tsecret: '225fe6d12b73a7d51f2992ce82951dbf8c173fa4',\n",
+                          "lineNumber": 37,
+                          "lineChange": "removed"
+                        },
+                        {
+                          "line": "\thashAlgorithm: HashAlgorithm.RIPEMD_160,\n",
+                          "lineNumber": 37,
+                          "lineChange": "added"
+                        },
+                        {
+                          "line": "\tsecret: hash,\n",
+                          "lineNumber": 38,
+                          "lineChange": "added"
+                        }
+                      ]
+                    }
+                  ],
+                  "exampleCommitDescriptions": [],
+                  "precision": "very-high",
+                  "repoDatasetSize": 68,
+                  "cwe": [
+                    "CWE-547"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "results": [
+          {
+            "ruleId": "javascript/HardcodedNonCryptoSecret",
+            "ruleIndex": 0,
+            "level": "error",
+            "message": {
+              "text": "Avoid hardcoding values that are meant to be secret. Found a hardcoded string used in here.",
+              "markdown": "Avoid hardcoding values that are meant to be secret. Found {0} used in {1}.",
+              "arguments": [
+                "[a hardcoded string](0)",
+                "[here](1)"
+              ]
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "scripts/db/migrations/20230811153738_add_generated_grouping_columns_to_collections_table.ts",
+                    "uriBaseId": "%SRCROOT%"
+                  },
+                  "region": {
+                    "startLine": 4,
+                    "endLine": 4,
+                    "startColumn": 7,
+                    "endColumn": 10
+                  }
+                }
+              }
+            ],
+            "fingerprints": {
+              "0": "8244ef71e04e646035be8283832b6a309c2f85a239b702daa56de49737ce4087",
+              "1": "40c5fd92.4773f344.8b18f948.d7919eeb.ef9f7d82.5fce695c.ea4b1c47.89d75565.40c5fd92.4773f344.72aa1700.d7919eeb.ef9f7d82.5fce695c.ea4b1c47.89d75565"
+            },
+            "codeFlows": [
+              {
+                "threadFlows": [
+                  {
+                    "locations": [
+                      {
+                        "location": {
+                          "id": 0,
+                          "physicalLocation": {
+                            "artifactLocation": {
+                              "uri": "scripts/db/migrations/20230811153738_add_generated_grouping_columns_to_collections_table.ts",
+                              "uriBaseId": "%SRCROOT%"
+                            },
+                            "region": {
+                              "startLine": 4,
+                              "endLine": 4,
+                              "startColumn": 13,
+                              "endColumn": 37
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "location": {
+                          "id": 1,
+                          "physicalLocation": {
+                            "artifactLocation": {
+                              "uri": "scripts/db/migrations/20230811153738_add_generated_grouping_columns_to_collections_table.ts",
+                              "uriBaseId": "%SRCROOT%"
+                            },
+                            "region": {
+                              "startLine": 4,
+                              "endLine": 4,
+                              "startColumn": 7,
+                              "endColumn": 10
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "properties": {
+              "priorityScore": 770,
+              "priorityScoreFactors": [
+                {
+                  "label": true,
+                  "type": "hotFileCodeFlow"
+                },
+                {
+                  "label": true,
+                  "type": "fixExamples"
+                }
+              ],
+              "isAutofixable": false
+            }
+          },
+          {
+            "ruleId": "javascript/HttpToHttps",
+            "ruleIndex": 1,
+            "level": "warning",
+            "message": {
+              "text": "http.createServer uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.",
+              "markdown": "{0} uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.",
+              "arguments": [
+                "[http.createServer](0)"
+              ]
+            },
+            "suppressions": [
+              {
+                "justification": "False positive",
+                "kind": "inSource",
+                "properties": {
+                  "category": "wont-fix",
+                  "expiration": "13 days",
+                  "ignoredOn": "2024-02-23T16:08:25Z",
+                  "ignoredBy": {
+                    "name": "Neil M",
+                    "email": "test@test.io"
+                  }
+                }
+              }
+            ],
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "src/main.ts",
+                    "uriBaseId": "%SRCROOT%"
+                  },
+                  "region": {
+                    "startLine": 58,
+                    "endLine": 58,
+                    "startColumn": 3,
+                    "endColumn": 20
+                  }
+                }
+              }
+            ],
+            "fingerprints": {
+              "0": "69ef878978ddff268c5edf5768d46f867316d83c0f16e4f87a0c0f22c554192e",
+              "1": "d22593cc.4773f344.607187b5.8df9c25a.261b8da8.6f0d36d4.8b77c8f4.91c60b7d.d22593cc.706318d0.1a243e8e.8df9c25a.db4f5344.5fce695c.8b77c8f4.89d75565"
+            },
+            "codeFlows": [
+              {
+                "threadFlows": [
+                  {
+                    "locations": [
+                      {
+                        "location": {
+                          "id": 0,
+                          "physicalLocation": {
+                            "artifactLocation": {
+                              "uri": "src/main.ts",
+                              "uriBaseId": "%SRCROOT%"
+                            },
+                            "region": {
+                              "startLine": 58,
+                              "endLine": 58,
+                              "startColumn": 3,
+                              "endColumn": 20
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "properties": {
+              "priorityScore": 590,
+              "priorityScoreFactors": [
+                {
+                  "label": true,
+                  "type": "multipleOccurrence"
+                },
+                {
+                  "label": true,
+                  "type": "hotFileSource"
+                },
+                {
+                  "label": true,
+                  "type": "fixExamples"
+                }
+              ],
+              "isAutofixable": false
+            }
+          },
+          {
+            "ruleId": "javascript/HttpToHttps",
+            "ruleIndex": 1,
+            "level": "warning",
+            "message": {
+              "text": "http.createServer uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.",
+              "markdown": "{0} uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.",
+              "arguments": [
+                "[http.createServer](0)"
+              ]
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "src/main.ts",
+                    "uriBaseId": "%SRCROOT%"
+                  },
+                  "region": {
+                    "startLine": 59,
+                    "endLine": 59,
+                    "startColumn": 3,
+                    "endColumn": 20
+                  }
+                }
+              }
+            ],
+            "fingerprints": {
+              "0": "c4f8f4eaa6cc507baa24f02ec58f77281f7f15a09de14b318bebfb38cff5c72c",
+              "1": "aac70831.4773f344.607187b5.9a6c48e6.261b8da8.6f0d36d4.8b77c8f4.7cd39cb5.aac70831.4773f344.607187b5.9a6c48e6.261b8da8.6f0d36d4.8b77c8f4.7cd39cb5"
+            },
+            "codeFlows": [
+              {
+                "threadFlows": [
+                  {
+                    "locations": [
+                      {
+                        "location": {
+                          "id": 0,
+                          "physicalLocation": {
+                            "artifactLocation": {
+                              "uri": "src/main.ts",
+                              "uriBaseId": "%SRCROOT%"
+                            },
+                            "region": {
+                              "startLine": 59,
+                              "endLine": 59,
+                              "startColumn": 3,
+                              "endColumn": 20
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "properties": {
+              "priorityScore": 590,
+              "priorityScoreFactors": [
+                {
+                  "label": true,
+                  "type": "multipleOccurrence"
+                },
+                {
+                  "label": true,
+                  "type": "hotFileSource"
+                },
+                {
+                  "label": true,
+                  "type": "fixExamples"
+                }
+              ],
+              "isAutofixable": false
+            }
+          },
+          {
+            "ruleId": "javascript/HardcodedNonCryptoSecret/test",
+            "ruleIndex": 2,
+            "level": "note",
+            "message": {
+              "text": "Avoid hardcoding values that are meant to be secret. Found a hardcoded string used in here.",
+              "markdown": "Avoid hardcoding values that are meant to be secret. Found {0} used in {1}.",
+              "arguments": [
+                "[a hardcoded string](0)",
+                "[here](1)"
+              ]
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "test/service-tests/service-utils/knex.service-spec.ts",
+                    "uriBaseId": "%SRCROOT%"
+                  },
+                  "region": {
+                    "startLine": 72,
+                    "endLine": 72,
+                    "startColumn": 9,
+                    "endColumn": 15
+                  }
+                }
+              }
+            ],
+            "fingerprints": {
+              "0": "aa2f1e390ae7c762e8eacf5cabc0b6aae9bbd1e33d5a9fb1d21f0f46432677a4",
+              "1": "fc3065be.4773f344.607187b5.e052b9a9.79a7d027.fcf3002d.63c3be99.0d8886fe.fc3065be.4773f344.c9330245.e052b9a9.79a7d027.8020cfdf.63c3be99.0d8886fe"
+            },
+            "codeFlows": [
+              {
+                "threadFlows": [
+                  {
+                    "locations": [
+                      {
+                        "location": {
+                          "id": 0,
+                          "physicalLocation": {
+                            "artifactLocation": {
+                              "uri": "test/service-tests/service-utils/knex.service-spec.ts",
+                              "uriBaseId": "%SRCROOT%"
+                            },
+                            "region": {
+                              "startLine": 72,
+                              "endLine": 72,
+                              "startColumn": 17,
+                              "endColumn": 57
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "location": {
+                          "id": 1,
+                          "physicalLocation": {
+                            "artifactLocation": {
+                              "uri": "test/service-tests/service-utils/knex.service-spec.ts",
+                              "uriBaseId": "%SRCROOT%"
+                            },
+                            "region": {
+                              "startLine": 72,
+                              "endLine": 72,
+                              "startColumn": 9,
+                              "endColumn": 15
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "properties": {
+              "priorityScore": 440,
+              "priorityScoreFactors": [
+                {
+                  "label": true,
+                  "type": "multipleOccurrence"
+                },
+                {
+                  "label": true,
+                  "type": "hotFileSource"
+                },
+                {
+                  "label": true,
+                  "type": "fixExamples"
+                }
+              ],
+              "isAutofixable": false
+            }
+          },
+          {
+            "ruleId": "javascript/HardcodedNonCryptoSecret/test",
+            "ruleIndex": 2,
+            "level": "note",
+            "message": {
+              "text": "Avoid hardcoding values that are meant to be secret. Found a hardcoded string used in here.",
+              "markdown": "Avoid hardcoding values that are meant to be secret. Found {0} used in {1}.",
+              "arguments": [
+                "[a hardcoded string](0)",
+                "[here](1)"
+              ]
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "test/service-tests/service-utils/knex.service-spec.ts",
+                    "uriBaseId": "%SRCROOT%"
+                  },
+                  "region": {
+                    "startLine": 76,
+                    "endLine": 76,
+                    "startColumn": 9,
+                    "endColumn": 15
+                  }
+                }
+              }
+            ],
+            "fingerprints": {
+              "0": "38de968ba6105240552721b378ac14d3eb7bdd4ccc2c17a6e84caa66ba45f6f0",
+              "1": "fc3065be.4773f344.607187b5.e052b9a9.79a7d027.fcf3002d.a56a8b5b.3cee0341.fc3065be.4773f344.c9330245.e052b9a9.79a7d027.8020cfdf.6977003a.864f3ca8"
+            },
+            "codeFlows": [
+              {
+                "threadFlows": [
+                  {
+                    "locations": [
+                      {
+                        "location": {
+                          "id": 0,
+                          "physicalLocation": {
+                            "artifactLocation": {
+                              "uri": "test/service-tests/service-utils/knex.service-spec.ts",
+                              "uriBaseId": "%SRCROOT%"
+                            },
+                            "region": {
+                              "startLine": 76,
+                              "endLine": 76,
+                              "startColumn": 17,
+                              "endColumn": 30
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "location": {
+                          "id": 1,
+                          "physicalLocation": {
+                            "artifactLocation": {
+                              "uri": "test/service-tests/service-utils/knex.service-spec.ts",
+                              "uriBaseId": "%SRCROOT%"
+                            },
+                            "region": {
+                              "startLine": 76,
+                              "endLine": 76,
+                              "startColumn": 9,
+                              "endColumn": 15
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "properties": {
+              "priorityScore": 440,
+              "priorityScoreFactors": [
+                {
+                  "label": true,
+                  "type": "multipleOccurrence"
+                },
+                {
+                  "label": true,
+                  "type": "hotFileSource"
+                },
+                {
+                  "label": true,
+                  "type": "fixExamples"
+                }
+              ],
+              "isAutofixable": false
+            }
+          }
+        ],
+        "properties": {
+          "coverage": [
+            {
+              "isSupported": true,
+              "lang": "TypeScript",
+              "files": 347,
+              "type": "SUPPORTED"
+            },
+            {
+              "isSupported": true,
+              "lang": "JavaScript",
+              "files": 2,
+              "type": "SUPPORTED"
+            },
+            {
+              "isSupported": false,
+              "lang": "TypeScript",
+              "files": 5,
+              "type": "FAILED_PARSING"
+            }
+          ]
+        }
+      }
+    ]
+}

--- a/internal/presenters/testdata/with-ignores.json
+++ b/internal/presenters/testdata/with-ignores.json
@@ -673,7 +673,7 @@
                 "kind": "inSource",
                 "properties": {
                   "category": "wont-fix",
-                  "expiration": "13 days",
+                  "expiration": "15 days",
                   "ignoredOn": "2024-02-23T16:08:25Z",
                   "ignoredBy": {
                     "name": "Neil M",

--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -34,5 +34,6 @@ const (
 	FF_CODE_CONSISTENT_IGNORES string = "internal_snyk_code_ignores_enabled"
 
 	// flags
-	FLAG_EXPERIMENTAL string = "experimental"
+	FLAG_EXPERIMENTAL    string = "experimental"
+	FLAG_INCLUDE_IGNORES string = "include-ignores"
 )

--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -36,4 +36,5 @@ const (
 	// flags
 	FLAG_EXPERIMENTAL    string = "experimental"
 	FLAG_INCLUDE_IGNORES string = "include-ignores"
+	FLAG_ONLY_IGNORES    string = "only-ignores"
 )

--- a/pkg/local_workflows/output_workflow.go
+++ b/pkg/local_workflows/output_workflow.go
@@ -161,16 +161,10 @@ func humanReadanbleSarifOutput(config configuration.Configuration, input []workf
 		debugLogger.Println(err)
 	}
 
-	meta := presenters.TestMeta{
-		OrgName:  config.GetString(configuration.ORGANIZATION),
-		TestPath: input[i].GetContentLocation(),
-	}
-	debugLogger.Printf("humanReadanbleSarifOutput: %v", meta)
-
 	p := presenters.SarifTestResults(
 		sarif,
-		presenters.WithOrgName(meta.OrgName),
-		presenters.WithTestPath(meta.TestPath),
+		presenters.WithOrgName(config.GetString(configuration.ORGANIZATION)),
+		presenters.WithTestPath(input[i].GetContentLocation()),
 		presenters.WithIgnored(includeIgnoredFindings),
 		presenters.WithOpen(includeOpenFindings),
 	)

--- a/pkg/local_workflows/output_workflow.go
+++ b/pkg/local_workflows/output_workflow.go
@@ -23,7 +23,7 @@ const (
 	OUTPUT_CONFIG_KEY_JSON_FILE       = "json-file-output"
 	OUTPUT_CONFIG_KEY_SARIF           = "sarif"
 	OUTPUT_CONFIG_KEY_SARIF_FILE      = "sarif-file-output"
-	OUTPUT_CONFIG_KEY_INCLUDE_IGNORES = "include-ignores"
+	OUTPUT_CONFIG_KEY_INCLUDE_IGNORES = configuration.FLAG_INCLUDE_IGNORES
 )
 
 // InitOutputWorkflow initializes the output workflow

--- a/pkg/local_workflows/output_workflow.go
+++ b/pkg/local_workflows/output_workflow.go
@@ -19,12 +19,10 @@ import (
 var WORKFLOWID_OUTPUT_WORKFLOW workflow.Identifier = workflow.NewWorkflowIdentifier("output")
 
 const (
-	OUTPUT_CONFIG_KEY_JSON            = "json"
-	OUTPUT_CONFIG_KEY_JSON_FILE       = "json-file-output"
-	OUTPUT_CONFIG_KEY_SARIF           = "sarif"
-	OUTPUT_CONFIG_KEY_SARIF_FILE      = "sarif-file-output"
-	OUTPUT_CONFIG_KEY_INCLUDE_IGNORES = configuration.FLAG_INCLUDE_IGNORES
-	OUTPUT_CONFIG_KEY_ONLY_IGNORES    = configuration.FLAG_ONLY_IGNORES
+	OUTPUT_CONFIG_KEY_JSON       = "json"
+	OUTPUT_CONFIG_KEY_JSON_FILE  = "json-file-output"
+	OUTPUT_CONFIG_KEY_SARIF      = "sarif"
+	OUTPUT_CONFIG_KEY_SARIF_FILE = "sarif-file-output"
 )
 
 // InitOutputWorkflow initializes the output workflow
@@ -36,8 +34,8 @@ func InitOutputWorkflow(engine workflow.Engine) error {
 	outputConfig.String(OUTPUT_CONFIG_KEY_JSON_FILE, "", "Write json output to file")
 	outputConfig.Bool(OUTPUT_CONFIG_KEY_SARIF, false, "Print sarif output to console")
 	outputConfig.String(OUTPUT_CONFIG_KEY_SARIF_FILE, "", "Write sarif output to file")
-	outputConfig.Bool(OUTPUT_CONFIG_KEY_INCLUDE_IGNORES, false, "Include ignored findings in the output")
-	outputConfig.Bool(OUTPUT_CONFIG_KEY_ONLY_IGNORES, false, "Hide open issues in the output")
+	outputConfig.Bool(configuration.FLAG_INCLUDE_IGNORES, false, "Include ignored findings in the output")
+	outputConfig.Bool(configuration.FLAG_ONLY_IGNORES, false, "Hide open issues in the output")
 
 	entry, err := engine.Register(WORKFLOWID_OUTPUT_WORKFLOW, workflow.ConfigurationOptionsFromFlagset(outputConfig), outputWorkflowEntryPointImpl)
 	entry.SetVisibility(false)
@@ -154,8 +152,8 @@ func jsonWriteToFile(debugLogger *zerolog.Logger, input []workflow.Data, i int, 
 }
 
 func humanReadanbleSarifOutput(config configuration.Configuration, input []workflow.Data, i int, outputDestination iUtils.OutputDestination, debugLogger *zerolog.Logger, singleData []byte) {
-	includeOpenFindings := !config.GetBool(OUTPUT_CONFIG_KEY_ONLY_IGNORES)
-	includeIgnoredFindings := config.GetBool(OUTPUT_CONFIG_KEY_INCLUDE_IGNORES) || config.GetBool(OUTPUT_CONFIG_KEY_ONLY_IGNORES)
+	includeOpenFindings := !config.GetBool(configuration.FLAG_ONLY_IGNORES)
+	includeIgnoredFindings := config.GetBool(configuration.FLAG_INCLUDE_IGNORES) || config.GetBool(configuration.FLAG_ONLY_IGNORES)
 
 	var sarif sarif.SarifDocument
 	err := json.Unmarshal(singleData, &sarif)

--- a/pkg/local_workflows/output_workflow.go
+++ b/pkg/local_workflows/output_workflow.go
@@ -166,7 +166,16 @@ func humanReadanbleSarifOutput(config configuration.Configuration, input []workf
 		TestPath: input[i].GetContentLocation(),
 	}
 	debugLogger.Printf("humanReadanbleSarifOutput: %v", meta)
-	humanReadableResult, err := presenters.PresenterSarifResultsPretty(sarif, meta, includeIgnoredFindings, includeOpenFindings)
+
+	p := presenters.SarifTestResults(
+		sarif,
+		presenters.WithOrgName(meta.OrgName),
+		presenters.WithTestPath(meta.TestPath),
+		presenters.WithIgnored(includeIgnoredFindings),
+		presenters.WithOpen(includeOpenFindings),
+	)
+
+	humanReadableResult, err := p.Render()
 	if err != nil {
 		debugLogger.Println(err)
 	}

--- a/pkg/local_workflows/output_workflow_test.go
+++ b/pkg/local_workflows/output_workflow_test.go
@@ -224,6 +224,7 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 	})
 
 	t.Run("should print human readable output for sarif data without ignored rules", func(t *testing.T) {
+		ignoreExpiry := "13 days"
 		input := sarif.SarifDocument{
 			Runs: []sarif.Run{
 				{
@@ -236,9 +237,18 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 					Results: []sarif.Result{
 						{Level: "error"},
 						{
-							Level:        "error",
-							Suppressions: make([]sarif.Suppression, 1),
-							RuleID:       "rule1",
+							Level: "error",
+							Suppressions: []sarif.Suppression{
+								{
+									Justification: "wont-fix",
+									Properties: sarif.SuppressionProperties{
+										Category:   "category",
+										Expiration: &ignoreExpiry,
+										IgnoredOn:  "ignoredOn",
+									},
+								},
+							},
+							RuleID: "rule1",
 						},
 					},
 					Tool: sarif.Tool{

--- a/pkg/local_workflows/output_workflow_test.go
+++ b/pkg/local_workflows/output_workflow_test.go
@@ -379,7 +379,7 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 			assert.Contains(t, str, "Ignored rule")
 		}).Times(1)
 
-		config.Set("include-ignores", true)
+		config.Set(configuration.FLAG_INCLUDE_IGNORES, true)
 
 		// execute
 		output, err := outputWorkflowEntryPoint(invocationContextMock, []workflow.Data{sarifData}, outputDestination)

--- a/pkg/local_workflows/output_workflow_test.go
+++ b/pkg/local_workflows/output_workflow_test.go
@@ -316,7 +316,9 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 				},
 				{
 					Results: []sarif.Result{
-						{Level: "error"},
+						{Level: "error",
+							RuleID: "openIssue",
+						},
 						{
 							Level:        "error",
 							Suppressions: make([]sarif.Suppression, 1),
@@ -354,6 +356,34 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 										Cwe:                []string{""},
 									},
 								},
+								{
+									ID:   "openIssue",
+									Name: "This rule is open",
+									ShortDescription: sarif.ShortDescription{
+										Text: "This rule is open",
+									},
+									Help: sarif.Help{
+										Text: "",
+									},
+									DefaultConfiguration: sarif.DefaultConfiguration{
+										Level: "error",
+									},
+									Properties: sarif.RuleProperties{
+										Tags: []string{"tag1", "tag2"},
+										ShortDescription: sarif.ShortDescription{
+											Text: "",
+										},
+										Help: struct {
+											Markdown string `json:"markdown"`
+											Text     string `json:"text"`
+										}{Markdown: "", Text: ""},
+										Categories:         []string{},
+										ExampleCommitFixes: []sarif.ExampleCommitFix{},
+										Precision:          "",
+										RepoDatasetSize:    0,
+										Cwe:                []string{""},
+									},
+								},
 							},
 						},
 					},
@@ -377,9 +407,126 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 		outputDestination.EXPECT().Println(gomock.Any()).Do(func(str string) {
 			assert.Contains(t, str, "Total issues:   5")
 			assert.Contains(t, str, "Ignored rule")
+			assert.Contains(t, str, "This rule is open")
 		}).Times(1)
 
 		config.Set(configuration.FLAG_INCLUDE_IGNORES, true)
+
+		// execute
+		output, err := outputWorkflowEntryPoint(invocationContextMock, []workflow.Data{sarifData}, outputDestination)
+
+		// assert
+		assert.Nil(t, err)
+		assert.Equal(t, []workflow.Data{}, output)
+	})
+
+	t.Run("should print human readable output for sarif data only showing ignored data", func(t *testing.T) {
+		input := sarif.SarifDocument{
+			Runs: []sarif.Run{
+				{
+					Results: []sarif.Result{
+						{Level: "error"},
+						{Level: "warning"},
+					},
+				},
+				{
+					Results: []sarif.Result{
+						{
+							Level:  "error",
+							RuleID: "openIssue",
+						},
+						{
+							Level:        "error",
+							Suppressions: make([]sarif.Suppression, 1),
+							RuleID:       "rule1",
+						},
+					},
+					Tool: sarif.Tool{
+						Driver: sarif.Driver{
+							Rules: []sarif.Rule{
+								{
+									ID:   "rule1",
+									Name: "Ignored rule",
+									ShortDescription: sarif.ShortDescription{
+										Text: "Ignored rule",
+									},
+									Help: sarif.Help{
+										Text: "Rule 1 help",
+									},
+									DefaultConfiguration: sarif.DefaultConfiguration{
+										Level: "error",
+									},
+									Properties: sarif.RuleProperties{
+										Tags: []string{"tag1", "tag2"},
+										ShortDescription: sarif.ShortDescription{
+											Text: "Rule 1 description",
+										},
+										Help: struct {
+											Markdown string `json:"markdown"`
+											Text     string `json:"text"`
+										}{Markdown: "", Text: ""},
+										Categories:         []string{},
+										ExampleCommitFixes: []sarif.ExampleCommitFix{},
+										Precision:          "",
+										RepoDatasetSize:    0,
+										Cwe:                []string{""},
+									},
+								},
+								{
+									ID:   "openIssue",
+									Name: "This rule is open",
+									ShortDescription: sarif.ShortDescription{
+										Text: "This rule is open",
+									},
+									Help: sarif.Help{
+										Text: "",
+									},
+									DefaultConfiguration: sarif.DefaultConfiguration{
+										Level: "error",
+									},
+									Properties: sarif.RuleProperties{
+										Tags: []string{"tag1", "tag2"},
+										ShortDescription: sarif.ShortDescription{
+											Text: "",
+										},
+										Help: struct {
+											Markdown string `json:"markdown"`
+											Text     string `json:"text"`
+										}{Markdown: "", Text: ""},
+										Categories:         []string{},
+										ExampleCommitFixes: []sarif.ExampleCommitFix{},
+										Precision:          "",
+										RepoDatasetSize:    0,
+										Cwe:                []string{""},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Results: []sarif.Result{
+						{Level: "note", Suppressions: make([]sarif.Suppression, 1)},
+					},
+				},
+			},
+		}
+
+		rawSarif, err := json.Marshal(input)
+		assert.Nil(t, err)
+
+		workflowIdentifier := workflow.NewTypeIdentifier(WORKFLOWID_OUTPUT_WORKFLOW, "output")
+		sarifData := workflow.NewData(workflowIdentifier, content_type.SARIF_JSON, rawSarif)
+		sarifData.SetContentLocation("/mypath")
+
+		// mock assertions
+		outputDestination.EXPECT().Println(gomock.Any()).Do(func(str string) {
+			assert.Contains(t, str, "Total issues:   5")
+			assert.Contains(t, str, "Ignored rule")
+			assert.NotContains(t, str, "This rule is open")
+		}).Times(1)
+
+		config.Set(configuration.FLAG_ONLY_IGNORES, true)
 
 		// execute
 		output, err := outputWorkflowEntryPoint(invocationContextMock, []workflow.Data{sarifData}, outputDestination)

--- a/pkg/local_workflows/output_workflow_test.go
+++ b/pkg/local_workflows/output_workflow_test.go
@@ -223,7 +223,7 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 		assert.Equal(t, []workflow.Data{}, output)
 	})
 
-	t.Run("should print human readable output for sarif data", func(t *testing.T) {
+	t.Run("should print human readable output for sarif data without ignored rules", func(t *testing.T) {
 		input := sarif.SarifDocument{
 			Runs: []sarif.Run{
 				{
@@ -235,7 +235,45 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 				{
 					Results: []sarif.Result{
 						{Level: "error"},
-						{Level: "error", Suppressions: make([]sarif.Suppression, 1)},
+						{
+							Level:        "error",
+							Suppressions: make([]sarif.Suppression, 1),
+							RuleID:       "rule1",
+						},
+					},
+					Tool: sarif.Tool{
+						Driver: sarif.Driver{
+							Rules: []sarif.Rule{
+								{
+									ID:   "rule1",
+									Name: "Ignored rule",
+									ShortDescription: sarif.ShortDescription{
+										Text: "Ignored rule",
+									},
+									Help: sarif.Help{
+										Text: "Rule 1 help",
+									},
+									DefaultConfiguration: sarif.DefaultConfiguration{
+										Level: "error",
+									},
+									Properties: sarif.RuleProperties{
+										Tags: []string{"tag1", "tag2"},
+										ShortDescription: sarif.ShortDescription{
+											Text: "Rule 1 description",
+										},
+										Help: struct {
+											Markdown string `json:"markdown"`
+											Text     string `json:"text"`
+										}{Markdown: "", Text: ""},
+										Categories:         []string{},
+										ExampleCommitFixes: []sarif.ExampleCommitFix{},
+										Precision:          "",
+										RepoDatasetSize:    0,
+										Cwe:                []string{""},
+									},
+								},
+							},
+						},
 					},
 				},
 				{
@@ -256,7 +294,92 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 		// mock assertions
 		outputDestination.EXPECT().Println(gomock.Any()).Do(func(str string) {
 			assert.Contains(t, str, "Total issues:   5")
+			assert.NotContains(t, str, "Ignored rule")
 		}).Times(1)
+
+		// execute
+		output, err := outputWorkflowEntryPoint(invocationContextMock, []workflow.Data{sarifData}, outputDestination)
+
+		// assert
+		assert.Nil(t, err)
+		assert.Equal(t, []workflow.Data{}, output)
+	})
+
+	t.Run("should print human readable output for sarif data including ignored data", func(t *testing.T) {
+		input := sarif.SarifDocument{
+			Runs: []sarif.Run{
+				{
+					Results: []sarif.Result{
+						{Level: "error"},
+						{Level: "warning"},
+					},
+				},
+				{
+					Results: []sarif.Result{
+						{Level: "error"},
+						{
+							Level:        "error",
+							Suppressions: make([]sarif.Suppression, 1),
+							RuleID:       "rule1",
+						},
+					},
+					Tool: sarif.Tool{
+						Driver: sarif.Driver{
+							Rules: []sarif.Rule{
+								{
+									ID:   "rule1",
+									Name: "Ignored rule",
+									ShortDescription: sarif.ShortDescription{
+										Text: "Ignored rule",
+									},
+									Help: sarif.Help{
+										Text: "Rule 1 help",
+									},
+									DefaultConfiguration: sarif.DefaultConfiguration{
+										Level: "error",
+									},
+									Properties: sarif.RuleProperties{
+										Tags: []string{"tag1", "tag2"},
+										ShortDescription: sarif.ShortDescription{
+											Text: "Rule 1 description",
+										},
+										Help: struct {
+											Markdown string `json:"markdown"`
+											Text     string `json:"text"`
+										}{Markdown: "", Text: ""},
+										Categories:         []string{},
+										ExampleCommitFixes: []sarif.ExampleCommitFix{},
+										Precision:          "",
+										RepoDatasetSize:    0,
+										Cwe:                []string{""},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Results: []sarif.Result{
+						{Level: "note", Suppressions: make([]sarif.Suppression, 1)},
+					},
+				},
+			},
+		}
+
+		rawSarif, err := json.Marshal(input)
+		assert.Nil(t, err)
+
+		workflowIdentifier := workflow.NewTypeIdentifier(WORKFLOWID_OUTPUT_WORKFLOW, "output")
+		sarifData := workflow.NewData(workflowIdentifier, content_type.SARIF_JSON, rawSarif)
+		sarifData.SetContentLocation("/mypath")
+
+		// mock assertions
+		outputDestination.EXPECT().Println(gomock.Any()).Do(func(str string) {
+			assert.Contains(t, str, "Total issues:   5")
+			assert.Contains(t, str, "Ignored rule")
+		}).Times(1)
+
+		config.Set("include-ignores", true)
 
 		// execute
 		output, err := outputWorkflowEntryPoint(invocationContextMock, []workflow.Data{sarifData}, outputDestination)

--- a/pkg/local_workflows/output_workflow_test.go
+++ b/pkg/local_workflows/output_workflow_test.go
@@ -224,75 +224,7 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 	})
 
 	t.Run("should print human readable output for sarif data without ignored rules", func(t *testing.T) {
-		ignoreExpiry := "13 days"
-		input := sarif.SarifDocument{
-			Runs: []sarif.Run{
-				{
-					Results: []sarif.Result{
-						{Level: "error"},
-						{Level: "warning"},
-					},
-				},
-				{
-					Results: []sarif.Result{
-						{Level: "error"},
-						{
-							Level: "error",
-							Suppressions: []sarif.Suppression{
-								{
-									Justification: "wont-fix",
-									Properties: sarif.SuppressionProperties{
-										Category:   "category",
-										Expiration: &ignoreExpiry,
-										IgnoredOn:  "ignoredOn",
-									},
-								},
-							},
-							RuleID: "rule1",
-						},
-					},
-					Tool: sarif.Tool{
-						Driver: sarif.Driver{
-							Rules: []sarif.Rule{
-								{
-									ID:   "rule1",
-									Name: "Ignored rule",
-									ShortDescription: sarif.ShortDescription{
-										Text: "Ignored rule",
-									},
-									Help: sarif.Help{
-										Text: "Rule 1 help",
-									},
-									DefaultConfiguration: sarif.DefaultConfiguration{
-										Level: "error",
-									},
-									Properties: sarif.RuleProperties{
-										Tags: []string{"tag1", "tag2"},
-										ShortDescription: sarif.ShortDescription{
-											Text: "Rule 1 description",
-										},
-										Help: struct {
-											Markdown string `json:"markdown"`
-											Text     string `json:"text"`
-										}{Markdown: "", Text: ""},
-										Categories:         []string{},
-										ExampleCommitFixes: []sarif.ExampleCommitFix{},
-										Precision:          "",
-										RepoDatasetSize:    0,
-										Cwe:                []string{""},
-									},
-								},
-							},
-						},
-					},
-				},
-				{
-					Results: []sarif.Result{
-						{Level: "note", Suppressions: make([]sarif.Suppression, 1)},
-					},
-				},
-			},
-		}
+		input := getSarifInput()
 
 		rawSarif, err := json.Marshal(input)
 		assert.Nil(t, err)
@@ -316,95 +248,7 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 	})
 
 	t.Run("should print human readable output for sarif data including ignored data", func(t *testing.T) {
-		input := sarif.SarifDocument{
-			Runs: []sarif.Run{
-				{
-					Results: []sarif.Result{
-						{Level: "error"},
-						{Level: "warning"},
-					},
-				},
-				{
-					Results: []sarif.Result{
-						{Level: "error",
-							RuleID: "openIssue",
-						},
-						{
-							Level:        "error",
-							Suppressions: make([]sarif.Suppression, 1),
-							RuleID:       "rule1",
-						},
-					},
-					Tool: sarif.Tool{
-						Driver: sarif.Driver{
-							Rules: []sarif.Rule{
-								{
-									ID:   "rule1",
-									Name: "Ignored rule",
-									ShortDescription: sarif.ShortDescription{
-										Text: "Ignored rule",
-									},
-									Help: sarif.Help{
-										Text: "Rule 1 help",
-									},
-									DefaultConfiguration: sarif.DefaultConfiguration{
-										Level: "error",
-									},
-									Properties: sarif.RuleProperties{
-										Tags: []string{"tag1", "tag2"},
-										ShortDescription: sarif.ShortDescription{
-											Text: "Rule 1 description",
-										},
-										Help: struct {
-											Markdown string `json:"markdown"`
-											Text     string `json:"text"`
-										}{Markdown: "", Text: ""},
-										Categories:         []string{},
-										ExampleCommitFixes: []sarif.ExampleCommitFix{},
-										Precision:          "",
-										RepoDatasetSize:    0,
-										Cwe:                []string{""},
-									},
-								},
-								{
-									ID:   "openIssue",
-									Name: "This rule is open",
-									ShortDescription: sarif.ShortDescription{
-										Text: "This rule is open",
-									},
-									Help: sarif.Help{
-										Text: "",
-									},
-									DefaultConfiguration: sarif.DefaultConfiguration{
-										Level: "error",
-									},
-									Properties: sarif.RuleProperties{
-										Tags: []string{"tag1", "tag2"},
-										ShortDescription: sarif.ShortDescription{
-											Text: "",
-										},
-										Help: struct {
-											Markdown string `json:"markdown"`
-											Text     string `json:"text"`
-										}{Markdown: "", Text: ""},
-										Categories:         []string{},
-										ExampleCommitFixes: []sarif.ExampleCommitFix{},
-										Precision:          "",
-										RepoDatasetSize:    0,
-										Cwe:                []string{""},
-									},
-								},
-							},
-						},
-					},
-				},
-				{
-					Results: []sarif.Result{
-						{Level: "note", Suppressions: make([]sarif.Suppression, 1)},
-					},
-				},
-			},
-		}
+		input := getSarifInput()
 
 		rawSarif, err := json.Marshal(input)
 		assert.Nil(t, err)
@@ -431,96 +275,7 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 	})
 
 	t.Run("should print human readable output for sarif data only showing ignored data", func(t *testing.T) {
-		input := sarif.SarifDocument{
-			Runs: []sarif.Run{
-				{
-					Results: []sarif.Result{
-						{Level: "error"},
-						{Level: "warning"},
-					},
-				},
-				{
-					Results: []sarif.Result{
-						{
-							Level:  "error",
-							RuleID: "openIssue",
-						},
-						{
-							Level:        "error",
-							Suppressions: make([]sarif.Suppression, 1),
-							RuleID:       "rule1",
-						},
-					},
-					Tool: sarif.Tool{
-						Driver: sarif.Driver{
-							Rules: []sarif.Rule{
-								{
-									ID:   "rule1",
-									Name: "Ignored rule",
-									ShortDescription: sarif.ShortDescription{
-										Text: "Ignored rule",
-									},
-									Help: sarif.Help{
-										Text: "Rule 1 help",
-									},
-									DefaultConfiguration: sarif.DefaultConfiguration{
-										Level: "error",
-									},
-									Properties: sarif.RuleProperties{
-										Tags: []string{"tag1", "tag2"},
-										ShortDescription: sarif.ShortDescription{
-											Text: "Rule 1 description",
-										},
-										Help: struct {
-											Markdown string `json:"markdown"`
-											Text     string `json:"text"`
-										}{Markdown: "", Text: ""},
-										Categories:         []string{},
-										ExampleCommitFixes: []sarif.ExampleCommitFix{},
-										Precision:          "",
-										RepoDatasetSize:    0,
-										Cwe:                []string{""},
-									},
-								},
-								{
-									ID:   "openIssue",
-									Name: "This rule is open",
-									ShortDescription: sarif.ShortDescription{
-										Text: "This rule is open",
-									},
-									Help: sarif.Help{
-										Text: "",
-									},
-									DefaultConfiguration: sarif.DefaultConfiguration{
-										Level: "error",
-									},
-									Properties: sarif.RuleProperties{
-										Tags: []string{"tag1", "tag2"},
-										ShortDescription: sarif.ShortDescription{
-											Text: "",
-										},
-										Help: struct {
-											Markdown string `json:"markdown"`
-											Text     string `json:"text"`
-										}{Markdown: "", Text: ""},
-										Categories:         []string{},
-										ExampleCommitFixes: []sarif.ExampleCommitFix{},
-										Precision:          "",
-										RepoDatasetSize:    0,
-										Cwe:                []string{""},
-									},
-								},
-							},
-						},
-					},
-				},
-				{
-					Results: []sarif.Result{
-						{Level: "note", Suppressions: make([]sarif.Suppression, 1)},
-					},
-				},
-			},
-		}
+		input := getSarifInput()
 
 		rawSarif, err := json.Marshal(input)
 		assert.Nil(t, err)
@@ -545,4 +300,96 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, []workflow.Data{}, output)
 	})
+}
+
+func getSarifInput() sarif.SarifDocument {
+	return sarif.SarifDocument{
+		Runs: []sarif.Run{
+			{
+				Results: []sarif.Result{
+					{Level: "error"},
+					{Level: "warning"},
+				},
+			},
+			{
+				Results: []sarif.Result{
+					{Level: "error",
+						RuleID: "openIssue",
+					},
+					{
+						Level:        "error",
+						Suppressions: make([]sarif.Suppression, 1),
+						RuleID:       "rule1",
+					},
+				},
+				Tool: sarif.Tool{
+					Driver: sarif.Driver{
+						Rules: []sarif.Rule{
+							{
+								ID:   "rule1",
+								Name: "Ignored rule",
+								ShortDescription: sarif.ShortDescription{
+									Text: "Ignored rule",
+								},
+								Help: sarif.Help{
+									Text: "Rule 1 help",
+								},
+								DefaultConfiguration: sarif.DefaultConfiguration{
+									Level: "error",
+								},
+								Properties: sarif.RuleProperties{
+									Tags: []string{"tag1", "tag2"},
+									ShortDescription: sarif.ShortDescription{
+										Text: "Rule 1 description",
+									},
+									Help: struct {
+										Markdown string `json:"markdown"`
+										Text     string `json:"text"`
+									}{Markdown: "", Text: ""},
+									Categories:         []string{},
+									ExampleCommitFixes: []sarif.ExampleCommitFix{},
+									Precision:          "",
+									RepoDatasetSize:    0,
+									Cwe:                []string{""},
+								},
+							},
+							{
+								ID:   "openIssue",
+								Name: "This rule is open",
+								ShortDescription: sarif.ShortDescription{
+									Text: "This rule is open",
+								},
+								Help: sarif.Help{
+									Text: "",
+								},
+								DefaultConfiguration: sarif.DefaultConfiguration{
+									Level: "error",
+								},
+								Properties: sarif.RuleProperties{
+									Tags: []string{"tag1", "tag2"},
+									ShortDescription: sarif.ShortDescription{
+										Text: "",
+									},
+									Help: struct {
+										Markdown string `json:"markdown"`
+										Text     string `json:"text"`
+									}{Markdown: "", Text: ""},
+									Categories:         []string{},
+									ExampleCommitFixes: []sarif.ExampleCommitFix{},
+									Precision:          "",
+									RepoDatasetSize:    0,
+									Cwe:                []string{""},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Results: []sarif.Result{
+					{Level: "note", Suppressions: make([]sarif.Suppression, 1)},
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
Introduce support for hiding ignored items by default, this aligns with the current behaviour of the Typescript implementation. 

The new functionality here is to introduce 2 new flags `--include-ignores` and `--only-ignores` which can be used to toggle which items are displayed in the output. 

These screengrabs show the different flags and resulting output. 

By default we only show the open issues, there are four items visible:
![Demo001](https://github.com/snyk/go-application-framework/assets/472589/18ac7cc6-c55b-4c27-9bdc-d0d417c8debd)

Using `--include-ignores` will show also the ignored issue, there are now five items visible:
![Demo002](https://github.com/snyk/go-application-framework/assets/472589/ee4ce782-a181-4f6a-8ce2-6758430be7d8)

Using `--only-ignores` will only show the ignored issue(s), there is now one item visible:
![Demo003](https://github.com/snyk/go-application-framework/assets/472589/cea9ea44-1d94-43b8-aebb-f83fb53027c3)
