### PR TITLE
fix: Fix incorrectly initialized clone with regards to env vars

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -279,14 +279,13 @@ func (ev *extendedViper) Clone() Configuration {
 	defer ev.mutex.RUnlock()
 
 	// manually clone the Configuration instance
-	var clone Configuration
+	options := []Opts{}
 	if ev.configType == jsonFile {
 		configFileUsed := ev.viper.ConfigFileUsed()
-		clone = NewFromFiles(configFileUsed)
-	} else {
-		clone = NewInMemory()
+		options = append(options, WithFiles(configFileUsed))
 	}
 
+	clone := NewWithOpts(options...)
 	clone.SetStorage(ev.storage)
 	keys := ev.viper.AllKeys()
 	for i := range keys {

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -291,7 +291,7 @@ func Test_ConfigurationClone(t *testing.T) {
 	flagset.Bool("debug", true, "debugging")
 	flagset.Float64("size", 10, "size")
 
-	config := NewFromFiles(TEST_FILENAME)
+	config := NewWithOpts(WithFiles(TEST_FILENAME))
 	err := config.AddFlagSet(flagset)
 	assert.NoError(t, err)
 
@@ -352,6 +352,7 @@ func Test_ConfigurationClone(t *testing.T) {
 
 	// we assume that a cloned configuration uses the same storage object. Just the pointer is cloned.
 	assert.Equal(t, config.(*extendedViper).storage, clonedConfig.(*extendedViper).storage)
+	assert.Equal(t, config.(*extendedViper).automaticEnvEnabled, clonedConfig.(*extendedViper).automaticEnvEnabled)
 
 	cleanupConfigstore(t)
 }


### PR DESCRIPTION
A previous fix to handle only a defined set of environment variables was incomplete. A cloned configuration was still consuming all Environment Variables automatically. This is now a minimal fix to address the incorrectly cloned Configuration with respect to the `automaticEnvEnabled` setting. 

A follow up task shall take a closer look at the cloning and the tests around it to close potential remaining gaps in the solution.