### PR TITLE
feat: use gaf to get sast settings

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -5,7 +5,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/common"
 	"io"
 	"net/http"
 	"net/url"
@@ -22,7 +22,7 @@ type ApiClient interface {
 	GetFeatureFlag(flagname string, origId string) (bool, error)
 	GetUserMe() (string, error)
 	GetSelf() (contract.SelfResponse, error)
-	GetSastSettings(orgId string) (configuration.SastResponse, error)
+	GetSastSettings(orgId string) (common.SastResponse, error)
 }
 
 var _ ApiClient = (*snykApiClient)(nil)
@@ -197,9 +197,9 @@ func (a *snykApiClient) GetSelf() (contract.SelfResponse, error) {
 	return selfData, nil
 }
 
-func (a *snykApiClient) GetSastSettings(orgId string) (configuration.SastResponse, error) {
-	var response configuration.SastResponse
-	var defaultResult configuration.SastResponse
+func (a *snykApiClient) GetSastSettings(orgId string) (common.SastResponse, error) {
+	var response common.SastResponse
+	var defaultResult common.SastResponse
 
 	endpoint := a.url + "/v1/cli-config/settings/sast?org=" + url.QueryEscape(orgId)
 	res, err := a.client.Get(endpoint)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -5,6 +5,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/snyk/go-application-framework/pkg/configuration"
 	"io"
 	"net/http"
 	"net/url"
@@ -21,7 +22,7 @@ type ApiClient interface {
 	GetFeatureFlag(flagname string, origId string) (bool, error)
 	GetUserMe() (string, error)
 	GetSelf() (contract.SelfResponse, error)
-	GetSastSettings(orgId string) (contract.SastResponse, error)
+	GetSastSettings(orgId string) (configuration.SastResponse, error)
 }
 
 var _ ApiClient = (*snykApiClient)(nil)
@@ -196,9 +197,9 @@ func (a *snykApiClient) GetSelf() (contract.SelfResponse, error) {
 	return selfData, nil
 }
 
-func (a *snykApiClient) GetSastSettings(orgId string) (contract.SastResponse, error) {
-	var response contract.SastResponse
-	var defaultResult contract.SastResponse
+func (a *snykApiClient) GetSastSettings(orgId string) (configuration.SastResponse, error) {
+	var response configuration.SastResponse
+	var defaultResult configuration.SastResponse
 
 	endpoint := a.url + "/v1/cli-config/settings/sast?org=" + url.QueryEscape(orgId)
 	res, err := a.client.Get(endpoint)

--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -5,12 +5,13 @@
 package mocks
 
 import (
-	"github.com/snyk/go-application-framework/pkg/common"
 	http "net/http"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
 	contract "github.com/snyk/go-application-framework/internal/api/contract"
+
+	"github.com/snyk/go-application-framework/pkg/common"
 )
 
 // MockApiClient is a mock of ApiClient interface.

--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	"github.com/snyk/go-application-framework/pkg/configuration"
 	http "net/http"
 	reflect "reflect"
 
@@ -81,10 +82,10 @@ func (mr *MockApiClientMockRecorder) GetOrgIdFromSlug(slugName interface{}) *gom
 }
 
 // GetSastSettings mocks base method.
-func (m *MockApiClient) GetSastSettings(orgId string) (contract.SastResponse, error) {
+func (m *MockApiClient) GetSastSettings(orgId string) (configuration.SastResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSastSettings", orgId)
-	ret0, _ := ret[0].(contract.SastResponse)
+	ret0, _ := ret[0].(configuration.SastResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -5,7 +5,7 @@
 package mocks
 
 import (
-	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/common"
 	http "net/http"
 	reflect "reflect"
 
@@ -82,10 +82,10 @@ func (mr *MockApiClientMockRecorder) GetOrgIdFromSlug(slugName interface{}) *gom
 }
 
 // GetSastSettings mocks base method.
-func (m *MockApiClient) GetSastSettings(orgId string) (configuration.SastResponse, error) {
+func (m *MockApiClient) GetSastSettings(orgId string) (common.SastResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSastSettings", orgId)
-	ret0, _ := ret[0].(configuration.SastResponse)
+	ret0, _ := ret[0].(common.SastResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/common/sast_settings.go
+++ b/pkg/common/sast_settings.go
@@ -1,4 +1,4 @@
-package configuration
+package common
 
 type LocalCodeEngine struct {
 	AllowCloudUpload bool   `json:"allowCloudUpload"`

--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -38,6 +38,7 @@ const (
 	WORKING_DIRECTORY              string = "internal_working_dir"
 	IS_FEDRAMP                     string = "internal_is_fedramp"
 	ORGANIZATION_SLUG              string = "internal_org_slug"
+	SAST_SETTINGS                  string = "internal_sast_settings"
 	AUTHENTICATION_SUBDOMAINS      string = "internal_auth_subdomain"             // array of additional subdomains to add authentication for
 	AUTHENTICATION_ADDITIONAL_URLS string = "internal_additional_auth_urls"       // array of additional urls to add authentication for
 	ADD_TRUSTED_CA_FILE            string = "internal_additional_trusted_ca_file" // pem file location containing additional CAs to trust

--- a/pkg/configuration/sast_settings.go
+++ b/pkg/configuration/sast_settings.go
@@ -1,4 +1,4 @@
-package contract
+package configuration
 
 type LocalCodeEngine struct {
 	AllowCloudUpload bool   `json:"allowCloudUpload"`

--- a/pkg/configuration/storage.go
+++ b/pkg/configuration/storage.go
@@ -3,7 +3,6 @@ package configuration
 import (
 	"context"
 	"encoding/json"
-	"github.com/snyk/go-application-framework/internal/utils"
 
 	"os"
 	"path/filepath"
@@ -11,6 +10,8 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
+
+	"github.com/snyk/go-application-framework/internal/utils"
 )
 
 //go:generate $GOPATH/bin/mockgen -source=storage.go -destination ../mocks/config_storage.go -package mocks -self_package github.com/snyk/go-application-framework/pkg/configuration/

--- a/pkg/configuration/storage.go
+++ b/pkg/configuration/storage.go
@@ -3,14 +3,14 @@ package configuration
 import (
 	"context"
 	"encoding/json"
+	"github.com/snyk/go-application-framework/internal/utils"
+
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
 
 	"github.com/gofrs/flock"
-
-	"github.com/snyk/go-application-framework/internal/utils"
 )
 
 //go:generate $GOPATH/bin/mockgen -source=storage.go -destination ../mocks/config_storage.go -package mocks -self_package github.com/snyk/go-application-framework/pkg/configuration/

--- a/pkg/local_workflows/code_workflow.go
+++ b/pkg/local_workflows/code_workflow.go
@@ -2,7 +2,6 @@ package localworkflows
 
 import (
 	"fmt"
-	"github.com/snyk/go-application-framework/pkg/common"
 
 	"github.com/rs/zerolog"
 	"github.com/snyk/error-catalog-golang-public/code"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/snyk/go-application-framework/internal/api"
 	"github.com/snyk/go-application-framework/internal/utils"
+	"github.com/snyk/go-application-framework/pkg/common"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/code_workflow"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/config_utils"

--- a/pkg/local_workflows/code_workflow.go
+++ b/pkg/local_workflows/code_workflow.go
@@ -2,6 +2,7 @@ package localworkflows
 
 import (
 	"fmt"
+	"github.com/snyk/go-application-framework/pkg/common"
 
 	"github.com/rs/zerolog"
 	"github.com/snyk/error-catalog-golang-public/code"
@@ -44,7 +45,7 @@ func GetCodeFlagSet() *pflag.FlagSet {
 // WORKFLOWID_CODE defines a new workflow identifier
 var WORKFLOWID_CODE workflow.Identifier = workflow.NewWorkflowIdentifier(codeWorkflowName)
 
-func getSastSettings(engine workflow.Engine) (*configuration.SastResponse, error) {
+func getSastSettings(engine workflow.Engine) (*common.SastResponse, error) {
 	config := engine.GetConfiguration()
 	org := config.GetString(configuration.ORGANIZATION)
 

--- a/pkg/local_workflows/code_workflow_test.go
+++ b/pkg/local_workflows/code_workflow_test.go
@@ -37,9 +37,9 @@ func Test_Code_entrypoint(t *testing.T) {
 		fmt.Println(r.URL)
 		if strings.HasSuffix(r.URL.String(), "/v1/cli-config/settings/sast?org="+org) {
 			sastSettingsCalled++
-			sastSettings := &contract.SastResponse{
+			sastSettings := &configuration.SastResponse{
 				SastEnabled: true,
-				LocalCodeEngine: contract.LocalCodeEngine{
+				LocalCodeEngine: configuration.LocalCodeEngine{
 					Enabled: true, /* ensures that legacycli will be called */
 				},
 			}
@@ -98,7 +98,7 @@ func Test_Code_entrypoint(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, rs)
 	assert.Equal(t, expectedData, rs[0].GetPayload().(string))
-	assert.Equal(t, 1, sastSettingsCalled)
+	assert.Equal(t, 2, sastSettingsCalled)
 }
 
 func Test_Code_legacyImplementation_happyPath(t *testing.T) {

--- a/pkg/local_workflows/code_workflow_test.go
+++ b/pkg/local_workflows/code_workflow_test.go
@@ -3,6 +3,7 @@ package localworkflows
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/snyk/go-application-framework/pkg/common"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -37,9 +38,9 @@ func Test_Code_entrypoint(t *testing.T) {
 		fmt.Println(r.URL)
 		if strings.HasSuffix(r.URL.String(), "/v1/cli-config/settings/sast?org="+org) {
 			sastSettingsCalled++
-			sastSettings := &configuration.SastResponse{
+			sastSettings := &common.SastResponse{
 				SastEnabled: true,
-				LocalCodeEngine: configuration.LocalCodeEngine{
+				LocalCodeEngine: common.LocalCodeEngine{
 					Enabled: true, /* ensures that legacycli will be called */
 				},
 			}


### PR DESCRIPTION
Changes in Go Application Framework:

- added a `defaultFuncGetSastSettings` callback function that executes when the snyk-ls asks for sast settings from the Go Application Framework Configuration.
- moved sast_settings.go from "/internal/api/contract" to `/pkg/common` to be used in snyk-ls.
- introduced a new constant for the new settings in Configuration: `SAST_SETTINGS` 
- removed the cachedResponse 