### PR TITLE
fix: update SARIF schema link to the latest 2.1.0 version

### DIFF
--- a/internal/cueutils/source/sarif-schema-2.1.0.json
+++ b/internal/cueutils/source/sarif-schema-2.1.0.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Static Analysis Results Format (SARIF) Version 2.1.0 JSON Schema",
-  "id": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "id": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
   "description": "Static Analysis Results Format (SARIF) Version 2.1.0 JSON Schema: a standard format for the output of static analysis tools.",
   "additionalProperties": false,
   "type": "object",
@@ -15,12 +15,13 @@
 
     "version": {
       "description": "The SARIF format version of this log file.",
-      "enum": [ "2.1.0" ]
+      "enum": [ "2.1.0" ],
+      "type": "string"
     },
 
     "runs": {
       "description": "The set of runs contained in this log file.",
-      "type": "array",
+      "type": [ "array", "null" ],
       "minItems": 0,
       "uniqueItems": false,
       "items": {
@@ -181,7 +182,8 @@
               "userSpecifiedConfiguration",
               "toolSpecifiedConfiguration",
               "debugOutputFile"
-            ]
+            ],
+            "type": "string"
           }
         },
 
@@ -535,7 +537,9 @@
     },
 
     "exception": {
+      "description": "Describes a runtime exception encountered during the execution of an analysis tool.",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
 
         "kind": {
@@ -572,7 +576,9 @@
     },
 
     "externalProperties": {
+      "description": "The top-level element of an external property file.",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
 
         "schema": {
@@ -583,17 +589,18 @@
 
         "version": {
           "description": "The SARIF format version of this external properties object.",
-          "enum": [ "2.1.0" ]
+          "enum": [ "2.1.0" ],
+          "type": "string"
         },
 
         "guid": {
-          "description": "A stable, unique identifer for this external properties object, in the form of a GUID.",
+          "description": "A stable, unique identifier for this external properties object, in the form of a GUID.",
           "type": "string",
           "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
         },
 
         "runGuid": {
-          "description": "A stable, unique identifer for the run associated with this external properties object, in the form of a GUID.",
+          "description": "A stable, unique identifier for the run associated with this external properties object, in the form of a GUID.",
           "type": "string",
           "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
         },
@@ -763,7 +770,9 @@
     },
 
     "externalPropertyFileReference": {
+      "description": "Contains information that enables a SARIF consumer to locate the external property file that contains the value of an externalized property associated with the run.",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
 
         "location": {
@@ -772,7 +781,7 @@
         },
 
         "guid": {
-          "description": "A stable, unique identifer for the external property file in the form of a GUID.",
+          "description": "A stable, unique identifier for the external property file in the form of a GUID.",
           "type": "string",
           "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
         },
@@ -1130,13 +1139,13 @@
         },
 
         "startTimeUtc": {
-          "description": "The Coordinated Universal Time (UTC) date and time at which the run started. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "description": "The Coordinated Universal Time (UTC) date and time at which the invocation started. See \"Date/time properties\" in the SARIF spec for the required format.",
           "type": "string",
           "format": "date-time"
         },
 
         "endTimeUtc": {
-          "description": "The Coordinated Universal Time (UTC) date and time at which the run ended. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "description": "The Coordinated Universal Time (UTC) date and time at which the invocation ended. See \"Date/time properties\" in the SARIF spec for the required format.",
           "type": "string",
           "format": "date-time"
         },
@@ -1216,27 +1225,27 @@
         },
 
         "machine": {
-          "description": "The machine that hosted the analysis tool run.",
+          "description": "The machine on which the invocation occurred.",
           "type": "string"
         },
 
         "account": {
-          "description": "The account that ran the analysis tool.",
+          "description": "The account under which the invocation occurred.",
           "type": "string"
         },
 
         "processId": {
-          "description": "The process id for the analysis tool run.",
+          "description": "The id of the process in which the invocation occurred.",
           "type": "integer"
         },
 
         "executableLocation": {
-          "description": "An absolute URI specifying the location of the analysis tool's executable.",
+          "description": "An absolute URI specifying the location of the executable that was invoked.",
           "$ref": "#/definitions/artifactLocation"
         },
 
         "workingDirectory": {
-          "description": "The working directory for the analysis tool run.",
+          "description": "The working directory for the invocation.",
           "$ref": "#/definitions/artifactLocation"
         },
 
@@ -1460,7 +1469,8 @@
         }
       },
       "anyOf": [
-        { "required": [ "text" ] }
+        { "required": [ "text" ] },
+        { "required": [ "id" ] }
       ]
     },
 
@@ -1556,7 +1566,8 @@
         "level": {
           "description": "A value specifying the severity level of the notification.",
           "default": "warning",
-          "enum": [ "none", "note", "warning", "error" ]
+          "enum": [ "none", "note", "warning", "error" ],
+          "type": "string"
         },
 
         "threadId": {
@@ -1627,6 +1638,9 @@
       },
 
       "anyOf": [
+        {
+          "required": [ "address" ]
+        },
         {
           "required": [ "artifactLocation" ]
         }
@@ -1765,7 +1779,13 @@
           "description": "Key/value pairs that provide additional information about the region.",
           "$ref": "#/definitions/propertyBag"
         }
-      }
+      },
+
+      "anyOf": [
+        { "required": [ "startLine" ] },
+        { "required": [ "charOffset" ] },
+        { "required": [ "byteOffset" ] }
+      ]
     },
 
     "replacement": {
@@ -1815,7 +1835,7 @@
         },
 
         "guid": {
-          "description": "A unique identifer for the reporting descriptor in the form of a GUID.",
+          "description": "A unique identifier for the reporting descriptor in the form of a GUID.",
           "type": "string",
           "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
         },
@@ -1914,7 +1934,8 @@
         "level": {
           "description": "Specifies the failure level for the report.",
           "default": "warning",
-          "enum": [ "none", "note", "warning", "error" ]
+          "enum": [ "none", "note", "warning", "error" ],
+          "type": "string"
         },
 
         "rank": {
@@ -2019,7 +2040,7 @@
       "properties": {
 
         "ruleId": {
-          "description": "The stable, unique identifier of the rule, if any, to which this notification is relevant. This member can be used to retrieve rule metadata from the rules dictionary, if it exists.",
+          "description": "The stable, unique identifier of the rule, if any, to which this result is relevant.",
           "type": "string"
         },
 
@@ -2038,13 +2059,15 @@
         "kind": {
           "description": "A value that categorizes results by evaluation state.",
           "default": "fail",
-          "enum": [ "notApplicable", "pass", "fail", "review", "open", "informational" ]
+          "enum": [ "notApplicable", "pass", "fail", "review", "open", "informational" ],
+          "type": "string"
         },
 
         "level": {
           "description": "A value specifying the severity level of the result.",
           "default": "warning",
-          "enum": [ "none", "note", "warning", "error" ]
+          "enum": [ "none", "note", "warning", "error" ],
+          "type": "string"
         },
 
         "message": {
@@ -2069,7 +2092,7 @@
         },
 
         "guid": {
-          "description": "A stable, unique identifer for the result in the form of a GUID.",
+          "description": "A stable, unique identifier for the result in the form of a GUID.",
           "type": "string",
           "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
         },
@@ -2159,7 +2182,7 @@
 
         "suppressions": {
           "description": "A set of suppressions relevant to this result.",
-          "type": ["array", "null"],
+          "type": "array",
           "minItems": 0,
           "uniqueItems": true,
           "items": {
@@ -2174,7 +2197,8 @@
             "unchanged",
             "updated",
             "absent"
-          ]
+          ],
+          "type": "string"
         },
 
         "rank": {
@@ -2344,7 +2368,7 @@
           "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase culture code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
           "type": "string",
           "default": "en-US",
-          "pattern": "^[a-zA-Z]{2}|^[a-zA-Z]{2}-[a-zA-Z]{2}]?$"
+          "pattern": "^[a-zA-Z]{2}(-[a-zA-Z]{2})?$"
         },
 
         "versionControlProvenance": {
@@ -2464,7 +2488,8 @@
 
         "columnKind": {
           "description": "Specifies the unit in which the tool measures columns.",
-          "enum": [ "utf16CodeUnits", "unicodeCodePoints" ]
+          "enum": [ "utf16CodeUnits", "unicodeCodePoints" ],
+          "type": "string"
         },
 
         "externalPropertyFileReferences": {
@@ -2580,7 +2605,7 @@
         },
 
         "guid": {
-          "description": "A stable, unique identifer for this object's containing run object in the form of a GUID.",
+          "description": "A stable, unique identifier for this object's containing run object in the form of a GUID.",
           "type": "string",
           "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
         },
@@ -2601,6 +2626,7 @@
     "specialLocations": {
       "description": "Defines locations of special significance to SARIF consumers.",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
 
         "displayBase": {
@@ -2691,7 +2717,7 @@
       "properties": {
 
         "guid": {
-          "description": "A stable, unique identifer for the suprression in the form of a GUID.",
+          "description": "A stable, unique identifier for the suprression in the form of a GUID.",
           "type": "string",
           "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
         },
@@ -2701,16 +2727,18 @@
           "enum": [
             "inSource",
             "external"
-          ]
+          ],
+          "type": "string"
         },
 
-        "state": {
-          "description": "A string that indicates the state of the suppression.",
+        "status": {
+          "description": "A string that indicates the review status of the suppression.",
           "enum": [
             "accepted",
             "underReview",
             "rejected"
-          ]
+          ],
+          "type": "string"
         },
 
         "justification": {
@@ -2732,7 +2760,9 @@
     },
 
     "threadFlow": {
+      "description": "Describes a sequence of code locations that specify a path through a single thread of execution such as an operating system or fiber.",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
 
         "id": {
@@ -2861,7 +2891,8 @@
         "importance": {
           "description": "Specifies the importance of this location in understanding the code flow in which it occurs. The order from most to least important is \"essential\", \"important\", \"unimportant\". Default: \"important\".",
           "enum": [ "important", "essential", "unimportant" ],
-          "default": "important"
+          "default": "important",
+          "type": "string"
         },
 
         "webRequest": {
@@ -2919,7 +2950,7 @@
       "properties": {
 
         "guid": {
-          "description": "A unique identifer for the tool component in the form of a GUID.",
+          "description": "A unique identifier for the tool component in the form of a GUID.",
           "type": "string",
           "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
         },
@@ -3047,7 +3078,7 @@
           "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase language code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
           "type": "string",
           "default": "en-US",
-          "pattern": "^[a-zA-Z]{2}|^[a-zA-Z]{2}-[a-zA-Z]{2}]?$"
+          "pattern": "^[a-zA-Z]{2}(-[a-zA-Z]{2})?$"
         },
 
         "contents": {
@@ -3059,7 +3090,8 @@
             "enum": [
               "localizedData",
               "nonLocalizedData"
-            ]
+            ],
+            "type": "string"
           }
         },
 
@@ -3110,8 +3142,9 @@
     },
 
     "toolComponentReference": {
-      "description": "",
+      "description": "Identifies a particular toolComponent object, either the driver or an extension.",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
 
         "name": {
@@ -3142,6 +3175,7 @@
     "translationMetadata": {
       "description": "Provides additional metadata related to translation.",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
 
         "name": {
@@ -3232,8 +3266,9 @@
     },
 
     "webRequest": {
-      "description": "A web request object.",
+      "description": "Describes an HTTP request.",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
 
         "index": {
@@ -3293,8 +3328,9 @@
     },
 
     "webResponse": {
-      "description": "A web response object.",
+      "description": "Describes the response to an HTTP request.",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
 
         "index": {

--- a/internal/presenters/templates/local_finding.sarif.tmpl
+++ b/internal/presenters/templates/local_finding.sarif.tmpl
@@ -1,6 +1,6 @@
 {{define "main" }}
 	{
-		"$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/schemas/sarif-schema-2.1.0.json",
+		"$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
 		"version": "2.1.0",
 		"runs": [
 		{{- range $result := $.Results}}

--- a/pkg/local_workflows/testdata/sarif-snyk-goof-ignores.json
+++ b/pkg/local_workflows/testdata/sarif-snyk-goof-ignores.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/schemas/sarif-schema-2.1.0.json",
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
   "version": "2.1.0",
   "runs": [
     {


### PR DESCRIPTION
Picked up the changes from #343, just updates the SARIF schema link to the latest errata version. 

Ref: [CLI-470](https://snyksec.atlassian.net/browse/CLI-470)

[CLI-470]: https://snyksec.atlassian.net/browse/CLI-470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ