### PR TITLE
fix: add default oss product for monitor as well

### DIFF
--- a/pkg/instrumentation/categories.go
+++ b/pkg/instrumentation/categories.go
@@ -67,7 +67,7 @@ func determineCategoryFromArgs(args []string, knownCommands []string, flagsAllow
 				flags = append(flags, strings.ToLower(flagName))
 			}
 		} else if slices.Contains(knownCommands, arg) {
-			if len(commands) == 0 && arg == "test" {
+			if len(commands) == 0 && (arg == "test" || arg == "monitor") {
 				result = append(commands, productFallback)
 			}
 

--- a/pkg/instrumentation/categories_test.go
+++ b/pkg/instrumentation/categories_test.go
@@ -16,6 +16,7 @@ func TestCategorizeCliArgs(t *testing.T) {
 	}{
 		// Happy Path Tests (Valid Commands & Flags)
 		{"OSS test", []string{"snyk", "test"}, []string{"oss", "test"}, nil},
+		{"OSS test", []string{"snyk", "monitor"}, []string{"oss", "monitor"}, nil},
 		{"OSS test with unmanaged flag", []string{"snyk", "test", "--unmanaged"}, []string{"oss", "test", "unmanaged"}, nil},
 		{"Code test", []string{"snyk", "code", "test"}, []string{"code", "test"}, nil},
 		{"IAC describe", []string{"snyk", "iac", "describe"}, []string{"iac", "describe"}, nil},

--- a/pkg/instrumentation/categories_test.go
+++ b/pkg/instrumentation/categories_test.go
@@ -16,7 +16,7 @@ func TestCategorizeCliArgs(t *testing.T) {
 	}{
 		// Happy Path Tests (Valid Commands & Flags)
 		{"OSS test", []string{"snyk", "test"}, []string{"oss", "test"}, nil},
-		{"OSS test", []string{"snyk", "monitor"}, []string{"oss", "monitor"}, nil},
+		{"OSS monitor", []string{"snyk", "monitor"}, []string{"oss", "monitor"}, nil},
 		{"OSS test with unmanaged flag", []string{"snyk", "test", "--unmanaged"}, []string{"oss", "test", "unmanaged"}, nil},
 		{"Code test", []string{"snyk", "code", "test"}, []string{"code", "test"}, nil},
 		{"IAC describe", []string{"snyk", "iac", "describe"}, []string{"iac", "describe"}, nil},


### PR DESCRIPTION
The current implementation was missing the default product for monitor commands.