### PR TITLE
chore: introduce formatting and lint for cuelang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ format:
 	@gofmt -w -l -e .
 
 .PHONY: lint
-lint: $(GO_BIN)/golangci-lint
+lint: $(GO_BIN)/golangci-lint $(GO_BIN)/cue
 	@echo "Linting..."
 	@cue fmt --all-errors --check internal/cueutils/**/**/*.cue internal/cueutils/**/*.cue
 	@./scripts/lint.sh
@@ -44,9 +44,11 @@ generate:
 	@go generate ./...
 
 .PHONY: tools
-tools: $(GO_BIN)/golangci-lint
+tools: $(GO_BIN)/golangci-lint $(GO_BIN)/cue
 	GOBIN=$(GO_BIN) go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.3.0
 	GOBIN=$(GO_BIN) go install github.com/golang/mock/mockgen@v1.6.0
+
+$(GO_BIN)/cue:
 	GOBIN=$(GO_BIN) go install cuelang.org/go/cmd/cue@v0.10.0
 
 $(GO_BIN)/golangci-lint:

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,13 @@ SHELL := env PATH=$(GO_BIN):$(PATH) $(SHELL)
 .PHONY: format
 format:
 	@echo "Formatting..."
+	@cue fmt internal/cueutils/**/**/*.cue internal/cueutils/**/*.cue
 	@gofmt -w -l -e .
 
 .PHONY: lint
 lint: $(GO_BIN)/golangci-lint
 	@echo "Linting..."
+	@cue fmt --all-errors --check internal/cueutils/**/**/*.cue internal/cueutils/**/*.cue
 	@./scripts/lint.sh
 	$(GO_BIN)/golangci-lint run ./...
 

--- a/internal/cueutils/convert/to_cli/from_testapi.cue
+++ b/internal/cueutils/convert/to_cli/from_testapi.cue
@@ -5,19 +5,19 @@ import "snyk.io/dragonfly/pkg/schemas:testapi"
 input: _
 
 input: {
-    test: testapi.#TestResource
-    findings: [...testapi.#FindingResource]
+	test: testapi.#TestResource
+	findings: [...testapi.#FindingResource]
 }
 
 // This should align with
 // LocalFinding definition
 output: {
-    findings: [ for finding in input.findings {
-        attributes: finding.attributes
-        id: finding.id
-        relationships: finding.relationships
-        type: finding.type
-    } ]
-    summary: input.test.attributes.summary
-    outcome: input.test.attributes.outcome
+	findings: [for finding in input.findings {
+		attributes:    finding.attributes
+		id:            finding.id
+		relationships: finding.relationships
+		type:          finding.type
+	}]
+	summary: input.test.attributes.summary
+	outcome: input.test.attributes.outcome
 }

--- a/internal/cueutils/convert/to_testapi/from_cli_test_managed.cue
+++ b/internal/cueutils/convert/to_testapi/from_cli_test_managed.cue
@@ -1,10 +1,13 @@
 package from_cli_test_managed
 
 import "list"
+
 import "strings"
+
 import "uuid"
 
 import "snyk.io/dragonfly/pkg/schemas:cli_test_managed"
+
 import "snyk.io/dragonfly/pkg/schemas:testapi"
 
 input: _
@@ -15,103 +18,103 @@ input: cli_test_managed.#Result
 // Validate the output as conforming to a composition of
 // a Test resource and an array of Finding resources.
 output: {
-    test: testapi.#TestResource
-    findings: [...testapi.#FindingResource]
+	test: testapi.#TestResource
+	findings: [...testapi.#FindingResource]
 }
 
 // TODO: Inject from runtime context
 context: {
-    org: id: "f640a238-ee99-44d4-8d49-42ec6af96bc6"
-    test: id: "12d77614-e02d-44d7-bb52-3a1b179d5890"
+	org: id:  "f640a238-ee99-44d4-8d49-42ec6af96bc6"
+	test: id: "12d77614-e02d-44d7-bb52-3a1b179d5890"
 }
 
 _summary: testapi.#FindingsSummary
 _summary: {
-    counts: {
-        count: 0
-        count_suppressed: 0
-        count_adjusted: 0
+	counts: {
+		count:            0
+		count_suppressed: 0
+		count_adjusted:   0
 
-        count_by: severity: {
-            critical: 0
-            high: 0
-            medium: 0
-            low: 0
-            none: 0
-        }
-        count_by_adjusted: severity: {
-            critical: 0
-            high: 0
-            medium: 0
-            low: 0
-            none: 0
-        }
-        count_key_order_asc: {
-            severity: ["none", "low", "medium", "high", "critical"]
-        }
-    }
+		count_by: severity: {
+			critical: 0
+			high:     0
+			medium:   0
+			low:      0
+			none:     0
+		}
+		count_by_adjusted: severity: {
+			critical: 0
+			high:     0
+			medium:   0
+			low:      0
+			none:     0
+		}
+		count_key_order_asc: {
+			severity: ["none", "low", "medium", "high", "critical"]
+		}
+	}
 }
 
 // Transform the input into the output
 output: test: {
-    id: context.test.id
-    type: "tests"
-    attributes: {
-        state: {}
-        outcome: result: [
-            if input.ok { "pass" },
-            "fail",
-        ][0]
-        summary: _summary
-    }
-    relationships: {
-        findings: {
-            links: {
-                related: "/orgs/\(context.org.id)/test/\(context.test.id)/findings"
-            }
-        }
-    }
+	id:   context.test.id
+	type: "tests"
+	attributes: {
+		state: {}
+		outcome: result: [
+			if input.ok {"pass"},
+			"fail",
+		][0]
+		summary: _summary
+	}
+	relationships: {
+		findings: {
+			links: {
+				related: "/orgs/\(context.org.id)/test/\(context.test.id)/findings"
+			}
+		}
+	}
 }
-output: findings: [ for finding in _findings {
-    {
-        id: uuid.SHA1("be52d740-04f5-44da-8e17-1cf03d2281d7", finding.fingerprint.value),
-        type: "findings"
-        attributes: finding
-        relationships: {}
-    }
+output: findings: [for finding in _findings {
+	{
+		id:         uuid.SHA1("be52d740-04f5-44da-8e17-1cf03d2281d7", finding.fingerprint.value)
+		type:       "findings"
+		attributes: finding
+		relationships: {}
+	}
 }]
 
-_findings: list.Sort([ for vuln in input.vulnerabilities {
-    let _fingerprintValue = "\( vuln.name ):\( vuln.id ):\( strings.Join(vuln.from, "/"))"
-    {
-        fingerprint: {
-            scheme: "sca-problem"
-            value: _fingerprintValue
-        }
-        component: {
-            name: input.displayTargetFile
-            scan_type: "sca"
-        }
-        message: {
-            header: "\(vuln.title)"
-            let _descLen = len(strings.Runes(vuln.description))
-            text: strings.SliceRunes(vuln.description, 0, [
-                if _descLen < 2000 { _descLen },
-                2000
-            ][0])
-        }
-        rating: {
-            severity: {
-                value: vuln.severity
-            }
-            severity_method: "CVSSv31"
-        }
-        locations: [{
-            dependency_path: [for semver in vuln.from {
-                let parts = strings.SplitN(semver, "@", 2)
-                package_name: parts[0]
-                package_version: parts[1]
-            }]
-        }]
-    }
-}], { T: _, x: T, y: T, less: x.rating.severity.value < y.rating.severity.value })
+_findings: list.Sort([for vuln in input.vulnerabilities {
+	let _fingerprintValue = "\( vuln.name ):\( vuln.id ):\( strings.Join(vuln.from, "/"))"
+	{
+		fingerprint: {
+			scheme: "sca-problem"
+			value:  _fingerprintValue
+		}
+		component: {
+			name:      input.displayTargetFile
+			scan_type: "sca"
+		}
+		message: {
+			header: "\(vuln.title)"
+			let _descLen = len(strings.Runes(vuln.description))
+			text: strings.SliceRunes(vuln.description, 0, [
+				if _descLen < 2000 {_descLen},
+				2000,
+			][0])
+		}
+		rating: {
+			severity: {
+				value: vuln.severity
+			}
+			severity_method: "CVSSv31"
+		}
+		locations: [{
+			dependency_path: [for semver in vuln.from {
+				let parts = strings.SplitN(semver, "@", 2)
+				package_name:    parts[0]
+				package_version: parts[1]
+			}]
+		}]
+	}
+}], {T: _, x: T, y: T, less: x.rating.severity.value < y.rating.severity.value})

--- a/internal/cueutils/schemas/cli_test_managed.cue
+++ b/internal/cueutils/schemas/cli_test_managed.cue
@@ -53,7 +53,7 @@ info: {
 	{[!~"^(licenseType|severity|instructions)$"]: _}
 }
 #LicensesPolicy: {
-	severities!: [string]: _
+	severities!: [string]:      _
 	orgLicenseRules!: [string]: #LicenseSeverity
 	{[!~"^(severities|orgLicenseRules)$"]: _}
 }
@@ -84,9 +84,9 @@ info: {
 #Remediation: {
 	unresolved?: [...#Vulnerability]
 	upgrade?: [string]: #UpgradePackage
-	patch?: [string]: #PatchRemediation
-	ignore?: [string]: _
-	pin?: [string]: #UpgradePackage
+	patch?: [string]:   #PatchRemediation
+	ignore?: [string]:  _
+	pin?: [string]:     #UpgradePackage
 	{[!~"^(unresolved|upgrade|patch|ignore|pin)$"]: _}
 }
 #Result: {

--- a/internal/cueutils/schemas/v1_test_dep_graph.cue
+++ b/internal/cueutils/schemas/v1_test_dep_graph.cue
@@ -135,7 +135,7 @@ info: {
 	{[!~"^(licenseType|severity|instructions)$"]: _}
 }
 #LicensesPolicy: {
-	severities!: [string]: _
+	severities!: [string]:      _
 	orgLicenseRules!: [string]: #LicenseSeverity
 	{[!~"^(severities|orgLicenseRules)$"]: _}
 }
@@ -179,9 +179,9 @@ info: {
 #Remediation: {
 	unresolved!: [...#IssueData]
 	upgrade!: [string]: #UpgradePackage
-	patch!: [string]: #PatchRemediation
-	ignore!: [string]: _
-	pin!: [string]: #UpgradePackage
+	patch!: [string]:   #PatchRemediation
+	ignore!: [string]:  _
+	pin!: [string]:     #UpgradePackage
 	{[!~"^(unresolved|upgrade|patch|ignore|pin)$"]: _}
 }
 #ResponseBody: {
@@ -191,7 +191,7 @@ info: {
 }
 #Result: {
 	affectedPkgs!: [string]: #AffectedPackage
-	issuesData!: [string]: #IssueData
+	issuesData!: [string]:   #IssueData
 	remediation!: #Remediation
 	{[!~"^(affectedPkgs|issuesData|remediation)$"]: _}
 }


### PR DESCRIPTION
Update to the project's build system and linting tools.

**Changes:**

* **Formatting:** Added `cue fmt` command to format `.cue` files within the `internal/cueutils` directory.
* **Linting:**
    * Added `cue` as a linting tool alongside `golangci-lint`.
    * Updated `lint` target to include linting `.cue` files with `cue fmt --all-errors --check`.
* **Dependencies:** Added installation instructions for `cue` within the `tools` target.

**Benefits:**

* Improved code formatting consistency for `.cue` files.
* Enhanced code quality by adding linting support for `.cue` files.

**Testing:**

Please review the changes and verify that the build process and linting continue to function as expected.

**Additional Notes:**

* The diff shows specific changes made to the `Makefile` and relevant `.cue` files within the `internal/cueutils` directory.

This description outlines the key changes, their benefits, and testing instructions.  
