### PR TITLE
fix: left padding for tip content [CLI-311]

### DIFF
--- a/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
+++ b/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
@@ -32,7 +32,7 @@ Open Issues
 
 💡 Tip
 
-To view ignored issues, use the --include-ignores option.
+   To view ignored issues, use the --include-ignores option.
 
 ---
 
@@ -93,7 +93,7 @@ Open Issues
 
 💡 Tip
 
-To view ignored issues, use the --include-ignores option.
+   To view ignored issues, use the --include-ignores option.
 
 ---
 
@@ -113,7 +113,7 @@ Testing /path/to/project ...
 
 💡 Tip
 
-To view ignored issues, use the --include-ignores option.
+   To view ignored issues, use the --include-ignores option.
 
 ---
 
@@ -174,7 +174,7 @@ To view ignored issues, use the --include-ignores option.
 
 💡 Tip
 
-To view ignored issues, use the --include-ignores option.
+   To view ignored issues, use the --include-ignores option.
 
 ---
 
@@ -300,7 +300,7 @@ Ignored Issues
 
 💡 Tip
 
-Ignores are currently managed in the Snyk Web UI.
+   Ignores are currently managed in the Snyk Web UI.
 To edit or remove the ignore please go to: https://app.snyk.io/
 
 ╭─────────────────────────────────────────────────────╮

--- a/internal/presenters/components.go
+++ b/internal/presenters/components.go
@@ -94,7 +94,7 @@ func getFormattedProperties(properties []FindingProperty) string {
 }
 
 func RenderTip(str string) string {
-	return fmt.Sprintf("\n💡 Tip\n\n%s", str)
+	return fmt.Sprintf("\n💡 Tip\n\n   %s", str)
 }
 
 func FilterSeverityASC(original []string, severityMinLevel string) []string {


### PR DESCRIPTION
Note here that the Tip content should be indented to align with the title. 

![Screenshot 2024-05-13 at 17 08 37](https://github.com/snyk/go-application-framework/assets/472589/c5b50b3f-d7a7-4185-9480-5b508b96d3f8)
