### PR TITLE
fix: use cli runtime info when translating v1 data

### DIFF
--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -190,8 +190,8 @@ func instrumentScanDoneEvent(invocationCtx workflow.InvocationContext, input wor
 
 	// required v2 analytics parameters
 	userAgent := networking.UserAgentInfo{
-		App:                           scanDoneEvent.Data.Attributes.Application,
-		AppVersion:                    scanDoneEvent.Data.Attributes.ApplicationVersion,
+		App:                           invocationCtx.GetRuntimeInfo().GetName(),
+		AppVersion:                    invocationCtx.GetRuntimeInfo().GetVersion(),
 		Integration:                   scanDoneEvent.Data.Attributes.IntegrationName,
 		IntegrationVersion:            scanDoneEvent.Data.Attributes.IntegrationVersion,
 		IntegrationEnvironment:        scanDoneEvent.Data.Attributes.IntegrationEnvironment,

--- a/pkg/local_workflows/report_analytics_workflow_test.go
+++ b/pkg/local_workflows/report_analytics_workflow_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/snyk/go-application-framework/pkg/analytics"
+	"github.com/snyk/go-application-framework/pkg/runtimeinfo"
 
 	"github.com/stretchr/testify/require"
 
@@ -174,6 +175,7 @@ func Test_ReportAnalytics_ReportAnalyticsEntryPoint_usesCLIInput(t *testing.T) {
 	invocationContextMock.EXPECT().GetAnalytics().Return(a).AnyTimes()
 	invocationContextMock.EXPECT().GetNetworkAccess().Return(networkAccessMock).AnyTimes()
 	invocationContextMock.EXPECT().GetEngine().Return(engineMock).AnyTimes()
+	invocationContextMock.EXPECT().GetRuntimeInfo().Return(runtimeinfo.New(runtimeinfo.WithName("snyk-cli"), runtimeinfo.WithVersion("1.1233.0"))).AnyTimes()
 	engineMock.EXPECT().GetWorkflows().AnyTimes()
 	networkAccessMock.EXPECT().GetHttpClient().Return(mockClient).AnyTimes()
 
@@ -286,8 +288,8 @@ func testGetScanDonePayloadString() string {
 			"attributes": {
 				"path": "/my/file",
 				"device_id": "unique-uuid",
-				"application": "snyk-cli",
-				"application_version": "1.1233.0",
+				"application": "Pycharm",
+				"application_version": "2023.1",
 				"os": "macOS",
 				"arch": "ARM64",
 				"integration_name": "IntelliJ",


### PR DESCRIPTION
IDEs send app name and version as the IDE name, which makes it redundant, as the same info is in the environment. This PR ensures to keep CLI version information.