### PR TITLE
refactor: use function options pattern

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/rs/zerolog v1.32.0
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
-	github.com/snyk/code-client-go v1.4.2
+	github.com/snyk/code-client-go v1.4.5
 	github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -324,6 +324,10 @@ github.com/skeema/knownhosts v1.2.1 h1:SHWdIUa82uGZz+F+47k8SY4QhhI291cXCpopT1lK2
 github.com/skeema/knownhosts v1.2.1/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
 github.com/snyk/code-client-go v1.4.2 h1:Vy27Xr6CVAs0qKZlU8I/fxWWI6X2ppzan6IZnUJYmvg=
 github.com/snyk/code-client-go v1.4.2/go.mod h1:Kkr7pQc8ItsBZSYd6A1S4r4VHO6HNyTWZsqi18sAtwQ=
+github.com/snyk/code-client-go v1.4.4 h1:QQLHCwJUXLVWSINI+nBZiYqCtt5RuyWy5duk3nPAf5I=
+github.com/snyk/code-client-go v1.4.4/go.mod h1:Kkr7pQc8ItsBZSYd6A1S4r4VHO6HNyTWZsqi18sAtwQ=
+github.com/snyk/code-client-go v1.4.5 h1:r112huvRXv6gsHNUkeFLMbEz8dOLBv+v/hZDJfuPZaA=
+github.com/snyk/code-client-go v1.4.5/go.mod h1:Kkr7pQc8ItsBZSYd6A1S4r4VHO6HNyTWZsqi18sAtwQ=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/spf13/afero v1.9.2 h1:j49Hj62F0n+DaZ1dDCvhABaPNSGNkt32oRFxI33IEMw=

--- a/pkg/local_workflows/code_workflow/code_client_helper.go
+++ b/pkg/local_workflows/code_workflow/code_client_helper.go
@@ -1,10 +1,7 @@
 package code_workflow
 
 import (
-	"context"
 	"strings"
-
-	"github.com/snyk/code-client-go/observability"
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
 )
@@ -27,37 +24,4 @@ func (c *codeClientConfig) SnykCodeApi() string {
 
 func (c *codeClientConfig) SnykApi() string {
 	return c.localConfiguration.GetString(configuration.API_URL)
-}
-
-type codeClientErrorReporter struct{}
-
-func (c *codeClientErrorReporter) FlushErrorReporting() {}
-func (c *codeClientErrorReporter) CaptureError(err error, options observability.ErrorReporterOptions) bool {
-	return true
-}
-
-type codeClientSpan struct {
-	transactionName string
-	operationName   string
-}
-
-func (c *codeClientSpan) SetTransactionName(name string) { c.transactionName = name }
-func (c *codeClientSpan) StartSpan(ctx context.Context)  {}
-func (c *codeClientSpan) Finish()                        {}
-func (c *codeClientSpan) GetOperation() string           { return c.operationName }
-func (c *codeClientSpan) GetTxName() string              { return c.transactionName }
-func (c *codeClientSpan) GetTraceId() string             { return "" } // TODO: interaction id
-func (c *codeClientSpan) Context() context.Context       { return context.Background() }
-func (c *codeClientSpan) GetDurationMs() int64           { return 0 }
-
-type codeClientInstrumentor struct{}
-
-func (c *codeClientInstrumentor) StartSpan(ctx context.Context, operation string) observability.Span {
-	return &codeClientSpan{operationName: operation}
-}
-func (c *codeClientInstrumentor) NewTransaction(ctx context.Context, txName string, operation string) observability.Span {
-	return &codeClientSpan{operationName: operation, transactionName: txName}
-}
-func (c *codeClientInstrumentor) Finish(span observability.Span) {
-	span.Finish()
 }

--- a/pkg/local_workflows/code_workflow/native_workflow.go
+++ b/pkg/local_workflows/code_workflow/native_workflow.go
@@ -72,13 +72,18 @@ func defaultAnalyzeFunction(path string, httpClientFunc func() *http.Client, log
 
 	changedFiles := make(map[string]bool)
 	ctx := context.Background()
-	codeInstrumentor := &codeClientInstrumentor{}
-	codeErrorReporter := &codeClientErrorReporter{}
-	httpClient := codeclienthttp.NewHTTPClient(httpClientFunc, codeclienthttp.WithLogger(logger))
+	httpClient := codeclienthttp.NewHTTPClient(
+		httpClientFunc,
+		codeclienthttp.WithLogger(logger),
+	)
 	codeScannerConfig := &codeClientConfig{
 		localConfiguration: config,
 	}
-	codeScanner := codeclient.NewCodeScanner(httpClient, codeScannerConfig, codeInstrumentor, codeErrorReporter, logger)
+	codeScanner := codeclient.NewCodeScanner(
+		codeScannerConfig,
+		httpClient,
+		codeclient.WithLogger(logger),
+	)
 	result, _, err = codeScanner.UploadAndAnalyze(ctx, interactionId, path, files, changedFiles)
 	return result, err
 }


### PR DESCRIPTION
Updates the code-client-go library and picks up the logging improvements and function options pattern changes. We have also introduced a fallback instrumentor and error reporter so that the CLI doesn't need to create dummy ones. If you want to override them you can still do, but for now the fallbacks do exactly what the ones implemented here do.