### PR TITLE
feat: export TokenColor helpers

### DIFF
--- a/internal/presenters/styles.go
+++ b/internal/presenters/styles.go
@@ -4,10 +4,12 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/snyk/go-application-framework/pkg/ui"
 )
 
-var boxStyle = lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).
-	BorderForeground(lipgloss.NoColor{}).
+var boxStyle = lipgloss.NewStyle().
+	BorderStyle(lipgloss.RoundedBorder()).
+	BorderForeground(ui.TokenColor("border.plain")).
 	PaddingLeft(1).
 	PaddingRight(4)
 
@@ -16,11 +18,8 @@ func renderBold(str string) string {
 }
 
 func renderInSeverityColor(severity string, str string) string {
-	severityToColor := map[string]lipgloss.TerminalColor{
-		"LOW":    lipgloss.NoColor{},
-		"MEDIUM": lipgloss.AdaptiveColor{Light: "9", Dark: "3"},
-		"HIGH":   lipgloss.AdaptiveColor{Light: "9", Dark: "1"},
-	}
-	severityStyle := lipgloss.NewStyle().Foreground(severityToColor[strings.ToUpper(severity)])
+	severityStyle := lipgloss.NewStyle().Foreground(
+		ui.TokenColor("severity." + strings.ToLower(severity)),
+	)
 	return severityStyle.Render(str)
 }

--- a/pkg/ui/tokens.go
+++ b/pkg/ui/tokens.go
@@ -1,0 +1,26 @@
+package ui
+
+import "github.com/charmbracelet/lipgloss"
+
+var tokenMap map[string]lipgloss.TerminalColor
+
+func init() {
+	tokenMap = map[string]lipgloss.TerminalColor{
+		"severity.critical": lipgloss.AdaptiveColor{Light: "13", Dark: "5"},
+		"severity.high":     lipgloss.AdaptiveColor{Light: "9", Dark: "1"},
+		"severity.medium":   lipgloss.AdaptiveColor{Light: "9", Dark: "3"},
+		"severity.low":      lipgloss.NoColor{},
+		"text.plain":        lipgloss.NoColor{},
+		"border.plain":      lipgloss.NoColor{},
+	}
+}
+
+func TokenColor(name string) lipgloss.TerminalColor {
+	val, ok := tokenMap[name]
+
+	if !ok {
+		return lipgloss.NoColor{}
+	}
+
+	return val
+}

--- a/pkg/ui/tokens_test.go
+++ b/pkg/ui/tokens_test.go
@@ -1,0 +1,21 @@
+package ui_test
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/snyk/go-application-framework/pkg/ui"
+	"github.com/stretchr/testify/assert" // Using testify for better assertions
+)
+
+func TestTokenColorExistingToken(t *testing.T) {
+	expectedColor := lipgloss.AdaptiveColor{Light: "13", Dark: "5"}
+	actualColor := ui.TokenColor("severity.critical")
+	assert.Equal(t, expectedColor, actualColor, "TokenColor should return the correct color for existing tokens")
+}
+
+func TestTokenColorNonexistentToken(t *testing.T) {
+	expectedColor := lipgloss.NoColor{}
+	actualColor := ui.TokenColor("invalid.token")
+	assert.Equal(t, expectedColor, actualColor, "TokenColor should return NoColor for non-existent tokens")
+}


### PR DESCRIPTION
Introduce a new `TokenColor` helper for resolving a token name to a specific Terminal.Color value. This can be adopted by any extensions rendering output to terminal.

Benefits:

* Introducing tokens for color management allows for centralized control and easy customization of UI styles.
* It promotes code readability and maintainability by keeping color definitions separated from UI component logic.

Questions:
* Should our `go-application-framework` have knowledge of the Terminal Colours? In theory folks could be building any kind of application with these workflows