### PR TITLE
feat(instrumentation): derive category vector CLI-307

### DIFF
--- a/pkg/analytics/categories.go
+++ b/pkg/analytics/categories.go
@@ -1,0 +1,163 @@
+package analytics
+
+import (
+	"slices"
+	"strings"
+)
+
+// ParseCliArgs categorizes command-line arguments into a structured slice.
+//
+// This function receives the entire os.Args slice (including the program name at index 0)
+// and processes the arguments to determine the product, commands, and flags.
+// It is designed to handle arguments in any order.
+//
+// The function performs the following actions:
+//  1. It identifies the product based on the following rules:
+//     - If the command is "test" and no other commands are present, the product is "oss" (open-source software).
+//     - Otherwise, no product is explicitly identified.
+//  2. It extracts known commands and whitelisted flags from the arguments. Flags after a double dash ("--") are ignored.
+//  3. It constructs a slice containing the categorized arguments in the following order:
+//     - [product] (if applicable)
+//     - [command(s)]
+//     - [flags] (without leading dashes)
+//
+// If no known commands or flags are found, the returned slice will be empty.
+//
+// Example:
+//
+//	args := []string{"cli", "scan", "--debug", "--"}
+//	knownCommands := []string{"scan", "build"}
+//	flagsAllowList := []string{"debug", "verbose"}
+//	result := ParseCliArgs(args, knownCommands, flagsAllowList)
+//	// result: ["scan", "debug"]
+//
+// Parameters:
+//   - args: A slice of strings representing the entire os.Args.
+//   - knownCommands: A slice of valid command names.
+//   - flagsAllowList: A slice of valid flag names (without leading dashes).
+//
+// Returns:
+//   - A slice of strings containing the categorized arguments.
+func ParseCliArgs(args []string, knownCommands []string, flagsAllowList []string, knownProducts []string) []string {
+	commands := []string{}
+	flags := []string{}
+	result := []string{}
+
+	productFallback := "oss"
+
+	// Separate parsing of commands and flags to ensure correct ordering in the category vector
+	// regardless of how they are provided in the command line.
+	for _, arg := range args[1:] {
+		if strings.HasPrefix(arg, "-") {
+			if arg == "--" {
+				break
+			}
+
+			// Split the flag into key and potential value
+			flagParts := strings.SplitN(arg, "=", 2)
+			flagName := strings.TrimLeft(flagParts[0], "-")
+
+			if slices.Contains(flagsAllowList, flagName) {
+				flags = append(flags, flagName)
+			}
+		} else if slices.Contains(knownCommands, arg) {
+			if len(commands) == 0 && arg == "test" {
+				result = append(commands, productFallback)
+			}
+
+			commands = append(commands, arg)
+		}
+	}
+
+	result = append(result, commands...)
+	result = append(result, flags...)
+
+	return result
+}
+
+var PRODUCTS = []string{"code", "iac", "container", "sbom"}
+var KNOWN_COMMANDS = []string{"test", "code", "monitor", "iac", "rules", "describe", "sbom", "container", "debug"}
+var ALLOWED_FLAGS = []string{
+	"print-dep-paths",
+	"print-deps",
+	"max-depth",
+	"policy-path",
+	"project-name",
+	"target-reference",
+	"remote-repo-url",
+	"exclude-base-image-vulns",
+	"exclude-app-vulns",
+	"dev",
+	"advertise-subprojects-count",
+	"project-tags",
+	"all-projects",
+	"all-sub-projects",
+	"app-vulns",
+	"code",
+	"command",
+	"commit-id",
+	"config-dir",
+	"criticality",
+	"debug",
+	"detection-depth",
+	"docker",
+	"driftignore",
+	"dry-run",
+	"exclude",
+	"exclude-missing",
+	"exclude-unmanaged",
+	"experimental",
+	"fail-fast",
+	"fail-on",
+	"fetch-tfstate-headers",
+	"file",
+	"filter",
+	"from",
+	"gradle-sub-project",
+	"group-issues",
+	"html",
+	"html-file-output",
+	"iac",
+	"id",
+	"ignore",
+	"ignore-policy",
+	"init-script",
+	"insecure",
+	"is-docker-user",
+	"json",
+	"kind",
+	"loose",
+	"maven-aggregate-project",
+	"no-markdown",
+	"org",
+	"package-manager",
+	"path",
+	"policy",
+	"project-id",
+	"project-names",
+	"prune-repeated-subdependencies",
+	"quiet",
+	"report",
+	"sarif",
+	"scan-all-unmanaged",
+	"service",
+	"severity-threshold",
+	"show-vuln-paths",
+	"show-vulnerable-paths",
+	"strict",
+	"strict-out-of-sync",
+	"tags",
+	"target-name",
+	"test-dep-graph-docker-endpoint",
+	"tf-lockfile",
+	"tf-provider-version",
+	"tfc-endpoint",
+	"tfc-token",
+	"to",
+	"traverse-node-modules",
+	"trust-policies",
+	"unmanaged",
+	"var-file",
+	"vuln-endpoint",
+	"yarn-workspaces",
+}

--- a/pkg/analytics/categories_test.go
+++ b/pkg/analytics/categories_test.go
@@ -1,0 +1,53 @@
+package analytics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCategorizeCliArgs(t *testing.T) {
+	// Test Data Setup
+	testCases := []struct {
+		name           string
+		args           []string
+		expectedOutput []string
+		expectedError  error
+	}{
+		// Happy Path Tests (Valid Commands & Flags)
+		{"OSS test", []string{"snyk", "test"}, []string{"oss", "test"}, nil},
+		{"OSS test with unmanaged flag", []string{"snyk", "test", "--unmanaged"}, []string{"oss", "test", "unmanaged"}, nil},
+		{"Code test", []string{"snyk", "code", "test"}, []string{"code", "test"}, nil},
+		{"IAC describe", []string{"snyk", "iac", "describe"}, []string{"iac", "describe"}, nil},
+		{"IAC rules test", []string{"snyk", "iac", "rules", "test"}, []string{"iac", "rules", "test"}, nil},
+		{"OSS sbom", []string{"snyk", "sbom"}, []string{"sbom"}, nil},
+		{"Container sbom with all-projects flag", []string{"snyk", "container", "sbom", "--all-projects"}, []string{"container", "sbom", "all-projects"}, nil},
+		{"Command with debug flag", []string{"snyk", "test", "--debug"}, []string{"oss", "test", "debug"}, nil},
+
+		// Real-World Example with Mixed Input
+		{"Mixed flags and commands", []string{"snyk", "-d", "test", "../folder/", "--org=myorg", "--remote-repo-url", "https://github.com/snyk"}, []string{"oss", "test", "org", "remote-repo-url"}, nil},
+		{"Mixed wrong flags value and commands", []string{"snyk", "-d", "test", "../folder/", "--org=+myorg", "--remote-repo-url", "https://github.com/snyk"}, []string{"oss", "test", "org", "remote-repo-url"}, nil},
+		{"Mixed wrong flags and commands", []string{"snyk", "-d", "test", "../folder/", "--org+=myorg", "--remote-repo-url", "https://github.com/snyk"}, []string{"oss", "test", "remote-repo-url"}, nil},
+
+		// Missing or Invalid Commands
+		{"Invalid command", []string{"snyk", "invalid"}, []string{}, nil},
+		{"Invalid subcommand", []string{"snyk", "iac", "invalid"}, []string{"iac"}, nil},
+		{"Missing command", []string{"snyk"}, []string{}, nil}, // Empty output for no command
+		{"Valid command line ending parse check invalid flag", []string{"snyk", "test", "--", "--Dverbose=1"}, []string{"oss", "test"}, nil},
+		{"Valid command line ending parse check allowlisted flag", []string{"snyk", "test", "--", "--debug=1"}, []string{"oss", "test"}, nil},
+		{"Invalid commandline ending check with invalid flag", []string{"snyk", "tests", "--", "--Dverbose=1"}, []string{}, nil},
+
+		// Unsupported Flags (Should be Omitted)
+		{"Unsupported flag", []string{"snyk", "test", "--unsupported"}, []string{"oss", "test"}, nil},
+		{"Unsupported flag with valid ones", []string{"snyk", "test", "--unmanaged", "--unsupported"}, []string{"oss", "test", "unmanaged"}, nil},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Execute the function under test
+			categories := ParseCliArgs(tc.args, KNOWN_COMMANDS, ALLOWED_FLAGS, PRODUCTS)
+
+			// Assertions
+			assert.Equal(t, tc.expectedOutput, categories)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the `ParseCliArgs ` function to parse command-line arguments into product/command/flag categories as per the RFC.  The function uses whitelists and known commands to determine the correct categories, defaulting to "oss" if no product is explicitly provided.