### PR TITLE
fix: remove unused --only-ignores flag CLI-319

### DIFF
--- a/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
+++ b/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
@@ -32,7 +32,7 @@ Open Issues
 
 💡 Tip
 
-To view ignored issues, use the --include-ignores option. To view ignored issues only, use the --only-ignores option.
+To view ignored issues, use the --include-ignores option.
 
 ---
 
@@ -93,7 +93,7 @@ Open Issues
 
 💡 Tip
 
-To view ignored issues, use the --include-ignores option. To view ignored issues only, use the --only-ignores option.
+To view ignored issues, use the --include-ignores option.
 
 ---
 
@@ -113,7 +113,7 @@ Testing /path/to/project ...
 
 💡 Tip
 
-To view ignored issues, use the --include-ignores option. To view ignored issues only, use the --only-ignores option.
+To view ignored issues, use the --include-ignores option.
 
 ---
 
@@ -174,7 +174,7 @@ To view ignored issues, use the --include-ignores option. To view ignored issues
 
 💡 Tip
 
-To view ignored issues, use the --include-ignores option. To view ignored issues only, use the --only-ignores option.
+To view ignored issues, use the --include-ignores option.
 
 ---
 
@@ -219,7 +219,7 @@ Open Issues
 
 💡 Tip
 
-To view ignored issues, use the --include-ignores option. To view ignored issues only, use the --only-ignores option.
+To view ignored issues, use the --include-ignores option.
 
 ---
 
@@ -315,8 +315,5 @@ To edit or remove the ignore please go to: https://app.snyk.io/
 │   Open issues:    4 [ 1 HIGH  1 MEDIUM  2 LOW ]     │
 ╰─────────────────────────────────────────────────────╯
 
-💡 Tip
-
-To view ignored issues only, use the --only-ignores option.
 
 ---

--- a/internal/presenters/components.go
+++ b/internal/presenters/components.go
@@ -11,29 +11,24 @@ import (
 	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
 )
 
-func RenderFindings(findings []Finding, showIgnored bool, showOpen bool) string {
+func RenderFindings(findings []Finding, showIgnored bool) string {
 	if len(findings) == 0 {
 		return ""
 	}
 
 	response := ""
 
-	if showOpen {
-		response += RenderTitle("Open Issues")
+	response += RenderTitle("Open Issues")
 
-		for _, finding := range findings {
-			if finding.Ignored {
-				continue
-			}
-			response += RenderFinding(finding)
+	for _, finding := range findings {
+		if finding.Ignored {
+			continue
 		}
-	}
-
-	if showOpen && showIgnored {
-		response += RenderDivider()
+		response += RenderFinding(finding)
 	}
 
 	if showIgnored {
+		response += RenderDivider()
 		response += RenderTitle("Ignored Issues")
 
 		for _, finding := range findings {

--- a/internal/presenters/presenter_sarif_results_pretty.go
+++ b/internal/presenters/presenter_sarif_results_pretty.go
@@ -26,7 +26,6 @@ type FindingProperty struct {
 
 type Presenter struct {
 	ShowIgnored      bool
-	ShowOpen         bool
 	Input            sarif.SarifDocument
 	OrgName          string
 	TestPath         string
@@ -38,12 +37,6 @@ type PresenterOption func(*Presenter)
 func WithIgnored(showIgnored bool) PresenterOption {
 	return func(p *Presenter) {
 		p.ShowIgnored = showIgnored
-	}
-}
-
-func WithOpen(showOpen bool) PresenterOption {
-	return func(p *Presenter) {
-		p.ShowOpen = showOpen
 	}
 }
 
@@ -68,7 +61,6 @@ func WithSeverityThershold(severityMinLevel string) PresenterOption {
 func SarifTestResults(sarifDocument sarif.SarifDocument, options ...PresenterOption) *Presenter {
 	p := &Presenter{
 		ShowIgnored:      false,
-		ShowOpen:         true,
 		Input:            sarifDocument,
 		OrgName:          "",
 		TestPath:         "",
@@ -110,7 +102,7 @@ func (p *Presenter) Render() (string, error) {
 	str := strings.Join([]string{
 		"",
 		renderBold(fmt.Sprintf("Testing %s ...", p.TestPath)),
-		RenderFindings(findings, p.ShowIgnored, p.ShowOpen),
+		RenderFindings(findings, p.ShowIgnored),
 		summaryOutput,
 		getFinalTip(p.ShowIgnored),
 		"",

--- a/internal/presenters/presenter_sarif_results_pretty.go
+++ b/internal/presenters/presenter_sarif_results_pretty.go
@@ -112,7 +112,7 @@ func (p *Presenter) Render() (string, error) {
 		renderBold(fmt.Sprintf("Testing %s ...", p.TestPath)),
 		RenderFindings(findings, p.ShowIgnored, p.ShowOpen),
 		summaryOutput,
-		getFinalTip(p.ShowIgnored, p.ShowOpen),
+		getFinalTip(p.ShowIgnored),
 		"",
 	}, "\n")
 
@@ -216,14 +216,10 @@ func convertSarifToFindingsList(input sarif.SarifDocument) []Finding {
 	return findings
 }
 
-func getFinalTip(showIgnored bool, showOpen bool) string {
-	tip := "To view ignored issues, use the --include-ignores option. To view ignored issues only, use the --only-ignores option."
+func getFinalTip(showIgnored bool) string {
+	tip := "To view ignored issues, use the --include-ignores option."
 	if showIgnored {
-		tip = `To view ignored issues only, use the --only-ignores option.`
-	}
-
-	if showIgnored && !showOpen {
-		tip = `To view ignored and open issues, use the --include-ignores option.`
+		return ""
 	}
 
 	return RenderTip(tip)

--- a/internal/presenters/presenter_sarif_results_pretty_test.go
+++ b/internal/presenters/presenter_sarif_results_pretty_test.go
@@ -149,43 +149,7 @@ func TestPresenterSarifResultsPretty_IncludeIgnored(t *testing.T) {
 	require.Contains(t, result, "src/main.ts, line 58")
 	require.Contains(t, result, "Ignored Issues")
 	require.Contains(t, result, "Ignores are currently managed in the Snyk Web UI.")
-	require.Contains(t, result, "To view ignored issues only, use the --only-ignores option.")
-
-	snaps.MatchSnapshot(t, result)
-}
-
-func TestPresenterSarifResultsPretty_OnlyIgnored(t *testing.T) {
-	fd, err := os.Open("testdata/with-ignores.json")
-	require.Nil(t, err)
-
-	var input sarif.SarifDocument
-
-	err = json.NewDecoder(fd).Decode(&input)
-	require.Nil(t, err)
-
-	lipgloss.SetColorProfile(termenv.Ascii)
-	p := presenters.SarifTestResults(
-		input,
-		presenters.WithOrgName("test-org"),
-		presenters.WithTestPath("/path/to/project"),
-		presenters.WithIgnored(true),
-		presenters.WithOpen(false),
-	)
-
-	result, err := p.Render()
-
-	require.Nil(t, err)
-	require.Contains(t, result, "Ignored Issues")
-	require.Contains(t, result, "! [ IGNORED ] [MEDIUM]")
-	require.Contains(t, result, "Path:       src/main.ts, line 58")
-	require.Contains(t, result, "Category:   Won't fix")
-	require.Contains(t, result, "Expiration: 15 days")
-	require.Contains(t, result, "Ignored on: February 23, 2024")
-	require.Contains(t, result, "Ignored by: Neil M")
-	require.Contains(t, result, "Reason:     False positive")
-
-	require.Contains(t, result, "Ignores are currently managed in the Snyk Web UI.")
-	require.Contains(t, result, "To view ignored and open issues, use the --include-ignores option.")
+	require.NotContains(t, result, "To view ignored and open issues, use the --include-ignores option.pre")
 
 	snaps.MatchSnapshot(t, result)
 }

--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -36,6 +36,5 @@ const (
 	// flags
 	FLAG_EXPERIMENTAL       string = "experimental"
 	FLAG_INCLUDE_IGNORES    string = "include-ignores"
-	FLAG_ONLY_IGNORES       string = "only-ignores"
 	FLAG_SEVERITY_THRESHOLD string = "severity-threshold"
 )

--- a/pkg/local_workflows/output_workflow.go
+++ b/pkg/local_workflows/output_workflow.go
@@ -37,7 +37,6 @@ func InitOutputWorkflow(engine workflow.Engine) error {
 	outputConfig.Bool(OUTPUT_CONFIG_KEY_SARIF, false, "Print sarif output to console")
 	outputConfig.String(OUTPUT_CONFIG_KEY_SARIF_FILE, "", "Write sarif output to file")
 	outputConfig.Bool(configuration.FLAG_INCLUDE_IGNORES, false, "Include ignored findings in the output")
-	outputConfig.Bool(configuration.FLAG_ONLY_IGNORES, false, "Hide open issues in the output")
 	outputConfig.String(configuration.FLAG_SEVERITY_THRESHOLD, "low", "Severity threshold for findings to be included in the output")
 
 	entry, err := engine.Register(WORKFLOWID_OUTPUT_WORKFLOW, workflow.ConfigurationOptionsFromFlagset(outputConfig), outputWorkflowEntryPointImpl)
@@ -198,8 +197,7 @@ func jsonWriteToFile(debugLogger *zerolog.Logger, input []workflow.Data, i int, 
 }
 
 func humanReadableSarifOutput(config configuration.Configuration, input []workflow.Data, i int, outputDestination iUtils.OutputDestination, debugLogger *zerolog.Logger, singleData []byte) {
-	includeOpenFindings := !config.GetBool(configuration.FLAG_ONLY_IGNORES)
-	includeIgnoredFindings := config.GetBool(configuration.FLAG_INCLUDE_IGNORES) || config.GetBool(configuration.FLAG_ONLY_IGNORES)
+	includeIgnoredFindings := config.GetBool(configuration.FLAG_INCLUDE_IGNORES)
 
 	var sarif sarif.SarifDocument
 	err := json.Unmarshal(singleData, &sarif)
@@ -212,7 +210,6 @@ func humanReadableSarifOutput(config configuration.Configuration, input []workfl
 		presenters.WithOrgName(config.GetString(configuration.ORGANIZATION)),
 		presenters.WithTestPath(input[i].GetContentLocation()),
 		presenters.WithIgnored(includeIgnoredFindings),
-		presenters.WithOpen(includeOpenFindings),
 		presenters.WithSeverityThershold(config.GetString(configuration.FLAG_SEVERITY_THRESHOLD)),
 	)
 

--- a/pkg/local_workflows/output_workflow_test.go
+++ b/pkg/local_workflows/output_workflow_test.go
@@ -329,32 +329,6 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 		}
 		assert.Equal(t, 1, len(output))
 	})
-
-	t.Run("should print human readable output for sarif data only showing ignored data", func(t *testing.T) {
-		input := getSarifInput()
-		rawSarif, err := json.Marshal(input)
-		assert.Nil(t, err)
-
-		workflowIdentifier := workflow.NewTypeIdentifier(WORKFLOWID_OUTPUT_WORKFLOW, "output")
-		sarifData := workflow.NewData(workflowIdentifier, content_type.SARIF_JSON, rawSarif)
-		sarifData.SetContentLocation("/mypath")
-
-		// mock assertions
-		outputDestination.EXPECT().Println(gomock.Any()).Do(func(str string) {
-			assert.Contains(t, str, "Total issues:   5")
-			assert.Contains(t, str, "Ignored rule")
-			assert.NotContains(t, str, "This rule is open")
-		}).Times(1)
-
-		config.Set(configuration.FLAG_ONLY_IGNORES, true)
-
-		// execute
-		output, err := outputWorkflowEntryPoint(invocationContextMock, []workflow.Data{sarifData}, outputDestination)
-
-		// assert
-		assert.Nil(t, err)
-		assert.Equal(t, []workflow.Data{}, output)
-	})
 }
 
 func getSarifInput() sarif.SarifDocument {


### PR DESCRIPTION
After discussion we have decided **not** to support an `--only-ignores` flag in the initial release of this capability. We may introduce some filtering mechanism in the future but that work needs some further exploration to understand requirements. 
