### PR TITLE
feat(instrumentation): add interaction id header for network requests CLI-325

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -353,3 +353,7 @@ func DetermineStage(isCiEnvironment bool) string {
 
 	return "dev"
 }
+
+func AssembleUrnFromUUID(uuid string) string {
+	return fmt.Sprintf("urn:snyk:interaction:%s", uuid)
+}


### PR DESCRIPTION
First PR for CLI-325. 
We generate urn identifier and attach it as a header to the network requests.