### PR TITLE
fix: include zero count severities [CLI-311]

### DIFF
--- a/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
+++ b/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
@@ -18,17 +18,17 @@ Open Issues
    Info: The SHA1 hash (used in crypto.sha1.New) is insecure. Consider changing it to a secure hash algorithm
 
 
-╭──────────────────────────────────────────────╮
-│ Test Summary                                 │
-│                                              │
-│   Organization:      test-org                │
-│   Test type:         Static code analysis    │
-│   Project path:      /path/to/project        │
-│                                              │
-│   Total issues:   3                          │
-│   Ignored issues: 0 [ 0 LOW ]                │
-│   Open issues:    3 [ 3 LOW ]                │
-╰──────────────────────────────────────────────╯
+╭─────────────────────────────────────────────────────╮
+│ Test Summary                                        │
+│                                                     │
+│   Organization:      test-org                       │
+│   Test type:         Static code analysis           │
+│   Project path:      /path/to/project               │
+│                                                     │
+│   Total issues:   3                                 │
+│   Ignored issues: 0 [ 0 HIGH  0 MEDIUM  0 LOW ]     │
+│   Open issues:    3 [ 0 HIGH  0 MEDIUM  3 LOW ]     │
+╰─────────────────────────────────────────────────────╯
 
 💡 Tip
 
@@ -79,17 +79,17 @@ Open Issues
    Info: Unsanitized input from an HTTP parameter flows into findById, where it is used in an NoSQL query. This may result in an NoSQL Injection vulnerability.
 
 
-╭──────────────────────────────────────────────╮
-│ Test Summary                                 │
-│                                              │
-│   Organization:      test-org                │
-│   Test type:         Static code analysis    │
-│   Project path:      /path/to/project        │
-│                                              │
-│   Total issues:   9                          │
-│   Ignored issues: 0 [ 0 HIGH  0 MEDIUM ]     │
-│   Open issues:    9 [ 4 HIGH  5 MEDIUM ]     │
-╰──────────────────────────────────────────────╯
+╭─────────────────────────────────────────────────────╮
+│ Test Summary                                        │
+│                                                     │
+│   Organization:      test-org                       │
+│   Test type:         Static code analysis           │
+│   Project path:      /path/to/project               │
+│                                                     │
+│   Total issues:   9                                 │
+│   Ignored issues: 0 [ 0 HIGH  0 MEDIUM  0 LOW ]     │
+│   Open issues:    9 [ 4 HIGH  5 MEDIUM  0 LOW ]     │
+╰─────────────────────────────────────────────────────╯
 
 💡 Tip
 
@@ -160,17 +160,17 @@ To view ignored issues, use the --include-ignores option.
    Info: Unsanitized input from an HTTP parameter flows into findById, where it is used in an NoSQL query. This may result in an NoSQL Injection vulnerability.
 
 
-╭──────────────────────────────────────────────╮
-│ [1mTest Summary[0m                                 │
-│                                              │
-│   Organization:      test-org                │
-│   Test type:         Static code analysis    │
-│   Project path:      /path/to/project        │
-│                                              │
-│   Total issues:   9                          │
-│   Ignored issues: [1m0[0m [[31m 0 HIGH [0m[33m 0 MEDIUM [0m]     │
-│   Open issues:    [1m9[0m [[31m 4 HIGH [0m[33m 5 MEDIUM [0m]     │
-╰──────────────────────────────────────────────╯
+╭─────────────────────────────────────────────────────╮
+│ [1mTest Summary[0m                                        │
+│                                                     │
+│   Organization:      test-org                       │
+│   Test type:         Static code analysis           │
+│   Project path:      /path/to/project               │
+│                                                     │
+│   Total issues:   9                                 │
+│   Ignored issues: [1m0[0m [[31m 0 HIGH [0m[33m 0 MEDIUM [0m 0 LOW ]     │
+│   Open issues:    [1m9[0m [[31m 4 HIGH [0m[33m 5 MEDIUM [0m 0 LOW ]     │
+╰─────────────────────────────────────────────────────╯
 
 💡 Tip
 

--- a/internal/presenters/components.go
+++ b/internal/presenters/components.go
@@ -143,6 +143,14 @@ func RenderSummary(summary *json_schemas.TestSummary, orgName string, testPath s
 				ignoredIssueLabelledCount += renderInSeverityColor(severity, fmt.Sprintf(" %d %s ", result.Ignored, strings.ToUpper(severity)))
 			}
 		}
+
+		if !strings.Contains(openIssueLabelledCount, strings.ToUpper(severity)) {
+			openIssueLabelledCount += renderInSeverityColor(severity, fmt.Sprintf(" %d %s ", 0, strings.ToUpper(severity)))
+		}
+
+		if !strings.Contains(ignoredIssueLabelledCount, strings.ToUpper(severity)) {
+			ignoredIssueLabelledCount += renderInSeverityColor(severity, fmt.Sprintf(" %d %s ", 0, strings.ToUpper(severity)))
+		}
 	}
 
 	openIssueCountWithSeverities := fmt.Sprintf("%s [%s]", renderBold(strconv.Itoa(openIssueCount)), openIssueLabelledCount)

--- a/internal/presenters/presenter_sarif_results_pretty_test.go
+++ b/internal/presenters/presenter_sarif_results_pretty_test.go
@@ -78,6 +78,9 @@ func TestPresenterSarifResultsPretty_MediumHighIssues(t *testing.T) {
 	result, err := p.Render()
 
 	require.Nil(t, err)
+
+	require.Contains(t, result, "[ 0 HIGH  0 MEDIUM  0 LOW ]")
+	require.Contains(t, result, "[ 4 HIGH  5 MEDIUM  0 LOW ]")
 	snaps.MatchSnapshot(t, result)
 }
 

--- a/internal/utils/sarif/sarif.go
+++ b/internal/utils/sarif/sarif.go
@@ -33,6 +33,7 @@ func CreateCodeSummary(input *sarif.SarifDocument) *json_schemas.TestSummary {
 
 	summary := json_schemas.NewTestSummary(summaryType)
 	resultMap := map[string]*json_schemas.TestSummaryResult{}
+	summary.SeverityOrderAsc = []string{"low", "medium", "high"}
 
 	for _, run := range input.Runs {
 		for _, result := range run.Results {


### PR DESCRIPTION
Ensure that we show `0` counts for any severities where we found no vulnerabilities.

This improves the consistency of the interface and clearly communicates that we have found no known vulnerabilities. 

![Screenshot 2024-05-13 at 17 06 12](https://github.com/snyk/go-application-framework/assets/472589/ed75a90a-b2b6-417a-8e9b-9e0636ae7910)

Note: Ignore the purple underline, that is an artefact of the screengrab process 🙈 