### PR TITLE
feat: wrap authentication error for matching

### DIFF
--- a/pkg/networking/middleware/auth_header.go
+++ b/pkg/networking/middleware/auth_header.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -82,6 +84,15 @@ func ShouldRequireAuthentication(
 	return false, nil
 }
 
+// ErrAuthenticationFailed indicates that authentication failed in the
+// networking middleware.
+var ErrAuthenticationFailed = fmt.Errorf("authentication failed")
+
+// AddAuthenticationHeader determines whether a request needs authentication,
+// negotiates authorization and sets request headers if necessary.
+//
+// If this fails due to an authentication error, the resulting error will match
+// ErrAuthenticationFailed.
 func AddAuthenticationHeader(
 	authenticator auth.Authenticator,
 	config configuration.Configuration,
@@ -98,5 +109,8 @@ func AddAuthenticationHeader(
 	}
 
 	err = authenticator.AddAuthenticationHeader(request)
-	return err
+	if err != nil {
+		return errors.Join(err, ErrAuthenticationFailed)
+	}
+	return nil
 }


### PR DESCRIPTION
Wrap authentication failure errors with ErrAuthenticationFailed so that callers of NetworkAccess.AddHeaders can match this particular error condition: whether headers failed to add due to an authentication failure.

CLI-392