### PR TITLE
feat(code_workflow): support .snyk style excludes when applying filtering rules

### DIFF
--- a/pkg/local_workflows/code_workflow/native_workflow.go
+++ b/pkg/local_workflows/code_workflow/native_workflow.go
@@ -91,7 +91,7 @@ func defaultAnalyzeFunction(path string, httpClientFunc func() *http.Client, log
 // Return a channel that notifies each file in the path that doesn't match the filter rules
 func getFilesForPath(path string) (<-chan string, error) {
 	filter := utils.NewFileFilter(path)
-	rules, err := filter.GetRules([]string{".gitignore", ".dcignore"})
+	rules, err := filter.GetRules([]string{".gitignore", ".dcignore", ".snyk"})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/local_workflows/code_workflow/native_workflow.go
+++ b/pkg/local_workflows/code_workflow/native_workflow.go
@@ -65,7 +65,7 @@ func defaultAnalyzeFunction(path string, httpClientFunc func() *http.Client, log
 
 	logger.Debug().Msgf("Interaction ID: %s", interactionId)
 
-	files, err := getFilesForPath(path)
+	files, err := getFilesForPath(path, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -89,8 +89,8 @@ func defaultAnalyzeFunction(path string, httpClientFunc func() *http.Client, log
 }
 
 // Return a channel that notifies each file in the path that doesn't match the filter rules
-func getFilesForPath(path string) (<-chan string, error) {
-	filter := utils.NewFileFilter(path)
+func getFilesForPath(path string, logger *zerolog.Logger) (<-chan string, error) {
+	filter := utils.NewFileFilter(path, logger)
 	rules, err := filter.GetRules([]string{".gitignore", ".dcignore", ".snyk"})
 	if err != nil {
 		return nil, err

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -274,6 +274,29 @@ func testCases(t *testing.T) []fileFilterTestCase {
 			filesToFilter: []string{"a/file2.js"},
 			expectedFiles: []string{"file1.js", "a/file1.txt", ".dcignore", "a/.dcignore"},
 		},
+		{
+			name:      "Supports .snyk style exclude rules",
+			repoPath:  t.TempDir(),
+			ruleFiles: []string{".snyk"},
+			ruleFilesContent: map[string]string{
+				".snyk": `
+exclude:
+  code:
+    - path/to/code/ignore1
+    - path/to/code/ignore2
+  global:
+    - path/to/global/ignore1
+    - path/to/global/ignore2
+`,
+			},
+			filesToFilter: []string{
+				"path/to/code/ignore1/ignoredFile.java",
+				"path/to/code/ignore2/ignoredFile.java",
+				"path/to/global/ignore1/ignoredFile.java",
+				"path/to/global/ignore2/ignoredFile.java",
+			},
+			expectedFiles: []string{"path/to/code/notIgnored.java", ".snyk"},
+		},
 	}
 	return cases
 }

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,7 +34,7 @@ func TestFileFilter_GetAllFiles(t *testing.T) {
 		tempFile2 := filepath.Join(tempDir, "test2.ts")
 		createFileInPath(t, tempFile2, []byte{})
 
-		fileFilter := NewFileFilter(tempDir)
+		fileFilter := NewFileFilter(tempDir, &log.Logger)
 		actualFiles := fileFilter.GetAllFiles()
 		expectedFiles := []string{tempFile1, tempFile2}
 
@@ -56,7 +57,7 @@ func TestFileFilter_GetRules(t *testing.T) {
 
 	t.Run("includes default rules", func(t *testing.T) {
 		// create fileFilter
-		fileFilter := NewFileFilter(tempDir)
+		fileFilter := NewFileFilter(tempDir, &log.Logger)
 		actualRules, err := fileFilter.GetRules([]string{})
 		assert.NoError(t, err)
 
@@ -70,7 +71,7 @@ func TestFileFilter_GetRules(t *testing.T) {
 
 		// create fileFilter
 		ruleFiles := []string{".gitignore"}
-		fileFilter := NewFileFilter(tempDir)
+		fileFilter := NewFileFilter(tempDir, &log.Logger)
 		actualRules, err := fileFilter.GetRules(ruleFiles)
 		assert.NoError(t, err)
 
@@ -93,7 +94,7 @@ func TestFileFilter_GetFilteredFiles(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			setupTestFileSystem(t, testCase)
 
-			fileFilter := NewFileFilter(testCase.repoPath)
+			fileFilter := NewFileFilter(testCase.repoPath, &log.Logger)
 
 			files := fileFilter.GetAllFiles()
 
@@ -138,7 +139,7 @@ func BenchmarkFileFilter_GetFilteredFiles(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		fileFilter := NewFileFilter(rootDir)
+		fileFilter := NewFileFilter(rootDir, &log.Logger)
 
 		b.StartTimer()
 		files := fileFilter.GetAllFiles()


### PR DESCRIPTION
This PR should add support for `.snyk` style excludes when applying filtering rules for the `code_workflow`

To test locally:
- use local version of GAF in CLI `replace github.com/snyk/go-application-framework => ../../go-application-framework` in `go.mod`
- build a local cli binary `make clean build`
- add a `.snyk` file to repository that has a valid `excludes` section
- run local cli binary `<path/to/local/cli/binary> code test`
- validate that `.snyk` `excludes` are filtered