### PR TITLE
chore: Support rendering findings models multiple times in parallel

### DIFF
--- a/pkg/local_workflows/data_transformation_workflow.go
+++ b/pkg/local_workflows/data_transformation_workflow.go
@@ -7,13 +7,14 @@ import (
 
 	"cuelang.org/go/cue/cuecontext"
 	cuejson "cuelang.org/go/pkg/encoding/json"
+	"github.com/spf13/pflag"
+
 	cueutil "github.com/snyk/go-application-framework/internal/cueutils"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/content_type"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/local_models"
 	"github.com/snyk/go-application-framework/pkg/workflow"
-	"github.com/spf13/pflag"
 )
 
 const (
@@ -88,7 +89,7 @@ func dataTransformationEntryPoint(invocationCtx workflow.InvocationContext, inpu
 	d := workflow.NewData(
 		workflow.NewTypeIdentifier(WORKFLOWID_DATATRANSFORMATION, DataTransformationWorkflowName),
 		content_type.LOCAL_FINDING_MODEL,
-		bytes, workflow.WithConfiguration(config), workflow.WithLogger(logger))
+		bytes, workflow.WithConfiguration(config), workflow.WithLogger(logger), workflow.WithInputData(summaryInput))
 	d.SetContentLocation(contentLocation)
 	output = append(output, d)
 

--- a/pkg/local_workflows/filter_workflow.go
+++ b/pkg/local_workflows/filter_workflow.go
@@ -5,13 +5,14 @@ import (
 	"strings"
 
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+	"github.com/spf13/pflag"
+
 	"github.com/snyk/go-application-framework/internal/utils/findings"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/content_type"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/local_models"
 	"github.com/snyk/go-application-framework/pkg/utils"
 	"github.com/snyk/go-application-framework/pkg/workflow"
-	"github.com/spf13/pflag"
 )
 
 const (
@@ -121,6 +122,7 @@ func filterFindingsEntryPoint(invocationCtx workflow.InvocationContext, input []
 				workflow.NewTypeIdentifier(WORKFLOWID_FILTER_FINDINGS, FilterFindingsWorkflowName),
 				content_type.LOCAL_FINDING_MODEL,
 				filteredFindingsBytes,
+				workflow.WithInputData(data),
 			))
 		} else {
 			output = append(output, data)

--- a/pkg/local_workflows/output_workflow/constants.go
+++ b/pkg/local_workflows/output_workflow/constants.go
@@ -1,0 +1,10 @@
+package output_workflow
+
+const (
+	OUTPUT_CONFIG_KEY_JSON       = "json"
+	OUTPUT_CONFIG_KEY_JSON_FILE  = "json-file-output"
+	OUTPUT_CONFIG_KEY_SARIF      = "sarif"
+	OUTPUT_CONFIG_KEY_SARIF_FILE = "sarif-file-output"
+	OUTPUT_CONFIG_TEMPLATE_FILE  = "internal_template_file"
+	DEFAULT_WRITER               = "default"
+)

--- a/pkg/local_workflows/output_workflow/findings_model_tools.go
+++ b/pkg/local_workflows/output_workflow/findings_model_tools.go
@@ -1,0 +1,161 @@
+package output_workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/rs/zerolog"
+	"golang.org/x/sync/semaphore"
+
+	"github.com/snyk/go-application-framework/internal/presenters"
+	iUtils "github.com/snyk/go-application-framework/internal/utils"
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/content_type"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/local_models"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+)
+
+type WriterEntry struct {
+	writer    io.Writer
+	mimeType  string
+	templates []string
+	closer    func() error
+}
+
+func getListOfFindings(input []workflow.Data, debugLogger *zerolog.Logger) (findings []*local_models.LocalFinding, remainingData []workflow.Data) {
+	findings = []*local_models.LocalFinding{}
+	remainingData = []workflow.Data{}
+
+	for i := range input {
+		if !strings.HasPrefix(input[i].GetContentType(), content_type.LOCAL_FINDING_MODEL) {
+			remainingData = append(remainingData, input[i])
+			continue
+		}
+		debugLogger.Info().Msgf("[%s] Handling findings model", input[i].GetIdentifier().String())
+		var localFindingsModel local_models.LocalFinding
+		localFindingsBytes, ok := input[i].GetPayload().([]byte)
+		if !ok {
+			debugLogger.Warn().Err(fmt.Errorf("invalid payload type: %T", input[i].GetPayload()))
+			continue
+		}
+
+		err := json.Unmarshal(localFindingsBytes, &localFindingsModel)
+		if err != nil {
+			debugLogger.Warn().Err(err).Msg("Failed to unmarshal local finding")
+			continue
+		}
+		findings = append(findings, &localFindingsModel)
+	}
+	return findings, remainingData
+}
+
+func getWritersToUse(config configuration.Configuration, outputDestination iUtils.OutputDestination) (map[string]*WriterEntry, error) {
+	writerMap := map[string]*WriterEntry{
+		DEFAULT_WRITER: {
+			writer:    outputDestination.GetWriter(),
+			mimeType:  presenters.DefaultMimeType,
+			templates: presenters.DefaultTemplateFiles,
+		},
+	}
+
+	outputFileName := config.GetString(OUTPUT_CONFIG_KEY_SARIF_FILE)
+	if len(outputFileName) > 0 {
+		file, fileErr := os.OpenFile(outputFileName, os.O_WRONLY|os.O_CREATE, 0644)
+		if fileErr != nil {
+			return nil, fileErr
+		}
+
+		writerMap[OUTPUT_CONFIG_KEY_SARIF_FILE] = &WriterEntry{
+			writer:    file,
+			mimeType:  presenters.ApplicationSarifMimeType,
+			templates: presenters.ApplicationSarifTemplates,
+			closer:    func() error { return file.Close() },
+		}
+	}
+
+	if config.GetBool(OUTPUT_CONFIG_KEY_SARIF) {
+		writerMap[DEFAULT_WRITER].mimeType = presenters.ApplicationSarifMimeType
+		writerMap[DEFAULT_WRITER].templates = presenters.ApplicationSarifTemplates
+	}
+
+	if config.IsSet(OUTPUT_CONFIG_TEMPLATE_FILE) {
+		writerMap[DEFAULT_WRITER].templates = []string{config.GetString(OUTPUT_CONFIG_TEMPLATE_FILE)}
+	}
+
+	return writerMap, nil
+}
+
+func useRendererWith(name string, wEntry *WriterEntry, debugLogger *zerolog.Logger, findings []*local_models.LocalFinding, config configuration.Configuration, invocation workflow.InvocationContext) {
+	debugLogger.Info().Msgf("[%s] Creating findings model renderer", name)
+
+	if wEntry.closer != nil {
+		defer func() {
+			closeErr := wEntry.closer()
+			if closeErr != nil {
+				debugLogger.Err(closeErr).Msgf("[%s] Error while closing writer.", name)
+			}
+		}()
+	}
+
+	renderer := presenters.NewLocalFindingsRenderer(
+		findings,
+		config,
+		wEntry.writer,
+		presenters.WithRuntimeInfo(invocation.GetRuntimeInfo()),
+	)
+
+	debugLogger.Info().Msgf("[%s] Rendering %s with %s", name, wEntry.mimeType, wEntry.templates)
+	err := renderer.RenderTemplate(wEntry.templates, wEntry.mimeType)
+	if err != nil {
+		debugLogger.Warn().Err(err).Msgf("[%s] Failed to render local finding", name)
+		return
+	}
+
+	debugLogger.Info().Msgf("[%s] Rendering done", name)
+}
+
+func HandleContentTypeFindingsModel(input []workflow.Data, invocation workflow.InvocationContext, outputDestination iUtils.OutputDestination) ([]workflow.Data, error) {
+	debugLogger := invocation.GetEnhancedLogger()
+	config := invocation.GetConfiguration()
+
+	findings, remainingData := getListOfFindings(input, debugLogger)
+	if len(findings) == 0 {
+		debugLogger.Info().Msg("No findings to process")
+		return input, nil
+	}
+
+	threadCount := max(int64(config.GetInt(configuration.MAX_THREADS)), 1)
+	debugLogger.Info().Msgf("Thread count: %d", threadCount)
+
+	writerMap, err := getWritersToUse(config, outputDestination)
+	if err != nil {
+		debugLogger.Err(err).Msg("Failed to initialize all required writers")
+	}
+
+	// iterate over all writers and render for each of them
+	ctx := context.Background()
+	availableThreads := semaphore.NewWeighted(threadCount)
+	for k, v := range writerMap {
+		err = availableThreads.Acquire(ctx, 1)
+		if err != nil {
+			debugLogger.Err(err).Msgf("[%s] Failed to acquire threading lock.", k)
+		}
+
+		go func() {
+			defer availableThreads.Release(1)
+			useRendererWith(k, v, debugLogger, findings, config, invocation)
+		}()
+	}
+
+	err = availableThreads.Acquire(ctx, threadCount)
+	if err != nil {
+		debugLogger.Err(err).Msg("Failed to wait for all threads")
+	}
+
+	debugLogger.Info().Msgf("All Rendering done")
+	return remainingData, nil
+}


### PR DESCRIPTION
The use case for parallel rendering of the same findings models is for example when the writer differ, like writing to a file and stdout, as it is currently supported.