### PR TITLE
chore: update native code test feature flags

### DIFF
--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -45,8 +45,8 @@ const (
 	UNKNOWN_ARGS                   string = "internal_unknown_arguments"          // arguments unknown to the current application but maybe relevant for delegated application calls
 	IN_MEMORY_THRESHOLD_BYTES      string = "internal_in_memory_threshold_bytes"  // threshold to determine where to store workflow.Data
 	// feature flags
-	FF_OAUTH_AUTH_FLOW_ENABLED        string = "internal_snyk_oauth_enabled"
-	FF_CODE_CONSISTENT_IGNORES        string = "internal_snyk_code_ignores_enabled"
-	FF_CODE_CONSISTENT_REPORT_ENABLED string = "internal_snyk_code_ignores_report_enabled"
-	FF_TRANSFORMATION_WORKFLOW        string = "internal_snyk_transformation_workflow_enabled"
+	FF_OAUTH_AUTH_FLOW_ENABLED    string = "internal_snyk_oauth_enabled"
+	FF_CODE_CONSISTENT_IGNORES    string = "internal_snyk_code_ignores_enabled"
+	FF_CODE_NATIVE_IMPLEMENTATION string = "internal_snyk_code_native_implementation"
+	FF_TRANSFORMATION_WORKFLOW    string = "internal_snyk_transformation_workflow_enabled"
 )

--- a/pkg/local_workflows/code_workflow.go
+++ b/pkg/local_workflows/code_workflow.go
@@ -107,19 +107,17 @@ func getSlceEnabled(engine workflow.Engine) configuration.DefaultValueFunction {
 
 func useNativeImplementation(config configuration.Configuration, logger *zerolog.Logger, sastEnabled bool) bool {
 	useConsistentIgnoresFF := config.GetBool(configuration.FF_CODE_CONSISTENT_IGNORES)
-	useNativeReportFF := config.GetBool(configuration.FF_CODE_CONSISTENT_REPORT_ENABLED)
+	useNativeImplementationFF := config.GetBool(configuration.FF_CODE_NATIVE_IMPLEMENTATION)
 	reportEnabled := config.GetBool(code_workflow.ConfigurationReportFlag)
 	scleEnabled := config.GetBool(code_workflow.ConfigurarionSlceEnabled)
 
-	useLegacyReport := reportEnabled && !useNativeReportFF
-	nativeImplementationEnabled := useConsistentIgnoresFF && !useLegacyReport && !scleEnabled
+	nativeImplementationEnabled := useConsistentIgnoresFF && useNativeImplementationFF && !scleEnabled
 
 	logger.Debug().Msgf("SAST Enabled:       %v", sastEnabled)
 	logger.Debug().Msgf("Report enabled:     %v", reportEnabled)
 	logger.Debug().Msgf("SLCE enabled:       %v", scleEnabled)
-	logger.Debug().Msgf("Consistent Ignores:")
-	logger.Debug().Msgf("  FF ignores: %v", useConsistentIgnoresFF)
-	logger.Debug().Msgf("  FF report: %v", useNativeReportFF)
+	logger.Debug().Msgf("FF consistent ignores: %v", useConsistentIgnoresFF)
+	logger.Debug().Msgf("FF native implementation: %v", useNativeImplementationFF)
 
 	return nativeImplementationEnabled
 }
@@ -138,7 +136,7 @@ func InitCodeWorkflow(engine workflow.Engine) error {
 	engine.GetConfiguration().AddDefaultValue(code_workflow.ConfigurarionSlceEnabled, getSlceEnabled(engine))
 	engine.GetConfiguration().AddDefaultValue(code_workflow.ConfigurationTestFLowName, configuration.StandardDefaultValueFunction("cli_test"))
 	config_utils.AddFeatureFlagToConfig(engine, configuration.FF_CODE_CONSISTENT_IGNORES, "snykCodeConsistentIgnores")
-	config_utils.AddFeatureFlagToConfig(engine, configuration.FF_CODE_CONSISTENT_REPORT_ENABLED, code_workflow.FfNameNativeReport)
+	config_utils.AddFeatureFlagToConfig(engine, configuration.FF_CODE_NATIVE_IMPLEMENTATION, code_workflow.FfNameNativeImplementation)
 
 	return err
 }

--- a/pkg/local_workflows/code_workflow.go
+++ b/pkg/local_workflows/code_workflow.go
@@ -111,7 +111,7 @@ func useNativeImplementation(config configuration.Configuration, logger *zerolog
 	reportEnabled := config.GetBool(code_workflow.ConfigurationReportFlag)
 	scleEnabled := config.GetBool(code_workflow.ConfigurarionSlceEnabled)
 
-	nativeImplementationEnabled := useConsistentIgnoresFF && useNativeImplementationFF && !scleEnabled
+	nativeImplementationEnabled := (useConsistentIgnoresFF || useNativeImplementationFF) && !scleEnabled
 
 	logger.Debug().Msgf("SAST Enabled:       %v", sastEnabled)
 	logger.Debug().Msgf("Report enabled:     %v", reportEnabled)

--- a/pkg/local_workflows/code_workflow/native_workflow.go
+++ b/pkg/local_workflows/code_workflow/native_workflow.go
@@ -40,7 +40,7 @@ const (
 	ConfigurationCommitId              = "commit-id"
 	ConfigurationSastEnabled           = "internal_sast_enabled"
 	ConfigurarionSlceEnabled           = "internal_snyk_scle_enabled"
-	FfNameNativeReport                 = "snykCodeReportConsistentIgnores"
+	FfNameNativeImplementation         = "snykCodeClientNativeImplementation"
 )
 
 type reportType string

--- a/pkg/local_workflows/code_workflow_test.go
+++ b/pkg/local_workflows/code_workflow_test.go
@@ -350,12 +350,12 @@ func Test_Code_nativeImplementation_analysisEmpty(t *testing.T) {
 
 func Test_Code_FF_CODE_CONSISTENT_IGNORES(t *testing.T) {
 	response := contract.OrgFeatureFlagResponse{}
-	responseReport := contract.OrgFeatureFlagResponse{}
+	responseNativeImpl := contract.OrgFeatureFlagResponse{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		data, err := json.Marshal(response)
 
-		if strings.Contains(r.URL.Path, code_workflow.FfNameNativeReport) {
-			data, err = json.Marshal(responseReport)
+		if strings.Contains(r.URL.Path, code_workflow.FfNameNativeImplementation) {
+			data, err = json.Marshal(responseNativeImpl)
 		}
 
 		assert.NoError(t, err)
@@ -391,10 +391,10 @@ func Test_Code_FF_CODE_CONSISTENT_IGNORES(t *testing.T) {
 		assert.False(t, consistentIgnores)
 	})
 
-	t.Run("Report Feature Flag set", func(t *testing.T) {
+	t.Run("Local Native Implementation Feature Flag set", func(t *testing.T) {
 		config.Set(configuration.ORGANIZATION, orgId)
-		responseReport = contract.OrgFeatureFlagResponse{Code: http.StatusOK, Ok: true}
-		consistentIgnores := config.GetBool(configuration.FF_CODE_CONSISTENT_REPORT_ENABLED)
+		responseNativeImpl = contract.OrgFeatureFlagResponse{Code: http.StatusOK, Ok: true}
+		consistentIgnores := config.GetBool(configuration.FF_CODE_NATIVE_IMPLEMENTATION)
 		assert.True(t, consistentIgnores)
 	})
 }
@@ -402,12 +402,12 @@ func Test_Code_FF_CODE_CONSISTENT_IGNORES(t *testing.T) {
 func Test_Code_UseNativeImplementation(t *testing.T) {
 	logger := zerolog.Nop()
 
-	//reportEnabled bool, reportFeatureFlag bool, ignoresFeatureFlag bool
+	//reportEnabled bool, nativeImplementationFeatureFlag bool, ignoresFeatureFlag bool
 	t.Run("cci feature flag disabled, report disabled", func(t *testing.T) {
 		expected := false
 		config := configuration.NewWithOpts()
 		config.Set(configuration.FF_CODE_CONSISTENT_IGNORES, false)
-		config.Set(configuration.FF_CODE_CONSISTENT_REPORT_ENABLED, true)
+		config.Set(configuration.FF_CODE_NATIVE_IMPLEMENTATION, true)
 		config.Set(code_workflow.ConfigurationReportFlag, false)
 		config.Set(code_workflow.ConfigurarionSlceEnabled, false)
 		actual := useNativeImplementation(config, &logger, true)
@@ -418,7 +418,7 @@ func Test_Code_UseNativeImplementation(t *testing.T) {
 		expected := false
 		config := configuration.NewWithOpts()
 		config.Set(configuration.FF_CODE_CONSISTENT_IGNORES, false)
-		config.Set(configuration.FF_CODE_CONSISTENT_REPORT_ENABLED, true)
+		config.Set(configuration.FF_CODE_NATIVE_IMPLEMENTATION, true)
 		config.Set(code_workflow.ConfigurationReportFlag, true)
 		config.Set(code_workflow.ConfigurarionSlceEnabled, false)
 		actual := useNativeImplementation(config, &logger, true)
@@ -429,7 +429,7 @@ func Test_Code_UseNativeImplementation(t *testing.T) {
 		expected := false
 		config := configuration.NewWithOpts()
 		config.Set(configuration.FF_CODE_CONSISTENT_IGNORES, true)
-		config.Set(configuration.FF_CODE_CONSISTENT_REPORT_ENABLED, false)
+		config.Set(configuration.FF_CODE_NATIVE_IMPLEMENTATION, false)
 		config.Set(code_workflow.ConfigurationReportFlag, true)
 		config.Set(code_workflow.ConfigurarionSlceEnabled, false)
 		actual := useNativeImplementation(config, &logger, true)
@@ -440,7 +440,7 @@ func Test_Code_UseNativeImplementation(t *testing.T) {
 		expected := true
 		config := configuration.NewWithOpts()
 		config.Set(configuration.FF_CODE_CONSISTENT_IGNORES, true)
-		config.Set(configuration.FF_CODE_CONSISTENT_REPORT_ENABLED, true)
+		config.Set(configuration.FF_CODE_NATIVE_IMPLEMENTATION, true)
 		config.Set(code_workflow.ConfigurationReportFlag, true)
 		config.Set(code_workflow.ConfigurarionSlceEnabled, false)
 		actual := useNativeImplementation(config, &logger, true)
@@ -451,7 +451,7 @@ func Test_Code_UseNativeImplementation(t *testing.T) {
 		expected := false
 		config := configuration.NewWithOpts()
 		config.Set(configuration.FF_CODE_CONSISTENT_IGNORES, true)
-		config.Set(configuration.FF_CODE_CONSISTENT_REPORT_ENABLED, true)
+		config.Set(configuration.FF_CODE_NATIVE_IMPLEMENTATION, true)
 		config.Set(code_workflow.ConfigurationReportFlag, true)
 		config.Set(code_workflow.ConfigurarionSlceEnabled, true)
 		actual := useNativeImplementation(config, &logger, true)

--- a/pkg/local_workflows/code_workflow_test.go
+++ b/pkg/local_workflows/code_workflow_test.go
@@ -403,56 +403,51 @@ func Test_Code_UseNativeImplementation(t *testing.T) {
 	logger := zerolog.Nop()
 
 	//reportEnabled bool, nativeImplementationFeatureFlag bool, ignoresFeatureFlag bool
-	t.Run("cci feature flag disabled, report disabled", func(t *testing.T) {
+	t.Run("cci feature flag disabled, native implementation disabled", func(t *testing.T) {
 		expected := false
 		config := configuration.NewWithOpts()
 		config.Set(configuration.FF_CODE_CONSISTENT_IGNORES, false)
-		config.Set(configuration.FF_CODE_NATIVE_IMPLEMENTATION, true)
-		config.Set(code_workflow.ConfigurationReportFlag, false)
+		config.Set(configuration.FF_CODE_NATIVE_IMPLEMENTATION, false)
 		config.Set(code_workflow.ConfigurarionSlceEnabled, false)
 		actual := useNativeImplementation(config, &logger, true)
 		assert.Equal(t, expected, actual)
 	})
 
-	t.Run("cci feature flag disabled, report enabled", func(t *testing.T) {
-		expected := false
+	t.Run("cci feature flag disabled, native implementation enabled", func(t *testing.T) {
+		expected := true
 		config := configuration.NewWithOpts()
 		config.Set(configuration.FF_CODE_CONSISTENT_IGNORES, false)
 		config.Set(configuration.FF_CODE_NATIVE_IMPLEMENTATION, true)
-		config.Set(code_workflow.ConfigurationReportFlag, true)
 		config.Set(code_workflow.ConfigurarionSlceEnabled, false)
 		actual := useNativeImplementation(config, &logger, true)
 		assert.Equal(t, expected, actual)
 	})
 
-	t.Run("cci feature flag enabled, report enabled, cci-report feature flag disabled", func(t *testing.T) {
-		expected := false
+	t.Run("cci feature flag enabled, native implementation disabled", func(t *testing.T) {
+		expected := true
 		config := configuration.NewWithOpts()
 		config.Set(configuration.FF_CODE_CONSISTENT_IGNORES, true)
 		config.Set(configuration.FF_CODE_NATIVE_IMPLEMENTATION, false)
-		config.Set(code_workflow.ConfigurationReportFlag, true)
 		config.Set(code_workflow.ConfigurarionSlceEnabled, false)
 		actual := useNativeImplementation(config, &logger, true)
 		assert.Equal(t, expected, actual)
 	})
 
-	t.Run("cci feature flag enabled, report enabled", func(t *testing.T) {
+	t.Run("cci feature flag enabled, native implementation enabled", func(t *testing.T) {
 		expected := true
 		config := configuration.NewWithOpts()
 		config.Set(configuration.FF_CODE_CONSISTENT_IGNORES, true)
 		config.Set(configuration.FF_CODE_NATIVE_IMPLEMENTATION, true)
-		config.Set(code_workflow.ConfigurationReportFlag, true)
 		config.Set(code_workflow.ConfigurarionSlceEnabled, false)
 		actual := useNativeImplementation(config, &logger, true)
 		assert.Equal(t, expected, actual)
 	})
 
-	t.Run("cci feature flag enabled, report enabled but scle enabled", func(t *testing.T) {
+	t.Run("cci feature flag enabled, native implementation enabled but scle enabled", func(t *testing.T) {
 		expected := false
 		config := configuration.NewWithOpts()
 		config.Set(configuration.FF_CODE_CONSISTENT_IGNORES, true)
 		config.Set(configuration.FF_CODE_NATIVE_IMPLEMENTATION, true)
-		config.Set(code_workflow.ConfigurationReportFlag, true)
 		config.Set(code_workflow.ConfigurarionSlceEnabled, true)
 		actual := useNativeImplementation(config, &logger, true)
 		assert.Equal(t, expected, actual)

--- a/pkg/local_workflows/code_workflow_test.go
+++ b/pkg/local_workflows/code_workflow_test.go
@@ -402,7 +402,7 @@ func Test_Code_FF_CODE_CONSISTENT_IGNORES(t *testing.T) {
 func Test_Code_UseNativeImplementation(t *testing.T) {
 	logger := zerolog.Nop()
 
-	//reportEnabled bool, nativeImplementationFeatureFlag bool, ignoresFeatureFlag bool
+	// cciFeatureFlagEnabled bool, nativeImplementationFeatureFlag bool, ignoresFeatureFlag bool
 	t.Run("cci feature flag disabled, native implementation disabled", func(t *testing.T) {
 		expected := false
 		config := configuration.NewWithOpts()


### PR DESCRIPTION
- Adds a new feature flag that enables the usage of the native code workflow even if the CCI flag is not enabled
- Removes the usage of the report flag from deciding when to use the native implementation

[CLI-775](https://snyksec.atlassian.net/browse/CLI-775)

[CLI-775]: https://snyksec.atlassian.net/browse/CLI-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ