### PR TITLE
fix: better env loading [IDE-1314]

### DIFF
--- a/pkg/envvars/environment.go
+++ b/pkg/envvars/environment.go
@@ -81,13 +81,16 @@ func LoadConfigFiles(customConfigFiles []string, workingDirectory string) {
 			envFilePath = filepath.Join(workingDirectory, envFilePath)
 		}
 
-		// Preserve original PATH and unset it so our prepending / appending logic works correctly
+		// Preserve original PATH and unset it to ensure correct precedence order.
+		// Without unsetting, if the config file has no PATH, SDK bins will be appended to original PATH (wrong precedence).
 		previousPath := os.Getenv(PathEnvVarName)
 		_ = os.Unsetenv(PathEnvVarName)
 
 		// overwrite existing variables with file config
 		err := gotenv.OverLoad(envFilePath)
 		if err != nil {
+			// Restore PATH if config file loading failed.
+			_ = os.Setenv(PathEnvVarName, previousPath)
 			continue
 		}
 

--- a/pkg/envvars/environment_test.go
+++ b/pkg/envvars/environment_test.go
@@ -151,6 +151,67 @@ func TestLoadConfiguredEnvironment(t *testing.T) {
 	})
 }
 
+func TestLoadConfigFiles(t *testing.T) {
+	t.Run("should load config files and prepend PATH", func(t *testing.T) {
+		dir := t.TempDir()
+		originalPath := "original" + pathListSep + "existing"
+		t.Setenv("PATH", originalPath)
+
+		// Create a config file with PATH entry (no overlapping paths)
+		configFileName := filepath.Join(dir, ".snyk.env")
+		configContent := []byte("TEST_VAR=test_value\nPATH=config" + pathListSep + "file\n")
+		err := os.WriteFile(configFileName, configContent, 0660)
+		require.NoError(t, err)
+
+		files := []string{configFileName}
+		LoadConfigFiles(files, dir)
+
+		// Verify environment variable was set
+		require.Equal(t, "test_value", os.Getenv("TEST_VAR"))
+
+		// Verify PATH was prepended (config path should come first)
+		expectedPath := "config" + pathListSep + "file" + pathListSep + "original" + pathListSep + "existing"
+		require.Equal(t, expectedPath, os.Getenv("PATH"))
+	})
+
+	t.Run("should handle relative config file paths", func(t *testing.T) {
+		dir := t.TempDir()
+		originalPath := "original"
+		t.Setenv("PATH", originalPath)
+
+		// Create a config file with relative path
+		configFileName := ".test.env"
+		configFilePath := filepath.Join(dir, configFileName)
+		configContent := []byte("PATH=relative" + pathListSep + "path\n")
+		err := os.WriteFile(configFilePath, configContent, 0660)
+		require.NoError(t, err)
+
+		files := []string{configFileName} // relative path
+		LoadConfigFiles(files, dir)
+
+		// Verify PATH was prepended
+		expectedPath := "relative" + pathListSep + "path" + pathListSep + originalPath
+		require.Equal(t, expectedPath, os.Getenv("PATH"))
+	})
+}
+
+func TestLoadShellEnvironment(t *testing.T) {
+	t.Run("should load shell environment and prepend PATH", func(t *testing.T) {
+		originalPath := "original" + pathListSep + "path"
+		t.Setenv("PATH", originalPath)
+
+		// Note: This test will only work properly on non-Windows systems
+		// and when a shell is available. On Windows or in environments
+		// without shell access, the function will be a no-op.
+		LoadShellEnvironment()
+
+		// The shell environment loading behavior depends on the actual shell
+		// and environment. We can't predict exact PATH changes, but we can
+		// verify the function doesn't crash and PATH is still set.
+		require.NotEmpty(t, os.Getenv("PATH"))
+	})
+}
+
 func setupTestFile(t *testing.T, fileName string, dir string) (string, string) {
 	t.Helper()
 	uniqueEnvVar := strconv.Itoa(rand.Int())


### PR DESCRIPTION
Previously we were not using the PATH from the user's shell (or Bash), now we will use both.
Plus, refactored to split the functions for shell environment loading and config file loading.
Plus, allowlisted the Homebrew version of Bash.
If `JAVA_HOME` and/or `GOROOT` are set in the project env files then we will prepend `${value}/bin` to the PATH.