### PR TITLE
fix: support empty path being passed to file_filter

### DIFF
--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -1,12 +1,13 @@
 package utils
 
 import (
-	"github.com/rs/zerolog"
-	"gopkg.in/yaml.v3"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/rs/zerolog"
+	"gopkg.in/yaml.v3"
 
 	gitignore "github.com/sabhiram/go-gitignore"
 )
@@ -31,9 +32,14 @@ func (fw *FileFilter) GetAllFiles() chan string {
 	go func() {
 		defer close(filesCh)
 		err := filepath.WalkDir(fw.path, func(path string, d fs.DirEntry, err error) error {
-			if !d.IsDir() && err == nil {
+			if err != nil {
+				return err
+			}
+
+			if !d.IsDir() {
 				filesCh <- path
 			}
+
 			return err
 		})
 		if err != nil {

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -45,6 +45,17 @@ func TestFileFilter_GetAllFiles(t *testing.T) {
 		}
 		assert.Equal(t, len(expectedFiles), actualFilesChanLen)
 	})
+
+	t.Run("handles empty path", func(t *testing.T) {
+		fileFilter := NewFileFilter("", &log.Logger)
+		actualFiles := fileFilter.GetAllFiles()
+
+		var actualFilesChanLen int
+		for range actualFiles {
+			actualFilesChanLen++
+		}
+		assert.Equal(t, 0, actualFilesChanLen)
+	})
 }
 
 func TestFileFilter_GetRules(t *testing.T) {


### PR DESCRIPTION
Handle errors when empty string is passed as target path. 