### PR TITLE
feat: introduce empty state for ignores [CLI-311]

### DIFF
--- a/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
+++ b/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
@@ -317,3 +317,47 @@ To edit or remove the ignore please go to: https://app.snyk.io/
 
 
 ---
+
+[TestPresenterSarifResultsPretty_IncludeIgnoredEmpty - 1]
+
+Testing /path/to/project ...
+
+Open Issues
+
+ ✗ [LOW] Use of Hardcoded Credentials
+   Path: pkg/analytics/analytics_test.go, line 248
+   Info: Do not hardcode credentials in code. Found hardcoded credential used in Username.
+
+ ✗ [LOW] Use of Hardcoded Credentials
+   Path: internal/api/api_test.go, line 159
+   Info: Do not hardcode credentials in code. Found hardcoded credential used in Username.
+
+ ✗ [LOW] Use of Password Hash With Insufficient Computational Effort
+   Path: pkg/analytics/analytics.go, line 230
+   Info: The SHA1 hash (used in crypto.sha1.New) is insecure. Consider changing it to a secure hash algorithm
+
+─────────────────────────────────────────────────────
+
+Ignored Issues
+
+  There are no ignored issues
+                             
+💡 Tip
+
+Ignores are currently managed in the Snyk Web UI.
+To edit or remove the ignore please go to: https://app.snyk.io/
+
+╭──────────────────────────────────────────────╮
+│ Test Summary                                 │
+│                                              │
+│   Organization:      test-org                │
+│   Test type:         Static code analysis    │
+│   Project path:      /path/to/project        │
+│                                              │
+│   Total issues:   3                          │
+│   Ignored issues: 0 [ 0 LOW ]                │
+│   Open issues:    3 [ 3 LOW ]                │
+╰──────────────────────────────────────────────╯
+
+
+---

--- a/internal/presenters/components.go
+++ b/internal/presenters/components.go
@@ -31,11 +31,20 @@ func RenderFindings(findings []Finding, showIgnored bool) string {
 		response += RenderDivider()
 		response += RenderTitle("Ignored Issues")
 
+		ignoredFindings := ""
+
 		for _, finding := range findings {
 			if !finding.Ignored {
 				continue
 			}
-			response += RenderFinding(finding)
+			ignoredFindings += RenderFinding(finding)
+		}
+
+		fmt.Printf("ignored findings: %s", ignoredFindings)
+		if ignoredFindings == "" {
+			response += renderBold("  There are no ignored issues\n")
+		} else {
+			response += ignoredFindings
 		}
 
 		response += RenderTip("Ignores are currently managed in the Snyk Web UI.\nTo edit or remove the ignore please go to: https://app.snyk.io/") + "\n"

--- a/internal/presenters/presenter_sarif_results_pretty_test.go
+++ b/internal/presenters/presenter_sarif_results_pretty_test.go
@@ -149,7 +149,34 @@ func TestPresenterSarifResultsPretty_IncludeIgnored(t *testing.T) {
 	require.Contains(t, result, "src/main.ts, line 58")
 	require.Contains(t, result, "Ignored Issues")
 	require.Contains(t, result, "Ignores are currently managed in the Snyk Web UI.")
+	require.NotContains(t, result, "Empty ignore issues state")
 	require.NotContains(t, result, "To view ignored and open issues, use the --include-ignores option.pre")
+
+	snaps.MatchSnapshot(t, result)
+}
+
+func TestPresenterSarifResultsPretty_IncludeIgnoredEmpty(t *testing.T) {
+	fd, err := os.Open("testdata/3-low-issues.json")
+	require.Nil(t, err)
+
+	var input sarif.SarifDocument
+
+	err = json.NewDecoder(fd).Decode(&input)
+	require.Nil(t, err)
+
+	lipgloss.SetColorProfile(termenv.Ascii)
+	p := presenters.SarifTestResults(
+		input,
+		presenters.WithOrgName("test-org"),
+		presenters.WithTestPath("/path/to/project"),
+		presenters.WithIgnored(true),
+	)
+
+	result, err := p.Render()
+
+	require.Nil(t, err)
+	require.NotContains(t, result, "[ IGNORED ]")
+	require.Contains(t, result, "There are no ignored issues")
 
 	snaps.MatchSnapshot(t, result)
 }


### PR DESCRIPTION
When there are no ignores returned we should include a clear
label to state this rather than create ambiguity as to whether
something was broken.

![Screenshot 2024-05-13 at 17 12 38](https://github.com/snyk/go-application-framework/assets/472589/389b858c-ea6a-437f-b516-e8b23c70018e)

