### PR TITLE
fix: incorrect error handling in org id default function

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -73,7 +73,7 @@ func defaultFuncOrganization(engine workflow.Engine, config configuration.Config
 			logger.Print("Failed to determine default value for \"ORGANIZATION\":", err)
 		}
 
-		return orgId, nil
+		return orgId, err
 	}
 	return callback
 }


### PR DESCRIPTION
The default function to determine the orgid always returned nil instead of an error, the error was just logged. This PR returns the error correctly and enables to handle it.