### PR TITLE
feat: introduce option to disable creating empty sarif files

### DIFF
--- a/pkg/local_workflows/output_workflow.go
+++ b/pkg/local_workflows/output_workflow.go
@@ -32,6 +32,9 @@ func InitOutputWorkflow(engine workflow.Engine) error {
 	outputConfig.Bool(configuration.FLAG_INCLUDE_IGNORES, false, "Include ignored findings in the output")
 	outputConfig.String(configuration.FLAG_SEVERITY_THRESHOLD, "low", "Severity threshold for findings to be included in the output")
 
+	// set default values for configuration values
+	engine.GetConfiguration().AddDefaultValue(output_workflow.OUTPUT_CONFIG_WRITE_EMPTY_FILE, configuration.StandardDefaultValueFunction(true))
+
 	entry, err := engine.Register(WORKFLOWID_OUTPUT_WORKFLOW, workflow.ConfigurationOptionsFromFlagset(outputConfig), outputWorkflowEntryPointImpl)
 	entry.SetVisibility(false)
 

--- a/pkg/local_workflows/output_workflow/constants.go
+++ b/pkg/local_workflows/output_workflow/constants.go
@@ -1,10 +1,11 @@
 package output_workflow
 
 const (
-	OUTPUT_CONFIG_KEY_JSON       = "json"
-	OUTPUT_CONFIG_KEY_JSON_FILE  = "json-file-output"
-	OUTPUT_CONFIG_KEY_SARIF      = "sarif"
-	OUTPUT_CONFIG_KEY_SARIF_FILE = "sarif-file-output"
-	OUTPUT_CONFIG_TEMPLATE_FILE  = "internal_template_file"
-	DEFAULT_WRITER               = "default"
+	OUTPUT_CONFIG_KEY_JSON         = "json"
+	OUTPUT_CONFIG_KEY_JSON_FILE    = "json-file-output"
+	OUTPUT_CONFIG_KEY_SARIF        = "sarif"
+	OUTPUT_CONFIG_KEY_SARIF_FILE   = "sarif-file-output"
+	OUTPUT_CONFIG_TEMPLATE_FILE    = "internal_template_file"
+	DEFAULT_WRITER                 = "default"
+	OUTPUT_CONFIG_WRITE_EMPTY_FILE = "internal_write_empty_file"
 )

--- a/pkg/local_workflows/output_workflow/constants.go
+++ b/pkg/local_workflows/output_workflow/constants.go
@@ -6,6 +6,6 @@ const (
 	OUTPUT_CONFIG_KEY_SARIF        = "sarif"
 	OUTPUT_CONFIG_KEY_SARIF_FILE   = "sarif-file-output"
 	OUTPUT_CONFIG_TEMPLATE_FILE    = "internal_template_file"
-	DEFAULT_WRITER                 = "default"
 	OUTPUT_CONFIG_WRITE_EMPTY_FILE = "internal_write_empty_file"
+	DEFAULT_WRITER                 = "default"
 )

--- a/pkg/local_workflows/output_workflow/findings_model_tools.go
+++ b/pkg/local_workflows/output_workflow/findings_model_tools.go
@@ -102,10 +102,12 @@ func getWritersToUse(config configuration.Configuration, outputDestination iUtil
 func getSarifFileRenderer(config configuration.Configuration, findings []*local_models.LocalFinding) (*WriterEntry, error) {
 	outputFileName := config.GetString(OUTPUT_CONFIG_KEY_SARIF_FILE)
 	if len(outputFileName) == 0 {
+		//nolint:nilnil // returning a nil writer is a valid case based on the configuration and is not an error case
 		return nil, nil
 	}
 
 	if !config.GetBool(OUTPUT_CONFIG_WRITE_EMPTY_FILE) && getTotalNumberOfFindings(findings) == 0 {
+		//nolint:nilnil // returning a nil writer is a valid case based on the configuration and is not an error case
 		return nil, nil
 	}
 
@@ -121,7 +123,6 @@ func getSarifFileRenderer(config configuration.Configuration, findings []*local_
 		closer:    func() error { return file.Close() },
 	}
 	return writer, nil
-
 }
 
 func useRendererWith(name string, wEntry *WriterEntry, debugLogger *zerolog.Logger, findings []*local_models.LocalFinding, config configuration.Configuration, invocation workflow.InvocationContext) {

--- a/pkg/local_workflows/output_workflow/findings_model_tools.go
+++ b/pkg/local_workflows/output_workflow/findings_model_tools.go
@@ -53,7 +53,19 @@ func getListOfFindings(input []workflow.Data, debugLogger *zerolog.Logger) (find
 	return findings, remainingData
 }
 
-func getWritersToUse(config configuration.Configuration, outputDestination iUtils.OutputDestination) (map[string]*WriterEntry, error) {
+func getTotalNumberOfFindings(findings []*local_models.LocalFinding) uint32 {
+	if findings == nil {
+		return 0
+	}
+
+	var count uint32
+	for i := range findings {
+		count = count + findings[i].Summary.Counts.Count
+	}
+	return count
+}
+
+func getWritersToUse(config configuration.Configuration, outputDestination iUtils.OutputDestination, findings []*local_models.LocalFinding) (map[string]*WriterEntry, error) {
 	writerMap := map[string]*WriterEntry{
 		DEFAULT_WRITER: {
 			writer:    outputDestination.GetWriter(),
@@ -66,19 +78,13 @@ func getWritersToUse(config configuration.Configuration, outputDestination iUtil
 		},
 	}
 
-	outputFileName := config.GetString(OUTPUT_CONFIG_KEY_SARIF_FILE)
-	if len(outputFileName) > 0 {
-		file, fileErr := os.OpenFile(outputFileName, os.O_WRONLY|os.O_CREATE, 0644)
-		if fileErr != nil {
-			return nil, fileErr
-		}
+	sarifWriter, err := getSarifFileRenderer(config, findings)
+	if err != nil {
+		return writerMap, err
+	}
 
-		writerMap[OUTPUT_CONFIG_KEY_SARIF_FILE] = &WriterEntry{
-			writer:    file,
-			mimeType:  presenters.ApplicationSarifMimeType,
-			templates: presenters.ApplicationSarifTemplates,
-			closer:    func() error { return file.Close() },
-		}
+	if sarifWriter != nil {
+		writerMap[OUTPUT_CONFIG_KEY_SARIF_FILE] = sarifWriter
 	}
 
 	if config.GetBool(OUTPUT_CONFIG_KEY_SARIF) {
@@ -91,6 +97,31 @@ func getWritersToUse(config configuration.Configuration, outputDestination iUtil
 	}
 
 	return writerMap, nil
+}
+
+func getSarifFileRenderer(config configuration.Configuration, findings []*local_models.LocalFinding) (*WriterEntry, error) {
+	outputFileName := config.GetString(OUTPUT_CONFIG_KEY_SARIF_FILE)
+	if len(outputFileName) == 0 {
+		return nil, nil
+	}
+
+	if !config.GetBool(OUTPUT_CONFIG_WRITE_EMPTY_FILE) && getTotalNumberOfFindings(findings) == 0 {
+		return nil, nil
+	}
+
+	file, fileErr := os.OpenFile(outputFileName, os.O_WRONLY|os.O_CREATE, 0644)
+	if fileErr != nil {
+		return nil, fileErr
+	}
+
+	writer := &WriterEntry{
+		writer:    file,
+		mimeType:  presenters.ApplicationSarifMimeType,
+		templates: presenters.ApplicationSarifTemplates,
+		closer:    func() error { return file.Close() },
+	}
+	return writer, nil
+
 }
 
 func useRendererWith(name string, wEntry *WriterEntry, debugLogger *zerolog.Logger, findings []*local_models.LocalFinding, config configuration.Configuration, invocation workflow.InvocationContext) {
@@ -135,7 +166,7 @@ func HandleContentTypeFindingsModel(input []workflow.Data, invocation workflow.I
 	threadCount := max(int64(config.GetInt(configuration.MAX_THREADS)), 1)
 	debugLogger.Info().Msgf("Thread count: %d", threadCount)
 
-	writerMap, err := getWritersToUse(config, outputDestination)
+	writerMap, err := getWritersToUse(config, outputDestination, findings)
 	if err != nil {
 		debugLogger.Err(err).Msg("Failed to initialize all required writers")
 	}

--- a/pkg/local_workflows/output_workflow/findings_model_tools_test.go
+++ b/pkg/local_workflows/output_workflow/findings_model_tools_test.go
@@ -64,7 +64,7 @@ func Test_getSarifFileRenderer(t *testing.T) {
 		renderer, err := getSarifFileRenderer(config, localFindings)
 		assert.NoError(t, err)
 		assert.NotNil(t, renderer)
-		renderer.closer()
+		assert.NoError(t, renderer.closer())
 	})
 
 	t.Run("write non empty file", func(t *testing.T) {
@@ -75,7 +75,7 @@ func Test_getSarifFileRenderer(t *testing.T) {
 		renderer, err := getSarifFileRenderer(config, localFindings)
 		assert.NoError(t, err)
 		assert.NotNil(t, renderer)
-		renderer.closer()
+		assert.NoError(t, renderer.closer())
 	})
 
 	t.Run("don't write empty file", func(t *testing.T) {

--- a/pkg/local_workflows/output_workflow/findings_model_tools_test.go
+++ b/pkg/local_workflows/output_workflow/findings_model_tools_test.go
@@ -59,7 +59,7 @@ func Test_getSarifFileRenderer(t *testing.T) {
 	t.Run("write empty file", func(t *testing.T) {
 		localFindings := getLocalFindingsSkeleton(t, 0)
 		config := configuration.NewWithOpts()
-		config.Set(OUTPUT_CONFIG_KEY_SARIF_FILE, "somefile")
+		config.Set(OUTPUT_CONFIG_KEY_SARIF_FILE, t.TempDir()+"/somefile")
 		config.Set(OUTPUT_CONFIG_WRITE_EMPTY_FILE, true)
 		renderer, err := getSarifFileRenderer(config, localFindings)
 		assert.NoError(t, err)
@@ -69,7 +69,7 @@ func Test_getSarifFileRenderer(t *testing.T) {
 	t.Run("write non empty file", func(t *testing.T) {
 		localFindings := getLocalFindingsSkeleton(t, 1)
 		config := configuration.NewWithOpts()
-		config.Set(OUTPUT_CONFIG_KEY_SARIF_FILE, "somefile")
+		config.Set(OUTPUT_CONFIG_KEY_SARIF_FILE, t.TempDir()+"/somefile")
 		config.Set(OUTPUT_CONFIG_WRITE_EMPTY_FILE, false)
 		renderer, err := getSarifFileRenderer(config, localFindings)
 		assert.NoError(t, err)
@@ -79,7 +79,7 @@ func Test_getSarifFileRenderer(t *testing.T) {
 	t.Run("don't write empty file", func(t *testing.T) {
 		localFindings := getLocalFindingsSkeleton(t, 0)
 		config := configuration.NewWithOpts()
-		config.Set(OUTPUT_CONFIG_KEY_SARIF_FILE, "somefile")
+		config.Set(OUTPUT_CONFIG_KEY_SARIF_FILE, t.TempDir()+"/somefile")
 		config.Set(OUTPUT_CONFIG_WRITE_EMPTY_FILE, false)
 		renderer, err := getSarifFileRenderer(config, localFindings)
 		assert.NoError(t, err)

--- a/pkg/local_workflows/output_workflow/findings_model_tools_test.go
+++ b/pkg/local_workflows/output_workflow/findings_model_tools_test.go
@@ -1,0 +1,88 @@
+package output_workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/local_models"
+)
+
+func getLocalFindingsSkeleton(t *testing.T, count uint32) []*local_models.LocalFinding {
+	t.Helper()
+
+	localFindings := make([]*local_models.LocalFinding, 0)
+	localFindings = append(localFindings, &local_models.LocalFinding{
+		Summary: struct {
+			Artifacts int                             `json:"artifacts"`
+			Counts    local_models.TypesFindingCounts `json:"counts"`
+			Coverage  []local_models.TypesCoverage    `json:"coverage"`
+			Path      string                          `json:"path"`
+			Type      string                          `json:"type"`
+		}{},
+	})
+	localFindings[0].Summary.Counts.Count = count
+	return localFindings
+}
+
+func Test_getTotalNumberOfFindings(t *testing.T) {
+	t.Run("nil findings", func(t *testing.T) {
+		expectedCount := uint32(0)
+		var localFindings []*local_models.LocalFinding
+
+		// method under test
+		actualCount := getTotalNumberOfFindings(localFindings)
+		assert.Equal(t, expectedCount, actualCount)
+	})
+
+	t.Run("count multiple findings", func(t *testing.T) {
+		expectedCount := uint32(8)
+		localFindings := getLocalFindingsSkeleton(t, 2)
+		localFindings = append(localFindings, getLocalFindingsSkeleton(t, 6)...)
+
+		// method under test
+		actualCount := getTotalNumberOfFindings(localFindings)
+		assert.Equal(t, expectedCount, actualCount)
+	})
+}
+
+func Test_getSarifFileRenderer(t *testing.T) {
+	t.Run("no file path specified", func(t *testing.T) {
+		localFindings := getLocalFindingsSkeleton(t, 3)
+		config := configuration.NewWithOpts()
+		renderer, err := getSarifFileRenderer(config, localFindings)
+		assert.NoError(t, err)
+		assert.Nil(t, renderer)
+	})
+
+	t.Run("write empty file", func(t *testing.T) {
+		localFindings := getLocalFindingsSkeleton(t, 0)
+		config := configuration.NewWithOpts()
+		config.Set(OUTPUT_CONFIG_KEY_SARIF_FILE, "somefile")
+		config.Set(OUTPUT_CONFIG_WRITE_EMPTY_FILE, true)
+		renderer, err := getSarifFileRenderer(config, localFindings)
+		assert.NoError(t, err)
+		assert.NotNil(t, renderer)
+	})
+
+	t.Run("write non empty file", func(t *testing.T) {
+		localFindings := getLocalFindingsSkeleton(t, 1)
+		config := configuration.NewWithOpts()
+		config.Set(OUTPUT_CONFIG_KEY_SARIF_FILE, "somefile")
+		config.Set(OUTPUT_CONFIG_WRITE_EMPTY_FILE, false)
+		renderer, err := getSarifFileRenderer(config, localFindings)
+		assert.NoError(t, err)
+		assert.NotNil(t, renderer)
+	})
+
+	t.Run("don't write empty file", func(t *testing.T) {
+		localFindings := getLocalFindingsSkeleton(t, 0)
+		config := configuration.NewWithOpts()
+		config.Set(OUTPUT_CONFIG_KEY_SARIF_FILE, "somefile")
+		config.Set(OUTPUT_CONFIG_WRITE_EMPTY_FILE, false)
+		renderer, err := getSarifFileRenderer(config, localFindings)
+		assert.NoError(t, err)
+		assert.Nil(t, renderer)
+	})
+}

--- a/pkg/local_workflows/output_workflow/findings_model_tools_test.go
+++ b/pkg/local_workflows/output_workflow/findings_model_tools_test.go
@@ -64,6 +64,7 @@ func Test_getSarifFileRenderer(t *testing.T) {
 		renderer, err := getSarifFileRenderer(config, localFindings)
 		assert.NoError(t, err)
 		assert.NotNil(t, renderer)
+		renderer.closer()
 	})
 
 	t.Run("write non empty file", func(t *testing.T) {
@@ -74,6 +75,7 @@ func Test_getSarifFileRenderer(t *testing.T) {
 		renderer, err := getSarifFileRenderer(config, localFindings)
 		assert.NoError(t, err)
 		assert.NotNil(t, renderer)
+		renderer.closer()
 	})
 
 	t.Run("don't write empty file", func(t *testing.T) {


### PR DESCRIPTION
In some situations the output workflow might not be required to create a file if there is no or no actual data given, for example when the list of findings is empty, it might not make sense to write a sarif file.

The example behaviour is a specific behaviour of the legacy CLI and is therefore considered a configuration option.