### PR TITLE
chore: add cross-region-routing flag

### DIFF
--- a/pkg/auth/oauth2authenticator.go
+++ b/pkg/auth/oauth2authenticator.go
@@ -353,7 +353,8 @@ func (o *oAuth2Authenticator) authenticateWithAuthorizationCode() error {
 			oauth2.SetAuthURLParam("code_challenge_method", "S256"),
 			oauth2.SetAuthURLParam("response_type", "code"),
 			oauth2.SetAuthURLParam("scope", "offline_access"),
-			oauth2.SetAuthURLParam("version", "2021-08-11~experimental"))
+			oauth2.SetAuthURLParam("version", "2021-08-11~experimental"),
+			oauth2.SetAuthURLParam("cross_region_routing", "true"))
 
 		// launch browser
 		go o.openBrowserFunc(authCodeUrl)


### PR DESCRIPTION
This adds `cross_region_routing=true` to the `oauth2/authorize` query.