### PR TITLE
fix: replace legacy endpoint used by whoami

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -18,6 +18,8 @@ type ApiClient interface {
 	GetOrgIdFromSlug(slugName string) (string, error)
 	Init(url string, client *http.Client)
 	GetFeatureFlag(flagname string, origId string) (bool, error)
+	GetUserMe() (string, error)
+	GetSelf() (contract.SelfResponse, error)
 }
 
 type snykApiClient struct {
@@ -72,62 +74,88 @@ func OrgsApiURL(baseURL, slugName string) (*url.URL, error) {
 }
 
 func (a *snykApiClient) GetDefaultOrgId() (string, error) {
-	u := a.url + "/rest/self?version=" + constants.SNYK_API_VERSION
-	res, err := a.client.Get(u)
-	if err != nil {
-		return "", fmt.Errorf("unable to retrieve org ID: %w", err)
-	}
-	//goland:noinspection GoUnhandledErrorResult
-	defer res.Body.Close()
-
-	body, err := io.ReadAll(res.Body)
+	selfData, err := a.GetSelf()
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve org ID: %w", err)
 	}
 
-	if res.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unable to retrieve org ID (status: %d)", res.StatusCode)
+	return selfData.Data.Attributes.DefaultOrgContext, nil
+}
+
+func (a *snykApiClient) GetUserMe() (string, error) {
+	selfData, err := a.GetSelf()
+	if err != nil {
+		return "", fmt.Errorf("error while fetching self data: %w", err) // Prioritize error
 	}
 
-	var userInfo contract.SelfResponse
-	if err = json.Unmarshal(body, &userInfo); err != nil {
-		return "", fmt.Errorf("unable to retrieve org ID (status: %d): %w", res.StatusCode, err)
+	if len(selfData.Data.Attributes.Username) == 0 {
+		return "", fmt.Errorf("error while extracting user: missing property 'username'")
 	}
 
-	return userInfo.Data.Attributes.DefaultOrgContext, nil
+	return selfData.Data.Attributes.Username, nil
 }
 
 func (a *snykApiClient) GetFeatureFlag(flagname string, orgId string) (bool, error) {
 	const defaultResult = false
 
-	u := a.url + "/v1/cli-config/feature-flags/" + flagname + "?org=" + orgId
+	endpoint := "/v1/cli-config/feature-flags/" + flagname + "?org=" + orgId
 
 	if len(orgId) <= 0 {
 		return defaultResult, fmt.Errorf("failed to lookup feature flag with orgiId not set")
 	}
 
-	res, err := a.client.Get(u)
-	if err != nil {
-		return defaultResult, fmt.Errorf("unable to retrieve feature flag: %w", err)
-	}
-	//goland:noinspection GoUnhandledErrorResult
-	defer res.Body.Close()
-
-	body, err := io.ReadAll(res.Body)
+	body, err := clientGet(a, endpoint)
 	if err != nil {
 		return defaultResult, fmt.Errorf("unable to retrieve feature flag: %w", err)
 	}
 
 	var flag contract.OrgFeatureFlagResponse
 	if err = json.Unmarshal(body, &flag); err != nil {
-		return defaultResult, fmt.Errorf("unable to retrieve feature flag (status: %d): %w", res.StatusCode, err)
+		return defaultResult, fmt.Errorf("unable to retrieve feature flag: %w", err)
 	}
 
-	if res.StatusCode != http.StatusOK || flag.Code == http.StatusUnauthorized || flag.Code == http.StatusForbidden {
+	if flag.Code == http.StatusUnauthorized || flag.Code == http.StatusForbidden {
 		return defaultResult, err
 	}
 
 	return true, nil
+}
+
+func (a *snykApiClient) GetSelf() (contract.SelfResponse, error) {
+	endpoint := constants.SNYK_API_SELF + constants.SNYK_API_VERSION
+	var selfData contract.SelfResponse
+
+	body, err := clientGet(a, endpoint)
+	if err != nil {
+		return selfData, err
+	}
+
+	if err = json.Unmarshal(body, &selfData); err != nil {
+		return selfData, fmt.Errorf("unable to retrieve self data: %w", err)
+	}
+
+	return selfData, nil
+}
+
+func clientGet(a *snykApiClient, endpoint string) ([]byte, error) {
+	url := a.url + endpoint
+
+	res, err := a.client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed (status: %d)", res.StatusCode)
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	defer res.Body.Close()
+	return body, nil
 }
 
 func (a *snykApiClient) Init(url string, client *http.Client) {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -2,12 +2,12 @@ package api_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 
@@ -21,7 +21,7 @@ func Test_GetDefaultOrgId_ReturnsCorrectOrgId(t *testing.T) {
 	t.Parallel()
 	selfResponse := newMockSelfResponse(t)
 	expectedOrgId := selfResponse.Data.Attributes.DefaultOrgContext
-	server := setupSingleReponseServer(t, "/rest/self?version="+constants.SNYK_API_VERSION, selfResponse)
+	server := setupSingleReponseServer(t, "/rest/self?version="+constants.SNYK_DEFAULT_API_VERSION, selfResponse)
 	client := api.NewApi(server.URL, http.DefaultClient)
 
 	// Act
@@ -42,9 +42,9 @@ func Test_GetOrgIdFromSlug_ReturnsCorrectOrgId(t *testing.T) {
 	for _, org := range orgResponse.Organizations {
 		slugName := org.Attributes.Slug
 		expectedOrgId := org.Id
-		u, err := api.OrgsApiURL("", slugName)
-		require.NoError(t, err)
-		server := setupSingleReponseServer(t, u.String(), orgResponse)
+		u := fmt.Sprintf("/rest/orgs?slug=%s&version=2024-03-12", slugName)
+
+		server := setupSingleReponseServer(t, u, orgResponse)
 		apiClient := api.NewApi(server.URL, http.DefaultClient)
 
 		// Act

--- a/internal/api/contract/UserMeResponse.go
+++ b/internal/api/contract/UserMeResponse.go
@@ -1,11 +1,5 @@
 package contract
 
-type Orgs struct {
-	Name  string `json:"name"`
-	Id    string `json:"id"`
-	Group Group  `json:"group"`
-}
-
 type Group struct {
 	Name string `json:"name"`
 	ID   string `json:"id"`
@@ -15,5 +9,4 @@ type UserMe struct {
 	Id       *string `json:"id"`
 	UserName *string `json:"username"`
 	Email    *string `json:"email"`
-	Orgs     []Orgs  `json:"orgs"`
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,4 +1,5 @@
 package constants
 
 const SNYK_DEFAULT_API_URL = "https://api.snyk.io"
-const SNYK_API_VERSION = "2022-09-15~experimental"
+const SNYK_API_VERSION = "2024-04-22"
+const SNYK_API_SELF = "/rest/self?version="

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,5 +1,4 @@
 package constants
 
 const SNYK_DEFAULT_API_URL = "https://api.snyk.io"
-const SNYK_API_VERSION = "2024-04-22"
-const SNYK_API_SELF = "/rest/self?version="
+const SNYK_DEFAULT_API_VERSION = "2024-04-22"

--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	contract "github.com/snyk/go-application-framework/internal/api/contract"
 )
 
 // MockApiClient is a mock of ApiClient interface.
@@ -77,6 +78,36 @@ func (m *MockApiClient) GetOrgIdFromSlug(slugName string) (string, error) {
 func (mr *MockApiClientMockRecorder) GetOrgIdFromSlug(slugName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgIdFromSlug", reflect.TypeOf((*MockApiClient)(nil).GetOrgIdFromSlug), slugName)
+}
+
+// GetSelf mocks base method.
+func (m *MockApiClient) GetSelf() (contract.SelfResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSelf")
+	ret0, _ := ret[0].(contract.SelfResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSelf indicates an expected call of GetSelf.
+func (mr *MockApiClientMockRecorder) GetSelf() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSelf", reflect.TypeOf((*MockApiClient)(nil).GetSelf))
+}
+
+// GetUserMe mocks base method.
+func (m *MockApiClient) GetUserMe() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserMe")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserMe indicates an expected call of GetUserMe.
+func (mr *MockApiClientMockRecorder) GetUserMe() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserMe", reflect.TypeOf((*MockApiClient)(nil).GetUserMe))
 }
 
 // Init mocks base method.

--- a/pkg/local_workflows/whoami_workflow_test.go
+++ b/pkg/local_workflows/whoami_workflow_test.go
@@ -12,14 +12,13 @@ import (
 
 	"github.com/golang/mock/gomock"
 
-	"github.com/snyk/go-application-framework/internal/constants"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/mocks"
 
 	"github.com/stretchr/testify/assert"
 )
 
-const referenceUrl = constants.SNYK_API_SELF + constants.SNYK_API_VERSION
+const referenceUrl = "/rest/self?version=2024-04-22"
 
 func Test_WhoAmI_whoAmIWorkflowEntryPoint_requireExperimentalFlag(t *testing.T) {
 	// setup


### PR DESCRIPTION
Replaced the legacy endpoint  /v1/user/me with the rest equivalent /rest/self in the whoami workflow