### PR TITLE
fix: add explicit duration value to reduce flakiness

### DIFF
--- a/pkg/workflow/analyticsWrapper_test.go
+++ b/pkg/workflow/analyticsWrapper_test.go
@@ -74,6 +74,8 @@ func TestAnalyticsWrapper_Setter(t *testing.T) {
 	// unset dynamically generated value
 	originalOutput.Id = ""
 	wrappedOutput.Id = ""
+	originalOutput.DurationMs = 1
+	wrappedOutput.DurationMs = 1
 
 	assert.Equal(t, originalOutput, wrappedOutput)
 }


### PR DESCRIPTION
Explicitly set the duration value in the analyticswrapper test, since using the actual duration in a test adds flakiness.