### PR TITLE
fix: Ensure to create folders for outputfile

### DIFF
--- a/internal/utils/file.go
+++ b/internal/utils/file.go
@@ -2,9 +2,20 @@ package utils
 
 import (
 	"io/fs"
+	"os"
+	"path/filepath"
 )
 
 const (
 	FILEPERM_755 fs.FileMode = 0755 // Owner=rwx, Group=r-x, Other=r-x
 	FILEPERM_666 fs.FileMode = 0666 // Owner=rw-, Group=rw-, Other=rw-
 )
+
+func CreateFilePath(path string) error {
+	dirPath := filepath.Dir(path)
+	if _, err := os.Stat(dirPath); os.IsNotExist(err) {
+		err = os.MkdirAll(dirPath, FILEPERM_755)
+		return err
+	}
+	return nil
+}

--- a/internal/utils/file_test.go
+++ b/internal/utils/file_test.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateFilePath(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "newDir", "file.txt")
+	pathToCreate := filepath.Dir(filePath)
+	err := CreateFilePath(filePath)
+	assert.NoError(t, err)
+	assert.DirExists(t, pathToCreate)
+}

--- a/pkg/local_workflows/output_workflow.go
+++ b/pkg/local_workflows/output_workflow.go
@@ -189,6 +189,11 @@ func jsonWriteToFile(debugLogger *zerolog.Logger, input []workflow.Data, i int, 
 	if err := outputDestination.Remove(jsonFileName); err != nil {
 		return fmt.Errorf("failed to remove existing output file: %w", err)
 	}
+
+	if err := iUtils.CreateFilePath(jsonFileName); err != nil {
+		return fmt.Errorf("failed to create output folder: %w", err)
+	}
+
 	if err := outputDestination.WriteFile(jsonFileName, singleData, iUtils.FILEPERM_666); err != nil {
 		return fmt.Errorf("failed to write json output: %w", err)
 	}

--- a/pkg/local_workflows/output_workflow/findings_model_tools.go
+++ b/pkg/local_workflows/output_workflow/findings_model_tools.go
@@ -111,6 +111,11 @@ func getSarifFileRenderer(config configuration.Configuration, findings []*local_
 		return nil, nil
 	}
 
+	pathError := iUtils.CreateFilePath(outputFileName)
+	if pathError != nil {
+		return nil, pathError
+	}
+
 	file, fileErr := os.OpenFile(outputFileName, os.O_WRONLY|os.O_CREATE, 0644)
 	if fileErr != nil {
 		return nil, fileErr

--- a/pkg/local_workflows/output_workflow/findings_model_tools_test.go
+++ b/pkg/local_workflows/output_workflow/findings_model_tools_test.go
@@ -1,6 +1,7 @@
 package output_workflow
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,32 +60,35 @@ func Test_getSarifFileRenderer(t *testing.T) {
 	t.Run("write empty file", func(t *testing.T) {
 		localFindings := getLocalFindingsSkeleton(t, 0)
 		config := configuration.NewWithOpts()
-		config.Set(OUTPUT_CONFIG_KEY_SARIF_FILE, t.TempDir()+"/somefile")
+		config.Set(OUTPUT_CONFIG_KEY_SARIF_FILE, filepath.Join(t.TempDir(), "not-existing", "somefile"))
 		config.Set(OUTPUT_CONFIG_WRITE_EMPTY_FILE, true)
 		renderer, err := getSarifFileRenderer(config, localFindings)
 		assert.NoError(t, err)
 		assert.NotNil(t, renderer)
 		assert.NoError(t, renderer.closer())
+		assert.FileExists(t, config.GetString(OUTPUT_CONFIG_KEY_SARIF_FILE))
 	})
 
 	t.Run("write non empty file", func(t *testing.T) {
 		localFindings := getLocalFindingsSkeleton(t, 1)
 		config := configuration.NewWithOpts()
-		config.Set(OUTPUT_CONFIG_KEY_SARIF_FILE, t.TempDir()+"/somefile")
+		config.Set(OUTPUT_CONFIG_KEY_SARIF_FILE, filepath.Join(t.TempDir(), "not-existing", "somefile"))
 		config.Set(OUTPUT_CONFIG_WRITE_EMPTY_FILE, false)
 		renderer, err := getSarifFileRenderer(config, localFindings)
 		assert.NoError(t, err)
 		assert.NotNil(t, renderer)
 		assert.NoError(t, renderer.closer())
+		assert.FileExists(t, config.GetString(OUTPUT_CONFIG_KEY_SARIF_FILE))
 	})
 
 	t.Run("don't write empty file", func(t *testing.T) {
 		localFindings := getLocalFindingsSkeleton(t, 0)
 		config := configuration.NewWithOpts()
-		config.Set(OUTPUT_CONFIG_KEY_SARIF_FILE, t.TempDir()+"/somefile")
+		config.Set(OUTPUT_CONFIG_KEY_SARIF_FILE, filepath.Join(t.TempDir(), "not-existing", "somefile"))
 		config.Set(OUTPUT_CONFIG_WRITE_EMPTY_FILE, false)
 		renderer, err := getSarifFileRenderer(config, localFindings)
 		assert.NoError(t, err)
 		assert.Nil(t, renderer)
+		assert.NoFileExists(t, config.GetString(OUTPUT_CONFIG_KEY_SARIF_FILE))
 	})
 }

--- a/pkg/local_workflows/output_workflow_test.go
+++ b/pkg/local_workflows/output_workflow_test.go
@@ -537,3 +537,19 @@ func BenchmarkTransformationAndOutputWorkflow(b *testing.B) {
 		}
 	})
 }
+
+func TestJsonWriteToFile(t *testing.T) {
+	i := 0
+	logger := zerolog.Nop()
+	outputDi := utils.NewOutputDestination()
+	fileName := filepath.Join(t.TempDir(), "not-existing", "file.json")
+	rawData := []byte("hello world")
+	data := []workflow.Data{
+		workflow.NewData(workflow.NewTypeIdentifier(WORKFLOWID_OUTPUT_WORKFLOW, "output"), "content-type", rawData),
+	}
+
+	assert.NoFileExists(t, fileName)
+	err := jsonWriteToFile(&logger, data, i, rawData, fileName, outputDi)
+	assert.NoError(t, err)
+	assert.FileExists(t, fileName)
+}


### PR DESCRIPTION
This PR ensures that if output files are specified, missing folders are being created, so that the file can be written.