### PR TITLE
fix: [CLI-888] allowing populated response in RoundTrip error cases

### DIFF
--- a/pkg/networking/middleware/response.go
+++ b/pkg/networking/middleware/response.go
@@ -40,11 +40,6 @@ func (rm ResponseMiddleware) RoundTrip(req *http.Request) (*http.Response, error
 
 	err = rm.errHandler(err, res.Request.Context())
 
-	// RoundTrip should return one or the other.
-	if err != nil {
-		res = nil
-	}
-
 	return res, err
 }
 

--- a/pkg/networking/middleware/response.go
+++ b/pkg/networking/middleware/response.go
@@ -31,7 +31,6 @@ func NewReponseMiddleware(roundTriper http.RoundTripper, config configuration.Co
 
 func (rm ResponseMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 	res, err := rm.next.RoundTrip(req)
-
 	if err != nil {
 		return res, err
 	}
@@ -43,7 +42,7 @@ func (rm ResponseMiddleware) RoundTrip(req *http.Request) (*http.Response, error
 	return res, err
 }
 
-// HandleResponse maps the response param to the eror catalog error.
+// HandleResponse maps the response param to the error catalog error.
 func HandleResponse(res *http.Response, config configuration.Configuration) error {
 	if res == nil {
 		return nil
@@ -75,6 +74,7 @@ func getErrorList(res *http.Response) []snyk_errors.Error {
 	if err != nil {
 		return []snyk_errors.Error{}
 	}
+
 	res.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
 	errorList, err := snyk_errors.FromJSONAPIErrorBytes(bodyBytes)

--- a/pkg/networking/middleware/response_test.go
+++ b/pkg/networking/middleware/response_test.go
@@ -47,6 +47,8 @@ func Test_ResponseMiddleware(t *testing.T) {
 			assert.Nil(t, err)
 		default:
 			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("hello"))
+			assert.Nil(t, err)
 		}
 	})
 	server := httptest.NewServer(handler)
@@ -242,7 +244,7 @@ func Test_ResponseMiddleware(t *testing.T) {
 
 				bodyBytes, err := io.ReadAll(res.Body)
 				assert.NoError(t, err, "Body should be readable")
-				assert.NotNil(t, bodyBytes, "Should be able to read body")
+				assert.NotEmpty(t, bodyBytes, "Should be able to read body")
 
 				err = res.Body.Close()
 				assert.NoError(t, err, "Body should close without errors")

--- a/pkg/networking/middleware/response_test.go
+++ b/pkg/networking/middleware/response_test.go
@@ -77,7 +77,7 @@ func Test_ResponseMiddleware(t *testing.T) {
 			req := buildRequest(url)
 			res, err := rt.RoundTrip(req)
 
-			assert.Nil(t, res)
+			assert.NotNil(t, res)
 			assert.ErrorAs(t, err, &snykErr)
 			assert.Equal(t, code, snykErr.StatusCode)
 
@@ -121,7 +121,7 @@ func Test_ResponseMiddleware(t *testing.T) {
 		req := buildRequest(server.URL + "/jsonapi-SNYK-0003")
 		res, err := rt.RoundTrip(req)
 
-		assert.Nil(t, res)
+		assert.NotNil(t, res)
 		assert.Error(t, err)
 
 		actual := snyk_errors.Error{}
@@ -138,7 +138,7 @@ func Test_ResponseMiddleware(t *testing.T) {
 		req := buildRequest(server.URL + "/jsonapi-SNYK-0000")
 		res, err := rt.RoundTrip(req)
 
-		assert.Nil(t, res)
+		assert.NotNil(t, res)
 		assert.Error(t, err)
 
 		actual := snyk_errors.Error{}
@@ -155,7 +155,7 @@ func Test_ResponseMiddleware(t *testing.T) {
 		req := buildRequest(server.URL + "/error-catalog")
 		res, err := rt.RoundTrip(req)
 
-		assert.Nil(t, res)
+		assert.NotNil(t, res)
 		assert.Error(t, err)
 
 		expected := snyk.NewBadGatewayError("")


### PR DESCRIPTION
We're implementing a change in how we handle network requests from the Legacy CLI in order to avoid writing the same logic for both the GAF network stack and the proxied requests from the Legacy CLI.

This requires us to keep the response object from the RoundTripper even on errors, which is a bit unidiomatic, but the best compromise I could find.

Currently, if our `RoundTrip()` logic fails on an error, we do not return the raw response, but only the error (which is probably correct), but in order for us to handle the errors from the legacy CLI correctly, we need to preserve the raw HTTP error and handle it later in the stack.

Relevant details from the dependent [CLI PR](https://github.com/snyk/cli/pull/5888):
> The relevant downstream logic is found in the `goproxy` [code](https://github.com/elazarl/goproxy/blob/088f758167d2ea5cf2a8e14aab45f825ef47399e/https.go#L331-L332) that expects a non-empty response body in order to not re-send a request that was intercepted by a custom handler.

Meaning that we need the intact response object in cases of errors, in order to adequately decorate the error responses from the Legacy CLI as it bubbles up the chain.