### PR TITLE
fix: [CLI-841] redacting extension endpoint of instrumentation payload

### DIFF
--- a/pkg/analytics/instrumentation_collector_test.go
+++ b/pkg/analytics/instrumentation_collector_test.go
@@ -3,10 +3,11 @@ package analytics
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/rs/zerolog"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/rs/zerolog"
 
 	"github.com/snyk/error-catalog-golang-public/snyk"
 	"github.com/stretchr/testify/assert"
@@ -218,7 +219,7 @@ func Test_InstrumentationCollector(t *testing.T) {
 
 		expectedV2InstrumentationObject.Data.Attributes.Interaction.Extension = &mockExtension
 
-		actualV2InstrumentationObject, err := GetV2InstrumentationObjectWithLogger(&logger, ic)
+		actualV2InstrumentationObject, err := GetV2InstrumentationObject(ic, WithLogger(&logger))
 		assert.NoError(t, err)
 		expectedV2InstrumentationJson, err := json.Marshal(expectedV2InstrumentationObject)
 		assert.NoError(t, err)
@@ -238,7 +239,7 @@ func Test_InstrumentationCollector(t *testing.T) {
 
 		expectedV2InstrumentationObject.Data.Attributes.Interaction.Extension = nil
 
-		actualV2InstrumentationObject, err := GetV2InstrumentationObjectWithLogger(&logger, ic)
+		actualV2InstrumentationObject, err := GetV2InstrumentationObject(ic, WithLogger(&logger))
 		assert.NoError(t, err)
 		expectedV2InstrumentationJson, err := json.Marshal(expectedV2InstrumentationObject)
 		assert.NoError(t, err)

--- a/pkg/analytics/instrumentation_collector_test.go
+++ b/pkg/analytics/instrumentation_collector_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/rs/zerolog"
 	"os"
-	"os/user"
 	"testing"
 	"time"
 
@@ -212,15 +211,9 @@ func Test_InstrumentationCollector(t *testing.T) {
 
 		ic.AddExtension("password", "hunter2")
 
-		u, err := user.Current()
-		assert.NoError(t, err)
-
-		ic.AddExtension("pathToSomething", fmt.Sprintf("/home/%s/.config", u.Username))
-
 		mockExtension := map[string]interface{}{
-			"strings":         "hello world",
-			"password":        "REDACTED",
-			"pathToSomething": "/home/REDACTED/.config",
+			"strings":  "hello world",
+			"password": "REDACTED",
 		}
 
 		expectedV2InstrumentationObject.Data.Attributes.Interaction.Extension = &mockExtension
@@ -278,6 +271,7 @@ func setupBaseCollector(t *testing.T) InstrumentationCollector {
 	ic.SetTestSummary(*json_schemas.NewTestSummary("sast", ""))
 	ic.SetTargetId("targetID")
 	ic.AddExtension("strings", "hello world")
+	ic.SetTimestamp(time.Date(2025, 1, 01, 0, 0, 0, 0, time.UTC))
 
 	return ic
 }
@@ -287,7 +281,6 @@ func buildExpectedBaseObject(t *testing.T) api.AnalyticsRequestBody {
 	t.Helper()
 
 	mockInteractionId := "interactionID"
-	mockTimestamp := time.Now()
 	mockStage := "cicd"
 	mockInstrumentationType := "analytics"
 	mockInteractionType := "Scan done"
@@ -311,7 +304,7 @@ func buildExpectedBaseObject(t *testing.T) api.AnalyticsRequestBody {
 					Stage:       &stage,
 					Status:      string(mockStatus),
 					Target:      api.Target{Id: mockTargetId},
-					TimestampMs: mockTimestamp.UnixMilli(),
+					TimestampMs: time.Date(2025, 1, 01, 0, 0, 0, 0, time.UTC).UnixMilli(),
 					Type:        mockInteractionType,
 				},
 				Runtime: &api.Runtime{},

--- a/pkg/analytics/instrumentation_collector_test.go
+++ b/pkg/analytics/instrumentation_collector_test.go
@@ -32,7 +32,7 @@ func Test_InstrumentationCollector(t *testing.T) {
 		actualV2InstrumentationJson, err := json.Marshal(actualV2InstrumentationObject)
 		assert.NoError(t, err)
 
-		assert.Equal(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
+		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
 	})
 
 	t.Run("it sets the userAgent application data", func(t *testing.T) {
@@ -57,7 +57,7 @@ func Test_InstrumentationCollector(t *testing.T) {
 		actualV2InstrumentationJson, err := json.Marshal(actualV2InstrumentationObject)
 		assert.NoError(t, err)
 
-		assert.Equal(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
+		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
 	})
 
 	t.Run("it sets the userAgent environment data", func(t *testing.T) {
@@ -82,7 +82,7 @@ func Test_InstrumentationCollector(t *testing.T) {
 		actualV2InstrumentationJson, err := json.Marshal(actualV2InstrumentationObject)
 		assert.NoError(t, err)
 
-		assert.Equal(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
+		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
 	})
 
 	t.Run("it sets the userAgent integration data", func(t *testing.T) {
@@ -107,7 +107,7 @@ func Test_InstrumentationCollector(t *testing.T) {
 		actualV2InstrumentationJson, err := json.Marshal(actualV2InstrumentationObject)
 		assert.NoError(t, err)
 
-		assert.Equal(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
+		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
 	})
 
 	t.Run("it sets the userAgent platform data", func(t *testing.T) {
@@ -132,7 +132,7 @@ func Test_InstrumentationCollector(t *testing.T) {
 		actualV2InstrumentationJson, err := json.Marshal(actualV2InstrumentationObject)
 		assert.NoError(t, err)
 
-		assert.Equal(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
+		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
 	})
 
 	t.Run("it sets the userAgent performance data", func(t *testing.T) {
@@ -154,7 +154,7 @@ func Test_InstrumentationCollector(t *testing.T) {
 		actualV2InstrumentationJson, err := json.Marshal(actualV2InstrumentationObject)
 		assert.NoError(t, err)
 
-		assert.Equal(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
+		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
 	})
 
 	t.Run("it should collect interaction errors", func(t *testing.T) {
@@ -178,7 +178,7 @@ func Test_InstrumentationCollector(t *testing.T) {
 		actualV2InstrumentationJson, err := json.Marshal(actualV2InstrumentationObject)
 		assert.NoError(t, err)
 
-		assert.Equal(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
+		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
 	})
 
 	t.Run("it should support all interaction extension types", func(t *testing.T) {
@@ -203,7 +203,7 @@ func Test_InstrumentationCollector(t *testing.T) {
 		actualV2InstrumentationJson, err := json.Marshal(actualV2InstrumentationObject)
 		assert.NoError(t, err)
 
-		assert.Equal(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
+		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
 	})
 
 	t.Run("it should sanitize potential PII data put in the extension type", func(t *testing.T) {
@@ -226,7 +226,7 @@ func Test_InstrumentationCollector(t *testing.T) {
 		actualV2InstrumentationJson, err := json.Marshal(actualV2InstrumentationObject)
 		assert.NoError(t, err)
 
-		assert.Equal(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
+		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
 	})
 
 	t.Run("it should remove the extension object gracefully if sanitation fails ", func(t *testing.T) {
@@ -246,7 +246,7 @@ func Test_InstrumentationCollector(t *testing.T) {
 		actualV2InstrumentationJson, err := json.Marshal(actualV2InstrumentationObject)
 		assert.NoError(t, err)
 
-		assert.Equal(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
+		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
 	})
 
 	t.Run("it should get the category vector", func(t *testing.T) {

--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -226,7 +226,6 @@ func instrumentScanDoneEvent(invocationCtx workflow.InvocationContext, input wor
 
 	data, err := analytics.GetV2InstrumentationObjectWithLogger(logger, ic)
 	if err != nil {
-
 		return nil, err
 	}
 

--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -224,7 +224,7 @@ func instrumentScanDoneEvent(invocationCtx workflow.InvocationContext, input wor
 	ic.SetTestSummary(toTestSummary(scanDoneEvent.Data.Attributes.UniqueIssueCount, scanDoneEvent.Data.Type))
 	ic.AddExtension("device_id", scanDoneEvent.Data.Attributes.DeviceId)
 
-	data, err := analytics.GetV2InstrumentationObjectWithLogger(logger, ic)
+	data, err := analytics.GetV2InstrumentationObject(ic, analytics.WithLogger(logger))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -224,8 +224,9 @@ func instrumentScanDoneEvent(invocationCtx workflow.InvocationContext, input wor
 	ic.SetTestSummary(toTestSummary(scanDoneEvent.Data.Attributes.UniqueIssueCount, scanDoneEvent.Data.Type))
 	ic.AddExtension("device_id", scanDoneEvent.Data.Attributes.DeviceId)
 
-	data, err := analytics.GetV2InstrumentationObject(ic)
+	data, err := analytics.GetV2InstrumentationObjectWithLogger(logger, ic)
 	if err != nil {
+
 		return nil, err
 	}
 


### PR DESCRIPTION
In https://github.com/snyk/cli/pull/5813 we are going to pass the legacy v1 analytics to the new analytics service, utilizing the `extension` attribute in the payload.

Since the extension payload can be used by all product lines, it would be good practice to ensure proper PII protection of that part of the payload.

Further, since the `v1` data is already passed through that sanitation logic, it makes sense to do the same to the data when passed to the analytics service.

I also re-wrote the test a tad to make each test independent of the other, as some test runners were mutating the assertion object. Also a tendency to flakiness as timestamps were being compared.