### PR TITLE
fix: log error when calling endpoint [IDE-418]

### DIFF
--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -132,8 +132,7 @@ func reportAnalyticsEntrypoint(invocationCtx workflow.InvocationContext, inputDa
 		// send to V2 analytics endpoint
 		callErr := callEndpoint(invocationCtx, input, url)
 		if callErr != nil {
-			err := fmt.Errorf("error calling endpoint for input at index %d: %w", i, callErr)
-			return nil, err
+			logger.Printf("error calling endpoint for input at index %d: %v", i, callErr)
 		}
 	}
 	logger.Printf(reportAnalyticsWorkflowName + " workflow end")


### PR DESCRIPTION
LS should not return an error to the IDEs if the analytics service isn't available or the call returns an error. Instead, it should submit a log.