### PR TITLE
feat: CLI renders real findings for consistent ignores

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.32.0
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
-	github.com/snyk/code-client-go v1.4.5
+	github.com/snyk/code-client-go v1.5.3
 	github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -322,8 +322,8 @@ github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NF
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.2.1 h1:SHWdIUa82uGZz+F+47k8SY4QhhI291cXCpopT1lK2AQ=
 github.com/skeema/knownhosts v1.2.1/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
-github.com/snyk/code-client-go v1.4.5 h1:r112huvRXv6gsHNUkeFLMbEz8dOLBv+v/hZDJfuPZaA=
-github.com/snyk/code-client-go v1.4.5/go.mod h1:Kkr7pQc8ItsBZSYd6A1S4r4VHO6HNyTWZsqi18sAtwQ=
+github.com/snyk/code-client-go v1.5.3 h1:EnHogM2uNnvkrfIJbkOGa9X1bOkU6bJR/QRQCwbK9gQ=
+github.com/snyk/code-client-go v1.5.3/go.mod h1:Kkr7pQc8ItsBZSYd6A1S4r4VHO6HNyTWZsqi18sAtwQ=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/spf13/afero v1.9.2 h1:j49Hj62F0n+DaZ1dDCvhABaPNSGNkt32oRFxI33IEMw=

--- a/pkg/local_workflows/output_workflow_test.go
+++ b/pkg/local_workflows/output_workflow_test.go
@@ -338,14 +338,7 @@ func getSarifInput() sarif.SarifDocument {
 									Level: "error",
 								},
 								Properties: sarif.RuleProperties{
-									Tags: []string{"tag1", "tag2"},
-									ShortDescription: sarif.ShortDescription{
-										Text: "Rule 1 description",
-									},
-									Help: struct {
-										Markdown string `json:"markdown"`
-										Text     string `json:"text"`
-									}{Markdown: "", Text: ""},
+									Tags:               []string{"tag1", "tag2"},
 									Categories:         []string{},
 									ExampleCommitFixes: []sarif.ExampleCommitFix{},
 									Precision:          "",
@@ -366,14 +359,7 @@ func getSarifInput() sarif.SarifDocument {
 									Level: "error",
 								},
 								Properties: sarif.RuleProperties{
-									Tags: []string{"tag1", "tag2"},
-									ShortDescription: sarif.ShortDescription{
-										Text: "",
-									},
-									Help: struct {
-										Markdown string `json:"markdown"`
-										Text     string `json:"text"`
-									}{Markdown: "", Text: ""},
+									Tags:               []string{"tag1", "tag2"},
 									Categories:         []string{},
 									ExampleCommitFixes: []sarif.ExampleCommitFix{},
 									Precision:          "",


### PR DESCRIPTION

The LS can now upgrade to the latest code-client-go version, so that we return the real findings for repos from the Analysis API.

I will also update the CLI once https://github.com/snyk/snyk-ls/pull/497 is also merged.