### PR TITLE
fix: add padding for entire body of tip message

### DIFF
--- a/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
+++ b/internal/presenters/__snapshots__/presenter_sarif_results_pretty_test.snap
@@ -300,8 +300,8 @@ Ignored Issues
 
 💡 Tip
 
-   Ignores are currently managed in the Snyk Web UI.
-To edit or remove the ignore please go to: https://app.snyk.io/
+   Ignores are currently managed in the Snyk Web UI.              
+   To edit or remove the ignore please go to: https://app.snyk.io/
 
 ╭─────────────────────────────────────────────────────╮
 │ Test Summary                                        │
@@ -345,8 +345,8 @@ Ignored Issues
                              
 💡 Tip
 
-   Ignores are currently managed in the Snyk Web UI.
-To edit or remove the ignore please go to: https://app.snyk.io/
+   Ignores are currently managed in the Snyk Web UI.              
+   To edit or remove the ignore please go to: https://app.snyk.io/
 
 ╭─────────────────────────────────────────────────────╮
 │ Test Summary                                        │
@@ -389,8 +389,8 @@ Open Issues
 💡 Tip
 
    You are currently viewing results with --severity-threshold=high applied.
-To view all issues, remove the --severity-threshold flag
-
+   To view all issues, remove the --severity-threshold flag                 
+                                                                            
 ╭──────────────────────────────────────────────╮
 │ Test Summary                                 │
 │                                              │

--- a/internal/presenters/components.go
+++ b/internal/presenters/components.go
@@ -158,7 +158,9 @@ func getFormattedProperties(properties []FindingProperty) string {
 }
 
 func RenderTip(str string) string {
-	return fmt.Sprintf("\n💡 Tip\n\n   %s", str)
+	body := lipgloss.NewStyle().
+		PaddingLeft(3)
+	return fmt.Sprintf("\n💡 Tip\n\n%s", body.Render(str))
 }
 
 func FilterSeverityASC(original []string, severityMinLevel string) []string {

--- a/internal/presenters/components.go
+++ b/internal/presenters/components.go
@@ -102,7 +102,7 @@ func RenderFindings(findings []Finding, showIgnored bool, isSeverityThresholdApp
 			response += ignoredFindings
 		}
 
-		response += RenderTip("Ignores are currently managed in the Snyk Web UI.\nTo edit or remove the ignore please go to: https://app.snyk.io/") + "\n"
+		response += RenderTip("Ignores are currently managed in the Snyk Web UI.\nTo edit or remove the ignore please go to: "+RenderLink("https://app.snyk.io/")) + "\n"
 	}
 
 	return response
@@ -124,6 +124,12 @@ func RenderFinding(finding Finding) string {
 		),
 		properties,
 	}, "\n")
+}
+
+func RenderLink(str string) string {
+	return lipgloss.NewStyle().
+		Foreground(lipgloss.Color("12")).
+		Render(str)
 }
 
 func RenderDivider() string {


### PR DESCRIPTION
The behaviour prior to this change was indenting only the first line
where as we want the entire body of the tip to be indented.
