### PR TITLE
chore: update ignore workflow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/oapi-codegen/oapi-codegen/v2 v2.4.1
 	github.com/oapi-codegen/runtime v1.1.1
-	github.com/snyk/error-catalog-golang-public v0.0.0-20250218074309-307ad7b38a60
+	github.com/snyk/error-catalog-golang-public v0.0.0-20250429130542-564b0605020e
 	github.com/subosito/gotenv v1.4.1
 	golang.org/x/sync v0.13.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnB
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/snyk/code-client-go v1.20.1 h1:38nEGzrQIh/aVLjR99jiTUQM0sL9SQAvhMfZGmd9G0w=
 github.com/snyk/code-client-go v1.20.1/go.mod h1:WH6lNkJc785hfXmwhixxWHix3O6z+1zwz40oK8vl/zg=
-github.com/snyk/error-catalog-golang-public v0.0.0-20250218074309-307ad7b38a60 h1:iB6z2BhBpfN9p0/dEZfwWvs7fpdZk3loooAih8yspS8=
-github.com/snyk/error-catalog-golang-public v0.0.0-20250218074309-307ad7b38a60/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
+github.com/snyk/error-catalog-golang-public v0.0.0-20250429130542-564b0605020e h1:XFGkHDWA8JTPLr82QzoKVqGytofEYBf68VqoUq8yvXk=
+github.com/snyk/error-catalog-golang-public v0.0.0-20250429130542-564b0605020e/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/speakeasy-api/jsonpath v0.6.1 h1:FWbuCEPGaJTVB60NZg2orcYHGZlelbNJAcIk/JGnZvo=

--- a/pkg/local_workflows/ignore_workflow/config.go
+++ b/pkg/local_workflows/ignore_workflow/config.go
@@ -30,13 +30,13 @@ func addCreateIgnoreDefaultConfigurationValues(invocationCtx workflow.Invocation
 		if !config.IsSet(ExpirationKey) {
 			return existingValue, nil
 		}
-		
+
 		err := isValidExpirationDate(existingValue)
 		if err != nil {
 			return "", err
 		}
 
-		return existingValue, nil	
+		return existingValue, nil
 	})
 
 	config.AddDefaultValue(FindingsIdKey, func(existingValue interface{}) (interface{}, error) {

--- a/pkg/local_workflows/ignore_workflow/config.go
+++ b/pkg/local_workflows/ignore_workflow/config.go
@@ -27,8 +27,16 @@ func addCreateIgnoreDefaultConfigurationValues(invocationCtx workflow.Invocation
 	})
 
 	config.AddDefaultValue(ExpirationKey, func(existingValue interface{}) (interface{}, error) {
-		isSet := config.IsSet(ExpirationKey)
-		return defaultFuncWithValidator(existingValue, userInterface, interactive, isSet, expirationDescription, isValidExpirationDate)
+		if !config.IsSet(ExpirationKey) {
+			return existingValue, nil
+		}
+		
+		err := isValidExpirationDate(existingValue)
+		if err != nil {
+			return "", err
+		}
+
+		return existingValue, nil	
 	})
 
 	config.AddDefaultValue(FindingsIdKey, func(existingValue interface{}) (interface{}, error) {

--- a/pkg/local_workflows/ignore_workflow/ignore_workflow.go
+++ b/pkg/local_workflows/ignore_workflow/ignore_workflow.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/snyk/code-client-go/sarif"
+	"github.com/snyk/error-catalog-golang-public/cli"
 
 	policyApi "github.com/snyk/go-application-framework/internal/api/policy/2024-10-15"
 	"github.com/snyk/go-application-framework/pkg/configuration"
@@ -27,7 +28,7 @@ const (
 	ignoreEditWorkflowName   = "ignore.edit"
 	ignoreDeleteWorkflowName = "ignore.delete"
 
-	FindingsIdKey         = "id"
+	FindingsIdKey         = "finding-id"
 	findingsIdDescription = "Findings Id"
 
 	IgnoreIdKey         = "ignore-id"
@@ -85,7 +86,7 @@ func ignoreCreateWorkflowEntryPoint(invocationCtx workflow.InvocationContext, _ 
 	id := invocationCtx.GetWorkflowIdentifier()
 
 	if !config.GetBool(configuration.FF_IAW_ENABLED) {
-		return nil, fmt.Errorf("ignoreApprovalWorkflow Feature flag is not enabled")
+		return nil, cli.NewFeatureUnderDevelopmentError("")
 	}
 
 	interactive := config.GetBool(InteractiveKey)


### PR DESCRIPTION
## What
Some small changes for the CLI RC regarding the ignore workflow.

- replace the feature flag error with the error catalog equivalent
- rename the `--id` parameter to `--finding-id` for better clarity 
- remove the interactive prompt for the `expiry` if the flag is not set

## Related:
- [CLI-IDE sync notes](https://snyksec.atlassian.net/wiki/spaces/CLI/pages/3215982961/IAW+Sync+CLI+IDE#28.04.2025)