### PR TITLE
fix: redirect stdout to stderr for browser pkg

### DIFF
--- a/pkg/auth/oauth2authenticator.go
+++ b/pkg/auth/oauth2authenticator.go
@@ -65,8 +65,8 @@ type oAuth2Authenticator struct {
 }
 
 func OpenBrowser(authUrl string) {
-	//nolint:errcheck // breaking api change needed to fix this
 	browser.Stdout = os.Stderr
+	//nolint:errcheck // breaking api change needed to fix this
 	_ = browser.OpenURL(authUrl)
 }
 

--- a/pkg/auth/oauth2authenticator.go
+++ b/pkg/auth/oauth2authenticator.go
@@ -14,6 +14,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -65,6 +66,7 @@ type oAuth2Authenticator struct {
 
 func OpenBrowser(authUrl string) {
 	//nolint:errcheck // breaking api change needed to fix this
+	browser.Stdout = os.Stderr
 	_ = browser.OpenURL(authUrl)
 }
 


### PR DESCRIPTION
Openbrowser on linux starts a new process and uses os.Stdout for Stdout by default. Which messes up the JRPC stream in LS.
Causing LS to crash