### PR TITLE
fix(file_filter): do not try and pass invalid ignore files

### DIFF
--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -51,8 +51,9 @@ func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
 	// iterate filesToFilter channel and find ignore filesToFilter
 	var ignoreFiles = make([]string, 0)
 	for file := range files {
+		fileName := filepath.Base(file)
 		for _, ruleFile := range ruleFiles {
-			if strings.Contains(file, ruleFile) {
+			if fileName == ruleFile {
 				ignoreFiles = append(ignoreFiles, file)
 			}
 		}


### PR DESCRIPTION
This fixes an issue when trying to pass ignore files. The logic that selects the files to parse did not take into account filenames that contain ignore files. e.g. `somefile.gitignore.ts` will be parsed by the gitignore parser when it should not be