### PR TITLE
fix: empty errors in serialized instrumentation data

### DIFF
--- a/pkg/analytics/instrumentation_collector.go
+++ b/pkg/analytics/instrumentation_collector.go
@@ -25,6 +25,7 @@ type InstrumentationCollector interface {
 	SetInteractionId(id string)
 	SetTimestamp(t time.Time)
 	SetDuration(duration time.Duration)
+	GetDuration() time.Duration
 	SetStage(s string)
 	SetType(t string)
 	SetInteractionType(t string)
@@ -75,6 +76,9 @@ func (ic *instrumentationCollectorImpl) SetTimestamp(t time.Time) {
 
 func (ic *instrumentationCollectorImpl) SetDuration(d time.Duration) {
 	ic.duration = d
+}
+func (ic *instrumentationCollectorImpl) GetDuration() time.Duration {
+	return ic.duration
 }
 
 func (ic *instrumentationCollectorImpl) SetStage(s string) {

--- a/pkg/analytics/instrumentation_collector.go
+++ b/pkg/analytics/instrumentation_collector.go
@@ -232,13 +232,14 @@ func toInteractionErrors(errors []error) *[]api.InteractionError {
 
 func toInteractionError(e error) *api.InteractionError {
 	errorCatalogError := snyk_errors.Error{}
-	interactionError := api.InteractionError{}
+	var interactionError *api.InteractionError
 
 	if errors.As(e, &errorCatalogError) {
+		interactionError = &api.InteractionError{}
 		interactionErrorCode := fmt.Sprintf("%d", errorCatalogError.StatusCode)
 		interactionError.Id = errorCatalogError.ErrorCode
 		interactionError.Code = &interactionErrorCode
 	}
 
-	return &interactionError
+	return interactionError
 }

--- a/pkg/analytics/instrumentation_collector_test.go
+++ b/pkg/analytics/instrumentation_collector_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/snyk/error-catalog-golang-public/snyk"
 	"github.com/stretchr/testify/assert"
 
 	api "github.com/snyk/go-application-framework/internal/api/clients"
@@ -180,7 +181,11 @@ func Test_InstrumentationCollector(t *testing.T) {
 		mockError := fmt.Errorf("oops")
 		ic.AddError(mockError)
 
-		expectedV2InstrumentationObject.Data.Attributes.Interaction.Errors = toInteractionErrors([]error{mockError})
+		snykError := snyk.NewBadRequestError("")
+		ic.AddError(snykError)
+
+		expectedV2InstrumentationObject.Data.Attributes.Interaction.Errors = toInteractionErrors([]error{mockError, snykError})
+		assert.Equal(t, 1, len(*expectedV2InstrumentationObject.Data.Attributes.Interaction.Errors))
 
 		actualV2InstrumentationObject, err := GetV2InstrumentationObject(ic)
 		assert.NoError(t, err)

--- a/pkg/instrumentation/categories.go
+++ b/pkg/instrumentation/categories.go
@@ -62,14 +62,14 @@ func DetermineCategoryFromArgs(args []string, knownCommands []string, flagsAllow
 			flagName := strings.TrimLeft(flagParts[0], "-")
 
 			if slices.Contains(flagsAllowList, flagName) {
-				flags = append(flags, flagName)
+				flags = append(flags, strings.ToLower(flagName))
 			}
 		} else if slices.Contains(knownCommands, arg) {
 			if len(commands) == 0 && arg == "test" {
 				result = append(commands, productFallback)
 			}
 
-			commands = append(commands, arg)
+			commands = append(commands, strings.ToLower(arg))
 		}
 	}
 

--- a/pkg/instrumentation/categories_test.go
+++ b/pkg/instrumentation/categories_test.go
@@ -51,3 +51,12 @@ func TestCategorizeCliArgs(t *testing.T) {
 		})
 	}
 }
+
+func Test_DetermineCategoryFromArgs_casing(t *testing.T) {
+	args := []string{"application", "Test", "--My-name"}
+	commands := []string{"Test"}
+	flags := []string{"My-name"}
+	expected := []string{"test", "my-name"}
+	actual := DetermineCategoryFromArgs(args, commands, flags)
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
* When errors don't have an id, don't add empty error structures to the serialized data
* ensure category vector is lower case
* add GetDuration()