### PR TITLE
fix: defaultFns accept config as a parameter

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -29,7 +29,7 @@ import (
 )
 
 func defaultFuncOrganizationSlug(engine workflow.Engine, config configuration.Configuration, logger *zerolog.Logger, apiClientFactory func(url string, client *http.Client) api.ApiClient) configuration.DefaultValueFunction {
-	callback := func(existingValue interface{}) (interface{}, error) {
+	callback := func(_ configuration.Configuration, existingValue interface{}) (interface{}, error) {
 		client := engine.GetNetworkAccess().GetHttpClient()
 		url := config.GetString(configuration.API_URL)
 		apiClient := apiClientFactory(url, client)
@@ -47,7 +47,7 @@ func defaultFuncOrganizationSlug(engine workflow.Engine, config configuration.Co
 }
 
 func defaultFuncOrganization(engine workflow.Engine, config configuration.Configuration, logger *zerolog.Logger, apiClientFactory func(url string, client *http.Client) api.ApiClient) configuration.DefaultValueFunction {
-	callback := func(existingValue interface{}) (interface{}, error) {
+	callback := func(_ configuration.Configuration, existingValue interface{}) (interface{}, error) {
 		client := engine.GetNetworkAccess().GetHttpClient()
 		url := config.GetString(configuration.API_URL)
 		apiClient := apiClientFactory(url, client)
@@ -78,8 +78,8 @@ func defaultFuncOrganization(engine workflow.Engine, config configuration.Config
 	return callback
 }
 
-func defaultFuncApiUrl(config configuration.Configuration, logger *zerolog.Logger) configuration.DefaultValueFunction {
-	callback := func(existingValue interface{}) (interface{}, error) {
+func defaultFuncApiUrl(_ configuration.Configuration, logger *zerolog.Logger) configuration.DefaultValueFunction {
+	callback := func(config configuration.Configuration, existingValue interface{}) (interface{}, error) {
 		urlString := constants.SNYK_DEFAULT_API_URL
 
 		urlFromOauthToken, err := auth.GetAudienceClaimFromOauthToken(config.GetString(auth.CONFIG_KEY_OAUTH_TOKEN))
@@ -105,7 +105,7 @@ func defaultFuncApiUrl(config configuration.Configuration, logger *zerolog.Logge
 }
 
 func defaultInputDirectory() configuration.DefaultValueFunction {
-	callback := func(existingValue interface{}) (interface{}, error) {
+	callback := func(_ configuration.Configuration, existingValue interface{}) (interface{}, error) {
 		if existingValue == nil {
 			path, err := os.Getwd()
 			if err != nil {
@@ -120,7 +120,7 @@ func defaultInputDirectory() configuration.DefaultValueFunction {
 }
 
 func defaultTempDirectory(engine workflow.Engine, config configuration.Configuration, logger *zerolog.Logger) configuration.DefaultValueFunction {
-	callback := func(existingValue interface{}) (interface{}, error) {
+	callback := func(_ configuration.Configuration, existingValue interface{}) (interface{}, error) {
 		version := "0.0.0"
 		ri := engine.GetRuntimeInfo()
 		if ri != nil && len(ri.GetVersion()) > 0 {
@@ -151,7 +151,7 @@ func defaultTempDirectory(engine workflow.Engine, config configuration.Configura
 }
 
 func defaultPreviewFeaturesEnabled(engine workflow.Engine) configuration.DefaultValueFunction {
-	callback := func(existingValue interface{}) (interface{}, error) {
+	callback := func(_ configuration.Configuration, existingValue interface{}) (interface{}, error) {
 		if existingValue != nil {
 			return existingValue, nil
 		}
@@ -173,7 +173,7 @@ func defaultPreviewFeaturesEnabled(engine workflow.Engine) configuration.Default
 }
 
 func defaultMaxNetworkRetryAttempts(engine workflow.Engine) configuration.DefaultValueFunction {
-	callback := func(existingValue interface{}) (interface{}, error) {
+	callback := func(_ configuration.Configuration, existingValue interface{}) (interface{}, error) {
 		const multipleAttempts = 3 // three here is chosen based on other places in the application
 		const singleAttempt = 1
 
@@ -219,7 +219,7 @@ func initConfiguration(engine workflow.Engine, config configuration.Configuratio
 	config.AddDefaultValue(configuration.API_URL, defaultFuncApiUrl(config, logger))
 	config.AddDefaultValue(configuration.TEMP_DIR_PATH, defaultTempDirectory(engine, config, logger))
 
-	config.AddDefaultValue(configuration.WEB_APP_URL, func(existingValue any) (any, error) {
+	config.AddDefaultValue(configuration.WEB_APP_URL, func(_ configuration.Configuration, existingValue any) (any, error) {
 		canonicalApiUrl := config.GetString(configuration.API_URL)
 		appUrl, err := api.DeriveAppUrl(canonicalApiUrl)
 		if err != nil {
@@ -232,7 +232,7 @@ func initConfiguration(engine workflow.Engine, config configuration.Configuratio
 	config.AddDefaultValue(configuration.ORGANIZATION, defaultFuncOrganization(engine, config, logger, apiClientFactory))
 	config.AddDefaultValue(configuration.ORGANIZATION_SLUG, defaultFuncOrganizationSlug(engine, config, logger, apiClientFactory))
 
-	config.AddDefaultValue(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, func(existingValue any) (any, error) {
+	config.AddDefaultValue(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, func(_ configuration.Configuration, existingValue any) (any, error) {
 		if existingValue == nil {
 			return true, nil
 		} else {
@@ -240,7 +240,7 @@ func initConfiguration(engine workflow.Engine, config configuration.Configuratio
 		}
 	})
 
-	config.AddDefaultValue(configuration.IS_FEDRAMP, func(existingValue any) (any, error) {
+	config.AddDefaultValue(configuration.IS_FEDRAMP, func(_ configuration.Configuration, existingValue any) (any, error) {
 		if existingValue == nil {
 			return api.IsFedramp(config.GetString(configuration.API_URL)), nil
 		} else {
@@ -256,7 +256,7 @@ func initConfiguration(engine workflow.Engine, config configuration.Configuratio
 }
 
 func customConfigFiles(config configuration.Configuration) configuration.DefaultValueFunction {
-	return func(existingValue interface{}) (interface{}, error) {
+	return func(_ configuration.Configuration, existingValue interface{}) (interface{}, error) {
 		var files []string
 		// last file usually wins if the same values are configured
 		// Precedence should be:

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -116,6 +116,13 @@ func StandardDefaultValueFunction(defaultValue interface{}) DefaultValueFunction
 	}
 }
 
+// ImmutableDefaultValueFunction returns a default value function that always returns the same value.
+func ImmutableDefaultValueFunction(defaultValue interface{}) DefaultValueFunction {
+	return func(_ Configuration, _ interface{}) (interface{}, error) {
+		return defaultValue, nil
+	}
+}
+
 // determineBasePath returns the base path for the configuration files.
 func determineBasePath() string {
 	homedir, err := os.UserHomeDir()

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -20,7 +20,7 @@ import (
 
 //go:generate $GOPATH/bin/mockgen -source=configuration.go -destination ../mocks/configuration.go -package mocks -self_package github.com/snyk/go-application-framework/pkg/configuration/
 
-type DefaultValueFunction func(existingValue interface{}) (interface{}, error)
+type DefaultValueFunction func(config Configuration, existingValue interface{}) (interface{}, error)
 
 type configType string
 type KeyType int
@@ -107,7 +107,7 @@ type extendedViper struct {
 
 // StandardDefaultValueFunction is a default value function that returns the default value if the existing value is nil.
 func StandardDefaultValueFunction(defaultValue interface{}) DefaultValueFunction {
-	return func(existingValue interface{}) (interface{}, error) {
+	return func(_ Configuration, existingValue interface{}) (interface{}, error) {
 		if existingValue != nil {
 			return existingValue, nil
 		} else {
@@ -458,7 +458,7 @@ func (ev *extendedViper) GetWithError(key string) (interface{}, error) {
 	// if nothing was found in the cache, try to execute the default function
 	if defaultFunc != nil {
 		var defErr error
-		value, defErr = defaultFunc(value)
+		value, defErr = defaultFunc(ev, value)
 		err = errors.Join(err, defErr)
 
 		// if enabled and no error occurred, store value in cache

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -230,7 +230,7 @@ func Test_ConfigurationSet_differentCases(t *testing.T) {
 		err := config.AddFlagSet(flagset)
 		assert.NoError(t, err)
 		config.AddAlternativeKeys(ORGANIZATION, []string{"snyk_cfg_org"})
-		config.AddDefaultValue(ORGANIZATION, func(existingValue interface{}) (interface{}, error) {
+		config.AddDefaultValue(ORGANIZATION, func(_ Configuration, existingValue interface{}) (interface{}, error) {
 			if existingValue != nil {
 				return existingValue, nil
 			}
@@ -396,7 +396,7 @@ func Test_DefaultValuehandling(t *testing.T) {
 		valueExplicitlySet := "explicitly set value"
 
 		config := NewInMemory()
-		config.AddDefaultValue(keyWithDefault, func(existingValue interface{}) (interface{}, error) {
+		config.AddDefaultValue(keyWithDefault, func(_ Configuration, existingValue interface{}) (interface{}, error) {
 			if existingValue != nil {
 				return existingValue, nil
 			}
@@ -434,7 +434,7 @@ func Test_DefaultValuehandling(t *testing.T) {
 		err := config.AddFlagSet(flagset)
 		assert.NoError(t, err)
 		config.AddAlternativeKeys(ORGANIZATION, []string{"snyk_cfg_org"})
-		config.AddDefaultValue(ORGANIZATION, func(existingValue interface{}) (interface{}, error) {
+		config.AddDefaultValue(ORGANIZATION, func(_ Configuration, existingValue interface{}) (interface{}, error) {
 			if existingValue != nil {
 				return existingValue, nil
 			}
@@ -800,7 +800,7 @@ func Test_Configuration_caching_enabled(t *testing.T) {
 	cacheDuration := 10 * time.Minute
 
 	config := NewWithOpts(WithCachingEnabled(cacheDuration))
-	config.AddDefaultValue(myKey, func(existingValue interface{}) (interface{}, error) {
+	config.AddDefaultValue(myKey, func(_ Configuration, existingValue interface{}) (interface{}, error) {
 		defaultFuncCalled++
 
 		if existingValue != nil {

--- a/pkg/local_workflows/code_workflow.go
+++ b/pkg/local_workflows/code_workflow.go
@@ -61,7 +61,7 @@ func getSastSettings(engine workflow.Engine) (*sast_contract.SastResponse, error
 }
 
 func getSastSettingsConfig(engine workflow.Engine) configuration.DefaultValueFunction {
-	callback := func(existingValue interface{}) (interface{}, error) {
+	callback := func(_ configuration.Configuration, existingValue interface{}) (interface{}, error) {
 		if existingValue != nil {
 			return existingValue, nil
 		}
@@ -78,7 +78,7 @@ func getSastSettingsConfig(engine workflow.Engine) configuration.DefaultValueFun
 }
 
 func getSastEnabled(engine workflow.Engine) configuration.DefaultValueFunction {
-	callback := func(existingValue interface{}) (interface{}, error) {
+	callback := func(_ configuration.Configuration, existingValue interface{}) (interface{}, error) {
 		if existingValue != nil {
 			return existingValue, nil
 		}
@@ -95,7 +95,7 @@ func getSastEnabled(engine workflow.Engine) configuration.DefaultValueFunction {
 }
 
 func getSlceEnabled(engine workflow.Engine) configuration.DefaultValueFunction {
-	callback := func(existingValue interface{}) (interface{}, error) {
+	callback := func(_ configuration.Configuration, existingValue interface{}) (interface{}, error) {
 		if existingValue != nil {
 			return existingValue, nil
 		}

--- a/pkg/local_workflows/config_utils/feature_flag.go
+++ b/pkg/local_workflows/config_utils/feature_flag.go
@@ -11,7 +11,7 @@ import (
 func AddFeatureFlagToConfig(engine workflow.Engine, configKey string, featureFlagName string) {
 	config := engine.GetConfiguration()
 
-	callback := func(existingValue interface{}) (interface{}, error) {
+	callback := func(_ configuration.Configuration, existingValue interface{}) (interface{}, error) {
 		if existingValue == nil {
 			httpClient := engine.GetNetworkAccess().GetHttpClient()
 			return GetFeatureFlagValue(featureFlagName, config, httpClient)

--- a/pkg/local_workflows/ignore_workflow/config.go
+++ b/pkg/local_workflows/ignore_workflow/config.go
@@ -18,26 +18,26 @@ import (
 func addCreateIgnoreDefaultConfigurationValues(invocationCtx workflow.InvocationContext) {
 	config := invocationCtx.GetConfiguration()
 
-	config.AddDefaultValue(RemoteRepoUrlKey, func(existingValue interface{}) (interface{}, error) {
+	config.AddDefaultValue(RemoteRepoUrlKey, func(_ configuration.Configuration, existingValue interface{}) (interface{}, error) {
 		return remoteRepoUrlDefaultFunc(existingValue, config)
 	})
 
-	config.AddDefaultValue(IgnoreTypeKey, func(existingValue interface{}) (interface{}, error) {
+	config.AddDefaultValue(IgnoreTypeKey, func(_ configuration.Configuration, existingValue interface{}) (interface{}, error) {
 		isSet := config.IsSet(IgnoreTypeKey)
 		return defaultFuncWithValidator(existingValue, isSet, isValidIgnoreType)
 	})
 
-	config.AddDefaultValue(ExpirationKey, func(existingValue interface{}) (interface{}, error) {
+	config.AddDefaultValue(ExpirationKey, func(_ configuration.Configuration, existingValue interface{}) (interface{}, error) {
 		isSet := config.IsSet(ExpirationKey)
 		return defaultFuncWithValidator(existingValue, isSet, isValidExpirationDate)
 	})
 
-	config.AddDefaultValue(FindingsIdKey, func(existingValue interface{}) (interface{}, error) {
+	config.AddDefaultValue(FindingsIdKey, func(_ configuration.Configuration, existingValue interface{}) (interface{}, error) {
 		isSet := config.IsSet(FindingsIdKey)
 		return defaultFuncWithValidator(existingValue, isSet, isValidFindingsId)
 	})
 
-	config.AddDefaultValue(ReasonKey, func(existingValue interface{}) (interface{}, error) {
+	config.AddDefaultValue(ReasonKey, func(_ configuration.Configuration, existingValue interface{}) (interface{}, error) {
 		isSet := config.IsSet(ReasonKey)
 		return defaultFuncWithValidator(existingValue, isSet, isValidReason)
 	})


### PR DESCRIPTION
BREAKING CHANGE: extends the method signature for configuration.DefaultValueFunction to accept configuration.Configuration as the first parameter