### PR TITLE
fix(instrumentation): CLI-335 add missing known commands

### DIFF
--- a/pkg/instrumentation/categories.go
+++ b/pkg/instrumentation/categories.go
@@ -79,7 +79,28 @@ func DetermineCategoryFromArgs(args []string, knownCommands []string, flagsAllow
 	return result
 }
 
-var KNOWN_COMMANDS = []string{"test", "code", "monitor", "iac", "rules", "describe", "container", "debug", "config"}
+var KNOWN_COMMANDS = []string{
+	"test",
+	"code",
+	"monitor",
+	"iac",
+	"rules",
+	"describe",
+	"container",
+	"debug",
+	"config",
+	"auth",
+	"ignore",
+	"log4shell",
+	"policy",
+	"fix",
+	"apps",
+	"capture",
+	"init",
+	"push",
+	"update-exclude-policy",
+}
+
 var KNOWN_FLAGS = []string{
 	"print-dep-paths",
 	"print-deps",


### PR DESCRIPTION
Extended the list of known commands based on the [docs](https://docs.snyk.io/snyk-cli/cli-commands-and-options-summary).