### PR TITLE
chore: Introduce GetCategory() convenience method

### DIFF
--- a/pkg/instrumentation/categories.go
+++ b/pkg/instrumentation/categories.go
@@ -86,7 +86,7 @@ func DetermineCategory(args []string, engine workflow.Engine) []string {
 	return determineCategoryFromArgs(args, knownCommands, knownFlags)
 }
 
-var known_commands = []string{
+var KNOWN_COMMANDS = []string{
 	"oss",
 	"test",
 	"code",

--- a/pkg/instrumentation/categories.go
+++ b/pkg/instrumentation/categories.go
@@ -82,7 +82,7 @@ func determineCategoryFromArgs(args []string, knownCommands []string, flagsAllow
 }
 
 func DetermineCategory(args []string, engine workflow.Engine) []string {
-	knownCommands, knownFlags := GetKnownCommandsAndFlags(engine)
+	knownCommands, knownFlags := getKnownCommandsAndFlags(engine)
 	return determineCategoryFromArgs(args, knownCommands, knownFlags)
 }
 

--- a/pkg/instrumentation/categories.go
+++ b/pkg/instrumentation/categories.go
@@ -3,6 +3,8 @@ package instrumentation
 import (
 	"slices"
 	"strings"
+
+	"github.com/snyk/go-application-framework/pkg/workflow"
 )
 
 // DetermineCategoryFromArgs categorizes command-line arguments into a structured slice.
@@ -28,7 +30,7 @@ import (
 //	args := []string{"cli", "scan", "--debug", "--"}
 //	knownCommands := []string{"scan", "build"}
 //	flagsAllowList := []string{"debug", "verbose"}
-//	result := DetermineCategoryFromArgs(args, knownCommands, flagsAllowList)
+//	result := determineCategoryFromArgs(args, knownCommands, flagsAllowList)
 //	// result: ["scan", "debug"]
 //
 // Parameters:
@@ -38,7 +40,7 @@ import (
 //
 // Returns:
 //   - A slice of strings containing the categorized arguments.
-func DetermineCategoryFromArgs(args []string, knownCommands []string, flagsAllowList []string) []string {
+func determineCategoryFromArgs(args []string, knownCommands []string, flagsAllowList []string) []string {
 	result := []string{}
 
 	if len(args) == 0 {
@@ -51,7 +53,7 @@ func DetermineCategoryFromArgs(args []string, knownCommands []string, flagsAllow
 
 	// Separate parsing of commands and flags to ensure correct ordering in the category vector
 	// regardless of how they are provided in the command line.
-	for _, arg := range args[1:] {
+	for _, arg := range args {
 		if strings.HasPrefix(arg, "-") {
 			if arg == "--" {
 				break
@@ -79,7 +81,13 @@ func DetermineCategoryFromArgs(args []string, knownCommands []string, flagsAllow
 	return result
 }
 
-var KNOWN_COMMANDS = []string{
+func DetermineCategory(args []string, engine workflow.Engine) []string {
+	knownCommands, knownFlags := GetKnownCommandsAndFlags(engine)
+	return determineCategoryFromArgs(args, knownCommands, knownFlags)
+}
+
+var known_commands = []string{
+	"oss",
 	"test",
 	"code",
 	"monitor",
@@ -101,7 +109,7 @@ var KNOWN_COMMANDS = []string{
 	"update-exclude-policy",
 }
 
-var KNOWN_FLAGS = []string{
+var known_flags = []string{
 	"print-dep-paths",
 	"print-deps",
 	"max-depth",

--- a/pkg/instrumentation/categories_test.go
+++ b/pkg/instrumentation/categories_test.go
@@ -44,7 +44,7 @@ func TestCategorizeCliArgs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Execute the function under test
-			categories := determineCategoryFromArgs(tc.args, known_commands, known_flags)
+			categories := determineCategoryFromArgs(tc.args, KNOWN_COMMANDS, known_flags)
 
 			// Assertions
 			assert.Equal(t, tc.expectedOutput, categories)

--- a/pkg/instrumentation/categories_test.go
+++ b/pkg/instrumentation/categories_test.go
@@ -44,7 +44,7 @@ func TestCategorizeCliArgs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Execute the function under test
-			categories := DetermineCategoryFromArgs(tc.args, KNOWN_COMMANDS, KNOWN_FLAGS)
+			categories := determineCategoryFromArgs(tc.args, known_commands, known_flags)
 
 			// Assertions
 			assert.Equal(t, tc.expectedOutput, categories)
@@ -57,6 +57,6 @@ func Test_DetermineCategoryFromArgs_casing(t *testing.T) {
 	commands := []string{"Test"}
 	flags := []string{"My-name"}
 	expected := []string{"test", "my-name"}
-	actual := DetermineCategoryFromArgs(args, commands, flags)
+	actual := determineCategoryFromArgs(args, commands, flags)
 	assert.Equal(t, expected, actual)
 }

--- a/pkg/instrumentation/instrumentation.go
+++ b/pkg/instrumentation/instrumentation.go
@@ -11,7 +11,7 @@ import (
 )
 
 func GetKnownCommandsAndFlags(engine workflow.Engine) ([]string, []string) {
-	knownCommands := known_commands
+	knownCommands := KNOWN_COMMANDS
 	knownFlags := known_flags
 
 	workflowIDs := engine.GetWorkflows()

--- a/pkg/instrumentation/instrumentation.go
+++ b/pkg/instrumentation/instrumentation.go
@@ -10,7 +10,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )
 
-func GetKnownCommandsAndFlags(engine workflow.Engine) ([]string, []string) {
+func getKnownCommandsAndFlags(engine workflow.Engine) ([]string, []string) {
 	knownCommands := KNOWN_COMMANDS
 	knownFlags := known_flags
 

--- a/pkg/instrumentation/instrumentation.go
+++ b/pkg/instrumentation/instrumentation.go
@@ -11,8 +11,8 @@ import (
 )
 
 func GetKnownCommandsAndFlags(engine workflow.Engine) ([]string, []string) {
-	knownCommands := KNOWN_COMMANDS
-	knownFlags := KNOWN_FLAGS
+	knownCommands := known_commands
+	knownFlags := known_flags
 
 	workflowIDs := engine.GetWorkflows()
 	for _, id := range workflowIDs {

--- a/pkg/instrumentation/instrumentation_test.go
+++ b/pkg/instrumentation/instrumentation_test.go
@@ -25,7 +25,7 @@ func Test_GetKnownCommandsAndFlags(t *testing.T) {
 	config := configuration.NewInMemory()
 	engine := workflow.NewWorkFlowEngine(config)
 	actualCommands, actualFlags := GetKnownCommandsAndFlags(engine)
-	assert.Equal(t, known_commands, actualCommands)
+	assert.Equal(t, KNOWN_COMMANDS, actualCommands)
 	assert.Equal(t, known_flags, actualFlags)
 }
 

--- a/pkg/instrumentation/instrumentation_test.go
+++ b/pkg/instrumentation/instrumentation_test.go
@@ -25,8 +25,8 @@ func Test_GetKnownCommandsAndFlags(t *testing.T) {
 	config := configuration.NewInMemory()
 	engine := workflow.NewWorkFlowEngine(config)
 	actualCommands, actualFlags := GetKnownCommandsAndFlags(engine)
-	assert.Equal(t, KNOWN_COMMANDS, actualCommands)
-	assert.Equal(t, KNOWN_FLAGS, actualFlags)
+	assert.Equal(t, known_commands, actualCommands)
+	assert.Equal(t, known_flags, actualFlags)
 }
 
 func Test_GetKnownCommandsAndFlags_Extension(t *testing.T) {

--- a/pkg/instrumentation/instrumentation_test.go
+++ b/pkg/instrumentation/instrumentation_test.go
@@ -24,7 +24,7 @@ func Test_DetermineStage(t *testing.T) {
 func Test_GetKnownCommandsAndFlags(t *testing.T) {
 	config := configuration.NewInMemory()
 	engine := workflow.NewWorkFlowEngine(config)
-	actualCommands, actualFlags := GetKnownCommandsAndFlags(engine)
+	actualCommands, actualFlags := getKnownCommandsAndFlags(engine)
 	assert.Equal(t, KNOWN_COMMANDS, actualCommands)
 	assert.Equal(t, known_flags, actualFlags)
 }
@@ -52,7 +52,7 @@ func Test_GetKnownCommandsAndFlags_Extension(t *testing.T) {
 	assert.NotNil(t, entry)
 	assert.NoError(t, err)
 
-	actualCommands, actualFlags := GetKnownCommandsAndFlags(engine)
+	actualCommands, actualFlags := getKnownCommandsAndFlags(engine)
 	assert.Contains(t, actualCommands, command1)
 	assert.Contains(t, actualCommands, command2)
 	assert.Contains(t, actualFlags, "ever")

--- a/pkg/instrumentation/test/instrumentation_public_test.go
+++ b/pkg/instrumentation/test/instrumentation_public_test.go
@@ -1,0 +1,27 @@
+package instrumentation_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/instrumentation"
+	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+)
+
+func Test_DetermineCategory(t *testing.T) {
+	args := []string{"application", "whoami", "--experimental", "-d"}
+	expected := []string{"whoami", "experimental"}
+
+	engine := workflow.NewWorkFlowEngine(configuration.NewInMemory())
+	err := localworkflows.Init(engine)
+	assert.NoError(t, err)
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	actual := instrumentation.DetermineCategory(args, engine)
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
By introducing the convenience method, we can reduce the public API as well.