### PR TITLE
fix: WIP make auth cancellable [IDE-962]

### DIFF
--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/snyk/go-application-framework/internal/api"
@@ -11,7 +12,8 @@ import (
 
 type Authenticator interface {
 	// Authenticate authenticates the user and returns an error if the authentication failed.
-	Authenticate() error
+	// Takes a context which can be used to interrupt the authentication.
+	Authenticate(ctx context.Context) error
 	// AddAuthenticationHeader adds the authentication header to the request.
 	AddAuthenticationHeader(request *http.Request) error
 	// IsSupported returns true if the authenticator is ready for use.

--- a/pkg/auth/oauth2authenticator_test.go
+++ b/pkg/auth/oauth2authenticator_test.go
@@ -349,7 +349,7 @@ func Test_Authenticate_CredentialsGrant(t *testing.T) {
 	config.Set(configuration.API_URL, srv.URL)
 
 	authenticator := NewOAuth2AuthenticatorWithOpts(config, WithHttpClient(http.DefaultClient))
-	err := authenticator.Authenticate()
+	err := authenticator.Authenticate(context.Background())
 	assert.Nil(t, err)
 
 	token := config.GetString(CONFIG_KEY_OAUTH_TOKEN)
@@ -399,7 +399,7 @@ func Test_Authenticate_AuthorizationCode(t *testing.T) {
 			WithOpenBrowserFunc(headlessOpenBrowserFunc(t)),
 		)
 
-		err := authenticator.Authenticate()
+		err := authenticator.Authenticate(context.Background())
 		assert.Nil(t, err)
 
 		assert.Equal(t, "{\"access_token\":\"a\",\"token_type\":\"b\",\"expiry\":\"0001-01-01T00:00:00Z\"}", config.GetString(CONFIG_KEY_OAUTH_TOKEN))
@@ -425,7 +425,7 @@ func Test_Authenticate_AuthorizationCode(t *testing.T) {
 			WithOpenBrowserFunc(headlessOpenBrowserFunc(t)),
 		)
 
-		err := authenticator.Authenticate()
+		err := authenticator.Authenticate(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, "{\"access_token\":\"a\",\"token_type\":\"b\",\"expiry\":\"0001-01-01T00:00:00Z\"}", config.GetString(CONFIG_KEY_OAUTH_TOKEN))
 	})
@@ -449,7 +449,7 @@ func Test_Authenticate_AuthorizationCode(t *testing.T) {
 			WithOpenBrowserFunc(headlessOpenBrowserFunc(t)),
 		)
 
-		err := authenticator.Authenticate()
+		err := authenticator.Authenticate(context.Background())
 		assert.ErrorContains(t, err, "invalid host")
 	})
 
@@ -471,7 +471,7 @@ func Test_Authenticate_AuthorizationCode(t *testing.T) {
 			WithOpenBrowserFunc(headlessOpenBrowserFunc(t)),
 		)
 
-		err := authenticator.Authenticate()
+		err := authenticator.Authenticate(context.Background())
 		assert.ErrorContains(t, err, "incorrect response state")
 	})
 }

--- a/pkg/auth/tokenauthenticator.go
+++ b/pkg/auth/tokenauthenticator.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -17,7 +18,7 @@ func NewTokenAuthenticator(tokenFunc func() string) Authenticator {
 	}
 }
 
-func (t *tokenAuthenticator) Authenticate() error {
+func (t *tokenAuthenticator) Authenticate(_ context.Context) error {
 	return nil
 }
 

--- a/pkg/local_workflows/auth_workflow.go
+++ b/pkg/local_workflows/auth_workflow.go
@@ -1,6 +1,7 @@
 package localworkflows
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -105,7 +106,7 @@ func entryPointDI(config configuration.Configuration, logger *zerolog.Logger, en
 		headless := config.GetBool(headlessFlag)
 		logger.Printf("Headless: %v", headless)
 
-		err = authenticator.Authenticate()
+		err = authenticator.Authenticate(context.Background())
 		if err != nil {
 			return err
 		}

--- a/pkg/local_workflows/auth_workflow_test.go
+++ b/pkg/local_workflows/auth_workflow_test.go
@@ -33,7 +33,7 @@ func Test_auth_oauth(t *testing.T) {
 
 	t.Run("happy", func(t *testing.T) {
 		config.Set(authTypeParameter, nil)
-		authenticator.EXPECT().Authenticate().Times(1).Return(nil)
+		authenticator.EXPECT().Authenticate(gomock.Any()).Times(1).Return(nil)
 		err = entryPointDI(config, &logger, engine, authenticator)
 		assert.NoError(t, err)
 	})
@@ -41,7 +41,7 @@ func Test_auth_oauth(t *testing.T) {
 	t.Run("unhappy", func(t *testing.T) {
 		config.Set(authTypeParameter, nil)
 		expectedErr := fmt.Errorf("someting went wrong")
-		authenticator.EXPECT().Authenticate().Times(1).Return(expectedErr)
+		authenticator.EXPECT().Authenticate(gomock.Any()).Times(1).Return(expectedErr)
 		err = entryPointDI(config, &logger, engine, authenticator)
 		assert.Equal(t, expectedErr, err)
 	})

--- a/pkg/mocks/authenticator.go
+++ b/pkg/mocks/authenticator.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	http "net/http"
 	reflect "reflect"
 
@@ -49,17 +50,17 @@ func (mr *MockAuthenticatorMockRecorder) AddAuthenticationHeader(request interfa
 }
 
 // Authenticate mocks base method.
-func (m *MockAuthenticator) Authenticate() error {
+func (m *MockAuthenticator) Authenticate(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Authenticate")
+	ret := m.ctrl.Call(m, "Authenticate", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Authenticate indicates an expected call of Authenticate.
-func (mr *MockAuthenticatorMockRecorder) Authenticate() *gomock.Call {
+func (mr *MockAuthenticatorMockRecorder) Authenticate(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Authenticate", reflect.TypeOf((*MockAuthenticator)(nil).Authenticate))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Authenticate", reflect.TypeOf((*MockAuthenticator)(nil).Authenticate), ctx)
 }
 
 // IsSupported mocks base method.


### PR DESCRIPTION
Previously you had to wait for the auth request to timeout. This change allows the caller to decide to cancel the current request on demand.

The linter complained the function was too long, so I had to split it.
Which at the same time I also prevented the function opening multiple browser windows if the listening HTTP server fails for an unexpected reason.