### PR TITLE
fix: use pointer for sastResponse and returning nil instead of empty [IDE-724]

### DIFF
--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -82,10 +82,10 @@ func (mr *MockApiClientMockRecorder) GetOrgIdFromSlug(slugName interface{}) *gom
 }
 
 // GetSastSettings mocks base method.
-func (m *MockApiClient) GetSastSettings(orgId string) (sast_contract.SastResponse, error) {
+func (m *MockApiClient) GetSastSettings(orgId string) (*sast_contract.SastResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSastSettings", orgId)
-	ret0, _ := ret[0].(sast_contract.SastResponse)
+	ret0, _ := ret[0].(*sast_contract.SastResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/local_workflows/code_workflow.go
+++ b/pkg/local_workflows/code_workflow.go
@@ -55,11 +55,11 @@ func getSastSettings(engine workflow.Engine) (*sast_contract.SastResponse, error
 	tmp, err := apiClient.GetSastSettings(org)
 	if err != nil {
 		engine.GetLogger().Err(err).Msg("Failed to access settings.")
-		return &tmp, err
+		return nil, err
 	}
 
-	engine.GetConfiguration().Set(code_workflow.ConfigurationSastSettings, &tmp)
-	return &tmp, nil
+	engine.GetConfiguration().Set(code_workflow.ConfigurationSastSettings, tmp)
+	return tmp, nil
 }
 
 func getSastSettingsConfig(engine workflow.Engine) configuration.DefaultValueFunction {
@@ -71,7 +71,7 @@ func getSastSettingsConfig(engine workflow.Engine) configuration.DefaultValueFun
 		response, err := getSastSettings(engine)
 		if err != nil {
 			engine.GetLogger().Err(err).Msg("Failed to access settings.")
-			return false, err
+			return nil, err
 		}
 
 		return response, nil


### PR DESCRIPTION
use pointer for sastResponse and returning nil instead of empty structs.