### PR TITLE
feat: handle non 2xx responses in GAF network stack

### DIFF
--- a/internal/utils/convert.go
+++ b/internal/utils/convert.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"strconv"
+)
+
+func ToBool(value interface{}) bool {
+	if value == nil {
+		return false
+	}
+
+	switch v := value.(type) {
+	case bool:
+		return v
+	case string:
+		boolResult, err := strconv.ParseBool(v)
+		if err != nil {
+			return false
+		}
+		return boolResult
+	}
+
+	return false
+}

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -380,6 +380,7 @@ func (ev *extendedViper) Get(key string) interface{} {
 	ev.mutex.Unlock()
 
 	if ok && defaultFunc != nil {
+		// nolint:errcheck // discarded err in favor of zero values
 		value, _ = defaultFunc(value)
 	}
 

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -380,7 +380,7 @@ func (ev *extendedViper) Get(key string) interface{} {
 	ev.mutex.Unlock()
 
 	if ok && defaultFunc != nil {
-		// nolint:errcheck // discarded err in favor of zero values
+		//nolint:errcheck // discarded err in favor of zero values
 		value, _ = defaultFunc(value)
 	}
 

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -1,7 +1,6 @@
 package configuration
 
 import (
-	"fmt"
 	"net/url"
 	"os"
 	"path"
@@ -43,7 +42,7 @@ type Configuration interface {
 	GetInt(key string) int
 	GetFloat64(key string) float64
 	GetUrl(key string) *url.URL
-	GetE(key string) (interface{}, error)
+	GetWithError(key string) (interface{}, error)
 
 	AddFlagSet(flagset *pflag.FlagSet) error
 	AllKeys() []string
@@ -387,16 +386,12 @@ func (ev *extendedViper) Get(key string) interface{} {
 	return value
 }
 
-// GetE returns a configuration value and and error if the value is not set.
-func (ev *extendedViper) GetE(key string) (value interface{}, err error) {
+// GetWithError returns a configuration value and and the potential error returned by the DefaultValueFunction for the configuration value.
+func (ev *extendedViper) GetWithError(key string) (value interface{}, err error) {
 	value = ev.get(key)
 
 	if ev.defaultValues[key] != nil {
 		value, err = ev.defaultValues[key](value)
-	}
-
-	if value == nil && err == nil {
-		err = fmt.Errorf("missing value")
 	}
 
 	return value, err

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -116,6 +116,36 @@ func Test_ConfigurationGet_ANALYTICS_DISABLED(t *testing.T) {
 	cleanUpEnvVars()
 }
 
+func Test_Configuration_GetE(t *testing.T) {
+	assert.Nil(t, prepareConfigstore(`{"snyk_oauth_token": "mytoken", "somethingElse": 12}`))
+
+	config := NewWithOpts(
+		WithFiles(TEST_FILENAME),
+		WithSupportedEnvVarPrefixes("snyk_"),
+	)
+
+	_ = os.Unsetenv(ANALYTICS_DISABLED)
+
+	actualValue, err := config.GetE(ANALYTICS_DISABLED)
+	assert.NotNil(t, err)
+	assert.Nil(t, actualValue)
+
+	t.Setenv("SNYK_DISABLE_ANALYTICS", "1")
+	actualValue, err = config.GetE(ANALYTICS_DISABLED)
+	assert.Nil(t, err)
+	assert.NotNil(t, actualValue)
+	assert.Equal(t, "1", actualValue)
+
+	t.Setenv("SNYK_DISABLE_ANALYTICS", "0")
+	actualValue, err = config.GetE(ANALYTICS_DISABLED)
+	assert.Nil(t, err)
+	assert.NotNil(t, actualValue)
+	assert.Equal(t, "0", actualValue)
+
+	cleanupConfigstore(t)
+	cleanUpEnvVars()
+}
+
 func Test_ConfigurationGet_ALTERNATE_KEYS(t *testing.T) {
 	key := "snyk_cfg_api"
 	expected := "value"
@@ -200,11 +230,11 @@ func Test_ConfigurationSet_differentCases(t *testing.T) {
 		err := config.AddFlagSet(flagset)
 		assert.NoError(t, err)
 		config.AddAlternativeKeys(ORGANIZATION, []string{"snyk_cfg_org"})
-		config.AddDefaultValue(ORGANIZATION, func(existingValue interface{}) interface{} {
+		config.AddDefaultValue(ORGANIZATION, func(existingValue interface{}) (interface{}, error) {
 			if existingValue != nil {
-				return existingValue
+				return existingValue, nil
 			}
-			return defaultValue
+			return defaultValue, nil
 		})
 
 		// not set
@@ -365,12 +395,11 @@ func Test_DefaultValuehandling(t *testing.T) {
 		valueExplicitlySet := "explicitly set value"
 
 		config := NewInMemory()
-		config.AddDefaultValue(keyWithDefault, func(existingValue interface{}) interface{} {
+		config.AddDefaultValue(keyWithDefault, func(existingValue interface{}) (interface{}, error) {
 			if existingValue != nil {
-				return existingValue
+				return existingValue, nil
 			}
-
-			return valueWithDefault
+			return valueWithDefault, nil
 		})
 
 		// access value that has a default value
@@ -404,11 +433,11 @@ func Test_DefaultValuehandling(t *testing.T) {
 		err := config.AddFlagSet(flagset)
 		assert.NoError(t, err)
 		config.AddAlternativeKeys(ORGANIZATION, []string{"snyk_cfg_org"})
-		config.AddDefaultValue(ORGANIZATION, func(existingValue interface{}) interface{} {
+		config.AddDefaultValue(ORGANIZATION, func(existingValue interface{}) (interface{}, error) {
 			if existingValue != nil {
-				return existingValue
+				return existingValue, nil
 			}
-			return defaultValue
+			return defaultValue, nil
 		})
 
 		// not set

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -126,18 +126,18 @@ func Test_Configuration_GetE(t *testing.T) {
 
 	_ = os.Unsetenv(ANALYTICS_DISABLED)
 
-	actualValue, err := config.GetE(ANALYTICS_DISABLED)
-	assert.NotNil(t, err)
+	actualValue, err := config.GetWithError(ANALYTICS_DISABLED)
+	assert.Nil(t, err)
 	assert.Nil(t, actualValue)
 
 	t.Setenv("SNYK_DISABLE_ANALYTICS", "1")
-	actualValue, err = config.GetE(ANALYTICS_DISABLED)
+	actualValue, err = config.GetWithError(ANALYTICS_DISABLED)
 	assert.Nil(t, err)
 	assert.NotNil(t, actualValue)
 	assert.Equal(t, "1", actualValue)
 
 	t.Setenv("SNYK_DISABLE_ANALYTICS", "0")
-	actualValue, err = config.GetE(ANALYTICS_DISABLED)
+	actualValue, err = config.GetWithError(ANALYTICS_DISABLED)
 	assert.Nil(t, err)
 	assert.NotNil(t, actualValue)
 	assert.Equal(t, "0", actualValue)

--- a/pkg/local_workflows/code_workflow.go
+++ b/pkg/local_workflows/code_workflow.go
@@ -1,6 +1,8 @@
 package localworkflows
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 
 	"github.com/snyk/error-catalog-golang-public/code"
@@ -86,7 +88,7 @@ func codeWorkflowEntryPoint(invocationCtx workflow.InvocationContext, _ []workfl
 	config := invocationCtx.GetConfiguration()
 	logger := invocationCtx.GetEnhancedLogger()
 
-	sastEnabledI, err := config.GetE(ConfigurationSastEnabled)
+	sastEnabledI, err := config.GetWithError(ConfigurationSastEnabled)
 	if err != nil {
 		return result, err
 	}
@@ -102,7 +104,7 @@ func codeWorkflowEntryPoint(invocationCtx workflow.InvocationContext, _ []workfl
 	logger.Debug().Msgf("Report enabled:     %v", reportEnabled)
 
 	if !sastEnabled {
-		return result, code.NewFeatureIsNotEnabledError("Snyk Code is not supported for your current organization.")
+		return result, code.NewFeatureIsNotEnabledError(fmt.Sprintf("Snyk Code is not supported for your current organization: `%s`.", config.GetString(configuration.ORGANIZATION_SLUG)))
 	}
 
 	if ignoresFeatureFlag && !reportEnabled {

--- a/pkg/local_workflows/code_workflow.go
+++ b/pkg/local_workflows/code_workflow.go
@@ -98,7 +98,6 @@ func codeWorkflowEntryPoint(invocationCtx workflow.InvocationContext, _ []workfl
 	ignoresFeatureFlag := config.GetBool(configuration.FF_CODE_CONSISTENT_IGNORES)
 	reportEnabled := config.GetBool("report")
 
-	logger.Debug().Msg("code workflow start")
 	logger.Debug().Msgf("SAST Enabled:       %v", sastEnabled)
 	logger.Debug().Msgf("Consistent Ignores: %v", ignoresFeatureFlag)
 	logger.Debug().Msgf("Report enabled:     %v", reportEnabled)

--- a/pkg/local_workflows/code_workflow.go
+++ b/pkg/local_workflows/code_workflow.go
@@ -83,7 +83,7 @@ func codeWorkflowEntryPoint(invocationCtx workflow.InvocationContext, _ []workfl
 	config := invocationCtx.GetConfiguration()
 	engine := invocationCtx.GetEngine()
 	logger := invocationCtx.GetEnhancedLogger()
-	
+
 	ignoresFeatureFlag := config.GetBool(configuration.FF_CODE_CONSISTENT_IGNORES)
 	reportEnabled := config.GetBool("report")
 	sastEnabled, err := getSastEnabled(config, engine)

--- a/pkg/local_workflows/config_utils/feature_flag.go
+++ b/pkg/local_workflows/config_utils/feature_flag.go
@@ -9,7 +9,7 @@ import (
 func AddFeatureFlagToConfig(engine workflow.Engine, configKey string, featureFlagName string) {
 	config := engine.GetConfiguration()
 
-	callback := func(existingValue interface{}) interface{} {
+	callback := func(existingValue interface{}) (interface{}, error) {
 		if existingValue == nil {
 			httpClient := engine.GetNetworkAccess().GetHttpClient()
 			logger := engine.GetLogger()
@@ -20,9 +20,9 @@ func AddFeatureFlagToConfig(engine workflow.Engine, configKey string, featureFla
 			if err != nil {
 				logger.Printf("Failed to determine feature flag \"%s\" for org \"%s\": %s", featureFlagName, org, err)
 			}
-			return result
+			return result, nil
 		} else {
-			return existingValue
+			return existingValue, nil
 		}
 	}
 

--- a/pkg/mocks/configuration.go
+++ b/pkg/mocks/configuration.go
@@ -324,6 +324,21 @@ func (mr *MockConfigurationMockRecorder) GetUrl(key interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUrl", reflect.TypeOf((*MockConfiguration)(nil).GetUrl), key)
 }
 
+// GetWithError mocks base method.
+func (m *MockConfiguration) GetWithError(key string) (interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWithError", key)
+	ret0, _ := ret[0].(interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWithError indicates an expected call of GetWithError.
+func (mr *MockConfigurationMockRecorder) GetWithError(key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWithError", reflect.TypeOf((*MockConfiguration)(nil).GetWithError), key)
+}
+
 // IsSet mocks base method.
 func (m *MockConfiguration) IsSet(key string) bool {
 	m.ctrl.T.Helper()

--- a/pkg/mocks/networking.go
+++ b/pkg/mocks/networking.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	http "net/http"
 	reflect "reflect"
 
@@ -48,6 +49,18 @@ func (m *MockNetworkAccess) AddDynamicHeaderField(key string, f networking.Dynam
 func (mr *MockNetworkAccessMockRecorder) AddDynamicHeaderField(key, f interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDynamicHeaderField", reflect.TypeOf((*MockNetworkAccess)(nil).AddDynamicHeaderField), key, f)
+}
+
+// AddErrorHandler mocks base method.
+func (m *MockNetworkAccess) AddErrorHandler(arg0 func(error, context.Context) error) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddErrorHandler", arg0)
+}
+
+// AddErrorHandler indicates an expected call of AddErrorHandler.
+func (mr *MockNetworkAccessMockRecorder) AddErrorHandler(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddErrorHandler", reflect.TypeOf((*MockNetworkAccess)(nil).AddErrorHandler), arg0)
 }
 
 // AddHeaderField mocks base method.

--- a/pkg/mocks/networking.go
+++ b/pkg/mocks/networking.go
@@ -5,7 +5,6 @@
 package mocks
 
 import (
-	context "context"
 	http "net/http"
 	reflect "reflect"
 
@@ -14,6 +13,7 @@ import (
 	auth "github.com/snyk/go-application-framework/pkg/auth"
 	configuration "github.com/snyk/go-application-framework/pkg/configuration"
 	networking "github.com/snyk/go-application-framework/pkg/networking"
+	networktypes "github.com/snyk/go-application-framework/pkg/networking/network_types"
 )
 
 // MockNetworkAccess is a mock of NetworkAccess interface.
@@ -52,7 +52,7 @@ func (mr *MockNetworkAccessMockRecorder) AddDynamicHeaderField(key, f interface{
 }
 
 // AddErrorHandler mocks base method.
-func (m *MockNetworkAccess) AddErrorHandler(arg0 func(error, context.Context) error) {
+func (m *MockNetworkAccess) AddErrorHandler(arg0 networktypes.ErrorHandlerFunc) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddErrorHandler", arg0)
 }
@@ -146,10 +146,10 @@ func (mr *MockNetworkAccessMockRecorder) GetConfiguration() *gomock.Call {
 }
 
 // GetErrorHandler mocks base method.
-func (m *MockNetworkAccess) GetErrorHandler() func(error, context.Context) error {
+func (m *MockNetworkAccess) GetErrorHandler() networktypes.ErrorHandlerFunc {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetErrorHandler")
-	ret0, _ := ret[0].(func(error, context.Context) error)
+	ret0, _ := ret[0].(networktypes.ErrorHandlerFunc)
 	return ret0
 }
 

--- a/pkg/mocks/networking.go
+++ b/pkg/mocks/networking.go
@@ -145,6 +145,20 @@ func (mr *MockNetworkAccessMockRecorder) GetConfiguration() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfiguration", reflect.TypeOf((*MockNetworkAccess)(nil).GetConfiguration))
 }
 
+// GetErrorHandler mocks base method.
+func (m *MockNetworkAccess) GetErrorHandler() func(error, context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetErrorHandler")
+	ret0, _ := ret[0].(func(error, context.Context) error)
+	return ret0
+}
+
+// GetErrorHandler indicates an expected call of GetErrorHandler.
+func (mr *MockNetworkAccessMockRecorder) GetErrorHandler() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetErrorHandler", reflect.TypeOf((*MockNetworkAccess)(nil).GetErrorHandler))
+}
+
 // GetHttpClient mocks base method.
 func (m *MockNetworkAccess) GetHttpClient() *http.Client {
 	m.ctrl.T.Helper()

--- a/pkg/networking/middleware/response.go
+++ b/pkg/networking/middleware/response.go
@@ -1,22 +1,72 @@
 package middleware
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/snyk/error-catalog-golang-public/snyk"
+	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+	"github.com/snyk/go-application-framework/pkg/configuration"
 	networktypes "github.com/snyk/go-application-framework/pkg/networking/network_types"
 )
 
 type ResponseMiddleware struct {
 	next       http.RoundTripper
+	config     configuration.Configuration
 	errHandler networktypes.ErrorHandlerFunc
 }
 
-func NewReponseMiddleware(roundTriper http.RoundTripper, errHandler networktypes.ErrorHandlerFunc) *ResponseMiddleware {
+func NewReponseMiddleware(roundTriper http.RoundTripper, config configuration.Configuration, errHandler networktypes.ErrorHandlerFunc) *ResponseMiddleware {
 	return &ResponseMiddleware{
 		next:       roundTriper,
+		config:     config,
 		errHandler: errHandler,
 	}
+}
+
+func (rm ResponseMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
+	res, err := rm.next.RoundTrip(req)
+
+	if err != nil {
+		return res, err
+	}
+
+	err = HandleResponse(res, rm.config)
+
+	if rm.errHandler != nil {
+		err = rm.errHandler(err, res.Request.Context())
+	}
+
+	// RoundTrip should return one or the other.
+	if err != nil {
+		res = nil
+	}
+
+	return res, err
+}
+
+// HandleResponse maps the response param to the eror catalog error.
+func HandleResponse(res *http.Response, config configuration.Configuration) error {
+	if res == nil {
+		return nil
+	}
+
+	apiUrl := config.GetString(configuration.API_URL)
+	additionalSubdomains := config.GetStringSlice(configuration.AUTHENTICATION_SUBDOMAINS)
+	additionalUrls := config.GetStringSlice(configuration.AUTHENTICATION_ADDITIONAL_URLS)
+	//nolint:errcheck // discarded error since it's returned only with the value of false
+	requiresAuth, _ := ShouldRequireAuthentication(apiUrl, res.Request.URL, additionalSubdomains, additionalUrls)
+
+	if !requiresAuth {
+		return nil
+	}
+
+	err := errFromStatusCode(res.StatusCode)
+	if err != nil {
+		return addMetadataToErr(err, res)
+	}
+
+	return nil
 }
 
 // errFromStatusCode matches the providede status code to an Error Catalog error. If no match is found, nil is returned.
@@ -33,32 +83,19 @@ func errFromStatusCode(code int) error {
 	}
 }
 
-// HandleResponse maps the response param to the eror catalog error.
-func HandleResponse(res *http.Response) error {
-	if err := errFromStatusCode(res.StatusCode); err != nil {
+// addMetadataToErr adds the request-id and request-url fields in the metadata map for the error.
+func addMetadataToErr(err error, res *http.Response) error {
+	snykErr := snyk_errors.Error{}
+	if !errors.As(err, &snykErr) {
 		return err
 	}
 
-	return nil
-}
-
-func (rm ResponseMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
-	res, err := rm.next.RoundTrip(req)
-
-	if err != nil {
-		return res, err
+	if snykErr.Meta == nil {
+		snykErr.Meta = make(map[string]any)
 	}
 
-	err = HandleResponse(res)
+	snykErr.Meta["request-id"] = res.Request.Header.Get("snyk-request-id")
+	snykErr.Meta["request-path"] = res.Request.URL.Path
 
-	if rm.errHandler != nil {
-		err = rm.errHandler(err, res.Request.Context())
-	}
-
-	// RoundTrip should return one or the other.
-	if err != nil {
-		res = nil
-	}
-
-	return res, err
+	return snykErr
 }

--- a/pkg/networking/middleware/response.go
+++ b/pkg/networking/middleware/response.go
@@ -2,9 +2,13 @@ package middleware
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/snyk/error-catalog-golang-public/snyk"
+	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 )
 
 type ResponseMiddleware struct {
@@ -16,6 +20,28 @@ func NewReponseMiddleware(roundTriper http.RoundTripper, errHandler func(error, 
 	return &ResponseMiddleware{
 		next:       roundTriper,
 		errHandler: errHandler,
+	}
+}
+
+func errFromResponse(res *http.Response) error {
+	if res.StatusCode >= 200 && res.StatusCode < 300 {
+		return nil
+	}
+
+	if err := errFromStatusCode(res.StatusCode); err != nil {
+		return err
+	}
+
+	if err := errFromJSONAPI(res); err != nil {
+		return err
+	}
+
+	return snyk_errors.Error{
+		Title:       "Unsuccessful network request",
+		Description: "A network request failed because with the resulting status code.",
+		StatusCode:  res.StatusCode,
+		Detail:      "Use the `-d` flag to inspect the request and response.",
+		Level:       "error",
 	}
 }
 
@@ -32,6 +58,18 @@ func errFromStatusCode(code int) error {
 	}
 }
 
+func errFromJSONAPI(res *http.Response) error {
+	snykErr := &jsonAPIErroResponse{}
+	defer res.Body.Close()
+
+	err := json.NewDecoder(res.Body).Decode(snykErr)
+	if err != nil {
+		return nil
+	}
+
+	return snykErr.ToErrorCatalog()
+}
+
 func (rm ResponseMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 	res, err := rm.next.RoundTrip(req)
 
@@ -39,7 +77,7 @@ func (rm ResponseMiddleware) RoundTrip(req *http.Request) (*http.Response, error
 		return nil, err
 	}
 
-	err = errFromStatusCode(res.StatusCode)
+	err = errFromResponse(res)
 
 	if rm.errHandler != nil {
 		err = rm.errHandler(err, res.Request.Context())
@@ -51,4 +89,35 @@ func (rm ResponseMiddleware) RoundTrip(req *http.Request) (*http.Response, error
 	}
 
 	return res, err
+}
+
+type jsonAPIErroResponse struct {
+	Errors []jsonAPIError `json:"errors"`
+}
+
+type jsonAPIError struct {
+	Detail string `json:"detail,omitempty"`
+	Status string `json:"status,omitempty"`
+	Title  string `json:"title,omitempty"`
+	Code   string `json:"code,omitempty"`
+}
+
+func (jar *jsonAPIErroResponse) ToErrorCatalog() error {
+	if len(jar.Errors) == 0 {
+		return nil
+	}
+
+	jsonErr := jar.Errors[0]
+	fmt.Println(jsonErr)
+	statusCode, err := strconv.Atoi(jsonErr.Status)
+	if err != nil {
+		statusCode = 0
+	}
+
+	return snyk_errors.Error{
+		Title:      jsonErr.Title,
+		Detail:     jsonErr.Detail,
+		StatusCode: statusCode,
+		ErrorCode:  jsonErr.Code,
+	}
 }

--- a/pkg/networking/middleware/response.go
+++ b/pkg/networking/middleware/response.go
@@ -1,18 +1,18 @@
 package middleware
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/snyk/error-catalog-golang-public/snyk"
+	networktypes "github.com/snyk/go-application-framework/pkg/networking/network_types"
 )
 
 type ResponseMiddleware struct {
 	next       http.RoundTripper
-	errHandler func(error, context.Context) error
+	errHandler networktypes.ErrorHandlerFunc
 }
 
-func NewReponseMiddleware(roundTriper http.RoundTripper, errHandler func(error, context.Context) error) *ResponseMiddleware {
+func NewReponseMiddleware(roundTriper http.RoundTripper, errHandler networktypes.ErrorHandlerFunc) *ResponseMiddleware {
 	return &ResponseMiddleware{
 		next:       roundTriper,
 		errHandler: errHandler,

--- a/pkg/networking/middleware/response.go
+++ b/pkg/networking/middleware/response.go
@@ -1,0 +1,54 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/snyk/error-catalog-golang-public/snyk"
+)
+
+type ResponseMiddleware struct {
+	next       http.RoundTripper
+	errHandler func(error, context.Context) error
+}
+
+func NewReponseMiddleware(roundTriper http.RoundTripper, errHandler func(error, context.Context) error) *ResponseMiddleware {
+	return &ResponseMiddleware{
+		next:       roundTriper,
+		errHandler: errHandler,
+	}
+}
+
+func errFromStatusCode(code int) error {
+	switch code {
+	case http.StatusUnauthorized:
+		return snyk.NewUnauthorisedError("Use `snyk auth` to authenticate.")
+	case http.StatusBadRequest:
+		return snyk.NewBadRequestError("The request cannot be processed.")
+	case http.StatusInternalServerError:
+		return snyk.NewServerError("Internal server error.")
+	default:
+		return nil
+	}
+}
+
+func (rm ResponseMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
+	res, err := rm.next.RoundTrip(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = errFromStatusCode(res.StatusCode)
+
+	if rm.errHandler != nil {
+		err = rm.errHandler(err, res.Request.Context())
+	}
+
+	// RoundTrip should return one or the other.
+	if err != nil {
+		res = nil
+	}
+
+	return res, err
+}

--- a/pkg/networking/middleware/response.go
+++ b/pkg/networking/middleware/response.go
@@ -107,7 +107,7 @@ func (jar *jsonAPIErroResponse) ToErrorCatalog() error {
 	}
 
 	jsonErr := jar.Errors[0]
-	
+
 	statusCode, err := strconv.Atoi(jsonErr.Status)
 	if err != nil {
 		statusCode = 0

--- a/pkg/networking/middleware/response.go
+++ b/pkg/networking/middleware/response.go
@@ -2,12 +2,9 @@ package middleware
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"strconv"
 
 	"github.com/snyk/error-catalog-golang-public/snyk"
-	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 )
 
 type ResponseMiddleware struct {
@@ -22,29 +19,8 @@ func NewReponseMiddleware(roundTriper http.RoundTripper, errHandler func(error, 
 	}
 }
 
-func errFromResponse(res *http.Response) error {
-	if res.StatusCode >= 200 && res.StatusCode < 300 {
-		return nil
-	}
-
-	if err := errFromStatusCode(res.StatusCode); err != nil {
-		return err
-	}
-
-	if err := errFromJSONAPI(res); err != nil {
-		return err
-	}
-
-	return snyk_errors.Error{
-		Title:       "Unsuccessful network request",
-		Description: "A network request failed because with the resulting status code.",
-		StatusCode:  res.StatusCode,
-		Detail:      "Use the `-d` flag to inspect the request and response.",
-		Level:       "error",
-	}
-}
-
-func errFromStatusCode(code int) error {
+// ErrFromStatusCode matches the providede status code to an Error Catalog error. If no match is found, nil is returned.
+func ErrFromStatusCode(code int) error {
 	switch code {
 	case http.StatusUnauthorized:
 		return snyk.NewUnauthorisedError("Use `snyk auth` to authenticate.")
@@ -57,26 +33,14 @@ func errFromStatusCode(code int) error {
 	}
 }
 
-func errFromJSONAPI(res *http.Response) error {
-	snykErr := &jsonAPIErroResponse{}
-	defer res.Body.Close()
-
-	err := json.NewDecoder(res.Body).Decode(snykErr)
-	if err != nil {
-		return nil
-	}
-
-	return snykErr.ToErrorCatalog()
-}
-
 func (rm ResponseMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 	res, err := rm.next.RoundTrip(req)
 
 	if err != nil {
-		return nil, err
+		return res, err
 	}
 
-	err = errFromResponse(res)
+	err = ErrFromStatusCode(res.StatusCode)
 
 	if rm.errHandler != nil {
 		err = rm.errHandler(err, res.Request.Context())
@@ -88,35 +52,4 @@ func (rm ResponseMiddleware) RoundTrip(req *http.Request) (*http.Response, error
 	}
 
 	return res, err
-}
-
-type jsonAPIErroResponse struct {
-	Errors []jsonAPIError `json:"errors"`
-}
-
-type jsonAPIError struct {
-	Detail string `json:"detail,omitempty"`
-	Status string `json:"status,omitempty"`
-	Title  string `json:"title,omitempty"`
-	Code   string `json:"code,omitempty"`
-}
-
-func (jar *jsonAPIErroResponse) ToErrorCatalog() error {
-	if len(jar.Errors) == 0 {
-		return nil
-	}
-
-	jsonErr := jar.Errors[0]
-
-	statusCode, err := strconv.Atoi(jsonErr.Status)
-	if err != nil {
-		statusCode = 0
-	}
-
-	return snyk_errors.Error{
-		Title:      jsonErr.Title,
-		Detail:     jsonErr.Detail,
-		StatusCode: statusCode,
-		ErrorCode:  jsonErr.Code,
-	}
 }

--- a/pkg/networking/middleware/response.go
+++ b/pkg/networking/middleware/response.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strconv"
 
@@ -108,7 +107,7 @@ func (jar *jsonAPIErroResponse) ToErrorCatalog() error {
 	}
 
 	jsonErr := jar.Errors[0]
-	fmt.Println(jsonErr)
+	
 	statusCode, err := strconv.Atoi(jsonErr.Status)
 	if err != nil {
 		statusCode = 0

--- a/pkg/networking/middleware/response_test.go
+++ b/pkg/networking/middleware/response_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/networking/middleware"
 	"github.com/stretchr/testify/assert"
 )
@@ -35,16 +36,22 @@ func Test_ResponseMiddleware(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	rt := middleware.NewReponseMiddleware(http.DefaultTransport, nil)
-
 	t.Run("no error for 2xx", func(t *testing.T) {
-		req := buildRequest(server.URL)
-		_, err := rt.RoundTrip(req)
+		config := getBaseConfig()
+		rt := middleware.NewReponseMiddleware(http.DefaultTransport, config, nil)
 
+		req := buildRequest(server.URL)
+		res, err := rt.RoundTrip(req)
+
+		assert.NotNil(t, res)
 		assert.Nil(t, err)
 	})
 
 	t.Run("proper errors for matching status codes", func(t *testing.T) {
+		config := getBaseConfig()
+		config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, []string{server.URL})
+		rt := middleware.NewReponseMiddleware(http.DefaultTransport, config, nil)
+
 		codes := []int{400, 401, 500}
 		for _, code := range codes {
 			snykErr := snyk_errors.Error{}
@@ -55,41 +62,72 @@ func Test_ResponseMiddleware(t *testing.T) {
 			assert.Nil(t, res)
 			assert.ErrorAs(t, err, &snykErr)
 			assert.Equal(t, code, snykErr.StatusCode)
+
+			// observability metadata
+			assert.Equal(t, snykErr.Meta["request-id"], "1234")
+			assert.Equal(t, snykErr.Meta["request-path"], fmt.Sprintf("/%d", code))
 		}
 	})
 
 	t.Run("no error if no status code matches", func(t *testing.T) {
-		req := buildRequest(server.URL + "/404")
-		_, err := rt.RoundTrip(req)
+		config := getBaseConfig()
+		config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, []string{server.URL})
 
+		rt := middleware.NewReponseMiddleware(http.DefaultTransport, config, nil)
+		req := buildRequest(server.URL + "/404")
+		res, err := rt.RoundTrip(req)
+
+		assert.NotNil(t, res)
 		assert.Nil(t, err)
+	})
+
+	t.Run("shoud not intercept external urls", func(t *testing.T) {
+		config := getBaseConfig()
+
+		// server url is not in the base config, so it's not intercepted
+		rt := middleware.NewReponseMiddleware(http.DefaultTransport, config, nil)
+		req := buildRequest(server.URL + "/401")
+		res, err := rt.RoundTrip(req)
+
+		assert.NotNil(t, res)
+		assert.Equal(t, res.StatusCode, http.StatusUnauthorized)
+		assert.NoError(t, err)
 	})
 }
 
 func Test_ResponseMiddleware_WithErrorHandler(t *testing.T) {
 	expectedErr := errors.New("Big oopsie in the middleware")
-
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
+	config := getBaseConfig()
+	config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, []string{server.URL})
 
-	rt := middleware.NewReponseMiddleware(http.DefaultTransport, func(err error, ctx context.Context) error {
+	rt := middleware.NewReponseMiddleware(http.DefaultTransport, config, func(err error, ctx context.Context) error {
 		return expectedErr // this will override error parameter
 	})
 
 	req := buildRequest(server.URL)
 	res, err := rt.RoundTrip(req)
+
 	assert.Nil(t, res)
-	assert.ErrorAs(t, err, &expectedErr)
+	assert.ErrorIs(t, err, expectedErr)
 }
 
 func buildRequest(url string) *http.Request {
 	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
+	req.Header.Set("snyk-request-id", "1234")
 	if err != nil {
 		panic(err)
 	}
 
 	return req
+}
+
+func getBaseConfig() configuration.Configuration {
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
+	config.Set(configuration.API_URL, "https://api.snyk.io")
+	return config
 }

--- a/pkg/networking/middleware/response_test.go
+++ b/pkg/networking/middleware/response_test.go
@@ -58,25 +58,11 @@ func Test_ResponseMiddleware(t *testing.T) {
 		}
 	})
 
-	t.Run("error from JSON API response", func(t *testing.T) {
-		req := buildRequest(server.URL + "/jsonapi")
-		_, err := rt.RoundTrip(req)
-
-		snykErr := snyk_errors.Error{}
-		assert.NotNil(t, err)
-		assert.ErrorAs(t, err, &snykErr)
-		assert.Equal(t, http.StatusProxyAuthRequired, snykErr.StatusCode)
-		assert.Equal(t, "Proxy auth required", snykErr.Detail)
-	})
-
-	t.Run("fallback error if no status code", func(t *testing.T) {
+	t.Run("no error if no status code matches", func(t *testing.T) {
 		req := buildRequest(server.URL + "/404")
 		_, err := rt.RoundTrip(req)
 
-		snykErr := snyk_errors.Error{}
-		assert.ErrorAs(t, err, &snykErr)
-		assert.Equal(t, http.StatusNotFound, snykErr.StatusCode)
-		assert.Equal(t, "Unsuccessful network request", snykErr.Title)
+		assert.Nil(t, err)
 	})
 }
 

--- a/pkg/networking/middleware/response_test.go
+++ b/pkg/networking/middleware/response_test.go
@@ -46,15 +46,16 @@ func Test_ResponseMiddleware(t *testing.T) {
 	})
 
 	t.Run("returns Erorr Catalog errors for matching status codes", func(t *testing.T) {
-		endpoints := []int{400, 401, 500}
-		for _, endpoint := range endpoints {
-			url := fmt.Sprintf("%s/%d", server.URL, endpoint)
+		codes := []int{400, 401, 500}
+		for _, code := range codes {
+			snykErr := snyk_errors.Error{}
+			url := fmt.Sprintf("%s/%d", server.URL, code)
 			req := buildRequest(url)
 
 			res, err := rt.RoundTrip(req)
 			assert.Nil(t, res)
-			assert.ErrorAs(t, err, &snyk_errors.Error{})
-			assert.Equal(t, err.(snyk_errors.Error).StatusCode, endpoint)
+			assert.ErrorAs(t, err, &snykErr)
+			assert.Equal(t, snykErr.StatusCode, code)
 		}
 	})
 }

--- a/pkg/networking/network_types/error_handler.go
+++ b/pkg/networking/network_types/error_handler.go
@@ -1,0 +1,5 @@
+package networktypes
+
+import "context"
+
+type ErrorHandlerFunc func(err error, ctx context.Context) error

--- a/pkg/networking/networking.go
+++ b/pkg/networking/networking.go
@@ -214,7 +214,7 @@ func (n *networkImpl) getUnauthorizedRoundTripper() http.RoundTripper {
 	transport := http.DefaultTransport.(*http.Transport) //nolint:forcetypeassert // panic here is reasonable
 	var crt http.RoundTripper = n.configureRoundTripper(transport)
 	if n.errorHandler != nil {
-		crt = middleware.NewReponseMiddleware(crt, n.errorHandler)
+		crt = middleware.NewReponseMiddleware(crt, n.config, n.errorHandler)
 	}
 	rt := defaultHeadersRoundTripper{
 		networkAccess:            n,

--- a/pkg/networking/networking.go
+++ b/pkg/networking/networking.go
@@ -39,6 +39,8 @@ type NetworkAccess interface {
 	AddRootCAs(pemFileLocation string) error
 	// AddErrorHandler registers an error handler for the underlying http.RoundTripper.
 	AddErrorHandler(func(err error, ctx context.Context) error)
+	// GetErrorHandler returns the registered error handler.
+	GetErrorHandler() func(err error, ctx context.Context) error
 	// GetAuthenticator returns the authenticator.
 	GetAuthenticator() auth.Authenticator
 
@@ -168,6 +170,10 @@ func (n *networkImpl) AddHeaderField(key, value string) {
 // that maps non 2xx status codes to Error Catalog errors.
 func (n *networkImpl) AddErrorHandler(handler func(err error, ctx context.Context) error) {
 	n.errorHandler = handler
+}
+
+func (n *networkImpl) GetErrorHandler() func(err error, ctx context.Context) error {
+	return n.errorHandler
 }
 
 // AddDynamicHeaderField enables to define functions that will be invoked when a header field is added to a request.


### PR DESCRIPTION
- Adds a new method to the NetworkAccess interface for registering an error handler
- Implements the handler for 401 unauthorized status code

Ticket: [CLI-575](https://snyksec.atlassian.net/browse/CLI-575)

[CLI-575]: https://snyksec.atlassian.net/browse/CLI-575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ