### PR TITLE
feat: use progress tracker from code-client-go [IDE-222]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.32.0
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
-	github.com/snyk/code-client-go v1.5.5
+	github.com/snyk/code-client-go v1.6.0
 	github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.32.0
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
-	github.com/snyk/code-client-go v1.6.0
+	github.com/snyk/code-client-go v1.6.1
 	github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
@@ -25,6 +25,7 @@ require (
 
 require (
 	github.com/mattn/go-isatty v0.0.20
+	github.com/oapi-codegen/runtime v1.1.1
 	github.com/snyk/error-catalog-golang-public v0.0.0-20240425141803-2516e42296c3
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -75,7 +76,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
-	github.com/oapi-codegen/runtime v1.1.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.9 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -313,6 +313,8 @@ github.com/skeema/knownhosts v1.2.2 h1:Iug2P4fLmDw9f41PB6thxUkNUkJzB5i+1/exaj40L
 github.com/skeema/knownhosts v1.2.2/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
 github.com/snyk/code-client-go v1.5.5 h1:YHgNvh17jVTuSvPVMoeNuDn40z1qb99EfXva/sSRCMw=
 github.com/snyk/code-client-go v1.5.5/go.mod h1:Kkr7pQc8ItsBZSYd6A1S4r4VHO6HNyTWZsqi18sAtwQ=
+github.com/snyk/code-client-go v1.6.0 h1:VIczLhRvdGbGTYxgXn5W7G1b1lMpBBjr0sOKZKVn/cE=
+github.com/snyk/code-client-go v1.6.0/go.mod h1:Kkr7pQc8ItsBZSYd6A1S4r4VHO6HNyTWZsqi18sAtwQ=
 github.com/snyk/error-catalog-golang-public v0.0.0-20240425141803-2516e42296c3 h1:ZUaY5LIVGQ0GScf1SsaqvUxaiGbBKgBBLsQUgB4Zx5o=
 github.com/snyk/error-catalog-golang-public v0.0.0-20240425141803-2516e42296c3/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=

--- a/go.sum
+++ b/go.sum
@@ -311,10 +311,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.2.2 h1:Iug2P4fLmDw9f41PB6thxUkNUkJzB5i+1/exaj40L3A=
 github.com/skeema/knownhosts v1.2.2/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
-github.com/snyk/code-client-go v1.5.5 h1:YHgNvh17jVTuSvPVMoeNuDn40z1qb99EfXva/sSRCMw=
-github.com/snyk/code-client-go v1.5.5/go.mod h1:Kkr7pQc8ItsBZSYd6A1S4r4VHO6HNyTWZsqi18sAtwQ=
-github.com/snyk/code-client-go v1.6.0 h1:VIczLhRvdGbGTYxgXn5W7G1b1lMpBBjr0sOKZKVn/cE=
-github.com/snyk/code-client-go v1.6.0/go.mod h1:Kkr7pQc8ItsBZSYd6A1S4r4VHO6HNyTWZsqi18sAtwQ=
+github.com/snyk/code-client-go v1.6.1 h1:wCCcsTLsk5ZAUwwAHiU35/hmmYzJ5lgFbcJ1fOk6L/k=
+github.com/snyk/code-client-go v1.6.1/go.mod h1:Kkr7pQc8ItsBZSYd6A1S4r4VHO6HNyTWZsqi18sAtwQ=
 github.com/snyk/error-catalog-golang-public v0.0.0-20240425141803-2516e42296c3 h1:ZUaY5LIVGQ0GScf1SsaqvUxaiGbBKgBBLsQUgB4Zx5o=
 github.com/snyk/error-catalog-golang-public v0.0.0-20240425141803-2516e42296c3/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=


### PR DESCRIPTION
Uses the new progress tracker factory and tracker from `code-client-go` in https://github.com/snyk/code-client-go/pull/49. It defaults to the noop tracker which does nothing.

To test:

- Run make build-debug in `snyk-ls` for the branch in https://github.com/snyk/snyk-ls/pull/514
- Add a `snyk-ls` and `go-application-framework` replace directive in the `go.mod` in `snyk`
- Run `make build` in `snyk`

![Screenshot 2024-05-23 at 18 39 51](https://github.com/snyk/go-application-framework/assets/81559517/f3d051ab-d39e-48a4-ba33-5d1633251aad)

