### PR TITLE
fix: fix backward compatibility issue in sarif driver name

### DIFF
--- a/internal/presenters/funcs.go
+++ b/internal/presenters/funcs.go
@@ -146,6 +146,7 @@ func getSarifTemplateFuncMap() template.FuncMap {
 	fnMap["SeverityToSarifLevel"] = func(s local_models.TypesFindingRatingSeverityValue) string {
 		return sarif.SeverityToSarifLevel(string(s))
 	}
+	fnMap["convertTypeToDriverName"] = sarif.ConvertTypeToDriverName
 	return fnMap
 }
 

--- a/internal/presenters/templates/local_finding.sarif.tmpl
+++ b/internal/presenters/templates/local_finding.sarif.tmpl
@@ -7,7 +7,7 @@
 			{
 				"tool": {
 					"driver" : {
-						"name" : "{{- getRuntimeInfo "name" }}",
+						"name" : "{{- convertTypeToDriverName $result.Summary.Type }}",
 						"semanticVersion" : "{{- getRuntimeInfo "version" }}",
 						"version" : "{{- getRuntimeInfo "version" }}",
 						"informationUri" : "https://docs.snyk.io/",

--- a/internal/utils/sarif/sarif.go
+++ b/internal/utils/sarif/sarif.go
@@ -85,3 +85,16 @@ func CreateCodeSummary(input *sarif.SarifDocument, projectPath string) *json_sch
 
 	return summary
 }
+
+func ConvertTypeToDriverName(s string) string {
+	switch s {
+	case "sast":
+		return "SnykCode"
+	case "container":
+		return "Snyk Container"
+	case "iac":
+		return "Snyk IaC"
+	default:
+		return "Snyk Open Source"
+	}
+}

--- a/internal/utils/sarif/sarif_test.go
+++ b/internal/utils/sarif/sarif_test.go
@@ -29,3 +29,18 @@ func TestSeverityLevelConverter(t *testing.T) {
 		assert.Equal(t, severity, actualSeverity)
 	}
 }
+
+func TestConvertTypeToDriverName(t *testing.T) {
+	expected := map[string]string{
+		"sast":      "SnykCode",
+		"iac":       "Snyk IaC",
+		"container": "Snyk Container",
+		"sca":       "Snyk Open Source",
+		"random":    "Snyk Open Source",
+	}
+
+	for input, expectedOutput := range expected {
+		actualOutput := ConvertTypeToDriverName(input)
+		assert.Equal(t, expectedOutput, actualOutput)
+	}
+}

--- a/pkg/local_workflows/output_workflow_test.go
+++ b/pkg/local_workflows/output_workflow_test.go
@@ -150,7 +150,7 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 	// invocation context mocks
 	invocationContextMock.EXPECT().GetConfiguration().Return(config).AnyTimes()
 	invocationContextMock.EXPECT().GetEnhancedLogger().Return(logger).AnyTimes()
-	invocationContextMock.EXPECT().GetRuntimeInfo().Return(runtimeinfo.New(runtimeinfo.WithName("SnykCode"), runtimeinfo.WithVersion("1.0.0"))).AnyTimes()
+	invocationContextMock.EXPECT().GetRuntimeInfo().Return(runtimeinfo.New(runtimeinfo.WithName("Random Application Name"), runtimeinfo.WithVersion("1.0.0"))).AnyTimes()
 
 	outputDestination.EXPECT().GetWriter().Return(writer).AnyTimes()
 


### PR DESCRIPTION
Instead of using runtime information in the Sarif driver name, derive the name from the Summary type. This shall fix a change in behaviour that caused issues in downstream processing of the Sarif data, where a certain value is expected.