### PR TITLE
fix: Sending behaviour in analytics report workflow

### DIFF
--- a/pkg/local_workflows/json_schemas/schemas.go
+++ b/pkg/local_workflows/json_schemas/schemas.go
@@ -20,6 +20,10 @@ const ScanDoneEventSchema = `{
           "type": "string",
           "description": "The type of data (\"analytics\")."
         },
+		"path": {
+          "type": "string",
+          "description": "Path to the scanned folder."
+        },
         "attributes": {
           "type": "object",
           "required": [

--- a/pkg/local_workflows/json_schemas/schemas.go
+++ b/pkg/local_workflows/json_schemas/schemas.go
@@ -159,6 +159,7 @@ type ScanDoneEvent struct {
 			UniqueIssueCount              UniqueIssueCount `json:"unique_issue_count"`
 			DurationMs                    string           `json:"duration_ms"`
 			TimestampFinished             time.Time        `json:"timestamp_finished"`
+			Path                          string           `json:"path,omitempty"`
 		} `json:"attributes"`
 	} `json:"data"`
 }

--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"runtime"
 	"strings"
 	"time"
 
@@ -195,8 +196,8 @@ func instrumentScanDoneEvent(invocationCtx workflow.InvocationContext, input wor
 		IntegrationVersion:            scanDoneEvent.Data.Attributes.IntegrationVersion,
 		IntegrationEnvironment:        scanDoneEvent.Data.Attributes.IntegrationEnvironment,
 		IntegrationEnvironmentVersion: scanDoneEvent.Data.Attributes.IntegrationEnvironmentVersion,
-		OS:                            scanDoneEvent.Data.Attributes.Os,
-		Arch:                          scanDoneEvent.Data.Attributes.Arch,
+		OS:                            runtime.GOOS,
+		Arch:                          runtime.GOARCH,
 	}
 	ic.SetUserAgent(userAgent)
 	ic.SetType(scanDoneEvent.Data.Type)

--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -4,17 +4,21 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/spf13/pflag"
+	"github.com/xeipuuv/gojsonschema"
+
 	"github.com/snyk/go-application-framework/pkg/analytics"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/instrumentation"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
 	"github.com/snyk/go-application-framework/pkg/networking"
+	"github.com/snyk/go-application-framework/pkg/utils"
 	"github.com/snyk/go-application-framework/pkg/workflow"
-	"github.com/spf13/pflag"
-	"github.com/xeipuuv/gojsonschema"
-	"net/http"
-	"strings"
-	"time"
 )
 
 var (
@@ -54,9 +58,9 @@ func InitReportAnalyticsWorkflow(engine workflow.Engine) error {
 func reportAnalyticsEntrypoint(invocationCtx workflow.InvocationContext, inputData []workflow.Data) ([]workflow.Data, error) {
 	// get necessary objects from invocation context
 	config := invocationCtx.GetConfiguration()
-	logger := invocationCtx.GetLogger()
+	logger := invocationCtx.GetEnhancedLogger()
 
-	logger.Println(reportAnalyticsWorkflowName + " workflow start")
+	logger.Printf(reportAnalyticsWorkflowName + " workflow start")
 
 	if !config.GetBool(configuration.FLAG_EXPERIMENTAL) {
 		return nil, fmt.Errorf("set `--experimental` flag to enable analytics report command")
@@ -77,16 +81,17 @@ func reportAnalyticsEntrypoint(invocationCtx workflow.InvocationContext, inputDa
 
 	var err error
 	for i, input := range inputData {
-		logger.Printf(fmt.Sprintf("processing element %d", i))
+		logger.Printf("[%d] Processing element", i)
+
 		payload, ok := input.GetPayload().([]byte)
 		if !ok {
 			return nil, fmt.Errorf("invalid payload type: %T", input.GetPayload())
 		}
 
+		version := 2
 		documentLoader := gojsonschema.NewBytesLoader(payload)
 
 		// check if payload is an analyticsV2 event
-		logger.Print("validating against schema: analyticsV2Event")
 		result, validationErr := gojsonschema.Validate(analyticsV2SchemaLoader, documentLoader)
 
 		if validationErr != nil {
@@ -95,8 +100,6 @@ func reportAnalyticsEntrypoint(invocationCtx workflow.InvocationContext, inputDa
 		}
 
 		if !result.Valid() {
-			logger.Print("validating against schema: scanDoneEvent")
-
 			// check if payload is a scanDone event (v1 analytics)
 			result, validationErr = gojsonschema.Validate(scanDoneSchemaLoader, documentLoader)
 
@@ -110,13 +113,20 @@ func reportAnalyticsEntrypoint(invocationCtx workflow.InvocationContext, inputDa
 				return nil, e
 			}
 
+			version = 1
+		}
+
+		logger.Printf("[%d] Schema Version: %d", i, version)
+
+		if version == 1 {
 			// convert scanDoneEvent payload to AnalyticsV2 payload
-			err = instrumentScanDoneEvent(invocationCtx, input)
+			input, err = instrumentScanDoneEvent(invocationCtx, input)
 			if err != nil {
 				return nil, err
 			}
-			return nil, nil
 		}
+
+		logger.Printf("[%d] Data: %s", i, input.GetPayload())
 
 		// send to V2 analytics endpoint
 		callErr := callEndpoint(invocationCtx, input, url)
@@ -125,7 +135,7 @@ func reportAnalyticsEntrypoint(invocationCtx workflow.InvocationContext, inputDa
 			return nil, err
 		}
 	}
-	logger.Println(reportAnalyticsWorkflowName + " workflow end")
+	logger.Printf(reportAnalyticsWorkflowName + " workflow end")
 	return nil, nil
 }
 
@@ -151,21 +161,31 @@ func callEndpoint(invocationCtx workflow.InvocationContext, input workflow.Data,
 	return nil
 }
 
-func instrumentScanDoneEvent(invocationCtx workflow.InvocationContext, input workflow.Data) error {
+func instrumentScanDoneEvent(invocationCtx workflow.InvocationContext, input workflow.Data) (workflow.Data, error) {
 	logger := invocationCtx.GetLogger()
-	a := invocationCtx.GetAnalytics()
-	ic := a.GetInstrumentation()
+	config := invocationCtx.GetConfiguration()
+
+	ic := analytics.NewInstrumentationCollector()
+	ic.SetInteractionId(instrumentation.AssembleUrnFromUUID(uuid.NewString()))
+
+	if config.IsSet(configuration.INPUT_DIRECTORY) {
+		targetId, targetIdError := instrumentation.GetTargetId(config.GetString(configuration.INPUT_DIRECTORY), instrumentation.AutoDetectedTargetId, instrumentation.WithConfiguredRepository(config))
+		if targetIdError != nil {
+			logger.Printf("Failed to derive target id, %v", targetIdError)
+		}
+		ic.SetTargetId(targetId)
+	}
 
 	var scanDoneEvent json_schemas.ScanDoneEvent
 	d, ok := input.GetPayload().([]byte)
 	if !ok {
-		return fmt.Errorf("invalid payload type: %T", input.GetPayload())
+		return nil, fmt.Errorf("invalid payload type: %T", input.GetPayload())
 	}
 
 	err := json.Unmarshal(d, &scanDoneEvent)
 	if err != nil {
 		logger.Printf("Error unmarshalling json: %v\n", err)
-		return err
+		return nil, err
 	}
 
 	// required v2 analytics parameters
@@ -200,7 +220,20 @@ func instrumentScanDoneEvent(invocationCtx workflow.InvocationContext, input wor
 	ic.SetTestSummary(toTestSummary(scanDoneEvent.Data.Attributes.UniqueIssueCount, scanDoneEvent.Data.Type))
 	ic.AddExtension("device_id", scanDoneEvent.Data.Attributes.DeviceId)
 
-	return nil
+	data, err := analytics.GetV2InstrumentationObject(ic)
+	if err != nil {
+		return nil, err
+	}
+
+	v2InstrumentationData := utils.ValueOf(json.Marshal(data))
+
+	inputData := workflow.NewData(
+		workflow.NewTypeIdentifier(WORKFLOWID_REPORT_ANALYTICS, "v2"),
+		"application/json",
+		v2InstrumentationData,
+	)
+
+	return inputData, nil
 }
 
 func toTestSummary(uic json_schemas.UniqueIssueCount, t string) json_schemas.TestSummary {

--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -122,6 +122,7 @@ func reportAnalyticsEntrypoint(invocationCtx workflow.InvocationContext, inputDa
 			// convert scanDoneEvent payload to AnalyticsV2 payload
 			input, err = instrumentScanDoneEvent(invocationCtx, input)
 			if err != nil {
+				logger.Printf("Error converting v1 -> v2: %v\n", err)
 				return nil, err
 			}
 		}
@@ -162,7 +163,7 @@ func callEndpoint(invocationCtx workflow.InvocationContext, input workflow.Data,
 }
 
 func instrumentScanDoneEvent(invocationCtx workflow.InvocationContext, input workflow.Data) (workflow.Data, error) {
-	logger := invocationCtx.GetLogger()
+	logger := invocationCtx.GetEnhancedLogger()
 	config := invocationCtx.GetConfiguration()
 
 	ic := analytics.NewInstrumentationCollector()
@@ -184,7 +185,6 @@ func instrumentScanDoneEvent(invocationCtx workflow.InvocationContext, input wor
 
 	err := json.Unmarshal(d, &scanDoneEvent)
 	if err != nil {
-		logger.Printf("Error unmarshalling json: %v\n", err)
 		return nil, err
 	}
 

--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -17,7 +17,6 @@ import (
 	"github.com/snyk/go-application-framework/pkg/instrumentation"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
 	"github.com/snyk/go-application-framework/pkg/networking"
-	"github.com/snyk/go-application-framework/pkg/utils"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )
 
@@ -225,7 +224,10 @@ func instrumentScanDoneEvent(invocationCtx workflow.InvocationContext, input wor
 		return nil, err
 	}
 
-	v2InstrumentationData := utils.ValueOf(json.Marshal(data))
+	v2InstrumentationData, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
 
 	inputData := workflow.NewData(
 		workflow.NewTypeIdentifier(WORKFLOWID_REPORT_ANALYTICS, "v2"),

--- a/pkg/local_workflows/report_analytics_workflow_test.go
+++ b/pkg/local_workflows/report_analytics_workflow_test.go
@@ -2,9 +2,11 @@ package localworkflows
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"regexp"
+	"runtime"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -211,7 +213,7 @@ func testPayload(payload string) workflow.Data {
 }
 
 func testGetAnalyticsV2PayloadString() string {
-	return `{
+	return fmt.Sprintf(`{
   "data": {
     "attributes": {
       "interaction": {
@@ -267,14 +269,14 @@ func testGetAnalyticsV2PayloadString() string {
           "duration_ms": 1000
         },
         "platform": {
-          "arch": "ARM64",
-          "os": "macOS"
+          "arch": "%s",
+          "os": "%s"
         }
       }
     },
     "type": "analytics"
   }
-}`
+}`, runtime.GOARCH, runtime.GOOS)
 }
 
 func testGetScanDonePayloadString() string {

--- a/pkg/local_workflows/report_analytics_workflow_test.go
+++ b/pkg/local_workflows/report_analytics_workflow_test.go
@@ -157,7 +157,6 @@ func Test_ReportAnalytics_ReportAnalyticsEntryPoint_usesCLIInput(t *testing.T) {
 
 	config.Set(configuration.ORGANIZATION, orgId)
 	config.Set(experimentalFlag, true)
-	config.Set(configuration.INPUT_DIRECTORY, "/my/file")
 
 	// setup mocks
 	ctrl := gomock.NewController(t)
@@ -283,6 +282,7 @@ func testGetScanDonePayloadString() string {
 		"data": {
 			"type": "analytics",
 			"attributes": {
+				"path": "/my/file",
 				"device_id": "unique-uuid",
 				"application": "snyk-cli",
 				"application_version": "1.1233.0",

--- a/pkg/local_workflows/report_analytics_workflow_test.go
+++ b/pkg/local_workflows/report_analytics_workflow_test.go
@@ -323,6 +323,7 @@ func testGetMockHTTPClient(t *testing.T, orgId string, requestPayload string) *h
 		require.Equal(t, "application/json", req.Header.Get("Content-Type"))
 		body, err := io.ReadAll(req.Body)
 
+		// used to replace whitespaces and uuids before comparing payloads
 		expression := regexp.MustCompile(`\s|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
 
 		require.NoError(t, err)


### PR DESCRIPTION
This fix changes the behaviour of the analytics report workflow to convert v1 data and send it directly. This change is necessary to work in VS and IntelliJ, since a previous assumption didn't work out.