### PR TITLE
chore: iaw uses org setting insted of feature flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/oapi-codegen/oapi-codegen/v2 v2.4.1
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/snyk/error-catalog-golang-public v0.0.0-20250625135845-2d6f9a31f318
+	github.com/snyk/error-catalog-golang-public v0.0.0-20250812140843-a01d75260003
 	github.com/subosito/gotenv v1.6.0
 	golang.org/x/net v0.38.0
 	golang.org/x/sync v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnB
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/snyk/code-client-go v1.21.3 h1:2+HPXCA9FGn3gaI1Jw1C4Ifn/NRAbSnmohFUvz4GC4I=
 github.com/snyk/code-client-go v1.21.3/go.mod h1:WH6lNkJc785hfXmwhixxWHix3O6z+1zwz40oK8vl/zg=
-github.com/snyk/error-catalog-golang-public v0.0.0-20250625135845-2d6f9a31f318 h1:2bNOlUstBBWHa3doBvdOBlMSu8AC01IHyNexT9MoKiM=
-github.com/snyk/error-catalog-golang-public v0.0.0-20250625135845-2d6f9a31f318/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
+github.com/snyk/error-catalog-golang-public v0.0.0-20250812140843-a01d75260003 h1:qeXih9sVe/WvhccE3MfEgglnSVKN1xTQBcsA/N96Kzo=
+github.com/snyk/error-catalog-golang-public v0.0.0-20250812140843-a01d75260003/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -249,7 +249,7 @@ func (a *snykApiClient) GetSastSettings(orgId string) (*sast_contract.SastRespon
 }
 
 func (a *snykApiClient) GetOrgSettings(orgId string) (*contract.OrgSettingsResponse, error) {
-	endpoint := a.url + fmt.Sprintf("/v1/org/%s/settings", url.QueryEscape(orgId))
+	endpoint := fmt.Sprintf("%s/v1/org/%s/settings", a.url, url.QueryEscape(orgId))
 	res, err := a.client.Get(endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve org settings: %w", err)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -25,6 +25,7 @@ type ApiClient interface {
 	GetUserMe() (string, error)
 	GetSelf() (contract.SelfResponse, error)
 	GetSastSettings(orgId string) (*sast_contract.SastResponse, error)
+	GetOrgSettings(orgId string) (*contract.OrgSettingsResponse, error)
 }
 
 var _ ApiClient = (*snykApiClient)(nil)
@@ -242,6 +243,28 @@ func (a *snykApiClient) GetSastSettings(orgId string) (*sast_contract.SastRespon
 	var response sast_contract.SastResponse
 	if err = json.Unmarshal(body, &response); err != nil {
 		return nil, fmt.Errorf("unable to retrieve settings (status: %d): %w", res.StatusCode, err)
+	}
+
+	return &response, err
+}
+
+func (a *snykApiClient) GetOrgSettings(orgId string) (*contract.OrgSettingsResponse, error) {
+	endpoint := a.url + fmt.Sprintf("/v1/org/%s/settings", url.QueryEscape(orgId))
+	res, err := a.client.Get(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve org settings: %w", err)
+	}
+	//goland:noinspection GoUnhandledErrorResult
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve org settings: %w", err)
+	}
+
+	var response contract.OrgSettingsResponse
+	if err = json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("unable to retrieve org settings (status: %d): %w", res.StatusCode, err)
 	}
 
 	return &response, err

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -249,22 +249,15 @@ func (a *snykApiClient) GetSastSettings(orgId string) (*sast_contract.SastRespon
 }
 
 func (a *snykApiClient) GetOrgSettings(orgId string) (*contract.OrgSettingsResponse, error) {
-	endpoint := fmt.Sprintf("%s/v1/org/%s/settings", a.url, url.QueryEscape(orgId))
-	res, err := a.client.Get(endpoint)
-	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve org settings: %w", err)
-	}
-	//goland:noinspection GoUnhandledErrorResult
-	defer res.Body.Close()
-
-	body, err := io.ReadAll(res.Body)
+	endpoint := fmt.Sprintf("/v1/org/%s/settings", url.QueryEscape(orgId))
+	body, err := clientGet(a, endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve org settings: %w", err)
 	}
 
 	var response contract.OrgSettingsResponse
 	if err = json.Unmarshal(body, &response); err != nil {
-		return nil, fmt.Errorf("unable to retrieve org settings (status: %d): %w", res.StatusCode, err)
+		return nil, err
 	}
 
 	return &response, err

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -249,15 +249,23 @@ func (a *snykApiClient) GetSastSettings(orgId string) (*sast_contract.SastRespon
 }
 
 func (a *snykApiClient) GetOrgSettings(orgId string) (*contract.OrgSettingsResponse, error) {
-	endpoint := fmt.Sprintf("/v1/org/%s/settings", url.QueryEscape(orgId))
-	body, err := clientGet(a, endpoint, nil)
+	endpoint := fmt.Sprintf("%s/v1/org/%s/settings", a.url, url.QueryEscape(orgId))
+
+	res, err := a.client.Get(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve org settings: %w", err)
+	}
+	//goland:noinspection GoUnhandledErrorResult
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve org settings: %w", err)
 	}
 
 	var response contract.OrgSettingsResponse
 	if err = json.Unmarshal(body, &response); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to retrieve org settings (status: %d): %w", res.StatusCode, err)
 	}
 
 	return &response, err

--- a/internal/api/contract/OrgSettingsResponse.go
+++ b/internal/api/contract/OrgSettingsResponse.go
@@ -11,6 +11,6 @@ type OrgRequestAccessSettings struct {
 }
 
 type OrgSettingsResponse struct {
-	Ignores       OrgIgnoreSettings        `json:"ignores"`
-	RequestAccess OrgRequestAccessSettings `json:"requestAccess"`
+	Ignores       *OrgIgnoreSettings        `json:"ignores"`
+	RequestAccess *OrgRequestAccessSettings `json:"requestAccess"`
 }

--- a/internal/api/contract/OrgSettingsResponse.go
+++ b/internal/api/contract/OrgSettingsResponse.go
@@ -1,5 +1,7 @@
 package contract
 
+// API reference: https://docs.snyk.io/snyk-api/reference/organizations-v1#get-org-orgid-settings
+
 type OrgIgnoreSettings struct {
 	ReasonRequired          bool `json:"reasonRequired,omitempty"`
 	AutoApproveIgnores      bool `json:"autoApproveIgnores,omitempty"`

--- a/internal/api/contract/OrgSettingsResponse.go
+++ b/internal/api/contract/OrgSettingsResponse.go
@@ -1,0 +1,11 @@
+package contract
+
+type OrgIgnoreSettings struct {
+	ReasonRequired          bool `json:"reasonRequired,omitempty"`
+	AutoApproveIgnores      bool `json:"autoApproveIgnores,omitempty"`
+	ApprovalWorkflowEnabled bool `json:"approvalWorkflowEnabled,omitempty"`
+}
+
+type OrgSettingsResponse struct {
+	Ignores OrgIgnoreSettings `json:"ignores"`
+}

--- a/internal/api/contract/OrgSettingsResponse.go
+++ b/internal/api/contract/OrgSettingsResponse.go
@@ -6,6 +6,11 @@ type OrgIgnoreSettings struct {
 	ApprovalWorkflowEnabled bool `json:"approvalWorkflowEnabled,omitempty"`
 }
 
+type OrgRequestAccessSettings struct {
+	Enabled bool `json:"enabled,omitempty"`
+}
+
 type OrgSettingsResponse struct {
-	Ignores OrgIgnoreSettings `json:"ignores"`
+	Ignores       OrgIgnoreSettings        `json:"ignores"`
+	RequestAccess OrgRequestAccessSettings `json:"requestAccess"`
 }

--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -81,6 +81,21 @@ func (mr *MockApiClientMockRecorder) GetOrgIdFromSlug(slugName interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgIdFromSlug", reflect.TypeOf((*MockApiClient)(nil).GetOrgIdFromSlug), slugName)
 }
 
+// GetOrgSettings mocks base method.
+func (m *MockApiClient) GetOrgSettings(orgId string) (*contract.OrgSettingsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrgSettings", orgId)
+	ret0, _ := ret[0].(*contract.OrgSettingsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOrgSettings indicates an expected call of GetOrgSettings.
+func (mr *MockApiClientMockRecorder) GetOrgSettings(orgId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgSettings", reflect.TypeOf((*MockApiClient)(nil).GetOrgSettings), orgId)
+}
+
 // GetOrganizations mocks base method.
 func (m *MockApiClient) GetOrganizations(limit int) (*contract.OrganizationsResponse, error) {
 	m.ctrl.T.Helper()

--- a/pkg/local_workflows/ignore_workflow/config.go
+++ b/pkg/local_workflows/ignore_workflow/config.go
@@ -45,7 +45,7 @@ func addCreateIgnoreDefaultConfigurationValues(invocationCtx workflow.Invocation
 }
 
 func getOrgIgnoreApprovalEnabled(engine workflow.Engine) configuration.DefaultValueFunction {
-	return func(existingValue interface{}) (interface{}, error) {
+	return func(_ configuration.Configuration, existingValue interface{}) (interface{}, error) {
 		if existingValue != nil {
 			return existingValue, nil
 		}
@@ -60,6 +60,10 @@ func getOrgIgnoreApprovalEnabled(engine workflow.Engine) configuration.DefaultVa
 		if err != nil {
 			engine.GetLogger().Err(err).Msg("Failed to access settings.")
 			return nil, err
+		}
+
+		if settings.Ignores == nil {
+			return false, nil
 		}
 
 		return settings.Ignores.ApprovalWorkflowEnabled, nil

--- a/pkg/local_workflows/ignore_workflow/config.go
+++ b/pkg/local_workflows/ignore_workflow/config.go
@@ -62,11 +62,11 @@ func getOrgIgnoreApprovalEnabled(engine workflow.Engine) configuration.DefaultVa
 			return nil, err
 		}
 
-		if settings.Ignores == nil {
-			return false, nil
+		if settings.Ignores != nil && settings.Ignores.ApprovalWorkflowEnabled {
+			return true, nil
 		}
 
-		return settings.Ignores.ApprovalWorkflowEnabled, nil
+		return false, nil
 	}
 }
 

--- a/pkg/local_workflows/ignore_workflow/ignore_workflow.go
+++ b/pkg/local_workflows/ignore_workflow/ignore_workflow.go
@@ -103,12 +103,17 @@ func ignoreCreateWorkflowEntryPoint(invocationCtx workflow.InvocationContext, _ 
 	id := invocationCtx.GetWorkflowIdentifier()
 
 	if !config.GetBool(ConfigIgnoreApprovalEnabled) {
+		orgName := config.GetString(configuration.ORGANIZATION_SLUG)
 		return nil, snyk_errors.Error{
-			ID:          "SNYK-CLI-0014",
-			Title:       "Organization setting not enabled",
-			Description: "The feature you are trying to use is not enabled you the current organization. Enable it in the settings or try switching the organization.",
-			Detail:      "",
-			Level:       "fatal",
+			Type:           "https://docs.snyk.io/scan-with-snyk/error-catalog#snyk-cli-0016",
+			Title:          "Feature not enabled",
+			Description:    "This feature is disabled for your current organization. You can enable it in the settings or switch to an organization where it's already enabled.",
+			StatusCode:     403,
+			ErrorCode:      "SNYK-CLI-0016",
+			Classification: "ACTIONABLE",
+			Links:          []string{},
+			Level:          "error",
+			Detail:         fmt.Sprintf("The Ignore Approval Workflow feature must be enabled for the %s organization. Enable it in your organization settings: Settings > General > Ignore approval workflow for Snyk Code.", orgName),
 		}
 	}
 

--- a/pkg/local_workflows/ignore_workflow/ignore_workflow.go
+++ b/pkg/local_workflows/ignore_workflow/ignore_workflow.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/snyk/code-client-go/sarif"
 	"github.com/snyk/error-catalog-golang-public/cli"
-	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 
 	policyApi "github.com/snyk/go-application-framework/internal/api/policy/2024-10-15"
 	"github.com/snyk/go-application-framework/pkg/configuration"
@@ -104,17 +103,7 @@ func ignoreCreateWorkflowEntryPoint(invocationCtx workflow.InvocationContext, _ 
 
 	if !config.GetBool(ConfigIgnoreApprovalEnabled) {
 		orgName := config.GetString(configuration.ORGANIZATION_SLUG)
-		return nil, snyk_errors.Error{
-			Type:           "https://docs.snyk.io/scan-with-snyk/error-catalog#snyk-cli-0016",
-			Title:          "Feature not enabled",
-			Description:    "This feature is disabled for your current organization. You can enable it in the settings or switch to an organization where it's already enabled.",
-			StatusCode:     403,
-			ErrorCode:      "SNYK-CLI-0016",
-			Classification: "ACTIONABLE",
-			Links:          []string{},
-			Level:          "error",
-			Detail:         fmt.Sprintf("The Ignore Approval Workflow feature must be enabled for the %s organization. Enable it in your organization settings: Settings > General > Ignore approval workflow for Snyk Code.", orgName),
-		}
+		return nil, cli.NewFeatureNotEnabledError(fmt.Sprintf("The Ignore Approval Workflow feature must be enabled for the %s organization. Enable it in your organization settings: Settings > General > Ignore approval workflow for Snyk Code.", orgName))
 	}
 
 	interactive := config.GetBool(InteractiveKey)

--- a/pkg/local_workflows/ignore_workflow/ignore_workflow.go
+++ b/pkg/local_workflows/ignore_workflow/ignore_workflow.go
@@ -61,7 +61,7 @@ const (
 	interactiveEnsureVersionControlMessage    = "👉🏼 Ensure the code containing the issue is committed and pushed to remote origin, so approvers can review it."
 	interactiveIgnoreRequestSubmissionMessage = "✅ Your ignore request has been submitted."
 
-	configIgnoreApprovalEnabled = "internal_iaw_enabled"
+	ConfigIgnoreApprovalEnabled = "internal_iaw_enabled"
 )
 
 var reasonPromptHelpMap = map[string]string{
@@ -90,7 +90,7 @@ func InitIgnoreWorkflows(engine workflow.Engine) error {
 		return err
 	}
 
-	engine.GetConfiguration().AddDefaultValue(configIgnoreApprovalEnabled, getOrgIgnoreApprovalEnabled(engine))
+	engine.GetConfiguration().AddDefaultValue(ConfigIgnoreApprovalEnabled, getOrgIgnoreApprovalEnabled(engine))
 
 	return nil
 }
@@ -102,7 +102,7 @@ func ignoreCreateWorkflowEntryPoint(invocationCtx workflow.InvocationContext, _ 
 	config := invocationCtx.GetConfiguration()
 	id := invocationCtx.GetWorkflowIdentifier()
 
-	if !config.GetBool(configIgnoreApprovalEnabled) {
+	if !config.GetBool(ConfigIgnoreApprovalEnabled) {
 		return nil, snyk_errors.Error{
 			ID:          "SNYK-CLI-0014",
 			Title:       "Organization setting not enabled",

--- a/pkg/local_workflows/ignore_workflow/ignore_workflow_test.go
+++ b/pkg/local_workflows/ignore_workflow/ignore_workflow_test.go
@@ -51,7 +51,7 @@ func setupMockIgnoreContext(t *testing.T, payload string, statusCode int) *mocks
 	config := configuration.New()
 	config.Set(configuration.API_URL, "https://api.snyk.io")
 	config.Set(configuration.ORGANIZATION, uuid.New().String())
-	config.Set(configIgnoreApprovalEnabled, true)
+	config.Set(ConfigIgnoreApprovalEnabled, true)
 	// setup mocks
 	ctrl := gomock.NewController(t)
 	networkAccessMock := mocks.NewMockNetworkAccess(ctrl)
@@ -306,7 +306,7 @@ func Test_ignoreCreateWorkflowEntryPoint(t *testing.T) {
 
 		invocationContext := setupMockIgnoreContext(t, "{}", http.StatusCreated)
 		config := invocationContext.GetConfiguration()
-		config.Set(configIgnoreApprovalEnabled, false)
+		config.Set(ConfigIgnoreApprovalEnabled, false)
 
 		config.Set(InteractiveKey, false)
 
@@ -330,7 +330,7 @@ func setupInteractiveMockContext(t *testing.T, mockApiResponse string, mockApiSt
 	config := configuration.New()
 	config.Set(configuration.API_URL, "https://api.snyk.io")
 	config.Set(configuration.ORGANIZATION, uuid.New().String())
-	config.Set(configIgnoreApprovalEnabled, true)
+	config.Set(ConfigIgnoreApprovalEnabled, true)
 	config.Set(InteractiveKey, true) // Always interactive
 	config.Set(EnrichResponseKey, true)
 	config.Set(configuration.ORGANIZATION_SLUG, "some-org")

--- a/pkg/local_workflows/ignore_workflow/ignore_workflow_test.go
+++ b/pkg/local_workflows/ignore_workflow/ignore_workflow_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/snyk/go-application-framework/internal/api/contract"
 	policyApi "github.com/snyk/go-application-framework/internal/api/policy/2024-10-15"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
@@ -704,4 +705,115 @@ func Test_getExpireValue(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, result)
 	})
+}
+
+func Test_getOrgIgnoreApprovalEnabled(t *testing.T) {
+	t.Run("returns existing value when not nil", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockEngine := mocks.NewMockEngine(ctrl)
+		defaultValueFunc := getOrgIgnoreApprovalEnabled(mockEngine)
+
+		result, err := defaultValueFunc(nil, true)
+		assert.NoError(t, err)
+		assert.Equal(t, true, result)
+
+		result, err = defaultValueFunc(nil, false)
+		assert.NoError(t, err)
+		assert.Equal(t, false, result)
+	})
+
+	t.Run("approval workflow enabled", func(t *testing.T) {
+		result, err := setupMockEngineForOrgSettings(t, &contract.OrgSettingsResponse{
+			Ignores: &contract.OrgIgnoreSettings{ApprovalWorkflowEnabled: true},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, true, result)
+	})
+
+	t.Run("approval workflow disabled", func(t *testing.T) {
+		result, err := setupMockEngineForOrgSettings(t, &contract.OrgSettingsResponse{
+			Ignores: &contract.OrgIgnoreSettings{ApprovalWorkflowEnabled: false},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, false, result)
+	})
+
+	t.Run("ignores field is nil", func(t *testing.T) {
+		result, err := setupMockEngineForOrgSettings(t, &contract.OrgSettingsResponse{
+			Ignores: nil,
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, false, result)
+	})
+
+	t.Run("API call fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		logger := zerolog.Logger{}
+		orgId := uuid.New().String()
+		apiUrl := "https://api.snyk.io"
+
+		mockEngine := mocks.NewMockEngine(ctrl)
+		mockConfig := mocks.NewMockConfiguration(ctrl)
+		mockNetworkAccess := mocks.NewMockNetworkAccess(ctrl)
+
+		httpClient := localworkflows.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(bytes.NewBufferString("Internal Server Error")),
+			}
+		})
+
+		mockEngine.EXPECT().GetConfiguration().Return(mockConfig)
+		mockEngine.EXPECT().GetNetworkAccess().Return(mockNetworkAccess)
+		mockEngine.EXPECT().GetLogger().Return(&logger)
+		mockConfig.EXPECT().GetString(configuration.ORGANIZATION).Return(orgId)
+		mockConfig.EXPECT().GetString(configuration.API_URL).Return(apiUrl)
+		mockNetworkAccess.EXPECT().GetHttpClient().Return(httpClient)
+
+		defaultValueFunc := getOrgIgnoreApprovalEnabled(mockEngine)
+		result, err := defaultValueFunc(nil, nil)
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "unable to retrieve org settings")
+	})
+}
+
+func setupMockEngineForOrgSettings(t *testing.T, response *contract.OrgSettingsResponse) (interface{}, error) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	orgId := uuid.New().String()
+	apiUrl := "https://api.snyk.io"
+
+	responseJSON, err := json.Marshal(response)
+	assert.NoError(t, err)
+
+	mockEngine := mocks.NewMockEngine(ctrl)
+	mockConfig := mocks.NewMockConfiguration(ctrl)
+	mockNetworkAccess := mocks.NewMockNetworkAccess(ctrl)
+
+	httpClient := localworkflows.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewBuffer(responseJSON)),
+		}
+	})
+
+	mockEngine.EXPECT().GetConfiguration().Return(mockConfig)
+	mockEngine.EXPECT().GetNetworkAccess().Return(mockNetworkAccess)
+	mockConfig.EXPECT().GetString(configuration.ORGANIZATION).Return(orgId)
+	mockConfig.EXPECT().GetString(configuration.API_URL).Return(apiUrl)
+	mockNetworkAccess.EXPECT().GetHttpClient().Return(httpClient)
+
+	defaultValueFunc := getOrgIgnoreApprovalEnabled(mockEngine)
+	return defaultValueFunc(nil, nil)
 }

--- a/pkg/local_workflows/ignore_workflow/ignore_workflow_test.go
+++ b/pkg/local_workflows/ignore_workflow/ignore_workflow_test.go
@@ -51,7 +51,7 @@ func setupMockIgnoreContext(t *testing.T, payload string, statusCode int) *mocks
 	config := configuration.New()
 	config.Set(configuration.API_URL, "https://api.snyk.io")
 	config.Set(configuration.ORGANIZATION, uuid.New().String())
-	config.Set(configuration.FF_IAW_ENABLED, true)
+	config.Set(configIgnoreApprovalEnabled, true)
 	// setup mocks
 	ctrl := gomock.NewController(t)
 	networkAccessMock := mocks.NewMockNetworkAccess(ctrl)
@@ -306,7 +306,7 @@ func Test_ignoreCreateWorkflowEntryPoint(t *testing.T) {
 
 		invocationContext := setupMockIgnoreContext(t, "{}", http.StatusCreated)
 		config := invocationContext.GetConfiguration()
-		config.Set(configuration.FF_IAW_ENABLED, false)
+		config.Set(configIgnoreApprovalEnabled, false)
 
 		config.Set(InteractiveKey, false)
 
@@ -330,7 +330,7 @@ func setupInteractiveMockContext(t *testing.T, mockApiResponse string, mockApiSt
 	config := configuration.New()
 	config.Set(configuration.API_URL, "https://api.snyk.io")
 	config.Set(configuration.ORGANIZATION, uuid.New().String())
-	config.Set(configuration.FF_IAW_ENABLED, true)
+	config.Set(configIgnoreApprovalEnabled, true)
 	config.Set(InteractiveKey, true) // Always interactive
 	config.Set(EnrichResponseKey, true)
 	config.Set(configuration.ORGANIZATION_SLUG, "some-org")


### PR DESCRIPTION
Previously, the IAW create workflow was gated behind a feature flag check. For EA, customers should be able to opt in/out of using the ignore approval, so a new org setting was added for them to toggle on/off. 

This PR just swaps out the feature flag check with an fetching the org settings and checking whether IAW is enabled for the current org before proceeding with the ignore create workflow.

Ref: [CLI-1006](https://snyksec.atlassian.net/browse/CLI-1006)

[CLI-1006]: https://snyksec.atlassian.net/browse/CLI-1006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ