### PR TITLE
chore: extend network trace level debug logs to include request and response bodies

### DIFF
--- a/pkg/networking/logging.go
+++ b/pkg/networking/logging.go
@@ -12,6 +12,7 @@ import (
 )
 
 const defaultNetworkLogLevel = zerolog.DebugLevel
+const extendedNetworkLogLevel = zerolog.TraceLevel
 
 func shouldNotLog(currentLevel zerolog.Level, levelToLogAt zerolog.Level) bool {
 	// Don't log if logger level is above the threshold
@@ -103,7 +104,7 @@ func LogRequest(r *http.Request, logger *zerolog.Logger) {
 	logger.WithLevel(defaultNetworkLogLevel).Msgf("%s header: %v", logPrefixRequest, r.Header)
 
 	// additional logs for trace level logging
-	if shouldNotLog(logger.GetLevel(), zerolog.TraceLevel) {
+	if shouldNotLog(logger.GetLevel(), extendedNetworkLogLevel) {
 		return
 	}
 
@@ -121,7 +122,7 @@ func LogResponse(response *http.Response, logger *zerolog.Logger) {
 		logger.WithLevel(defaultNetworkLogLevel).Msgf("%s header: %v", logPrefixResponse, response.Header)
 
 		// additional logs for trace level logging and error responses
-		if !(response.StatusCode >= 400 || !shouldNotLog(logger.GetLevel(), zerolog.TraceLevel)) {
+		if !(response.StatusCode >= 400 || !shouldNotLog(logger.GetLevel(), extendedNetworkLogLevel)) {
 			return
 		}
 

--- a/pkg/networking/logging.go
+++ b/pkg/networking/logging.go
@@ -1,0 +1,130 @@
+package networking
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+const defaultNetworkLogLevel = zerolog.DebugLevel
+
+func shouldNotLog(currentLevel zerolog.Level, levelToLogAt zerolog.Level) bool {
+	// Don't log if logger level is above the threshold
+	return currentLevel > levelToLogAt
+}
+
+func getResponseBody(response *http.Response) io.ReadCloser {
+	if response.Body != nil {
+		bodyBytes, bodyErr := io.ReadAll(response.Body)
+		if bodyErr == nil {
+			response.Body.Close()
+			bodyReader := io.NopCloser(bytes.NewBuffer(bodyBytes))
+			response.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+			return bodyReader
+		}
+	}
+	return nil
+}
+
+func getRequestBody(request *http.Request) io.ReadCloser {
+	if request.GetBody != nil {
+		bodyReader, bodyErr := request.GetBody()
+		if bodyErr != nil {
+			return nil
+		}
+		return bodyReader
+	}
+
+	if request.Body != nil {
+		bodyBytes, bodyErr := io.ReadAll(request.Body)
+		if bodyErr == nil {
+			request.Body.Close()
+			bodyReader := io.NopCloser(bytes.NewBuffer(bodyBytes))
+			request.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+			return bodyReader
+		}
+	}
+
+	return nil
+}
+
+func decodeBody(bodyBytes []byte, contentEncoding string) (string, error) {
+	if contentEncoding == "gzip" {
+		reader, err := gzip.NewReader(bytes.NewReader(bodyBytes))
+		if err != nil {
+			return "", errors.Wrap(err, "failed to create gzip reader")
+		}
+		defer reader.Close()
+		decodedBytes, err := io.ReadAll(reader)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to read decoded body")
+		}
+		return string(decodedBytes), nil
+	} else {
+		return string(bodyBytes), nil
+	}
+}
+
+func logBody(logger *zerolog.Logger, logLevel zerolog.Level, logPrefix string, body io.ReadCloser, header http.Header) {
+	if body != nil {
+		bodyBytes, bodyErr := io.ReadAll(body)
+		defer func() {
+			closeErr := body.Close()
+			if closeErr != nil {
+				logger.WithLevel(logLevel).Err(closeErr).Msg("failed to close body")
+			}
+		}()
+
+		if bodyErr != nil {
+			return
+		}
+
+		bodyString, err := decodeBody(bodyBytes, header.Get("Content-Encoding"))
+		if err != nil {
+			logger.WithLevel(logLevel).Err(err).Msgf("%s Failed to decode request body", logPrefix)
+		} else if len(bodyString) > 0 {
+			logger.WithLevel(logLevel).Msgf("%s body: %v", logPrefix, bodyString)
+		}
+	}
+}
+
+func LogRequest(r *http.Request, logger *zerolog.Logger) {
+	if shouldNotLog(logger.GetLevel(), defaultNetworkLogLevel) { // Don't log if logger level is above the threshold
+		return
+	}
+
+	logPrefixRequest := fmt.Sprintf("> request [%p]:", r)
+	logger.WithLevel(defaultNetworkLogLevel).Msgf("%s %s %s", logPrefixRequest, r.Method, r.URL.String())
+	logger.WithLevel(defaultNetworkLogLevel).Msgf("%s header: %v", logPrefixRequest, r.Header)
+
+	// additional logs for trace level logging
+	if shouldNotLog(logger.GetLevel(), zerolog.TraceLevel) {
+		return
+	}
+
+	logBody(logger, defaultNetworkLogLevel, logPrefixRequest, getRequestBody(r), r.Header)
+}
+
+func LogResponse(response *http.Response, logger *zerolog.Logger) {
+	if shouldNotLog(logger.GetLevel(), defaultNetworkLogLevel) { // Don't log if logger level is above the threshold
+		return
+	}
+
+	if response != nil {
+		logPrefixResponse := fmt.Sprintf("< response [%p]:", response.Request)
+		logger.WithLevel(defaultNetworkLogLevel).Msgf("%s %s", logPrefixResponse, response.Status)
+		logger.WithLevel(defaultNetworkLogLevel).Msgf("%s header: %v", logPrefixResponse, response.Header)
+
+		// additional logs for trace level logging and error responses
+		if !(response.StatusCode >= 400 || !shouldNotLog(logger.GetLevel(), zerolog.TraceLevel)) {
+			return
+		}
+
+		logBody(logger, defaultNetworkLogLevel, logPrefixResponse, getResponseBody(response), response.Header)
+	}
+}

--- a/pkg/networking/logging_test.go
+++ b/pkg/networking/logging_test.go
@@ -1,0 +1,285 @@
+package networking
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+)
+
+func Test_shouldNotLog(t *testing.T) {
+	testCases := []struct {
+		name           string
+		currentLevel   zerolog.Level
+		levelToLogAt   zerolog.Level
+		expectedResult bool
+	}{
+		{
+			name:           "CurrentLevelAboveThreshold",
+			currentLevel:   zerolog.WarnLevel,
+			levelToLogAt:   zerolog.DebugLevel,
+			expectedResult: true,
+		},
+		{
+			name:           "CurrentLevelBelowThreshold",
+			currentLevel:   zerolog.DebugLevel,
+			levelToLogAt:   zerolog.WarnLevel,
+			expectedResult: false,
+		},
+		{
+			name:           "CurrentLevelEqualToThreshold",
+			currentLevel:   zerolog.InfoLevel,
+			levelToLogAt:   zerolog.InfoLevel,
+			expectedResult: false,
+		},
+		{
+			name:           "TraceLevelBelowDebug",
+			currentLevel:   zerolog.TraceLevel,
+			levelToLogAt:   zerolog.DebugLevel,
+			expectedResult: false,
+		},
+		{
+			name:           "PanicLevelAboveError",
+			currentLevel:   zerolog.PanicLevel,
+			levelToLogAt:   zerolog.ErrorLevel,
+			expectedResult: true,
+		},
+		{
+			name:           "FatalLevelAboveError",
+			currentLevel:   zerolog.FatalLevel,
+			levelToLogAt:   zerolog.ErrorLevel,
+			expectedResult: true,
+		},
+		{
+			name:           "DisabledLevelAboveAll",
+			currentLevel:   zerolog.Disabled,
+			levelToLogAt:   zerolog.TraceLevel,
+			expectedResult: true,
+		},
+		{
+			name:           "DisabledLevelAboveAll",
+			currentLevel:   zerolog.NoLevel,
+			levelToLogAt:   zerolog.TraceLevel,
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := shouldNotLog(tc.currentLevel, tc.levelToLogAt)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func Test_LogRequest_NoLog(t *testing.T) {
+	buffer := bytes.Buffer{}
+	logger := zerolog.New(&buffer).Level(zerolog.InfoLevel)
+	request := &http.Request{}
+
+	// method under test
+	LogRequest(request, &logger)
+
+	assert.Empty(t, buffer.Bytes())
+}
+
+func Test_LogRequest_happyPath_server_request(t *testing.T) {
+	expectedBody := "hello world"
+	body := io.NopCloser(bytes.NewBufferString(expectedBody))
+
+	logBuffer := bytes.Buffer{}
+	logger := zerolog.New(&logBuffer).Level(zerolog.TraceLevel)
+	request, err := http.NewRequest(http.MethodGet, "http://localhost/", body)
+	assert.NoError(t, err)
+
+	// method under test
+	LogRequest(request, &logger)
+	assert.Contains(t, logBuffer.String(), expectedBody)
+
+	// ensure that the request body can still be read
+	actualBody, err := io.ReadAll(request.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBody, string(actualBody))
+}
+
+func Test_LogRequest_happyPath_client_request(t *testing.T) {
+	expectedBody := "hello world"
+	body := io.NopCloser(bytes.NewBufferString(expectedBody))
+
+	logBuffer := bytes.Buffer{}
+	logger := zerolog.New(&logBuffer).Level(zerolog.TraceLevel)
+	request, err := http.NewRequest(http.MethodGet, "http://localhost/", nil)
+	request.GetBody = func() (io.ReadCloser, error) {
+		return body, nil
+	}
+	assert.NoError(t, err)
+
+	// method under test
+	LogRequest(request, &logger)
+	assert.Contains(t, logBuffer.String(), expectedBody)
+}
+
+func Test_LogRequest_happyPath_gzipped_request(t *testing.T) {
+	expectedBody := "hello world"
+	gzipBuffer := bytes.NewBuffer([]byte{})
+	gzipWriter := gzip.NewWriter(gzipBuffer)
+	n, err := gzipWriter.Write([]byte(expectedBody))
+	assert.NoError(t, err)
+	assert.Greater(t, n, 0)
+	err = gzipWriter.Close()
+	assert.NoError(t, err)
+
+	logBuffer := bytes.Buffer{}
+	logger := zerolog.New(&logBuffer).Level(extendedNetworkLogLevel)
+	request, err := http.NewRequest(http.MethodPost, "http://localhost/", gzipBuffer)
+	request.Header.Add("Content-Encoding", "gzip")
+	assert.NoError(t, err)
+
+	// method under test
+	LogRequest(request, &logger)
+	assert.Contains(t, logBuffer.String(), expectedBody)
+}
+
+func Test_LogResponse_happyPath(t *testing.T) {
+	logBuffer := bytes.NewBuffer([]byte{})
+	logger := zerolog.New(logBuffer).Level(zerolog.DebugLevel)
+
+	expectedBody := "hello world"
+	request := &http.Request{}
+
+	response := &http.Response{}
+	response.Request = request
+	response.Header = http.Header{}
+	response.StatusCode = http.StatusBadGateway
+	response.Body = io.NopCloser(bytes.NewBufferString(expectedBody))
+
+	// invoke method under test
+	LogResponse(response, &logger)
+	assert.Contains(t, logBuffer.String(), expectedBody)
+
+	// ensure the body is still existing after logging it
+	actualBody, err := io.ReadAll(response.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBody, string(actualBody))
+}
+
+func Test_LogResponse_nolog(t *testing.T) {
+	logBuffer := bytes.NewBuffer([]byte{})
+	logger := zerolog.New(logBuffer).Level(extendedNetworkLogLevel)
+
+	t.Run("nil response", func(t *testing.T) {
+		var response *http.Response
+
+		// invoke method under test
+		LogResponse(response, &logger)
+
+		actualLoggerContent := logBuffer.String()
+		assert.Empty(t, actualLoggerContent)
+	})
+
+	t.Run("non trace level logger", func(t *testing.T) {
+		response := &http.Response{}
+		nonTraceLogger := logger.Level(zerolog.InfoLevel)
+
+		// invoke method under test
+		LogResponse(response, &nonTraceLogger)
+
+		actualLoggerContent := logBuffer.String()
+		assert.Empty(t, actualLoggerContent)
+	})
+}
+
+func Test_logRoundTrip(t *testing.T) {
+	config := configuration.NewWithOpts()
+	expectedResponseBody := "hello client"
+	expectedResponseBodyError := "who are you?"
+	expectedRequestBody := "hello server"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/error" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, err := w.Write([]byte(expectedResponseBodyError))
+			assert.NoError(t, err)
+			return
+		}
+
+		_, err := w.Write([]byte(expectedResponseBody))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	t.Run("expect body to be logged", func(t *testing.T) {
+		logBuffer := bytes.NewBuffer([]byte{})
+		logger := zerolog.New(logBuffer).Level(extendedNetworkLogLevel)
+
+		network := NewNetworkAccess(config)
+		network.SetLogger(&logger)
+
+		response, err := network.GetHttpClient().Post(server.URL, "text/plain; charset=utf-8", bytes.NewBufferString(expectedRequestBody))
+		assert.NoError(t, err)
+		assert.NotNil(t, response)
+
+		actualLoggerContent := logBuffer.String()
+		assert.NotEmpty(t, actualLoggerContent)
+		assert.Contains(t, actualLoggerContent, expectedResponseBody)
+		assert.Contains(t, actualLoggerContent, expectedRequestBody)
+
+		t.Log(actualLoggerContent)
+	})
+
+	t.Run("expect no body to be logged", func(t *testing.T) {
+		logBuffer := bytes.NewBuffer([]byte{})
+		logger := zerolog.New(logBuffer).Level(defaultNetworkLogLevel)
+
+		network := NewNetworkAccess(config)
+		network.SetLogger(&logger)
+
+		response, err := network.GetHttpClient().Post(server.URL, "text/plain; charset=utf-8", bytes.NewBufferString(expectedRequestBody))
+		assert.NoError(t, err)
+		assert.NotNil(t, response)
+
+		actualLoggerContent := logBuffer.String()
+		assert.NotEmpty(t, actualLoggerContent)
+		assert.NotContains(t, actualLoggerContent, expectedResponseBody)
+		assert.NotContains(t, actualLoggerContent, expectedRequestBody)
+
+		t.Log(actualLoggerContent)
+	})
+
+	t.Run("info level logger", func(t *testing.T) {
+		logBuffer := bytes.NewBuffer([]byte{})
+		logger := zerolog.New(logBuffer).Level(zerolog.InfoLevel)
+
+		network := NewNetworkAccess(config)
+		network.SetLogger(&logger)
+
+		response, err := network.GetHttpClient().Post(server.URL, "text/plain; charset=utf-8", bytes.NewBufferString(expectedRequestBody))
+		assert.NoError(t, err)
+		assert.NotNil(t, response)
+
+		actualLoggerContent := logBuffer.String()
+		assert.Empty(t, actualLoggerContent)
+	})
+
+	t.Run("debug level logger for error response", func(t *testing.T) {
+		logBuffer := bytes.NewBuffer([]byte{})
+		logger := zerolog.New(logBuffer).Level(zerolog.DebugLevel)
+
+		network := NewNetworkAccess(config)
+		network.SetLogger(&logger)
+
+		response, err := network.GetHttpClient().Post(server.URL+"/error", "text/plain; charset=utf-8", bytes.NewBufferString(expectedRequestBody))
+		assert.NoError(t, err)
+		assert.NotNil(t, response)
+
+		actualLoggerContent := logBuffer.String()
+		assert.NotEmpty(t, actualLoggerContent)
+		assert.Contains(t, actualLoggerContent, expectedResponseBodyError)
+	})
+}

--- a/pkg/networking/networking.go
+++ b/pkg/networking/networking.go
@@ -1,7 +1,6 @@
 package networking
 
 import (
-	"bytes"
 	"crypto/x509"
 	"io"
 	"net/http"
@@ -73,40 +72,6 @@ type networkImpl struct {
 	logger         *zerolog.Logger
 }
 
-const defaultNetworkLogLevel = zerolog.DebugLevel
-
-func LogRequest(r *http.Request, logger *zerolog.Logger) {
-	if logger.GetLevel() > defaultNetworkLogLevel { // Don't log if logger level is above the threshold
-		return
-	}
-
-	logger.WithLevel(defaultNetworkLogLevel).Msgf("> request [%p]: %s %s", r, r.Method, r.URL.String())
-	logger.WithLevel(defaultNetworkLogLevel).Msgf("> request [%p]: header: %v", r, r.Header)
-}
-
-func LogResponse(response *http.Response, logger *zerolog.Logger) {
-	if logger.GetLevel() > defaultNetworkLogLevel { // Don't log if logger level is above the threshold
-		return
-	}
-
-	if response != nil {
-		logger.WithLevel(defaultNetworkLogLevel).Msgf("< response [%p]: %s", response.Request, response.Status)
-		logger.WithLevel(defaultNetworkLogLevel).Msgf("< response [%p]: header: %v", response.Request, response.Header)
-
-		// read body for error code
-		if response.StatusCode >= 400 {
-			bodyBytes, bodyErr := io.ReadAll(response.Body)
-			if bodyErr == nil {
-				response.Body.Close()
-				response.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-				logger.WithLevel(defaultNetworkLogLevel).Msgf("< response [%p]: body: %v", response.Request, string(bodyBytes))
-			} else {
-				logger.WithLevel(defaultNetworkLogLevel).Err(bodyErr).Msgf("< response [%p]: Failed to read response body", response.Request)
-			}
-		}
-	}
-}
-
 // defaultHeadersRoundTripper is a custom http.RoundTripper which decorates the request with default headers.
 type defaultHeadersRoundTripper struct {
 	encapsulatedRoundTripper http.RoundTripper
@@ -115,7 +80,7 @@ type defaultHeadersRoundTripper struct {
 }
 
 func (rt *defaultHeadersRoundTripper) logRoundTrip(request *http.Request, response *http.Response, err error) {
-	if rt.networkAccess == nil || rt.networkAccess.logger == nil || rt.networkAccess.logger.GetLevel() != rt.logLevel {
+	if rt.networkAccess == nil || rt.networkAccess.logger == nil || shouldNotLog(rt.networkAccess.logger.GetLevel(), rt.logLevel) {
 		return
 	}
 

--- a/pkg/networking/networking_test.go
+++ b/pkg/networking/networking_test.go
@@ -1,7 +1,6 @@
 package networking
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -15,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rs/zerolog"
 	"github.com/snyk/error-catalog-golang-public/snyk"
 	"github.com/snyk/go-httpauth/pkg/httpauth"
 	"github.com/stretchr/testify/assert"
@@ -464,59 +462,6 @@ func TestNetworkImpl_Clone(t *testing.T) {
 
 	assert.NotEqual(t, req1, req2)
 	assert.NotEqual(t, network.GetConfiguration(), clonedNetwork.GetConfiguration())
-}
-
-func TestNetworkImpl_LogResponse_happyPath(t *testing.T) {
-	logBuffer := bytes.NewBuffer([]byte{})
-	logger := zerolog.New(logBuffer).Level(zerolog.DebugLevel)
-
-	expectedBody := "hello world"
-	request := &http.Request{}
-
-	response := &http.Response{}
-	response.Request = request
-	response.Header = http.Header{}
-	response.StatusCode = http.StatusBadGateway
-	response.Body = io.NopCloser(bytes.NewBufferString(expectedBody))
-
-	// invoke method under test
-	LogResponse(response, &logger)
-
-	actualLoggerContent := logBuffer.String()
-	assert.Contains(t, actualLoggerContent, "body: "+expectedBody)
-
-	// ensure the body is still existing after logging it
-	actualBody, err := io.ReadAll(response.Body)
-	assert.NoError(t, err)
-	assert.Equal(t, expectedBody, string(actualBody))
-
-	t.Log(actualLoggerContent)
-}
-
-func TestNetworkImpl_LogResponse_nolog(t *testing.T) {
-	logBuffer := bytes.NewBuffer([]byte{})
-	logger := zerolog.New(logBuffer).Level(zerolog.TraceLevel)
-
-	t.Run("nil response", func(t *testing.T) {
-		var response *http.Response
-
-		// invoke method under test
-		LogResponse(response, &logger)
-
-		actualLoggerContent := logBuffer.String()
-		assert.Empty(t, actualLoggerContent)
-	})
-
-	t.Run("non trace level logger", func(t *testing.T) {
-		response := &http.Response{}
-		nonTraceLogger := logger.Level(zerolog.InfoLevel)
-
-		// invoke method under test
-		LogResponse(response, &nonTraceLogger)
-
-		actualLoggerContent := logBuffer.String()
-		assert.Empty(t, actualLoggerContent)
-	})
 }
 
 func TestNetworkImpl_ErrorHandler(t *testing.T) {


### PR DESCRIPTION
* This PR includes a fix where network logging was only available on debug level, trace level disabled it completely
* This PR extends the debug level logging of network requests to include request and response bodies in trace level logging. Response bodies continue to be logged in debug level logging when the response status code > 400.