### PR TITLE
fix: clarify wording on config check failure

### DIFF
--- a/pkg/local_workflows/config_utils/sanitycheck.go
+++ b/pkg/local_workflows/config_utils/sanitycheck.go
@@ -10,6 +10,8 @@ import (
 	"github.com/snyk/go-application-framework/pkg/utils"
 )
 
+const configCheckMismatchedUrlMsg = "\"Using API Url from authentication material, therefore ignoring the configured %s value.\""
+
 type SanityCheckResult struct {
 	Description string
 }
@@ -37,7 +39,7 @@ func CheckSanity(config configuration.Configuration) []SanityCheckResult {
 
 			if differentApiUrlsSpecified {
 				result = append(result, SanityCheckResult{
-					Description: fmt.Sprintf("Using API Url from authentication material, therefore ignoring the specified %s.", strings.ToUpper(strings.Join(keysSpecified, ", "))),
+					Description: fmt.Sprintf(configCheckMismatchedUrlMsg, strings.ToUpper(strings.Join(keysSpecified, ", "))),
 				})
 			}
 		}

--- a/pkg/local_workflows/config_utils/sanitycheck_test.go
+++ b/pkg/local_workflows/config_utils/sanitycheck_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,7 +42,7 @@ func Test_CheckSanity_ApiUrl(t *testing.T) {
 
 		result := CheckSanity(config)
 
-		expectedDescription := "Using API Url from authentication material, therefore ignoring the specified"
+		expectedDescription := fmt.Sprintf(configCheckMismatchedUrlMsg, "SNYK_API")
 		assert.Len(t, result, 1)
 		assert.Contains(t, result[0].Description, expectedDescription)
 	})


### PR DESCRIPTION
Adjust the wording for the config check to make it easier to understand. 

[CLI-564]

[CLI-564]: https://snyksec.atlassian.net/browse/CLI-564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ