### PR TITLE
chore: update LFM with suppressions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,12 @@ $(GO_BIN)/cue:
 $(GO_BIN)/golangci-lint:
 	curl -sSfL 'https://raw.githubusercontent.com/golangci/golangci-lint/${OVERRIDE_GOCI_LINT_V}/install.sh' | sh -s -- -b ${GO_BIN} ${OVERRIDE_GOCI_LINT_V}
 
+.PHONY: update-dragonfly
+update-dragonfly:
+	@scripts/pull-down-dragonfly-api-spec.sh
+	@make generate
+
+
 .PHONY: update-local-findings
 update-local-findings:
 	@scripts/pull-down-test-api-spec.sh

--- a/internal/cueutils/source/openapi/rest/generated.txt
+++ b/internal/cueutils/source/openapi/rest/generated.txt
@@ -1,1 +1,1 @@
-2025-02-04T12:08:26Z feat/local_findings_sarif 7ea0d951f96ab9276d29bba2325e3def97d93871
+2025-05-06T11:08:43Z feat/local_findings_sarif 14f202ae47066d8e0bce241c8d90c866cea17646

--- a/internal/cueutils/source/openapi/rest/test.spec.yaml
+++ b/internal/cueutils/source/openapi/rest/test.spec.yaml
@@ -570,9 +570,9 @@ components:
         - $ref: '#/components/schemas/types.CodeSastFingerprintV1'
         - $ref: '#/components/schemas/types.ScaProblemFingerprint'
         - $ref: '#/components/schemas/types.IdentityFingerprint'
-        - $ref: '#/components/schemas/types.FingerprintProjectV1'
-        - $ref: '#/components/schemas/types.FingerprintRepositoryV1'
-        - $ref: '#/components/schemas/types.FingerprintAssetV1'
+        - $ref: '#/components/schemas/types.CodeSastFingerprintProjectV1'
+        - $ref: '#/components/schemas/types.CodeSastFingerprintRepositoryV1'
+        - $ref: '#/components/schemas/types.CodeSastFingerprintAssetV1'
       discriminator:
         propertyName: scheme
         mapping:
@@ -580,9 +580,9 @@ components:
           code-sast-v1: '#/components/schemas/types.CodeSastFingerprintV1'
           sca-problem: '#/components/schemas/types.ScaProblemFingerprint'
           identity: '#/components/schemas/types.IdentityFingerprint'
-          snyk/org/project/finding/v1: '#/components/schemas/types.FingerprintProjectV1'
-          snyk/org/repository/finding/v1: '#/components/schemas/types.FingerprintRepositoryV1'
-          snyk/asset/finding/v1: '#/components/schemas/types.FingerprintAssetV1'
+          snyk/org/project/finding/v1: '#/components/schemas/types.CodeSastFingerprintProjectV1'
+          snyk/org/repository/finding/v1: '#/components/schemas/types.CodeSastFingerprintRepositoryV1'
+          snyk/asset/finding/v1: '#/components/schemas/types.CodeSastFingerprintAssetV1'
     LinkProperty:
       oneOf:
         - $ref: '#/components/schemas/io.snyk.api.common.LinkString'
@@ -816,6 +816,42 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/types.ThreadFlow'
+    types.CodeSastFingerprintAssetV1:
+      type: object
+      required:
+        - scheme
+        - value
+      properties:
+        scheme:
+          type: string
+          enum:
+            - snyk/asset/finding/v1
+        value:
+          type: string
+    types.CodeSastFingerprintProjectV1:
+      type: object
+      required:
+        - scheme
+        - value
+      properties:
+        scheme:
+          type: string
+          enum:
+            - snyk/org/project/finding/v1
+        value:
+          type: string
+    types.CodeSastFingerprintRepositoryV1:
+      type: object
+      required:
+        - scheme
+        - value
+      properties:
+        scheme:
+          type: string
+          enum:
+            - snyk/org/repository/finding/v1
+        value:
+          type: string
     types.CodeSastFingerprintV0:
       type: object
       required:
@@ -1620,42 +1656,6 @@ components:
           items:
             $ref: '#/components/schemas/types.Coverage'
       description: Summary statistics about a Test's Findings.
-    types.FingerprintAssetV1:
-      type: object
-      required:
-        - scheme
-        - value
-      properties:
-        scheme:
-          type: string
-          enum:
-            - snyk/asset/finding/v1
-        value:
-          type: string
-    types.FingerprintProjectV1:
-      type: object
-      required:
-        - scheme
-        - value
-      properties:
-        scheme:
-          type: string
-          enum:
-            - snyk/org/project/finding/v1
-        value:
-          type: string
-    types.FingerprintRepositoryV1:
-      type: object
-      required:
-        - scheme
-        - value
-      properties:
-        scheme:
-          type: string
-          enum:
-            - snyk/org/repository/finding/v1
-        value:
-          type: string
     types.GitCommit:
       type: string
       example: 23ee663c96889a1ce6f62217adf4dea2bea1b09e
@@ -1992,14 +1992,18 @@ components:
     types.Suppression:
       type: object
       required:
-        - kind
+        - id
+        - status
       properties:
-        kind:
+        id:
+          type: string
+          format: uuid
+        status:
           type: string
           enum:
-            - ignored
-            - pending_ignore_approval
-            - other
+            - accepted
+            - underReview
+            - rejected
         justification:
           type: string
         details:

--- a/internal/presenters/testdata/with-ignores-with-status.json
+++ b/internal/presenters/testdata/with-ignores-with-status.json
@@ -669,6 +669,7 @@
             },
             "suppressions": [
               {
+                "guid":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
                 "justification": "False positive",
                 "kind": "inSource",
                 "status": "accepted",

--- a/internal/presenters/testdata/with-ignores.json
+++ b/internal/presenters/testdata/with-ignores.json
@@ -669,6 +669,8 @@
             },
             "suppressions": [
               {
+                "guid":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                "status":"accepted",
                 "justification": "False positive",
                 "kind": "inSource",
                 "properties": {

--- a/pkg/local_workflows/data_transformation_workflow_test.go
+++ b/pkg/local_workflows/data_transformation_workflow_test.go
@@ -246,13 +246,13 @@ func Test_DataTransformation_with_Sarif_and_SummaryData(t *testing.T) {
 }
 
 func parseFingerprint(fp local_models.Fingerprint) (scheme string, value string, ok bool) {
-	if assetFp, err := fp.AsTypesFingerprintAssetV1(); err == nil {
+	if assetFp, err := fp.AsTypesCodeSastFingerprintAssetV1(); err == nil {
 		return string(assetFp.Scheme), assetFp.Value, true
 	}
-	if orgProjectFp, err := fp.AsTypesFingerprintProjectV1(); err == nil {
+	if orgProjectFp, err := fp.AsTypesCodeSastFingerprintProjectV1(); err == nil {
 		return string(orgProjectFp.Scheme), orgProjectFp.Value, true
 	}
-	if orgRepoFp, err := fp.AsTypesFingerprintRepositoryV1(); err == nil {
+	if orgRepoFp, err := fp.AsTypesCodeSastFingerprintRepositoryV1(); err == nil {
 		return string(orgRepoFp.Scheme), orgRepoFp.Value, true
 	}
 	return "", "", false

--- a/pkg/local_workflows/local_models/models.gen.go
+++ b/pkg/local_workflows/local_models/models.gen.go
@@ -29,6 +29,21 @@ const (
 	TypesBusinessCriticalityRiskFactorValueMedium TypesBusinessCriticalityRiskFactorValue = "medium"
 )
 
+// Defines values for TypesCodeSastFingerprintAssetV1Scheme.
+const (
+	Snykassetfindingv1 TypesCodeSastFingerprintAssetV1Scheme = "snyk/asset/finding/v1"
+)
+
+// Defines values for TypesCodeSastFingerprintProjectV1Scheme.
+const (
+	Snykorgprojectfindingv1 TypesCodeSastFingerprintProjectV1Scheme = "snyk/org/project/finding/v1"
+)
+
+// Defines values for TypesCodeSastFingerprintRepositoryV1Scheme.
+const (
+	Snykorgrepositoryfindingv1 TypesCodeSastFingerprintRepositoryV1Scheme = "snyk/org/repository/finding/v1"
+)
+
 // Defines values for TypesCodeSastFingerprintV0Scheme.
 const (
 	CodeSastV0 TypesCodeSastFingerprintV0Scheme = "code-sast-v0"
@@ -116,21 +131,6 @@ const (
 	Findings TypesFindingResourceType = "findings"
 )
 
-// Defines values for TypesFingerprintAssetV1Scheme.
-const (
-	Snykassetfindingv1 TypesFingerprintAssetV1Scheme = "snyk/asset/finding/v1"
-)
-
-// Defines values for TypesFingerprintProjectV1Scheme.
-const (
-	Snykorgprojectfindingv1 TypesFingerprintProjectV1Scheme = "snyk/org/project/finding/v1"
-)
-
-// Defines values for TypesFingerprintRepositoryV1Scheme.
-const (
-	Snykorgrepositoryfindingv1 TypesFingerprintRepositoryV1Scheme = "snyk/org/repository/finding/v1"
-)
-
 // Defines values for TypesGitSCMInputType.
 const (
 	GitScm TypesGitSCMInputType = "git-scm"
@@ -179,11 +179,11 @@ const (
 	True  TypesSuggestedPackageUpgradeUpgradeConflicts = true
 )
 
-// Defines values for TypesSuppressionKind.
+// Defines values for TypesSuppressionStatus.
 const (
-	TypesSuppressionKindIgnored               TypesSuppressionKind = "ignored"
-	TypesSuppressionKindOther                 TypesSuppressionKind = "other"
-	TypesSuppressionKindPendingIgnoreApproval TypesSuppressionKind = "pending_ignore_approval"
+	Accepted    TypesSuppressionStatus = "accepted"
+	Rejected    TypesSuppressionStatus = "rejected"
+	UnderReview TypesSuppressionStatus = "underReview"
 )
 
 // Defines values for TypesTestContextSdlcStage.
@@ -204,9 +204,9 @@ const (
 
 // Defines values for TypesTestOutcomeReason.
 const (
-	Other        TypesTestOutcomeReason = "other"
-	PolicyBreach TypesTestOutcomeReason = "policy_breach"
-	Timeout      TypesTestOutcomeReason = "timeout"
+	TypesTestOutcomeReasonOther        TypesTestOutcomeReason = "other"
+	TypesTestOutcomeReasonPolicyBreach TypesTestOutcomeReason = "policy_breach"
+	TypesTestOutcomeReasonTimeout      TypesTestOutcomeReason = "timeout"
 )
 
 // Defines values for TypesTestOutcomeResult.
@@ -433,6 +433,33 @@ type TypesBusinessCriticalityRiskFactorValue string
 type TypesCodeFlow struct {
 	ThreadFlows []TypesThreadFlow `json:"threadFlows"`
 }
+
+// TypesCodeSastFingerprintAssetV1 defines model for types.CodeSastFingerprintAssetV1.
+type TypesCodeSastFingerprintAssetV1 struct {
+	Scheme TypesCodeSastFingerprintAssetV1Scheme `json:"scheme"`
+	Value  string                                `json:"value"`
+}
+
+// TypesCodeSastFingerprintAssetV1Scheme defines model for TypesCodeSastFingerprintAssetV1.Scheme.
+type TypesCodeSastFingerprintAssetV1Scheme string
+
+// TypesCodeSastFingerprintProjectV1 defines model for types.CodeSastFingerprintProjectV1.
+type TypesCodeSastFingerprintProjectV1 struct {
+	Scheme TypesCodeSastFingerprintProjectV1Scheme `json:"scheme"`
+	Value  string                                  `json:"value"`
+}
+
+// TypesCodeSastFingerprintProjectV1Scheme defines model for TypesCodeSastFingerprintProjectV1.Scheme.
+type TypesCodeSastFingerprintProjectV1Scheme string
+
+// TypesCodeSastFingerprintRepositoryV1 defines model for types.CodeSastFingerprintRepositoryV1.
+type TypesCodeSastFingerprintRepositoryV1 struct {
+	Scheme TypesCodeSastFingerprintRepositoryV1Scheme `json:"scheme"`
+	Value  string                                     `json:"value"`
+}
+
+// TypesCodeSastFingerprintRepositoryV1Scheme defines model for TypesCodeSastFingerprintRepositoryV1.Scheme.
+type TypesCodeSastFingerprintRepositoryV1Scheme string
 
 // TypesCodeSastFingerprintV0 defines model for types.CodeSastFingerprintV0.
 type TypesCodeSastFingerprintV0 struct {
@@ -933,33 +960,6 @@ type TypesFindingsSummary struct {
 	Type      string             `json:"type"`
 }
 
-// TypesFingerprintAssetV1 defines model for types.FingerprintAssetV1.
-type TypesFingerprintAssetV1 struct {
-	Scheme TypesFingerprintAssetV1Scheme `json:"scheme"`
-	Value  string                        `json:"value"`
-}
-
-// TypesFingerprintAssetV1Scheme defines model for TypesFingerprintAssetV1.Scheme.
-type TypesFingerprintAssetV1Scheme string
-
-// TypesFingerprintProjectV1 defines model for types.FingerprintProjectV1.
-type TypesFingerprintProjectV1 struct {
-	Scheme TypesFingerprintProjectV1Scheme `json:"scheme"`
-	Value  string                          `json:"value"`
-}
-
-// TypesFingerprintProjectV1Scheme defines model for TypesFingerprintProjectV1.Scheme.
-type TypesFingerprintProjectV1Scheme string
-
-// TypesFingerprintRepositoryV1 defines model for types.FingerprintRepositoryV1.
-type TypesFingerprintRepositoryV1 struct {
-	Scheme TypesFingerprintRepositoryV1Scheme `json:"scheme"`
-	Value  string                             `json:"value"`
-}
-
-// TypesFingerprintRepositoryV1Scheme defines model for TypesFingerprintRepositoryV1.Scheme.
-type TypesFingerprintRepositoryV1Scheme string
-
 // TypesGitCommit Git commit SHA.
 type TypesGitCommit = string
 
@@ -1179,12 +1179,13 @@ type TypesSuggestedPackageUpgradeUpgradeConflicts bool
 type TypesSuppression struct {
 	// Details Suppression meta data
 	Details       *TypesSuppressionDetails `json:"details,omitempty"`
+	Id            openapi_types.UUID       `json:"id"`
 	Justification *string                  `json:"justification,omitempty"`
-	Kind          TypesSuppressionKind     `json:"kind"`
+	Status        TypesSuppressionStatus   `json:"status"`
 }
 
-// TypesSuppressionKind defines model for TypesSuppression.Kind.
-type TypesSuppressionKind string
+// TypesSuppressionStatus defines model for TypesSuppression.Status.
+type TypesSuppressionStatus string
 
 // TypesSuppressionDetails Suppression meta data
 type TypesSuppressionDetails struct {
@@ -2381,23 +2382,23 @@ func (t *Fingerprint) MergeTypesIdentityFingerprint(v TypesIdentityFingerprint) 
 	return err
 }
 
-// AsTypesFingerprintProjectV1 returns the union data inside the Fingerprint as a TypesFingerprintProjectV1
-func (t Fingerprint) AsTypesFingerprintProjectV1() (TypesFingerprintProjectV1, error) {
-	var body TypesFingerprintProjectV1
+// AsTypesCodeSastFingerprintProjectV1 returns the union data inside the Fingerprint as a TypesCodeSastFingerprintProjectV1
+func (t Fingerprint) AsTypesCodeSastFingerprintProjectV1() (TypesCodeSastFingerprintProjectV1, error) {
+	var body TypesCodeSastFingerprintProjectV1
 	err := json.Unmarshal(t.union, &body)
 	return body, err
 }
 
-// FromTypesFingerprintProjectV1 overwrites any union data inside the Fingerprint as the provided TypesFingerprintProjectV1
-func (t *Fingerprint) FromTypesFingerprintProjectV1(v TypesFingerprintProjectV1) error {
+// FromTypesCodeSastFingerprintProjectV1 overwrites any union data inside the Fingerprint as the provided TypesCodeSastFingerprintProjectV1
+func (t *Fingerprint) FromTypesCodeSastFingerprintProjectV1(v TypesCodeSastFingerprintProjectV1) error {
 	v.Scheme = "snyk/org/project/finding/v1"
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
 }
 
-// MergeTypesFingerprintProjectV1 performs a merge with any union data inside the Fingerprint, using the provided TypesFingerprintProjectV1
-func (t *Fingerprint) MergeTypesFingerprintProjectV1(v TypesFingerprintProjectV1) error {
+// MergeTypesCodeSastFingerprintProjectV1 performs a merge with any union data inside the Fingerprint, using the provided TypesCodeSastFingerprintProjectV1
+func (t *Fingerprint) MergeTypesCodeSastFingerprintProjectV1(v TypesCodeSastFingerprintProjectV1) error {
 	v.Scheme = "snyk/org/project/finding/v1"
 	b, err := json.Marshal(v)
 	if err != nil {
@@ -2409,23 +2410,23 @@ func (t *Fingerprint) MergeTypesFingerprintProjectV1(v TypesFingerprintProjectV1
 	return err
 }
 
-// AsTypesFingerprintRepositoryV1 returns the union data inside the Fingerprint as a TypesFingerprintRepositoryV1
-func (t Fingerprint) AsTypesFingerprintRepositoryV1() (TypesFingerprintRepositoryV1, error) {
-	var body TypesFingerprintRepositoryV1
+// AsTypesCodeSastFingerprintRepositoryV1 returns the union data inside the Fingerprint as a TypesCodeSastFingerprintRepositoryV1
+func (t Fingerprint) AsTypesCodeSastFingerprintRepositoryV1() (TypesCodeSastFingerprintRepositoryV1, error) {
+	var body TypesCodeSastFingerprintRepositoryV1
 	err := json.Unmarshal(t.union, &body)
 	return body, err
 }
 
-// FromTypesFingerprintRepositoryV1 overwrites any union data inside the Fingerprint as the provided TypesFingerprintRepositoryV1
-func (t *Fingerprint) FromTypesFingerprintRepositoryV1(v TypesFingerprintRepositoryV1) error {
+// FromTypesCodeSastFingerprintRepositoryV1 overwrites any union data inside the Fingerprint as the provided TypesCodeSastFingerprintRepositoryV1
+func (t *Fingerprint) FromTypesCodeSastFingerprintRepositoryV1(v TypesCodeSastFingerprintRepositoryV1) error {
 	v.Scheme = "snyk/org/repository/finding/v1"
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
 }
 
-// MergeTypesFingerprintRepositoryV1 performs a merge with any union data inside the Fingerprint, using the provided TypesFingerprintRepositoryV1
-func (t *Fingerprint) MergeTypesFingerprintRepositoryV1(v TypesFingerprintRepositoryV1) error {
+// MergeTypesCodeSastFingerprintRepositoryV1 performs a merge with any union data inside the Fingerprint, using the provided TypesCodeSastFingerprintRepositoryV1
+func (t *Fingerprint) MergeTypesCodeSastFingerprintRepositoryV1(v TypesCodeSastFingerprintRepositoryV1) error {
 	v.Scheme = "snyk/org/repository/finding/v1"
 	b, err := json.Marshal(v)
 	if err != nil {
@@ -2437,23 +2438,23 @@ func (t *Fingerprint) MergeTypesFingerprintRepositoryV1(v TypesFingerprintReposi
 	return err
 }
 
-// AsTypesFingerprintAssetV1 returns the union data inside the Fingerprint as a TypesFingerprintAssetV1
-func (t Fingerprint) AsTypesFingerprintAssetV1() (TypesFingerprintAssetV1, error) {
-	var body TypesFingerprintAssetV1
+// AsTypesCodeSastFingerprintAssetV1 returns the union data inside the Fingerprint as a TypesCodeSastFingerprintAssetV1
+func (t Fingerprint) AsTypesCodeSastFingerprintAssetV1() (TypesCodeSastFingerprintAssetV1, error) {
+	var body TypesCodeSastFingerprintAssetV1
 	err := json.Unmarshal(t.union, &body)
 	return body, err
 }
 
-// FromTypesFingerprintAssetV1 overwrites any union data inside the Fingerprint as the provided TypesFingerprintAssetV1
-func (t *Fingerprint) FromTypesFingerprintAssetV1(v TypesFingerprintAssetV1) error {
+// FromTypesCodeSastFingerprintAssetV1 overwrites any union data inside the Fingerprint as the provided TypesCodeSastFingerprintAssetV1
+func (t *Fingerprint) FromTypesCodeSastFingerprintAssetV1(v TypesCodeSastFingerprintAssetV1) error {
 	v.Scheme = "snyk/asset/finding/v1"
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
 }
 
-// MergeTypesFingerprintAssetV1 performs a merge with any union data inside the Fingerprint, using the provided TypesFingerprintAssetV1
-func (t *Fingerprint) MergeTypesFingerprintAssetV1(v TypesFingerprintAssetV1) error {
+// MergeTypesCodeSastFingerprintAssetV1 performs a merge with any union data inside the Fingerprint, using the provided TypesCodeSastFingerprintAssetV1
+func (t *Fingerprint) MergeTypesCodeSastFingerprintAssetV1(v TypesCodeSastFingerprintAssetV1) error {
 	v.Scheme = "snyk/asset/finding/v1"
 	b, err := json.Marshal(v)
 	if err != nil {
@@ -2488,11 +2489,11 @@ func (t Fingerprint) ValueByDiscriminator() (interface{}, error) {
 	case "sca-problem":
 		return t.AsTypesScaProblemFingerprint()
 	case "snyk/asset/finding/v1":
-		return t.AsTypesFingerprintAssetV1()
+		return t.AsTypesCodeSastFingerprintAssetV1()
 	case "snyk/org/project/finding/v1":
-		return t.AsTypesFingerprintProjectV1()
+		return t.AsTypesCodeSastFingerprintProjectV1()
 	case "snyk/org/repository/finding/v1":
-		return t.AsTypesFingerprintRepositoryV1()
+		return t.AsTypesCodeSastFingerprintRepositoryV1()
 	default:
 		return nil, errors.New("unknown discriminator value: " + discriminator)
 	}

--- a/pkg/local_workflows/local_models/transform.go
+++ b/pkg/local_workflows/local_models/transform.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/snyk/code-client-go/sarif"
 
 	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
@@ -122,6 +123,7 @@ func mapSuppressions(res sarif.Result) *TypesSuppression {
 		ignored_email = *suppression.Properties.IgnoredBy.Email
 	}
 	return &TypesSuppression{
+		Id: uuid.MustParse(suppression.Guid),
 		Details: &TypesSuppressionDetails{
 			Category:   string(suppression.Properties.Category),
 			Expiration: expiration,
@@ -132,7 +134,18 @@ func mapSuppressions(res sarif.Result) *TypesSuppression {
 			},
 		},
 		Justification: &suppression.Justification,
-		Kind:          "ignored",
+		Status:        toSuppressionStatus(suppression.Status),
+	}
+}
+
+func toSuppressionStatus(status sarif.SuppresionStatus) TypesSuppressionStatus {
+	switch status {
+	case "accepted":
+		return Accepted
+	case "underReview":
+		return UnderReview
+	default:
+		return Rejected
 	}
 }
 

--- a/pkg/local_workflows/testdata/sarif-snyk-goof-ignores.json
+++ b/pkg/local_workflows/testdata/sarif-snyk-goof-ignores.json
@@ -2602,6 +2602,8 @@
           },
           "suppressions": [
             {
+              "guid":"BFFA1C3C-7D67-4EDE-B6D0-7D5208AD041D",
+              "state": "accepted",
               "justification": "Experimenting with consistent ignores capability. ",
               "properties": {
                 "category": "temporary-ignore",
@@ -2771,6 +2773,8 @@
           },
           "suppressions": [
             {
+              "guid":"BFFA1C3C-7D67-4EDE-B6D0-7D5208AD041D",
+              "state": "accepted",
               "justification": "",
               "properties": {
                 "category": "not-vulnerable",
@@ -2983,6 +2987,8 @@
           },
           "suppressions": [
             {
+              "guid":"BFFA1C3C-7D67-4EDE-B6D0-7D5208AD041D",
+              "state": "accepted",
               "justification": "",
               "properties": {
                 "category": "not-vulnerable",

--- a/scripts/pull-down-dragonfly-api-spec.sh
+++ b/scripts/pull-down-dragonfly-api-spec.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 API_SPEC_PATH=$(realpath ../dragonfly)
-API_SPEC_BRANCH=${API_SPEC_BRANCH:-main}
+API_SPEC_BRANCH=${API_SPEC_BRANCH:-feat/local_findings_sarif}
 GENERATE_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 echo --------------------------------------------------------

--- a/scripts/pull-down-dragonfly-api-spec.sh
+++ b/scripts/pull-down-dragonfly-api-spec.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+API_SPEC_PATH=$(realpath ../dragonfly)
+API_SPEC_BRANCH=${API_SPEC_BRANCH:-main}
+GENERATE_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+echo --------------------------------------------------------
+echo Updating local findings from dragonfly!
+echo
+echo Path:   $API_SPEC_PATH
+echo Branch: $API_SPEC_BRANCH
+echo Date:   $GENERATE_DATE
+echo --------------------------------------------------------
+
+# Check if the directory exists
+if [[ ! -d "$API_SPEC_PATH" ]]; then
+  # Create the directory if it doesn't exist
+  git clone git@github.com:snyk/dragonfly.git $API_SPEC_PATH
+fi
+
+cd $API_SPEC_PATH
+git checkout $API_SPEC_BRANCH
+API_COMMIT=$(git rev-parse HEAD)
+git pull
+
+# Update dependencies
+npm ci
+# Trigger build of dragonfly project
+npm run build
+
+# Return to project directory
+cd -
+
+# Vendor OpenAPI build artefacts for use in cue
+cp -r $API_SPEC_PATH/tsp-output/@typespec/openapi3/ ./internal/cueutils/source/openapi/rest
+echo $GENERATE_DATE $API_SPEC_BRANCH $API_COMMIT > ./internal/cueutils/source/openapi/rest/generated.txt


### PR DESCRIPTION
What does this do?

- Reintroduces the old script for updating the LFM using our dragonfly branch (temporary, until we some more time to play around with the new test api)
- Updates the LFM, specifically the Suppression type to include the id and status fields
- Updates the transformations related to suppressions

TODOs:
- Some tests are failing, and will do so until the presenters are updated to account for the new changes