### PR TITLE
chore: refactor to use exposed method

### DIFF
--- a/pkg/networking/middleware/response.go
+++ b/pkg/networking/middleware/response.go
@@ -1,13 +1,12 @@
 package middleware
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/snyk/error-catalog-golang-public/snyk"
-	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	networktypes "github.com/snyk/go-application-framework/pkg/networking/network_types"
+	"github.com/snyk/go-application-framework/pkg/utils"
 )
 
 type ResponseMiddleware struct {
@@ -88,26 +87,8 @@ func addRequestDataToErr(err error, res *http.Response) error {
 	reqId := res.Request.Header.Get("snyk-request-id")
 	reqPath := res.Request.URL.Path
 
-	return AddMetaDataToErr(err, map[string]any{
+	return utils.AddMetaDataToErr(err, map[string]any{
 		"request-id":   reqId,
 		"request-path": reqPath,
 	})
-}
-
-// AddMetaDataToErr adds the provided metadata to the Error catalog error's metadata map.
-func AddMetaDataToErr(err error, meta map[string]any) error {
-	snykErr := snyk_errors.Error{}
-	if !errors.As(err, &snykErr) {
-		return err
-	}
-
-	if snykErr.Meta == nil {
-		snykErr.Meta = make(map[string]any)
-	}
-
-	for k, v := range meta {
-		snykErr.Meta[k] = v
-	}
-
-	return snykErr
 }

--- a/pkg/utils/errors.go
+++ b/pkg/utils/errors.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"errors"
+
+	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+)
+
+// AddMetaDataToErr adds the provided metadata to the Error catalog error's metadata map.
+func AddMetaDataToErr(err error, meta map[string]any) error {
+	snykErr := snyk_errors.Error{}
+	if !errors.As(err, &snykErr) {
+		return err
+	}
+
+	for k, v := range meta {
+		snyk_errors.WithMeta(k, v)(&snykErr)
+	}
+
+	return snykErr
+}

--- a/pkg/utils/errors_test.go
+++ b/pkg/utils/errors_test.go
@@ -1,0 +1,39 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddMetaDataToErr(t *testing.T) {
+	t.Run("adds metadata to error catalog error", func(t *testing.T) {
+		err := snyk_errors.Error{
+			ID: "some-id",
+		}
+		meta := map[string]any{
+			"foo": "bar",
+		}
+		errWithMeta := AddMetaDataToErr(err, meta)
+
+		// Type assertion to access the Meta field
+		var snykErr snyk_errors.Error
+		ok := errors.As(errWithMeta, &snykErr)
+		if !ok {
+			t.Fatal("expected errWithMeta to be of type snyk_errors.Error")
+		}
+		assert.Equal(t, meta, snykErr.Meta)
+		assert.Nil(t, err.Meta)
+	})
+
+	t.Run("returns original error if not error catalog error", func(t *testing.T) {
+		err := errors.New("my first error")
+		meta := map[string]any{
+			"foo": "bar",
+		}
+		errWithMeta := AddMetaDataToErr(err, meta)
+		assert.Equal(t, err, errWithMeta)
+	})
+}


### PR DESCRIPTION
**Changes:**

- The `AddMetaDataToErr` function now uses the `snyk_errors.WithMeta` helper function to add metadata to errors. This ensures a consistent approach to metadata handling and avoids potential issues with direct map manipulation.
- Added tests to verify the correct behavior of `AddMetaDataToErr`, including handling different error types and ensuring that the original error is not modified.
- Moves `AddMetaDataToErr` out to generic utils/error directory. 

Benefits:

- Improved consistency: Metadata is now added using a dedicated helper function, ensuring a standardized approach across the codebase.
- Reduced risk of errors: Using `WithMeta` eliminates potential issues with directly modifying the `Meta` map, such as accidentally overwriting existing metadata.
- Enhanced testability: The addition of tests provides better coverage and confidence in the correctness of the metadata handling logic.
- This refactoring improves the reliability and maintainability of the error handling code.
