### PR TITLE
refactor: move is CI environment out for reuse [CLI-324]

### DIFF
--- a/internal/utils/is-ci-environment.go
+++ b/internal/utils/is-ci-environment.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"os"
+
+	"github.com/snyk/go-application-framework/pkg/utils"
+)
+
+var (
+	// ciEnvironments is a list of environment variables that indicate a CI environment.
+	// it is used to determine if the command is running in a CI environment.
+	ciEnvironments = []string{
+		"SNYK_CI",
+		"CI",
+		"CONTINUOUS_INTEGRATION",
+		"BUILD_ID",
+		"BUILD_NUMBER",
+		"TEAMCITY_VERSION",
+		"TRAVIS",
+		"CIRCLECI",
+		"JENKINS_URL",
+		"HUDSON_URL",
+		"bamboo.buildKey",
+		"PHPCI",
+		"GOCD_SERVER_HOST",
+		"BUILDKITE",
+		"TF_BUILD",
+		"SYSTEM_TEAMFOUNDATIONSERVERURI", // for Azure DevOps Pipelines
+	}
+)
+
+func IsCiEnvironment() bool {
+	result := false
+
+	envMap := utils.ToKeyValueMap(os.Environ(), "=")
+	for i := range ciEnvironments {
+		if _, ok := envMap[ciEnvironments[i]]; ok {
+			result = true
+			break
+		}
+	}
+
+	return result
+}

--- a/internal/utils/is-ci-environment.go
+++ b/internal/utils/is-ci-environment.go
@@ -13,19 +13,87 @@ var (
 		"SNYK_CI",
 		"CI",
 		"CONTINUOUS_INTEGRATION",
+		"GOCD_SERVER_HOST",
+		// AppVeyor
+		"APPVEYOR",
+		// Azure Pipelines
+		"SYSTEM_TEAMFOUNDATIONCOLLECTIONURI",
+		"SYSTEM_TEAMFOUNDATIONSERVERURI",
+		"TF_BUILD",
+		// Appcircle
+		"AC_APPCIRCLE",
+		// Bamboo
+		"bamboo_planKey",
+		"bamboo.buildKey",
+		// Bitbucket Pipelines
+		"BITBUCKET_COMMIT",
+		// Bitrise
+		"BITRISE_IO",
+		// Buddy
+		"BUDDY_WORKSPACE_ID",
+		// Buildkite
+		"BUILDKITE",
+		// CircleCI
+		"CIRCLECI",
+		// Cirrus CI
+		"CIRRUS_CI",
+		// AWS CodeBuild
+		"CODEBUILD_BUILD_ARN",
+		// Codefresh
+		"CF_BUILD_ID",
+		// Drone
+		"DRONE",
+		// dsari
+		"DSARI",
+		// Expo Application Services
+		"EAS_BUILD",
+		// GitHub Actions
+		"GITHUB_ACTIONS",
+		// GitLab CI
+		"GITLAB_CI",
+		// GoCD
+		"GO_PIPELINE_LABEL",
+		// LayerCI
+		"LAYERCI",
+		// Hudson
+		"HUDSON_URL",
+		// Jenkins
+		"JENKINS_URL",
 		"BUILD_ID",
 		"BUILD_NUMBER",
-		"TEAMCITY_VERSION",
-		"TRAVIS",
-		"CIRCLECI",
-		"JENKINS_URL",
-		"HUDSON_URL",
-		"bamboo.buildKey",
+		// Magnum CI
+		"MAGNUM",
+		// Netlify CI
+		"NETLIFY",
+		// Nevercode
+		"NEVERCODE",
+		// PHPCI
 		"PHPCI",
-		"GOCD_SERVER_HOST",
-		"BUILDKITE",
-		"TF_BUILD",
-		"SYSTEM_TEAMFOUNDATIONSERVERURI", // for Azure DevOps Pipelines
+		// Render
+		"RENDER",
+		// Sail CI
+		"SAILCI",
+		// Semaphore
+		"SEMAPHORE",
+		// Screwdriver
+		"SCREWDRIVER",
+		// Shippable
+		"SHIPPABLE",
+		// Solano CI
+		"TDDIUM",
+		// Strider CD
+		"STRIDER",
+		// TaskCluster
+		"TASK_ID",
+		"RUN_ID",
+		// TeamCity
+		"TEAMCITY_VERSION",
+		// Travis CI
+		"TRAVIS",
+		// Vercel
+		"NOW_BUILDER",
+		// Visual Studio App Center
+		"APPCENTER_BUILD_ID",
 	}
 )
 

--- a/internal/utils/is-ci-environment_test.go
+++ b/internal/utils/is-ci-environment_test.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsCiEnvironment(t *testing.T) {
+	scenarios := ciEnvironments
+
+	for _, scenario := range scenarios {
+		t.Run(scenario, func(t *testing.T) {
+			t.Setenv(scenario, "foo")
+
+			assert.True(t, IsCiEnvironment())
+		})
+	}
+}

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"os/user"
 	"regexp"
 	"runtime"
@@ -18,9 +17,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-uuid"
+	utils2 "github.com/snyk/go-application-framework/internal/utils"
 
 	"github.com/snyk/go-application-framework/internal/api"
-	"github.com/snyk/go-application-framework/pkg/utils"
 )
 
 // Analytics is an interface for managing analytics.
@@ -98,28 +97,6 @@ type dataOutput struct {
 }
 
 var (
-	// ciEnvironments is a list of environment variables that indicate a CI environment.
-	// it is used to determine if the command is running in a CI environment.
-	// if it is, the x-is-ci header is set to true.
-	ciEnvironments = []string{
-		"SNYK_CI",
-		"CI",
-		"CONTINUOUS_INTEGRATION",
-		"BUILD_ID",
-		"BUILD_NUMBER",
-		"TEAMCITY_VERSION",
-		"TRAVIS",
-		"CIRCLECI",
-		"JENKINS_URL",
-		"HUDSON_URL",
-		"bamboo.buildKey",
-		"PHPCI",
-		"GOCD_SERVER_HOST",
-		"BUILDKITE",
-		"TF_BUILD",
-		"SYSTEM_TEAMFOUNDATIONSERVERURI", // for Azure DevOps Pipelines
-	}
-
 	// sensitiveFieldNames is a list of field names that should be sanitized.
 	// data sanitization is used to prevent sensitive data from being sent to the analytics server.
 	sensitiveFieldNames = []string{
@@ -200,17 +177,7 @@ func (a *AnalyticsImpl) SetClient(clientFunc func() *http.Client) {
 
 // IsCiEnvironment returns true if the command is running in a CI environment.
 func (a *AnalyticsImpl) IsCiEnvironment() bool {
-	result := false
-
-	envMap := utils.ToKeyValueMap(os.Environ(), "=")
-	for i := range ciEnvironments {
-		if _, ok := envMap[ciEnvironments[i]]; ok {
-			result = true
-			break
-		}
-	}
-
-	return result
+	return utils2.IsCiEnvironment()
 }
 
 // GetOutputData returns the analyticsOutput data.


### PR DESCRIPTION
Refactor isCiEnvironment check for usability and extend set of supported environments. 