### PR TITLE
fix: only read supported env vars (CLI-526)

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -1,6 +1,7 @@
 package configuration
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 	"path"
@@ -226,7 +227,9 @@ func (ev *extendedViper) get(key string) interface{} {
 	ev.mutex.Lock()
 	defer ev.mutex.Unlock()
 
-	// try to lookup given key
+	// try to lookup given key with SNYK_ prefix
+	ev.viper.SetEnvPrefix("snyk")
+	//ev.viper.BindEnv(key)
 	result := ev.viper.Get(key)
 	isSet := ev.viper.IsSet(key)
 
@@ -236,6 +239,7 @@ func (ev *extendedViper) get(key string) interface{} {
 	alternativeKeysSize := len(alternativeKeys)
 	for !isSet && index < alternativeKeysSize {
 		altKey := alternativeKeys[index]
+		fmt.Println(altKey, ": ", os.Getenv(strings.ToUpper(altKey)))
 		result = ev.viper.Get(altKey)
 		isSet = ev.viper.IsSet(altKey)
 		index++

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -1,7 +1,6 @@
 package configuration
 
 import (
-	"fmt"
 	"net/url"
 	"os"
 	"path"
@@ -150,7 +149,6 @@ func createViperDefaultConfig() *extendedViper {
 		persistedKeys:   make(map[string]bool),
 	}
 	config.viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-	config.viper.AutomaticEnv()
 	return config
 }
 
@@ -227,9 +225,13 @@ func (ev *extendedViper) get(key string) interface{} {
 	ev.mutex.Lock()
 	defer ev.mutex.Unlock()
 
+	// ensure we only get Snyk related keys (prefixed with SNYK_)
+	if ev.GetKeyType(key) == UnspecifiedKeyType {
+		ev.viper.BindEnv(key, "SNYK_"+strings.ToUpper(key))
+	} else {
+		ev.viper.BindEnv(key, strings.ToUpper(key))
+	}
 	// try to lookup given key with SNYK_ prefix
-	ev.viper.SetEnvPrefix("snyk")
-	//ev.viper.BindEnv(key)
 	result := ev.viper.Get(key)
 	isSet := ev.viper.IsSet(key)
 
@@ -239,7 +241,7 @@ func (ev *extendedViper) get(key string) interface{} {
 	alternativeKeysSize := len(alternativeKeys)
 	for !isSet && index < alternativeKeysSize {
 		altKey := alternativeKeys[index]
-		fmt.Println(altKey, ": ", os.Getenv(strings.ToUpper(altKey)))
+		ev.viper.BindEnv(altKey, strings.ToUpper(altKey))
 		result = ev.viper.Get(altKey)
 		isSet = ev.viper.IsSet(altKey)
 		index++

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -490,6 +491,26 @@ func Test_Configuration_GetKeyType(t *testing.T) {
 	)
 	assert.Equal(t, EnvVarKeyType, config.GetKeyType("snyk_something"))
 	assert.Equal(t, UnspecifiedKeyType, config.GetKeyType("app"))
+}
+
+func Test_Configuration_Locking(t *testing.T) {
+	var wg sync.WaitGroup
+	N := 100
+
+	config := New()
+
+	for i := range N {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			key := fmt.Sprintf("%d", i)
+			config.Set(key, i)
+			_ = config.Get(key)
+		}()
+	}
+
+	wg.Wait()
 }
 
 func Test_JsonStorage_Locking(t *testing.T) {

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -67,7 +67,7 @@ func Test_ConfigurationGet_AUTHENTICATION_TOKEN(t *testing.T) {
 
 func Test_ConfigurationGet_AUTHENTICATION_BEARER_TOKEN(t *testing.T) {
 	expectedValue := "anotherToken"
-	expectedValueDocker := "dockerTocken"
+	expectedValueDocker := "dockerToken"
 	assert.Nil(t, prepareConfigstore(`{"api": "mytoken", "somethingElse": 12}`))
 
 	config := NewFromFiles(TEST_FILENAME)

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -174,16 +174,12 @@ func Test_ConfigurationSet_differentCases(t *testing.T) {
 	actualValueInt = config.GetInt("api")
 	assert.Equal(t, 0, actualValueInt)
 
-	cleanupConfigstore(t)
-}
-
-func Test_ConfigurationSet_envVars(t *testing.T) {
 	t.Run("only read env vars prefixed with SNYK_", func(t *testing.T) {
-		key := "SNYK_ORG"
-		wrongKey := "ORG"
-		expected := "hello"
-		notExpected := "notAValidEnvVar"
 		defaultValue := "something"
+		key := "SNYK_CFG_ORG"
+		expected := "hello"
+		wrongKey := "ORG"
+		notExpected := "notAValidEnvVar"
 		flagset := pflag.NewFlagSet("test", pflag.ExitOnError)
 		flagset.String(ORGANIZATION, "", "org")
 

--- a/pkg/networking/networking_test.go
+++ b/pkg/networking/networking_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func getConfig() configuration.Configuration {
-	config := configuration.NewInMemory()
+	config := configuration.NewWithOpts(configuration.WithSupportedEnvVarPrefixes("snyk_"))
 	config.Set(configuration.API_URL, constants.SNYK_DEFAULT_API_URL)
 	config.Set(auth.CONFIG_KEY_OAUTH_TOKEN, "")
 	config.Set(configuration.AUTHENTICATION_TOKEN, "")

--- a/pkg/workflow/engine_test.go
+++ b/pkg/workflow/engine_test.go
@@ -138,8 +138,8 @@ func Test_EngineRegisterErrorHandling(t *testing.T) {
 }
 
 func Test_Engine_SetterGlobalValues(t *testing.T) {
-	config := configuration.NewInMemory()
-	config2 := configuration.NewInMemory()
+	config := configuration.NewWithOpts(configuration.WithSupportedEnvVarPrefixes("snyk_"))
+	config2 := configuration.NewWithOpts(configuration.WithSupportedEnvVarPrefixes("snyk_"))
 	logger2 := &zerolog.Logger{}
 
 	engine := NewWorkFlowEngine(config)


### PR DESCRIPTION
This PR makes changes so that environment variables that are supported by GAF are configurable as opposed to GAF automatically detecting supported environment variables. 