### PR TITLE
feat: clear auth config keys when switching auth types

### DIFF
--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -373,4 +373,28 @@ func Test_DefaultValuehandling(t *testing.T) {
 		assert.Equal(t, expected, actual)
 		assert.True(t, wasSet)
 	})
+
+	t.Run("set and unset", func(t *testing.T) {
+		fakehome := t.TempDir()
+		t.Setenv("HOME", fakehome)
+		configPath := filepath.Join(fakehome, ".config", "configstore", TEST_FILENAME_JSON)
+
+		assert.NoError(t, prepareConfigstore(`{"foo":"bar","baz":"quux"}`))
+		config := NewFromFiles(TEST_FILENAME)
+		config.SetStorage(NewJsonStorage(configPath))
+		config.AddAlternativeKeys("foo", []string{"foof", "floof"})
+
+		assert.Equal(t, "bar", config.Get("foo"))
+		assert.Equal(t, "quux", config.Get("baz"))
+
+		config.Unset("foo")
+
+		contents, err := os.ReadFile(configPath)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{"baz":"quux"}`, string(contents))
+
+		config = NewFromFiles(TEST_FILENAME)
+		assert.Equal(t, nil, config.Get("foo"))
+		assert.Equal(t, "quux", config.Get("baz"))
+	})
 }

--- a/pkg/local_workflows/auth_workflow.go
+++ b/pkg/local_workflows/auth_workflow.go
@@ -98,6 +98,9 @@ func entryPointDI(config configuration.Configuration, logger *zerolog.Logger, en
 	logger.Printf("Authentication Type: %s", authType)
 
 	if strings.EqualFold(authType, authTypeOAuth) { // OAUTH flow
+		logger.Printf("Unset legacy token key %q from config", configuration.AUTHENTICATION_TOKEN)
+		config.Unset(configuration.AUTHENTICATION_TOKEN)
+
 		headless := config.GetBool(headlessFlag)
 		logger.Printf("Headless: %v", headless)
 
@@ -108,9 +111,12 @@ func entryPointDI(config configuration.Configuration, logger *zerolog.Logger, en
 
 		fmt.Println(auth.AUTHENTICATED_MESSAGE)
 	} else { // LEGACY flow
+		logger.Printf("Unset oauth key %q from config", auth.CONFIG_KEY_OAUTH_TOKEN)
+		config.Unset(auth.CONFIG_KEY_OAUTH_TOKEN)
+
 		config.Set(configuration.RAW_CMD_ARGS, os.Args[1:])
 		config.Set(configuration.WORKFLOW_USE_STDIO, true)
-		config.Set(configuration.AUTHENTICATION_TOKEN, "") // unset token to avoid using it during authentication
+		config.Set(configuration.AUTHENTICATION_TOKEN, "") // clear token to avoid using it during authentication
 
 		_, legacyCLIError := engine.InvokeWithConfig(workflow.NewWorkflowIdentifier("legacycli"), config)
 		if legacyCLIError != nil {


### PR DESCRIPTION
Authenticating with token (deprecated) or oauth causes different config keys to be written to the config store. If these are unset, it potentially leaves stale auth information in the config. This also makes it difficult to determine which auth information is being used during CLI interactions.

This change forces the authentication config to be either oauth or token (deprecated). If one is set, the other method's keys are unset.

This required the addition of a Configuration.Unset method. "Unset" is a long-sought after feature of spf13/viper, which will probably never be added by the maintainer, but it is fairly straightforward to implement in coordination with the config file storage.