### PR TITLE
chore: ignore false positives

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -6,3 +6,7 @@
 9cab824f0ff3d537545ff7705817fe05ff0cad54:internal/presenters/testdata/with-ignores.json:generic-api-key:224
 9cab824f0ff3d537545ff7705817fe05ff0cad54:internal/presenters/testdata/with-ignores.json:generic-api-key:474
 9cab824f0ff3d537545ff7705817fe05ff0cad54:internal/presenters/testdata/with-ignores.json:generic-api-key:539
+b0ba7f6ed181c23a5c6532cf6f124b731d390f86:internal/presenters/testdata/with-ignores.json:generic-api-key:159
+b0ba7f6ed181c23a5c6532cf6f124b731d390f86:internal/presenters/testdata/with-ignores.json:generic-api-key:224
+b0ba7f6ed181c23a5c6532cf6f124b731d390f86:internal/presenters/testdata/with-ignores.json:generic-api-key:474
+b0ba7f6ed181c23a5c6532cf6f124b731d390f86:internal/presenters/testdata/with-ignores.json:generic-api-key:539


### PR DESCRIPTION
It seems that due to the squash merge we have invalidated our `.gitleaksignore` file. 