### PR TITLE
fix: add bold weight to summary output [CLI-311]

### DIFF
--- a/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
+++ b/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
@@ -161,7 +161,7 @@ To view ignored issues, use the --include-ignores option.
 
 
 ╭──────────────────────────────────────────────╮
-│ Test Summary                                 │
+│ [1mTest Summary[0m                                 │
 │                                              │
 │   Organization:      test-org                │
 │   Test type:         Static code analysis    │

--- a/internal/presenters/components.go
+++ b/internal/presenters/components.go
@@ -107,7 +107,7 @@ func FilterSeverityASC(original []string, severityMinLevel string) []string {
 
 func RenderSummary(summary *json_schemas.TestSummary, orgName string, testPath string, severityMinLevel string) (string, error) {
 	var buff bytes.Buffer
-	var summaryTemplate = template.Must(template.New("summary").Parse(`Test Summary
+	var summaryTemplate = template.Must(template.New("summary").Parse(`{{ .SummaryTitle }}
 
   Organization:      {{ .Org }}
   Test type:         {{ .Type }}
@@ -153,6 +153,7 @@ func RenderSummary(summary *json_schemas.TestSummary, orgName string, testPath s
 	}
 
 	err := summaryTemplate.Execute(&buff, struct {
+		SummaryTitle                    string
 		Org                             string
 		TestPath                        string
 		Type                            string
@@ -161,6 +162,7 @@ func RenderSummary(summary *json_schemas.TestSummary, orgName string, testPath s
 		OpenIssueCountWithSeverities    string
 		IgnoredIssueCountWithSeverities string
 	}{
+		SummaryTitle:                    renderBold("Test Summary"),
 		Org:                             orgName,
 		TestPath:                        testPath,
 		Type:                            testType,


### PR DESCRIPTION
Small nit, ensure Test Summary title is rendered in bold text. 

![Screenshot 2024-05-13 at 17 01 54](https://github.com/snyk/go-application-framework/assets/472589/a4c5de49-9266-4554-a348-613a7ec2946a)
