### PR TITLE
feat: Introduce retry middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/go-git/go-git/v5 v5.14.0
 	github.com/gofrs/flock v0.12.1
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
+github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/charmbracelet/lipgloss v0.10.0 h1:KWeXFSexGcfahHX+54URiZGkBFazf70JNMtwg/AFW3s=
 github.com/charmbracelet/lipgloss v0.10.0/go.mod h1:Wig9DSfvANsxqkRsqj6x87irdy123SR4dOXlKa91ciE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -173,14 +173,17 @@ func defaultPreviewFeaturesEnabled(engine workflow.Engine) configuration.Default
 
 func defaultMaxNetworkRetryAttempts(engine workflow.Engine) configuration.DefaultValueFunction {
 	callback := func(existingValue interface{}) (interface{}, error) {
+		const multipleAttempts = 3 // three here is chosen based on other places in the application
+		const singleAttempt = 1
+
 		if existingValue != nil {
 			return existingValue, nil
 		}
 
 		if engine.GetConfiguration().GetBool(configuration.PREVIEW_FEATURES_ENABLED) {
-			return 3, nil
+			return multipleAttempts, nil
 		}
-		return 1, nil
+		return singleAttempt, nil
 	}
 	return callback
 }

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -1,0 +1,169 @@
+package middleware
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+	"github.com/rs/zerolog"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+)
+
+const defaultRetryCount uint = 1 // Per default retries (=1) are disabled and need to be enabled via the configuration
+const defaultRetryAfterSeconds = 5
+const maxRetryAfter = 10 * time.Minute
+const ConfigurationKeyRetryAttempts = "internal_network_request_max_attempts"
+const configurationKeyRetryAfter = "internal_network_request_retry_after_seconds"
+const retryCountHeaderKey = "Snyk-Request-Attempt-Count"
+
+// This lookup table defines the response status codes that should be retried
+var statusCodesToRetryLUT = map[int]bool{
+	http.StatusTooManyRequests:     true,
+	http.StatusTooEarly:            true,
+	http.StatusRequestTimeout:      true,
+	http.StatusInternalServerError: true,
+	http.StatusBadGateway:          true,
+	http.StatusServiceUnavailable:  true,
+	http.StatusGatewayTimeout:      true,
+}
+
+var errRetryNecessary = errors.New("retry with backoff")
+var errRetryAfterHeaderError = errors.New("retry-after is too much in the future")
+
+type RetryMiddleware struct {
+	nextRoundtripper http.RoundTripper
+	config           configuration.Configuration
+	logger           *zerolog.Logger
+}
+
+func NewRetryMiddleware(config configuration.Configuration, logger *zerolog.Logger, roundTripper http.RoundTripper) *RetryMiddleware {
+	return &RetryMiddleware{
+		nextRoundtripper: roundTripper,
+		config:           config,
+		logger:           logger,
+	}
+}
+
+func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
+	var finalResponse *http.Response
+	var finalError error
+	var localBodyBuffer []byte
+	var maxAttempts = defaultRetryCount
+	var retryAfterSeconds = defaultRetryAfterSeconds
+	var actualAttempts = 0
+
+	if tmp := (uint)(rm.config.GetInt(ConfigurationKeyRetryAttempts)); tmp > 0 {
+		maxAttempts = tmp
+	}
+
+	if tmp := rm.config.GetInt(configurationKeyRetryAfter); tmp > 0 {
+		retryAfterSeconds = tmp
+	}
+
+	// if a body is available, create a local copy to be able to use it multiple times
+	if req.Body != nil && maxAttempts > 1 {
+		// possible optimization for large request bodies to not buffer in memory but in filesystem
+		var localBufferError error
+		localBodyBuffer, localBufferError = io.ReadAll(req.Body)
+		closeError := req.Body.Close()
+
+		if localBufferError != nil {
+			return nil, localBufferError
+		}
+		if closeError != nil {
+			return nil, closeError
+		}
+
+		req.Body = io.NopCloser(bytes.NewBuffer(localBodyBuffer))
+	}
+
+	op := func() (*http.Response, error) {
+		actualAttempts++
+
+		// create a local copy of the request
+		localRequest := *req
+		if len(localBodyBuffer) > 0 {
+			localRequest.Body = io.NopCloser(bytes.NewBuffer(localBodyBuffer))
+		}
+
+		// try to send request
+		response, err := rm.nextRoundtripper.RoundTrip(&localRequest)
+
+		// keep track of actual retry attempts for monitoring/logging
+		if response != nil && response.Header != nil && actualAttempts > 1 {
+			response.Header.Set(retryCountHeaderKey, fmt.Sprintf("%d", actualAttempts))
+		}
+
+		// errors from the next round tripper cannot not be retried
+		if err != nil {
+			return response, backoff.Permanent(err)
+		}
+
+		// depending on the response determine if we should retry
+		if retryError := shouldRetry(response); retryError != nil {
+			rm.logger.Debug().Msgf("Retrying request, reason: %v", retryError)
+			return response, retryError
+		}
+
+		return response, nil
+	}
+
+	backoffMethod := backoff.NewExponentialBackOff()
+	backoffMethod.InitialInterval = time.Duration(retryAfterSeconds) * time.Second
+	finalResponse, finalError = backoff.Retry(req.Context(), op, backoff.WithBackOff(backoffMethod), backoff.WithMaxTries(maxAttempts))
+
+	// if retries fail to resolve the issue, we need to unset the locally used error type to not return it from the RoundTripper
+	if errors.Is(finalError, errRetryNecessary) {
+		finalError = nil
+	}
+
+	return finalResponse, finalError
+}
+
+func shouldRetry(response *http.Response) error {
+	if statusCodesToRetryLUT[response.StatusCode] {
+		fixRetryDelay := time.Duration(0)
+
+		// try to read retry-after header if available
+		if headerRetryAfterValue := response.Header.Get("Retry-After"); len(headerRetryAfterValue) > 0 {
+			fixRetryDelay = parseRetryAfterHeader(headerRetryAfterValue)
+		}
+
+		// if the fix retry delay is too big, we rather fail permanently than blocking too long
+		if fixRetryDelay > maxRetryAfter {
+			return backoff.Permanent(errRetryAfterHeaderError)
+		}
+
+		// if a retry after is defined, this is the time to wait for
+		if fixRetryDelay > 0 {
+			return &backoff.RetryAfterError{Duration: fixRetryDelay}
+		}
+
+		// if no retry after is defined, the backoff strategy determines the time to wait for
+		return errRetryNecessary
+	}
+
+	return nil
+}
+
+func parseRetryAfterHeader(headerRetryAfterValue string) time.Duration {
+	// Retry-After: 1230
+	if tmp, err := strconv.ParseInt(headerRetryAfterValue, 10, 64); err == nil {
+		return time.Duration(tmp) * time.Second
+	}
+
+	// Retry-After: Fri, 31 Dec 1999 23:59:59 GMT
+	if tmp, err := time.Parse(time.RFC1123, headerRetryAfterValue); err == nil {
+		if until := tmp.Sub(time.Now()); until > 0 {
+			return until
+		}
+	}
+
+	return 0
+}

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -120,6 +120,7 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// if retries fail to resolve the issue, we need to unset the locally used error type to not return it from the RoundTripper
 	if errors.Is(finalError, errRetryNecessary) {
+		rm.logger.Warn().Msgf("Retry ultimately failed after %d attempts", maxAttempts)
 		finalError = nil
 	}
 

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -1,0 +1,300 @@
+package middleware
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cenkalti/backoff/v5"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+)
+
+// Helper to create a response
+func newResponse(statusCode int, headers http.Header) *http.Response {
+	if headers == nil {
+		headers = http.Header{}
+	}
+
+	localUrl, err := url.Parse("http://example.com")
+	if err != nil {
+		return nil
+	}
+
+	return &http.Response{
+		StatusCode: statusCode,
+		Header:     headers,
+		Request:    &http.Request{Method: http.MethodGet, URL: localUrl}, // Mock request for context
+	}
+}
+
+type failRoundtripper struct {
+	actualCount                  uint
+	NumberOfAttemptsUntilSuccess uint
+	Error                        error
+	ExpectedBody                 []byte
+	t                            *testing.T
+}
+
+func (f *failRoundtripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	f.actualCount++
+	f.t.Helper()
+	f.t.Logf("%s: roundtrip", time.Now())
+
+	headers := http.Header{}
+	bodyBytes, err := io.ReadAll(req.Body)
+	assert.NoError(f.t, err)
+
+	if len(f.ExpectedBody) > 0 {
+		assert.Equal(f.t, f.ExpectedBody, bodyBytes)
+	}
+
+	if f.actualCount < f.NumberOfAttemptsUntilSuccess {
+		return &http.Response{StatusCode: http.StatusInternalServerError, Header: headers}, f.Error
+	}
+
+	return &http.Response{StatusCode: http.StatusOK, Header: headers}, f.Error
+}
+
+func TestNewRetryMiddleware(t *testing.T) {
+	expectedBody := []byte("hello")
+	logger := zerolog.Nop()
+
+	t.Run("Happy path, no retry required", func(t *testing.T) {
+		var expectedAttempts uint = 1
+		failureRoundtripper := &failRoundtripper{
+			NumberOfAttemptsUntilSuccess: expectedAttempts,
+			ExpectedBody:                 expectedBody,
+			t:                            t,
+		}
+		config := configuration.NewWithOpts()
+		config.Set(ConfigurationKeyRetryAttempts, 3)
+		config.Set(configurationKeyRetryAfter, 1)
+
+		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
+		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
+		assert.NoError(t, err)
+		assert.NotNil(t, response)
+		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
+	})
+
+	t.Run("Happy path, retry resolves successfully", func(t *testing.T) {
+		var expectedAttempts uint = 3
+		failureRoundtripper := &failRoundtripper{
+			NumberOfAttemptsUntilSuccess: expectedAttempts,
+			ExpectedBody:                 expectedBody,
+			t:                            t,
+		}
+		config := configuration.NewWithOpts()
+		config.Set(ConfigurationKeyRetryAttempts, int(expectedAttempts))
+		config.Set(configurationKeyRetryAfter, 1)
+
+		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
+		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
+		assert.NoError(t, err)
+		assert.NotNil(t, response)
+		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
+		assert.Equal(t, fmt.Sprintf("%d", expectedAttempts), response.Header.Get(retryCountHeaderKey))
+	})
+
+	t.Run("Unhappy path, retries didn't resolve the issue", func(t *testing.T) {
+		var expectedAttempts uint = 3
+		failureRoundtripper := &failRoundtripper{
+			NumberOfAttemptsUntilSuccess: 10,
+			ExpectedBody:                 expectedBody,
+			t:                            t,
+		}
+		config := configuration.NewWithOpts()
+		config.Set(ConfigurationKeyRetryAttempts, int(expectedAttempts))
+		config.Set(configurationKeyRetryAfter, 1)
+
+		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
+		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
+		assert.NoError(t, err)
+		assert.NotNil(t, response)
+		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
+	})
+
+	t.Run("Unhappy path, non default values", func(t *testing.T) {
+		var expectedAttempts uint = 2
+		failureRoundtripper := &failRoundtripper{
+			NumberOfAttemptsUntilSuccess: 10,
+			ExpectedBody:                 expectedBody,
+			t:                            t,
+		}
+		config := configuration.NewWithOpts()
+		config.Set(ConfigurationKeyRetryAttempts, int(expectedAttempts))
+		config.Set(configurationKeyRetryAfter, 1)
+
+		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
+		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
+		assert.NoError(t, err)
+		assert.NotNil(t, response)
+		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
+	})
+
+	t.Run("Unhappy path, no retries", func(t *testing.T) {
+		var expectedAttempts uint = 1
+		failureRoundtripper := &failRoundtripper{
+			NumberOfAttemptsUntilSuccess: 10,
+			ExpectedBody:                 expectedBody,
+			t:                            t,
+		}
+		config := configuration.NewWithOpts()
+		config.Set(ConfigurationKeyRetryAttempts, int(expectedAttempts))
+		config.Set(configurationKeyRetryAfter, 1)
+
+		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
+		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
+		assert.NoError(t, err)
+		assert.NotNil(t, response)
+		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
+	})
+
+	t.Run("Unhappy path, lower level failure, no retries", func(t *testing.T) {
+		expectedErr := errors.New("blabla")
+		var expectedAttempts uint = 1
+
+		failureRoundtripper := &failRoundtripper{Error: expectedErr, t: t}
+		config := configuration.NewWithOpts()
+		testRequest := httptest.NewRequest(http.MethodGet, "/", nil)
+
+		// invoke system under test
+		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
+		_, err := sut.RoundTrip(testRequest)
+
+		assert.Equal(t, expectedErr.Error(), err.Error())
+		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
+	})
+}
+
+func Test_shouldRetry(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		response          *http.Response
+		expectedErrorIs   error
+		expectedRetryable *backoff.RetryAfterError // For checking RetryAfter duration
+		expectNilError    bool
+	}{
+		{
+			name:            "Retryable status code (429) with Retry-After header too far in the future (4years)",
+			response:        newResponse(http.StatusTooManyRequests, http.Header{"Retry-After": []string{"126144000"}}),
+			expectedErrorIs: &backoff.PermanentError{Err: errRetryAfterHeaderError},
+		},
+		{
+			name:              "Retryable status code (429) with Retry-After header",
+			response:          newResponse(http.StatusTooManyRequests, http.Header{"Retry-After": []string{"5"}}),
+			expectedRetryable: &backoff.RetryAfterError{Duration: 5 * time.Second},
+		},
+		{
+			name:            "Retryable status code (503) with invalid Retry-After header",
+			response:        newResponse(http.StatusServiceUnavailable, http.Header{"Retry-After": []string{"abc"}}),
+			expectedErrorIs: errRetryNecessary, // retryDelaySecs will be 0
+		},
+		{
+			name:            "Retryable status code (500) without Retry-After header",
+			response:        newResponse(http.StatusInternalServerError, nil),
+			expectedErrorIs: errRetryNecessary,
+		},
+		{
+			name:           "Non-retryable status code (200)",
+			response:       newResponse(http.StatusOK, nil),
+			expectNilError: true,
+		},
+		{
+			name:           "Non-retryable status code (400)",
+			response:       newResponse(http.StatusBadRequest, nil),
+			expectNilError: true,
+		},
+		{
+			name:            "Retryable status code (502) with Retry-After: 0",
+			response:        newResponse(http.StatusBadGateway, http.Header{"Retry-After": []string{"0"}}),
+			expectedErrorIs: errRetryNecessary, // retryDelaySecs will be 0
+		},
+		{
+			name:            "Retryable status code (504) with Retry-After: -1",
+			response:        newResponse(http.StatusGatewayTimeout, http.Header{"Retry-After": []string{"-1"}}),
+			expectedErrorIs: errRetryNecessary, // retryDelaySecs will be -1
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := shouldRetry(tt.response)
+
+			if tt.expectNilError {
+				assert.Nil(t, err)
+			} else {
+				assert.NotNil(t, err)
+				if tt.expectedErrorIs != nil {
+					assert.Equal(t, err.Error(), tt.expectedErrorIs.Error(), "Expected error to be of type %T, got %T (%v)", tt.expectedErrorIs, err, err)
+				}
+				if tt.expectedRetryable != nil {
+					var actualRetryableErr *backoff.RetryAfterError
+					isRetryable := errors.As(err, &actualRetryableErr)
+					assert.True(t, isRetryable, "Expected error to be a *backoff.RetryableError")
+					if isRetryable {
+						assert.Equal(t, tt.expectedRetryable, actualRetryableErr, "RetryAfter duration mismatch")
+					}
+				}
+			}
+		})
+	}
+}
+
+func Test_parseRetryAfterHeader(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		output time.Duration
+	}{
+		{
+			name:   "Parse seconds value",
+			input:  "10",
+			output: 10 * time.Second,
+		},
+		{
+			name:   "Parse date value",
+			input:  time.Now().Add(102 * time.Minute).Format(time.RFC1123),
+			output: 102 * time.Minute,
+		},
+		{
+			name:   "Parse date value in the past",
+			input:  "Wed, 21 Oct 2015 07:28:00 GMT",
+			output: 0 * time.Second,
+		},
+		{
+			name:   "Parse empty string",
+			input:  "",
+			output: 0 * time.Second,
+		},
+		{
+			name:   "Parse random string",
+			input:  "random",
+			output: 0 * time.Second,
+		},
+	}
+
+	for _, testcase := range tests {
+		t.Run(testcase.name, func(t *testing.T) {
+			actualOutput := parseRetryAfterHeader(testcase.input)
+			timeDistance := (testcase.output - actualOutput) / time.Second
+			t.Logf("Time distance: %v", timeDistance)
+			assert.Equal(t, 0.0, math.Abs(float64(timeDistance)))
+		})
+	}
+}

--- a/pkg/networking/networking.go
+++ b/pkg/networking/networking.go
@@ -192,6 +192,8 @@ func (n *networkImpl) getUnauthorizedRoundTripper() http.RoundTripper {
 	//nolint:errcheck // breaking api change needed to fix this
 	transport := http.DefaultTransport.(*http.Transport) //nolint:forcetypeassert // panic here is reasonable
 	var crt http.RoundTripper = n.configureRoundTripper(transport)
+	crt = middleware.NewRetryMiddleware(n.config, n.logger, crt)
+
 	if n.errorHandler != nil {
 		crt = middleware.NewReponseMiddleware(crt, n.config, n.errorHandler)
 	}


### PR DESCRIPTION
This PR introduces a retry middleware and adds it to the default network stack. Per default retries are disabled and the middleware will act as a pass through, but for `preview` versions and if the feature is enabled, network requests failing with a certain status code will automatically be retried.

This can be enabled for example in the CLI by setting the environment variable `INTERNAL_NETWORK_REQUEST_MAX_ATTEMPTS=<N>`, where <N> is the maximum number of request attempts, 1 being the minimum.

The Status Codes that will be retried can be found [here](https://github.com/snyk/go-application-framework/pull/346/files#diff-295d20b71bb7f7fdc47d3503d7fb17595142bb2c48dd5801cc4ad0517afb1a55R26)

There are some changes/improvement that are left for future iterations, like optimizations around memory consumption, observability and rollout.