### PR TITLE
fix: config persistence when config file is empty

### DIFF
--- a/pkg/configuration/storage.go
+++ b/pkg/configuration/storage.go
@@ -98,7 +98,7 @@ func (s *JsonStorage) Set(key string, value any) error {
 	}
 
 	fileBytes, err := os.ReadFile(s.path)
-	if err != nil {
+	if len(fileBytes) == 0 || err != nil {
 		const emptyJson = "{}"
 		fileBytes = []byte(emptyJson)
 	}

--- a/pkg/configuration/storage_test.go
+++ b/pkg/configuration/storage_test.go
@@ -131,6 +131,23 @@ func Test_JsonStorage_Set_InvalidValue(t *testing.T) {
 	})
 }
 
+func Test_JsonStorage_Set_EmptyFile_SetsValidEmptyJson(t *testing.T) {
+	// Arrange
+	t.Parallel()
+	configFile := filepath.Join(t.TempDir(), "test.json")
+	err := os.WriteFile(configFile, []byte(""), 0666)
+	assert.NoError(t, err)
+	storage := configuration.NewJsonStorage(configFile)
+
+	// Act
+	err = storage.Set(key, expectedValue)
+
+	// Assert
+	assert.NoError(t, err)
+	storedConfig := readStoredConfigFile(t, configFile)
+	assertConfigContainsKey(t, storedConfig, key, expectedValue)
+}
+
 func storageWithTempConfigFile(t *testing.T, jsonBytes []byte) *configuration.JsonStorage {
 	t.Helper()
 	configFile := filepath.Join(t.TempDir(), "test.json")


### PR DESCRIPTION
In some cases the settings file exists but it doesn't have any content.
I'm not sure why this happens.
Nonetheless I changed the Set func to check if file has no content. 
If it doesn't it will set it as empty json so that it won't fail on deserialize