### PR TITLE
feat: use new API endpoint for org retrieval [IDE-221]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,15 @@ module github.com/snyk/go-application-framework
 go 1.21
 
 require (
+	github.com/charmbracelet/lipgloss v0.10.0
 	github.com/fatih/color v1.13.0
 	github.com/gkampitakis/go-snaps v0.5.3
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-uuid v1.0.3
+	github.com/muesli/termenv v0.15.2
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
+	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.32.0
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/snyk/code-client-go v1.4.5
@@ -28,7 +31,6 @@ require (
 	github.com/alexbrainman/sspi v0.0.0-20210105120005-909beea2cc74 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/lipgloss v0.10.0 // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -69,13 +71,11 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
-	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/oapi-codegen/runtime v1.0.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.9 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/puzpuzpuz/xsync v1.5.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/viper v1.13.0
 	github.com/stretchr/testify v1.9.0
 	github.com/xeipuuv/gojsonschema v1.2.0
-	golang.org/x/oauth2 v0.5.0
+	golang.org/x/oauth2 v0.5.0 // TODO: this should be updated
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -322,10 +322,6 @@ github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NF
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.2.1 h1:SHWdIUa82uGZz+F+47k8SY4QhhI291cXCpopT1lK2AQ=
 github.com/skeema/knownhosts v1.2.1/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
-github.com/snyk/code-client-go v1.4.2 h1:Vy27Xr6CVAs0qKZlU8I/fxWWI6X2ppzan6IZnUJYmvg=
-github.com/snyk/code-client-go v1.4.2/go.mod h1:Kkr7pQc8ItsBZSYd6A1S4r4VHO6HNyTWZsqi18sAtwQ=
-github.com/snyk/code-client-go v1.4.4 h1:QQLHCwJUXLVWSINI+nBZiYqCtt5RuyWy5duk3nPAf5I=
-github.com/snyk/code-client-go v1.4.4/go.mod h1:Kkr7pQc8ItsBZSYd6A1S4r4VHO6HNyTWZsqi18sAtwQ=
 github.com/snyk/code-client-go v1.4.5 h1:r112huvRXv6gsHNUkeFLMbEz8dOLBv+v/hZDJfuPZaA=
 github.com/snyk/code-client-go v1.4.5/go.mod h1:Kkr7pQc8ItsBZSYd6A1S4r4VHO6HNyTWZsqi18sAtwQ=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -5,11 +5,12 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/snyk/go-application-framework/internal/api/contract"
-	"github.com/snyk/go-application-framework/internal/constants"
 	"io"
 	"net/http"
 	url2 "net/url"
+
+	"github.com/snyk/go-application-framework/internal/api/contract"
+	"github.com/snyk/go-application-framework/internal/constants"
 )
 
 type ApiClient interface {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -33,7 +33,7 @@ func (a *snykApiClient) GetOrgIdFromSlug(slugName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
@@ -60,7 +60,7 @@ func (a *snykApiClient) GetDefaultOrgId() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve org ID: %w", err)
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
@@ -92,7 +92,7 @@ func (a *snykApiClient) GetFeatureFlag(flagname string, orgId string) (bool, err
 	if err != nil {
 		return defaultResult, fmt.Errorf("unable to retrieve feature flag: %w", err)
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -25,9 +25,7 @@ type snykApiClient struct {
 }
 
 func (a *snykApiClient) GetOrgIdFromSlug(slugName string) (string, error) {
-	apiVersion := "version=2024-03-12"
-	escapedSlug := url2.PathEscape(slugName)
-	url := fmt.Sprintf("%s/rest/orgs?%s&slug=%s", a.url, apiVersion, escapedSlug)
+	url := GetOrgsApiURL(a.url, slugName)
 
 	res, err := a.client.Get(url)
 	if err != nil {
@@ -47,11 +45,19 @@ func (a *snykApiClient) GetOrgIdFromSlug(slugName string) (string, error) {
 	}
 
 	organizations := response.Organizations
-	if len(organizations) == 1 {
-		return organizations[0].Id, nil
+	for _, organization := range organizations {
+		if organization.Attributes.Slug == slugName {
+			return organization.Id, nil
+		}
 	}
-
 	return "", fmt.Errorf("org ID not found for slug %v", slugName)
+}
+
+func GetOrgsApiURL(baseURL, slugName string) string {
+	apiVersion := "version=2024-03-12"
+	escapedSlug := url2.PathEscape(slugName)
+	url := fmt.Sprintf("%s/rest/orgs?%s&slug=%s", baseURL, apiVersion, escapedSlug)
+	return url
 }
 
 func (a *snykApiClient) GetDefaultOrgId() (string, error) {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -36,14 +36,14 @@ func Test_GetOrgIdFromSlug_ReturnsCorrectOrgId(t *testing.T) {
 	t.Parallel()
 	orgResponse := newMockOrgResponse(t)
 	server := setupSingleReponseServer(t, "/v1/orgs", orgResponse)
-	api := api.NewApi(server.URL, http.DefaultClient)
+	apiClient := api.NewApi(server.URL, http.DefaultClient)
 
 	for _, org := range orgResponse.Organizations {
-		expectedOrgId := org.ID
-		slugName := org.Slug
+		expectedOrgId := org.Id
+		slugName := org.Attributes.Slug
 
 		// Act
-		orgId, err := api.GetOrgIdFromSlug(slugName)
+		orgId, err := apiClient.GetOrgIdFromSlug(slugName)
 		if err != nil {
 			t.Error(err)
 		}
@@ -93,28 +93,63 @@ func Test_GetFeatureFlag_true(t *testing.T) {
 
 func newMockOrgResponse(t *testing.T) contract.OrganizationsResponse {
 	t.Helper()
-
-	return contract.OrganizationsResponse{
-		Organizations: []contract.Organization{
-			{
-				Name:  "defaultOrg",
-				ID:    "27ce75bf-5794-4bfd-9ae7-e779f465abdf",
-				Slug:  "default-org",
-				URL:   "https://api.snyk.io/org/default-org",
-				Group: nil,
-			},
-			{
-				Name: "secondOrg",
-				ID:   "ebb351b1-e883-4a07-9ebb-75a7d22b56a8",
-				Slug: "second-org",
-				URL:  "https://api.snyk.io/org/second-org",
-				Group: &contract.Group{
-					Name: "ABCD INC",
-					ID:   "58eec199-6ec0-4881-9d0d-9f62ebc6b6ab",
+	/*
+		return contract.OrganizationsResponse{
+				Organizations: []contract.Organization{
+					{
+						Name:  "defaultOrg",
+						ID:    "27ce75bf-5794-4bfd-9ae7-e779f465abdf",
+						Slug:  "default-org",
+						URL:   "https://api.snyk.io/org/default-org",
+						Group: nil,
+					},
+					{
+						Name: "secondOrg",
+						ID:   "ebb351b1-e883-4a07-9ebb-75a7d22b56a8",
+						Slug: "second-org",
+						URL:  "https://api.snyk.io/org/second-org",
+						Group: &contract.Group{
+							Name: "ABCD INC",
+							ID:   "58eec199-6ec0-4881-9d0d-9f62ebc6b6ab",
+						},
+					},
 				},
-			},
-		},
-	}
+			}
+	*/
+	orgJson := `{
+  "data": [
+    {
+      "id": "27ce75bf-5794-4bfd-9ae7-e779f465abdf",
+      "type": "org",
+      "attributes": {
+        "is_personal": true,
+        "name": "defaultOrg",
+        "slug": "default-org"
+      },
+    },
+	{
+      "id": "ebb351b1-e883-4a07-9ebb-75a7d22b56a8",
+      "type": "org",
+      "attributes": {
+        "is_personal": true,
+        "name": "secondOrg",
+        "slug": "second-org"
+		"groupId": "58eec199-6ec0-4881-9d0d-9f62ebc6b6ab"
+      },
+    },
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+    "self": "/rest/orgs?version=2024-04-11",
+    "first": "/rest/orgs?version=2024-04-11"
+  }
+}
+`
+	var response contract.OrganizationsResponse
+	json.Unmarshal([]byte(orgJson), response)
+	return response
 }
 
 func setupSingleReponseServer(t *testing.T, url string, response any) *httptest.Server {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -148,7 +148,10 @@ func newMockOrgResponse(t *testing.T) contract.OrganizationsResponse {
 }
 `
 	var response contract.OrganizationsResponse
-	_ = json.Unmarshal([]byte(orgJson), &response)
+	err := json.Unmarshal([]byte(orgJson), &response)
+	if err != nil {
+		t.Fatal("can't create mock response")
+	}
 	return response
 }
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -2,10 +2,11 @@ package api_test
 
 import (
 	"encoding/json"
-	"github.com/pkg/errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/stretchr/testify/assert"
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 
@@ -41,7 +42,9 @@ func Test_GetOrgIdFromSlug_ReturnsCorrectOrgId(t *testing.T) {
 	for _, org := range orgResponse.Organizations {
 		slugName := org.Attributes.Slug
 		expectedOrgId := org.Id
-		server := setupSingleReponseServer(t, api.GetOrgsApiURL("", slugName), orgResponse)
+		u, err := api.OrgsApiURL("", slugName)
+		require.NoError(t, err)
+		server := setupSingleReponseServer(t, u.String(), orgResponse)
 		apiClient := api.NewApi(server.URL, http.DefaultClient)
 
 		// Act

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -19,10 +19,10 @@ func Test_GetDefaultOrgId_ReturnsCorrectOrgId(t *testing.T) {
 	selfResponse := newMockSelfResponse(t)
 	expectedOrgId := selfResponse.Data.Attributes.DefaultOrgContext
 	server := setupSingleReponseServer(t, "/rest/self?version="+constants.SNYK_API_VERSION, selfResponse)
-	api := api.NewApi(server.URL, http.DefaultClient)
+	client := api.NewApi(server.URL, http.DefaultClient)
 
 	// Act
-	orgId, err := api.GetDefaultOrgId()
+	orgId, err := client.GetDefaultOrgId()
 	if err != nil {
 		t.Error(err)
 	}
@@ -63,13 +63,13 @@ func Test_GetFeatureFlag_false(t *testing.T) {
 		Code: http.StatusForbidden,
 	}
 	server := setupSingleReponseServer(t, "/v1/cli-config/feature-flags/"+featureFlagName+"?org="+org, featureFlagResponse)
-	api := api.NewApi(server.URL, http.DefaultClient)
+	client := api.NewApi(server.URL, http.DefaultClient)
 
-	actual, err := api.GetFeatureFlag(featureFlagName, org)
+	actual, err := client.GetFeatureFlag(featureFlagName, org)
 	assert.NoError(t, err)
 	assert.False(t, actual)
 
-	actual, err = api.GetFeatureFlag("unknownFF", org)
+	actual, err = client.GetFeatureFlag("unknownFF", org)
 	assert.Error(t, err)
 	assert.False(t, actual)
 }
@@ -84,9 +84,9 @@ func Test_GetFeatureFlag_true(t *testing.T) {
 		Code: http.StatusOK,
 	}
 	server := setupSingleReponseServer(t, "/v1/cli-config/feature-flags/"+featureFlagName+"?org="+org, featureFlagResponse)
-	api := api.NewApi(server.URL, http.DefaultClient)
+	client := api.NewApi(server.URL, http.DefaultClient)
 
-	actual, err := api.GetFeatureFlag(featureFlagName, org)
+	actual, err := client.GetFeatureFlag(featureFlagName, org)
 	assert.NoError(t, err)
 	assert.True(t, actual)
 }
@@ -148,7 +148,7 @@ func newMockOrgResponse(t *testing.T) contract.OrganizationsResponse {
 }
 `
 	var response contract.OrganizationsResponse
-	json.Unmarshal([]byte(orgJson), response)
+	_ = json.Unmarshal([]byte(orgJson), &response)
 	return response
 }
 

--- a/internal/api/contract/OrgResponse.go
+++ b/internal/api/contract/OrgResponse.go
@@ -1,18 +1,35 @@
 package contract
 
-type Organization struct {
-	Name  string `json:"name"`
-	ID    string `json:"id"`
-	Slug  string `json:"slug"`
-	URL   string `json:"url"`
-	Group *Group `json:"group"`
+type OrgAttributes struct {
+	IsPersonal bool   `json:"is_personal"`
+	Name       string `json:"name"`
+	Slug       string `json:"slug"`
+	GroupId    string `json:"group_id,omitempty"`
 }
 
-type Group struct {
-	Name string `json:"name"`
-	ID   string `json:"id"`
+type OrgRelationships struct {
+	MemberRole struct {
+		Data struct {
+			Id   string `json:"id"`
+			Type string `json:"type"`
+		} `json:"data"`
+	} `json:"member_role"`
+}
+
+type Organization struct {
+	Id            string           `json:"id"`
+	Type          string           `json:"type"`
+	Attributes    OrgAttributes    `json:"attributes"`
+	Relationships OrgRelationships `json:"relationships"`
 }
 
 type OrganizationsResponse struct {
-	Organizations []Organization `json:"orgs"`
+	Organizations []Organization `json:"data"`
+	Jsonapi       struct {
+		Version string `json:"version"`
+	} `json:"jsonapi"`
+	Links struct {
+		Self  string `json:"self"`
+		First string `json:"first"`
+	} `json:"links"`
 }

--- a/internal/api/contract/UserMeResponse.go
+++ b/internal/api/contract/UserMeResponse.go
@@ -6,6 +6,11 @@ type Orgs struct {
 	Group Group  `json:"group"`
 }
 
+type Group struct {
+	Name string `json:"name"`
+	ID   string `json:"id"`
+}
+
 type UserMe struct {
 	Id       *string `json:"id"`
 	UserName *string `json:"username"`


### PR DESCRIPTION
This changes the API call to retrieve an org by slugname to the new endpoint at /rest/orgs