### PR TITLE
fix: windows support for cueutils

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ jobs:
       version: "current"
 
     steps:
+      - run:
+          name: Configure git to translate line terminators locally
+          command: git config --global core.autocrlf input
       - checkout
       - run:
           name: Run unit tests

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/oapi-codegen/oapi-codegen/v2 v2.3.0
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/snyk/error-catalog-golang-public v0.0.0-20240809094525-c48d19c27edb
+	github.com/subosito/gotenv v1.4.1
 	golang.org/x/sync v0.8.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -104,7 +105,6 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/tidwall/gjson v1.17.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/internal/cueutils/transformer.go
+++ b/internal/cueutils/transformer.go
@@ -17,7 +17,6 @@ const (
 	ToTestApiFromCliTestManaged = "convert/to_testapi/from_cli_test_managed.cue"
 	ToTestApiFromSarif          = "convert/to_testapi/from_sarif.cue"
 	ToCliFromTestApi            = "convert/to_cli/from_testapi.cue"
-	pathPrefix                  = "//" // Required for cross-platform support
 )
 
 type Transformer struct {
@@ -45,8 +44,9 @@ func NewTransformer(ctx *cue.Context, name string) (*Transformer, error) {
 		return nil, fmt.Errorf("failed to load module source: %w", err)
 	}
 	insts := load.Instances([]string{pathPrefix + name}, &load.Config{
-		Stdin:   &devnull,
-		Overlay: overlay,
+		Stdin:      &devnull,
+		Overlay:    overlay,
+		ModuleRoot: pathPrefix,
 	})
 	if ierr := insts[0].Err; ierr != nil {
 		return nil, fmt.Errorf("failed to load transform: %w %v", ierr, ierr.InputPositions())

--- a/internal/cueutils/transformer_unix.go
+++ b/internal/cueutils/transformer_unix.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package cueutils
+
+const (
+	pathPrefix = "/cue_loader_fakeroot/"
+)

--- a/internal/cueutils/transformer_windows.go
+++ b/internal/cueutils/transformer_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package cueutils
+
+const (
+	pathPrefix = "C:/cue_loader_fakeroot/"
+)

--- a/internal/presenters/presenter_local_finding_test.go
+++ b/internal/presenters/presenter_local_finding_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io"
 	"os"
-	"runtime"
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
@@ -18,13 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func skipWindows(t *testing.T) {
-	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping on windows device [CLI-514]")
-	}
-}
 
 func sarifToLocalFinding(t *testing.T, filename string) (localFinding local_models.LocalFinding, err error) {
 	t.Helper()
@@ -54,7 +46,6 @@ func sarifToLocalFinding(t *testing.T, filename string) (localFinding local_mode
 }
 
 func TestPresenterLocalFinding_NoIssues(t *testing.T) {
-	skipWindows(t)
 	fd, err := os.Open("testdata/local-findings-empty.json")
 	require.NoError(t, err)
 
@@ -77,7 +68,6 @@ func TestPresenterLocalFinding_NoIssues(t *testing.T) {
 }
 
 func TestPresenterLocalFinding_LowIssues(t *testing.T) {
-	skipWindows(t)
 	// Convert our sarif into localfindings
 	input, err := sarifToLocalFinding(t, "testdata/3-low-issues.json")
 	require.NoError(t, err)
@@ -96,7 +86,6 @@ func TestPresenterLocalFinding_LowIssues(t *testing.T) {
 }
 
 func TestPresenterLocalFinding_MediumHighIssues(t *testing.T) {
-	skipWindows(t)
 	input, err := sarifToLocalFinding(t, "testdata/4-high-5-medium.json")
 	require.Nil(t, err)
 
@@ -117,7 +106,6 @@ func TestPresenterLocalFinding_MediumHighIssues(t *testing.T) {
 }
 
 func TestPresenterLocalFinding_MediumHighIssuesWithColor(t *testing.T) {
-	skipWindows(t)
 	input, err := sarifToLocalFinding(t, "testdata/4-high-5-medium.json")
 	require.Nil(t, err)
 
@@ -137,7 +125,6 @@ func TestPresenterLocalFinding_MediumHighIssuesWithColor(t *testing.T) {
 }
 
 func TestPresenterLocalFinding_MediumHighIssuesWithColorLight(t *testing.T) {
-	skipWindows(t)
 	input, err := sarifToLocalFinding(t, "testdata/4-high-5-medium.json")
 	require.Nil(t, err)
 
@@ -158,7 +145,6 @@ func TestPresenterLocalFinding_MediumHighIssuesWithColorLight(t *testing.T) {
 }
 
 func TestPresenterLocalFinding_SeverityThresholdHighIssues(t *testing.T) {
-	skipWindows(t)
 	input, err := sarifToLocalFinding(t, "testdata/4-high-5-medium.json")
 	require.Nil(t, err)
 
@@ -182,7 +168,6 @@ func TestPresenterLocalFinding_SeverityThresholdHighIssues(t *testing.T) {
 }
 
 func TestPresenterLocalFinding_DefaultHideIgnored(t *testing.T) {
-	skipWindows(t)
 	input, err := sarifToLocalFinding(t, "testdata/with-ignores.json")
 	require.Nil(t, err)
 
@@ -202,7 +187,6 @@ func TestPresenterLocalFinding_DefaultHideIgnored(t *testing.T) {
 }
 
 func TestPresenterLocalFinding_IncludeIgnored(t *testing.T) {
-	skipWindows(t)
 	input, err := sarifToLocalFinding(t, "testdata/with-ignores.json")
 	require.Nil(t, err)
 
@@ -229,7 +213,6 @@ func TestPresenterLocalFinding_IncludeIgnored(t *testing.T) {
 }
 
 func TestPresenterLocalFinding_IncludeIgnoredEmpty(t *testing.T) {
-	skipWindows(t)
 	input, err := sarifToLocalFinding(t, "testdata/3-low-issues.json")
 	require.Nil(t, err)
 

--- a/pkg/local_workflows/data_transformation_workflow_test.go
+++ b/pkg/local_workflows/data_transformation_workflow_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io"
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -103,13 +102,6 @@ func getTestSarifBytes(t *testing.T) sarif.SarifDocument {
 	return sarifDoc
 }
 
-func skipWindows(t *testing.T) {
-	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping on windows device [CLI-514]")
-	}
-}
-
 func Test_DataTransformation_withUnsupportedInput(t *testing.T) {
 	invocationContext := setupMockTransformationContext(t, true)
 	logger := zerolog.Logger{}
@@ -152,8 +144,6 @@ func loadJsonFile(t *testing.T, filename string) []byte {
 }
 
 func Test_DataTransformation_with_Sarif_and_SummaryData(t *testing.T) {
-	skipWindows(t)
-
 	invocationContext := setupMockTransformationContext(t, true)
 	logger := zerolog.Logger{}
 	input := []workflow.Data{


### PR DESCRIPTION
Embedded cue module is loaded with a custom loader that resolves absolute paths, even though the paths are "virtual".

Adding a drive-letter seems to resolve problems with this when running on a Windows OS.

CLI-514