### PR TITLE
chore: use race detector for unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ base_image: &base_image
 jobs:
   unit_test:
     <<: *base_image
+    resource_class: medium
     steps:
       - checkout
       - run:

--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,12 @@ clean:
 .PHONY: test
 test:
 	@echo "Testing..."
-	@go test -cover ./...
+	@go test -cover ./... -race
 
 .PHONY: testv
 testv:
 	@echo "Testing verbosely..."
-	@go test -v ./...
+	@go test -v ./... -race
 
 .PHONY: generate
 generate:

--- a/pkg/configuration/storage_test.go
+++ b/pkg/configuration/storage_test.go
@@ -55,7 +55,7 @@ func Test_JsonStorage_Set_NoConfigFile(t *testing.T) {
 	}
 }
 
-func Test_JsonStorage_Set_ConfigFileHasValues(t *testing.T) {
+func Test_JsonStorage_Set_ConfigFileHasValues(t *testing.T) { //nolint:tparallel // subtests are not mutually exclusive
 	// Arrange
 	t.Parallel()
 	const preExistingKey = "someOtherKey"
@@ -79,16 +79,13 @@ func Test_JsonStorage_Set_ConfigFileHasValues(t *testing.T) {
 	// Assert
 	storedConfig := readStoredConfigFile(t, configFile)
 	t.Run("File contains key", func(t *testing.T) {
-		t.Parallel()
 		assertConfigContainsKey(t, storedConfig, key, expectedValue)
 	})
 	t.Run("Pre-stored values are not deleted", func(t *testing.T) {
-		t.Parallel()
 		assertConfigContainsKey(t, storedConfig, preExistingKey, preExistingValue)
 	})
 	assertSetCallDoesNotDeleteOtherValues(t, storage, configFile, expectedValue, key)
 	t.Run("Overwrites existing value", func(t *testing.T) {
-		t.Parallel()
 		const newValue = "new value"
 		assert.Contains(t, storedConfig, key)
 		err = storage.Set(key, newValue)


### PR DESCRIPTION
Add race detector to unit tests, go test ./... -race

Remove t.Parallel() from tests which operate on the same config file and potentially mutate and check the same key.

This fixes a data race in which a map loaded from a config file was concurrently accessed inappropriately in previously parallel tests.

It also removes an unstable test setup condition. "File contains key" was potentially in conflict with "Overwrites existing value" in Test_JsonStorage_Set_ConfigFileHasValues, even if storage.Set is mutually exclusive.