### PR TITLE
feat: render description for Error Catalog errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/oapi-codegen/oapi-codegen/v2 v2.3.0
 	github.com/oapi-codegen/runtime v1.1.1
-	github.com/snyk/error-catalog-golang-public v0.0.0-20240809094525-c48d19c27edb
+	github.com/snyk/error-catalog-golang-public v0.0.0-20241030160523-0aa643bb7069
 	github.com/subosito/gotenv v1.4.1
 	golang.org/x/sync v0.8.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -215,6 +215,8 @@ github.com/snyk/code-client-go v1.8.0 h1:6H883KAn7ybiSIxhvL2QR9yEyHgAwA2+9WVHMDN
 github.com/snyk/code-client-go v1.8.0/go.mod h1:orU911flV1kJQOlxxx0InUQkAfpBrcERsb2olfnlI8s=
 github.com/snyk/error-catalog-golang-public v0.0.0-20240809094525-c48d19c27edb h1:w9tJhpTFxWqAhLeraGsMExDjGK9x5Dwj1NRFwb+t+QE=
 github.com/snyk/error-catalog-golang-public v0.0.0-20240809094525-c48d19c27edb/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
+github.com/snyk/error-catalog-golang-public v0.0.0-20241030160523-0aa643bb7069 h1:Oj/BJAEMEuBjTAQ72UYB4tR0IZKOB2ZtdDnAnJDL1BM=
+github.com/snyk/error-catalog-golang-public v0.0.0-20241030160523-0aa643bb7069/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,6 @@ github.com/skeema/knownhosts v1.2.2 h1:Iug2P4fLmDw9f41PB6thxUkNUkJzB5i+1/exaj40L
 github.com/skeema/knownhosts v1.2.2/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
 github.com/snyk/code-client-go v1.8.0 h1:6H883KAn7ybiSIxhvL2QR9yEyHgAwA2+9WVHMDNEKa8=
 github.com/snyk/code-client-go v1.8.0/go.mod h1:orU911flV1kJQOlxxx0InUQkAfpBrcERsb2olfnlI8s=
-github.com/snyk/error-catalog-golang-public v0.0.0-20240809094525-c48d19c27edb h1:w9tJhpTFxWqAhLeraGsMExDjGK9x5Dwj1NRFwb+t+QE=
-github.com/snyk/error-catalog-golang-public v0.0.0-20240809094525-c48d19c27edb/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
 github.com/snyk/error-catalog-golang-public v0.0.0-20241030160523-0aa643bb7069 h1:Oj/BJAEMEuBjTAQ72UYB4tR0IZKOB2ZtdDnAnJDL1BM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20241030160523-0aa643bb7069/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -3,3 +3,5 @@ package constants
 const SNYK_DEFAULT_API_URL = "https://api.snyk.io"
 const SNYK_DEFAULT_API_VERSION = "2024-04-22"
 const SNYK_DEFAULT_IN_MEMORY_THRESHOLD_MB = 512 * 1024 * 1024
+const SNYK_DOCS_URL = "https://docs.snyk.io"
+const SNYK_DOCS_ERROR_CATALOG_PATH = "/scan-with-snyk/error-catalog"

--- a/internal/presenters/__snapshots__/components_test.snap
+++ b/internal/presenters/__snapshots__/components_test.snap
@@ -2,51 +2,70 @@
 [Test_RenderError/colors_for_severity_error - 1]
 
 [41m [0m[97;41mERROR[0m[41m [0m  [1mService temporarily throttled (SNYK-0001)[0m
-HTTP:    429 
+Status:  429 Too Many Requests 
+Details: The request rate limit has been exceeded. Wait a few minutes, then try again.  
+Docs:    https://docs.snyk.io/scan-with-snyk/error-catalog#snyk-0001 
 ---
 
 [Test_RenderError/colors_for_severity_error - 2]
 
 [41m [0m[97;41mERROR[0m[41m [0m  [1mService temporarily throttled (SNYK-0001)[0m
-HTTP:    429 
+Status:  429 Too Many Requests 
+Details: The request rate limit has been exceeded. Wait a few minutes, then try again.  
+Docs:    https://docs.snyk.io/scan-with-snyk/error-catalog#snyk-0001 
 ---
 
 [Test_RenderError/colors_for_severity_fatal - 1]
 
 [41m [0m[97;41mFATAL[0m[41m [0m  [1mService temporarily throttled (SNYK-0001)[0m
-HTTP:    429 
+Status:  429 Too Many Requests 
+Details: The request rate limit has been exceeded. Wait a few minutes, then try again.  
+Docs:    https://docs.snyk.io/scan-with-snyk/error-catalog#snyk-0001 
 ---
 
 [Test_RenderError/colors_for_severity_fatal - 2]
 
 [41m [0m[97;41mFATAL[0m[41m [0m  [1mService temporarily throttled (SNYK-0001)[0m
-HTTP:    429 
+Status:  429 Too Many Requests 
+Details: The request rate limit has been exceeded. Wait a few minutes, then try again.  
+Docs:    https://docs.snyk.io/scan-with-snyk/error-catalog#snyk-0001 
 ---
 
 [Test_RenderError/colors_for_severity_warn - 1]
 
 [43m [0m[30;43mWARN[0m[43m [0m   [1mService temporarily throttled (SNYK-0001)[0m
-HTTP:    429 
+Status:  429 Too Many Requests 
+Details: The request rate limit has been exceeded. Wait a few minutes, then try again.  
+Docs:    https://docs.snyk.io/scan-with-snyk/error-catalog#snyk-0001 
 ---
 
 [Test_RenderError/colors_for_severity_warn - 2]
 
 [43m [0m[30;43mWARN[0m[43m [0m   [1mService temporarily throttled (SNYK-0001)[0m
-HTTP:    429 
+Status:  429 Too Many Requests 
+Details: The request rate limit has been exceeded. Wait a few minutes, then try again.  
+Docs:    https://docs.snyk.io/scan-with-snyk/error-catalog#snyk-0001 
 ---
 
 [Test_RenderError/with_links - 1]
 
 [41m [0m[97;41mERROR[0m[41m [0m  [1mRequest not fulfilled due to server error (SNYK-9999)[0m
 Info:    An error                                                                       
-HTTP:    500 
-Help:    https://status.snyk.io/                                                                                                       
+Status:  500 Internal Server Error 
+Details: The server cannot process the request due to an unexpected error. Check Snyk   
+         status, then try again.                                                        
+Docs:    https://docs.snyk.io/scan-with-snyk/error-catalog#snyk-9999                                                                   
+         https://status.snyk.io/                                                                                                       
          https://docs.snyk.io/getting-started/supported-languages-frameworks-and-feature-availability-overview#code-analysis-snyk-code 
 ---
 
 [Test_RenderError/without_links - 1]
 
-[41m [0m[97;41mERROR[0m[41m [0m  [1mClient request cannot be processed (SNYK-0003)[0m
+[41m [0m[97;41mERROR[0m[41m [0m  [1mClient request cannot be processed[0m
 Info:    A short error description                                                      
-HTTP:    400 
+Status:  400 Bad Request 
+Details: The server cannot process the request due to a client error, such as malformed 
+         request syntax, size too large, invalid request message framing, or deceptive  
+         request routing. Review the request and try again.                             
 ---
+

--- a/internal/presenters/components.go
+++ b/internal/presenters/components.go
@@ -3,6 +3,8 @@ package presenters
 import (
 	"bytes"
 	"fmt"
+	"net/http"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -47,19 +49,45 @@ func RenderError(err snyk_errors.Error) string {
 
 	if err.StatusCode > 0 {
 		body = append(body, lipgloss.JoinHorizontal(lipgloss.Top,
-			label.Render("HTTP:"),
-			value.Render(strconv.Itoa(err.StatusCode)),
+			label.Render("Status:"),
+			value.Render(strconv.Itoa(err.StatusCode)+" "+http.StatusText(err.StatusCode)),
 		))
+	}
+
+	if len(err.Description) > 0 {
+		desc := err.Description
+		re := regexp.MustCompile("\n+")
+		lines := re.Split(desc, -1)
+
+		if len(lines) > 1 {
+			lines = lines[0:2]
+			for i, l := range lines {
+				lines[i] = strings.Trim(l, " \n")
+			}
+			desc = strings.Join(lines, " ")
+		}
+
+		body = append(body, lipgloss.JoinHorizontal(lipgloss.Top,
+			label.Render("Details:"),
+			value.Copy().Width(80).Render(desc),
+		))
+	}
+
+	title := strings.TrimSpace(err.Title)
+	if len(err.ErrorCode) > 0 {
+		link := "https://docs.snyk.io/scan-with-snyk/error-catalog#" + strings.ToLower(err.ErrorCode)
+		err.Links = append([]string{link}, err.Links...)
+		title = title + fmt.Sprintf(" (%s)", err.ErrorCode)
 	}
 
 	if len(err.Links) > 0 {
 		body = append(body, lipgloss.JoinHorizontal(lipgloss.Top,
-			label.Render("Help:"),
+			label.Render("Docs:"),
 			value.Render(strings.Join(err.Links, "\n")),
 		))
 	}
 
-	title := renderBold(strings.TrimSpace(err.Title) + " " + fmt.Sprintf("(%s)", err.ErrorCode))
+	title = renderBold(title)
 
 	return "\n" + backgroundHighlight.MarginRight(6-len(level)).Render(level) + " " + title + "\n" +
 		strings.Join(body, "\n")

--- a/internal/presenters/components.go
+++ b/internal/presenters/components.go
@@ -13,8 +13,11 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 
+	"github.com/snyk/go-application-framework/internal/constants"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
 )
+
+const valueStyleWidth = 80
 
 func errorLevelToStyle(errLevel string) lipgloss.Style {
 	style := lipgloss.NewStyle().
@@ -43,7 +46,7 @@ func RenderError(err snyk_errors.Error) string {
 	if len(err.Detail) > 0 {
 		body = append(body, lipgloss.JoinHorizontal(lipgloss.Top,
 			label.Render("Info:"),
-			value.Copy().Width(80).Render(err.Detail),
+			value.Copy().Width(valueStyleWidth).Render(err.Detail),
 		))
 	}
 
@@ -69,13 +72,14 @@ func RenderError(err snyk_errors.Error) string {
 
 		body = append(body, lipgloss.JoinHorizontal(lipgloss.Top,
 			label.Render("Details:"),
-			value.Copy().Width(80).Render(desc),
+			value.Copy().Width(valueStyleWidth).Render(desc),
 		))
 	}
 
 	title := strings.TrimSpace(err.Title)
 	if len(err.ErrorCode) > 0 {
-		link := "https://docs.snyk.io/scan-with-snyk/error-catalog#" + strings.ToLower(err.ErrorCode)
+		fragment := "#" + strings.ToLower(err.ErrorCode)
+		link := constants.SNYK_DOCS_URL + constants.SNYK_DOCS_ERROR_CATALOG_PATH + fragment
 		err.Links = append([]string{link}, err.Links...)
 		title = title + fmt.Sprintf(" (%s)", err.ErrorCode)
 	}

--- a/internal/presenters/components_test.go
+++ b/internal/presenters/components_test.go
@@ -31,7 +31,10 @@ func Test_RenderError(t *testing.T) {
 	t.Run("without links", func(t *testing.T) {
 		lipgloss.SetColorProfile(termenv.TrueColor)
 		lipgloss.SetHasDarkBackground(false)
-		output := RenderError(snyk.NewBadRequestError("A short error description"))
+		err := snyk.NewBadRequestError("A short error description")
+		// no error code => no error catalog link
+		err.ErrorCode = ""
+		output := RenderError(err)
 
 		assert.NotContains(t, output, "Help:")
 		snaps.MatchSnapshot(t, output)
@@ -44,7 +47,7 @@ func Test_RenderError(t *testing.T) {
 		err.Links = append(err.Links, "https://docs.snyk.io/getting-started/supported-languages-frameworks-and-feature-availability-overview#code-analysis-snyk-code")
 		output := RenderError(err)
 
-		assert.Contains(t, output, "Help:")
+		assert.Contains(t, output, "Docs:")
 		snaps.MatchSnapshot(t, output)
 	})
 }

--- a/pkg/ui/__snapshots__/consoleui_test.snap
+++ b/pkg/ui/__snapshots__/consoleui_test.snap
@@ -4,7 +4,11 @@
 [41m [0m[97;41mERROR[0m[41m [0m  [1mClient request cannot be processed (SNYK-0003)[0m
 Info:    If you carry on like this you will ensure the wrath of OWASP, the God of Code  
          Injection.                                                                     
-HTTP:    400 
-Help:    http://example.com/docs 
+Status:  400 Bad Request 
+Details: The server cannot process the request due to a client error, such as malformed 
+         request syntax, size too large, invalid request message framing, or deceptive  
+         request routing. Review the request and try again.                             
+Docs:    https://docs.snyk.io/scan-with-snyk/error-catalog#snyk-0003 
+         http://example.com/docs                                     
 
 ---


### PR DESCRIPTION
- Updates the dependency for the Error Catalog.
- Includes the description field in the RenderError output for errors from the Error Catalog, shortening the field to the first 2 paragraphs in case of longer descriptions. 
- Changed the label for the HTTP status and added the status code text next to the value.
- Changed the label for the links and added a default link for the error catalog page when the error code is present.
- Renders the title without the parentheses in case of no defined error code.

Ticket: [CLI-551](https://snyksec.atlassian.net/browse/CLI-551)


[CLI-551]: https://snyksec.atlassian.net/browse/CLI-551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ