### PR TITLE
test(whoami): refactor for rest api specific cases - CLI-21

### DIFF
--- a/internal/api/contract/UserMeResponse.go
+++ b/internal/api/contract/UserMeResponse.go
@@ -7,6 +7,7 @@ type Group struct {
 
 type UserMe struct {
 	Id       *string `json:"id"`
+	Name     *string `json:"name"`
 	UserName *string `json:"username"`
 	Email    *string `json:"email"`
 }

--- a/pkg/local_workflows/whoami_workflow.go
+++ b/pkg/local_workflows/whoami_workflow.go
@@ -68,6 +68,7 @@ func whoAmIWorkflowEntryPoint(invocationCtx workflow.InvocationContext, _ []work
 			Id:       &selfRes.Data.Id,
 			UserName: &selfRes.Data.Attributes.Username,
 			Email:    &selfRes.Data.Attributes.Email,
+			Name:     &selfRes.Data.Attributes.Name,
 		}
 
 		// parse response


### PR DESCRIPTION
This PR contains:
- refactoring of the tests for the whoami workflow and coverage for new rest API cases
- a fix for an edge case spotted during testing, when specifying --json output should also return name