### PR TITLE
fix(auth): auth failure when provided multiple pat regions with a valid region

### DIFF
--- a/pkg/auth/tokenauthenticator.go
+++ b/pkg/auth/tokenauthenticator.go
@@ -107,9 +107,10 @@ func DeriveEndpointFromPAT(pat string, config configuration.Configuration, clien
 		break
 	}
 
-	if errs != nil {
+	if errs != nil && len(endpoint) == 0 {
 		return "", errs
 	}
+
 	return endpoint, nil
 }
 

--- a/pkg/auth/tokenauthenticator_test.go
+++ b/pkg/auth/tokenauthenticator_test.go
@@ -61,6 +61,12 @@ func TestDeriveEndpointFromPAT(t *testing.T) {
 		assert.Equal(t, "https://api.snyk.io", endpoint)
 	})
 
+	t.Run("Multiple regions", func(t *testing.T) {
+		endpoint, err := DeriveEndpointFromPAT("valid_pat", config, client, []string{"https://someRandomUrl.com", server.URL, "https://someOtherRandomUrl.com"})
+		assert.NoError(t, err)
+		assert.Equal(t, "https://api.snyk.io", endpoint)
+	})
+
 	t.Run("Valid EU PAT", func(t *testing.T) {
 		endpoint, err := DeriveEndpointFromPAT("valid_eu_pat", config, client, []string{server.URL})
 		assert.NoError(t, err)
@@ -77,6 +83,12 @@ func TestDeriveEndpointFromPAT(t *testing.T) {
 		_, err := DeriveEndpointFromPAT("empty_pat", config, client, []string{server.URL})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid empty hostname")
+	})
+
+	t.Run("Bad URL", func(t *testing.T) {
+		_, err := DeriveEndpointFromPAT("empty_pat", config, client, []string{"https://someRandomUrl.com"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Authentication error")
 	})
 }
 


### PR DESCRIPTION
Prevents an auth error being thrown when iterating multiple PAT regions if there's a valid PAT region