### PR TITLE
feat: set api url from jwt audience claim

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -14,3 +14,4 @@ b0ba7f6ed181c23a5c6532cf6f124b731d390f86:internal/presenters/testdata/with-ignor
 237c7f05ec087733fa7929ee9fa3db2bd56bdba4:pkg/logging/scrubbingLogWriter_test.go:github-pat:183
 237c7f05ec087733fa7929ee9fa3db2bd56bdba4:pkg/logging/scrubbingLogWriter_test.go:snyk-api-token:208
 0481cdb4d07351149e65a57ebc9ad5b983896849:pkg/auth/oauth2authenticator.go:generic-api-key:30
+0a646dd3b9eeca0463fd8240b87957106f4b71f3:pkg/app/app_test.go:jwt:57

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 	"github.com/snyk/go-application-framework/internal/api"
 	"github.com/snyk/go-application-framework/internal/constants"
 	"github.com/snyk/go-application-framework/internal/mocks"
+	"github.com/snyk/go-application-framework/pkg/auth"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/runtimeinfo"
 	"github.com/snyk/go-application-framework/pkg/workflow"
@@ -83,6 +85,21 @@ func Test_CreateAppEngine_config_replaceV1inApi(t *testing.T) {
 
 	actualApiUrl := config.GetString(configuration.API_URL)
 	assert.Equal(t, expectApiUrl, actualApiUrl)
+}
+
+func Test_CreateAppEngine_config_oauthApiUrl(t *testing.T) {
+	config := configuration.New()
+	config.Set(auth.CONFIG_KEY_OAUTH_TOKEN,
+		// JWT generated at https://jwt.io with claim:
+		//   "aud": ["https://api.example.com"]
+		`{"access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJhdWQiOlsiaHR0cHM6Ly9hcGkuZXhhbXBsZS5jb20iXX0.hWq0fKukObQSkphAdyEC7-m4jXIb4VdWyQySmmgy0GU"}`,
+	)
+	logger := log.New(os.Stderr, "", 0)
+	engine := CreateAppEngineWithOptions(WithConfiguration(config), WithLogger(logger))
+	initConfiguration(engine, config, engine.GetLogger(), nil)
+
+	actualApiUrl := config.GetString(configuration.API_URL)
+	assert.Equal(t, "https://api.example.com", actualApiUrl)
 }
 
 func Test_initConfiguration_updateDefaultOrgId(t *testing.T) {


### PR DESCRIPTION
Snyk's OAuth implementation is capable of indicating the environment which the user is authenticated into and authorized to access.

This is specified in the audience JWT claim ("aud"). Snyk's implementation of this claim contains an array of strings, per RFC 7519.

If set and non-empty, the first audience URL is taken as the default API URL that the client should use, unless the endpoint was specifically configured.

---

- [ ] TODO: validate w/IDE team
- [ ] TODO: validate w/auth folks, work out env switching rabbit holes