### PR TITLE
fix: Fix handle partial writing of debug logs

### DIFF
--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -31,6 +31,7 @@ import (
 )
 
 const redactMask string = "***"
+const MAX_WRITE_RETRIES = 10
 
 type ScrubbingLogWriter interface {
 	AddTerm(term string, matchGroup int)
@@ -231,7 +232,7 @@ func internalWrite(dict ScrubbingDict, p []byte, writeFunc func(p []byte) (int, 
 		}
 
 		// circuit breaker
-		if errorsSeen > 10 {
+		if errorsSeen > MAX_WRITE_RETRIES {
 			return len(p), err
 		}
 	}

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -227,7 +227,7 @@ func internalWrite(dict ScrubbingDict, p []byte, writeFunc func(p []byte) (int, 
 		if err != nil {
 			errorsSeen++
 			// exponential backoff
-			time.Sleep(time.Millisecond * time.Duration(errorsSeen*errorsSeen*10))
+			time.Sleep(time.Millisecond * time.Duration(errorsSeen*errorsSeen))
 		}
 
 		// circuit breaker

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -135,7 +135,7 @@ func TestScrubbingIoWriter(t *testing.T) {
 
 	t.Run("handle writer error, all written", func(t *testing.T) {
 		expectedError := fmt.Errorf("something went wrong")
-		expectedData := []byte("djalskjkads")
+		expectedData := make([]byte, MAX_WRITE_RETRIES-3)
 		mockWriter := &mockWriter{
 			Error: expectedError,
 		}
@@ -146,7 +146,8 @@ func TestScrubbingIoWriter(t *testing.T) {
 	})
 	t.Run("handle writer error, not all written", func(t *testing.T) {
 		expectedError := fmt.Errorf("something went wrong")
-		expectedData := []byte("djalskjkadasdfs")
+		expectedData := make([]byte, MAX_WRITE_RETRIES*2)
+
 		mockWriter := &mockWriter{
 			Error:           expectedError,
 			MaxBytesToWrite: 1, // expected data has more than 10 bytes, we have 10 retries, so one should be fine


### PR DESCRIPTION
The change introduces partial writes of the underlying logger used by the scrubbing logger. Previously partial writes would have caused a loss of log information.