### PR TITLE
fix: line break in links

### DIFF
--- a/internal/presenters/__snapshots__/components_test.snap
+++ b/internal/presenters/__snapshots__/components_test.snap
@@ -3,15 +3,16 @@
 
 [41m [0m[97;41mERROR[0m[41m [0m  [1mClient request cannot be processed (SNYK-0003)[0m
 Info:    A short error description                                                      
-HTTP:    400                                                                            
+HTTP:    400 
 ---
 
 [Test_RenderError/with_links - 1]
 
 [41m [0m[97;41mERROR[0m[41m [0m  [1mRequest not fulfilled due to server error (SNYK-9999)[0m
 Info:    An error                                                                       
-HTTP:    500                                                                            
-Help:    https://status.snyk.io/                                                        
+HTTP:    500 
+Help:    https://status.snyk.io/                                                                                                       
+         https://docs.snyk.io/getting-started/supported-languages-frameworks-and-feature-availability-overview#code-analysis-snyk-code 
 ---
 
 [Test_RenderError/colours_for_each_severity - 1]

--- a/internal/presenters/components.go
+++ b/internal/presenters/components.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+
 	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
 )
 
@@ -40,7 +41,7 @@ func RenderError(err snyk_errors.Error) string {
 	if len(err.Detail) > 0 {
 		body = append(body, lipgloss.JoinHorizontal(lipgloss.Top,
 			label.Render("Info:"),
-			value.Width(80).Render(err.Detail),
+			value.Copy().Width(80).Render(err.Detail),
 		))
 	}
 

--- a/internal/presenters/components_test.go
+++ b/internal/presenters/components_test.go
@@ -40,7 +40,9 @@ func Test_RenderError(t *testing.T) {
 	t.Run("with links", func(t *testing.T) {
 		lipgloss.SetColorProfile(termenv.TrueColor)
 		lipgloss.SetHasDarkBackground(false)
-		output := RenderError(snyk.NewServerError("An error"))
+		err := snyk.NewServerError("An error")
+		err.Links = append(err.Links, "https://docs.snyk.io/getting-started/supported-languages-frameworks-and-feature-availability-overview#code-analysis-snyk-code")
+		output := RenderError(err)
 
 		assert.Contains(t, output, "Help:")
 		snaps.MatchSnapshot(t, output)

--- a/pkg/ui/__snapshots__/consoleui_test.snap
+++ b/pkg/ui/__snapshots__/consoleui_test.snap
@@ -4,7 +4,7 @@
 [41m [0m[97;41mERROR[0m[41m [0m  [1mClient request cannot be processed (SNYK-0003)[0m
 Info:    If you carry on like this you will ensure the wrath of OWASP, the God of Code  
          Injection.                                                                     
-HTTP:    400                                                                            
-Help:    http://example.com/docs                                                        
+HTTP:    400 
+Help:    http://example.com/docs 
 
 ---


### PR DESCRIPTION
The issue was mentioned [here](https://github.com/snyk/go-application-framework/pull/194#discussion_r1619071694) before but there seems to have been a regression.
This PR fixes the problem by copying the style before changing it and adding a test to detect a regression.