### PR TITLE
feat: DGP-391 - expose local policy through the Test API Client

### DIFF
--- a/pkg/apiclients/testapi/testapi.go
+++ b/pkg/apiclients/testapi/testapi.go
@@ -148,8 +148,9 @@ var (
 
 // StartTestParams defines parameters for the high-level StartTest function.
 type StartTestParams struct {
-	OrgID   string
-	Subject TestSubjectCreate
+	OrgID       string
+	Subject     TestSubjectCreate
+	LocalPolicy *LocalPolicy
 }
 
 // testResult is the concrete implementation of the TestResult interface for
@@ -231,6 +232,13 @@ func NewTestClient(serverBaseUrl string, options ...ConfigOption) (TestClient, e
 // Create the initial test and return a handle to poll it
 func (c *client) StartTest(ctx context.Context, params StartTestParams) (TestHandle, error) {
 	// Validate params
+	if params.LocalPolicy != nil && params.LocalPolicy.RiskScoreThreshold != nil {
+		threshold := *params.LocalPolicy.RiskScoreThreshold
+		if threshold > 1000 { // uint16 cannot be < 0
+			return nil, fmt.Errorf("RiskScoreThreshold must be between 0 and 1000, got %d", threshold)
+		}
+	}
+
 	if len(params.Subject.union) == 0 {
 		return nil, fmt.Errorf("subject is required in StartTestParams and must be populated")
 	}
@@ -244,6 +252,11 @@ func (c *client) StartTest(ctx context.Context, params StartTestParams) (TestHan
 
 	// Create test body
 	testAttributes := TestAttributesCreate{Subject: params.Subject}
+	if params.LocalPolicy != nil {
+		testAttributes.Config = &TestConfiguration{
+			LocalPolicy: params.LocalPolicy,
+		}
+	}
 	requestBody := TestRequestBody{
 		Data: TestDataCreate{
 			Attributes: testAttributes,

--- a/pkg/apiclients/testapi/testapi_test.go
+++ b/pkg/apiclients/testapi/testapi_test.go
@@ -52,13 +52,29 @@ func Test_StartTest_Success(t *testing.T) {
 
 	// Create a DepGraph to test
 	testSubject := newDepGraphTestSubject(t)
-	params := testapi.StartTestParams{OrgID: orgID.String(), Subject: testSubject}
+
+	// Define LocalPolicy
+	riskScoreThreshold := uint16(750)
+	localPolicy := &testapi.LocalPolicy{
+		RiskScoreThreshold: &riskScoreThreshold,
+	}
+
+	params := testapi.StartTestParams{
+		OrgID:       orgID.String(),
+		Subject:     testSubject,
+		LocalPolicy: localPolicy,
+	}
 
 	// Define expected request body that StartTest should generate
 	expectedRequestBody := testapi.TestRequestBody{
 		Data: testapi.TestDataCreate{
-			Attributes: testapi.TestAttributesCreate{Subject: params.Subject},
-			Type:       testapi.Tests,
+			Attributes: testapi.TestAttributesCreate{
+				Subject: params.Subject,
+				Config: &testapi.TestConfiguration{
+					LocalPolicy: localPolicy,
+				},
+			},
+			Type: testapi.Tests,
 		},
 	}
 
@@ -141,6 +157,105 @@ func Test_StartTest_Error_InvalidOrgID(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, handle)
 	assert.Contains(t, err.Error(), "invalid OrgID format")
+}
+
+// Checks valid range for risk score threshold when calling StartTest
+func Test_StartTest_RiskScoreThreshold_Validation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	orgID := uuid.New().String()
+	testSubject := newDepGraphTestSubject(t)
+
+	// Helper to create uint16 pointers
+	uint16Ptr := func(val uint16) *uint16 {
+		return &val
+	}
+
+	tests := []struct {
+		name          string
+		threshold     *uint16
+		expectError   bool
+		expectedError string
+	}{
+		{
+			name:        "nil threshold",
+			threshold:   nil,
+			expectError: false,
+		},
+		{
+			name:        "threshold 0",
+			threshold:   uint16Ptr(0),
+			expectError: false,
+		},
+		{
+			name:        "threshold 500",
+			threshold:   uint16Ptr(500),
+			expectError: false,
+		},
+		{
+			name:        "threshold 1000",
+			threshold:   uint16Ptr(1000),
+			expectError: false,
+		},
+		{
+			name:          "threshold 1001 (too high)",
+			threshold:     uint16Ptr(1001),
+			expectError:   true,
+			expectedError: "RiskScoreThreshold must be between 0 and 1000, got 1001",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			params := testapi.StartTestParams{
+				OrgID:   orgID,
+				Subject: testSubject,
+			}
+			if tt.threshold != nil {
+				params.LocalPolicy = &testapi.LocalPolicy{
+					RiskScoreThreshold: tt.threshold,
+				}
+			}
+
+			// For failed validation, this won't be hit.
+			// For successful validation, we mock a 202 response.
+			mockHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/tests") {
+					jobID := uuid.New()
+					respBody := fmt.Sprintf(`{
+						"jsonapi": {"version": "1.0"},
+						"data": {
+							"type": "job",
+							"id": "%s",
+							"attributes": {"status": "pending"}
+						}
+					}`, jobID)
+					w.Header().Set("Content-Type", "application/vnd.api+json")
+					w.WriteHeader(http.StatusAccepted)
+					_, errWrite := w.Write([]byte(respBody))
+					require.NoError(t, errWrite)
+					return
+				}
+				http.Error(w, "Unexpected request in mock server", http.StatusInternalServerError)
+			})
+			server, cleanup := startMockServer(t, mockHandler)
+			defer cleanup()
+
+			testClient, err := testapi.NewTestClient(server.URL)
+			require.NoError(t, err)
+
+			_, err = testClient.StartTest(ctx, params)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
 // StartTest returns error from 400 Bad Request


### PR DESCRIPTION
### What does this do?

- Allows Test API client users to set a local policy that is already available in the backend API spec.  This includes
  - RiskScoreThreshold
  - SeverityThreshold
  - SuppressPendingIgnores

- validates risk score threshold in range 0-1000
- updates unit tests to set policy and validate risk score threshold range

Jira: [DGP-391](https://snyksec.atlassian.net/browse/DGP-391)