### PR TITLE
fix: use default api when auto detection fails

### DIFF
--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -121,11 +121,21 @@ func Test_CreateAppEngine_config_PAT_autoRegionDetection(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("https://%s", apiUrl), actualApiUrl)
 	})
 
-	t.Run("invalid PAT reverts to default API URL", func(t *testing.T) {
+	t.Run("invalid PAT reverts to default API URL (with wrong payload)", func(t *testing.T) {
 		patWithExtraSegments := "snyk_uat.12345678.payload.signature.extra"
 		engine := CreateAppEngine()
 		config := engine.GetConfiguration()
 		config.Set(configuration.AUTHENTICATION_TOKEN, patWithExtraSegments)
+
+		actualApiUrl := config.GetString(configuration.API_URL)
+		assert.Equal(t, constants.SNYK_DEFAULT_API_URL, actualApiUrl)
+	})
+
+	t.Run("invalid PAT reverts to default API URL (with no hostname in claim)", func(t *testing.T) {
+		pat := createMockPAT(t, `{}`)
+		engine := CreateAppEngine()
+		config := engine.GetConfiguration()
+		config.Set(configuration.AUTHENTICATION_TOKEN, pat)
 
 		actualApiUrl := config.GetString(configuration.API_URL)
 		assert.Equal(t, constants.SNYK_DEFAULT_API_URL, actualApiUrl)

--- a/pkg/auth/tokenauthenticator.go
+++ b/pkg/auth/tokenauthenticator.go
@@ -24,7 +24,7 @@ const (
 // Claims represents the structure of the PATs claims, it does not represent all the claims; only the ones we need
 type Claims struct {
 	// Hostname PAT is valid for
-	Hostname string `json:"h,omitempty"`
+	Hostname string `json:"h"`
 }
 
 var _ Authenticator = (*tokenAuthenticator)(nil)
@@ -101,6 +101,10 @@ func GetApiUrlFromPAT(pat string) (string, error) {
 	}
 
 	hostname := claims.Hostname
+	if len(hostname) == 0 {
+		return "", fmt.Errorf("hostname is empty")
+	}
+
 	if !strings.HasPrefix(hostname, "http") {
 		hostname = fmt.Sprintf("https://%s", hostname)
 	}

--- a/pkg/auth/tokenauthenticator_test.go
+++ b/pkg/auth/tokenauthenticator_test.go
@@ -99,9 +99,8 @@ func TestGetApiUrlFromPAT(t *testing.T) {
 	t.Run("PAT without hostname in claims", func(t *testing.T) {
 		pat := createMockPAT(t, `{}`)
 		fmt.Println("pat", pat)
-		apiUrl, err := GetApiUrlFromPAT(pat)
-		assert.NoError(t, err)
-		assert.Equal(t, "http://api.snyk.io", apiUrl)
+		_, err := GetApiUrlFromPAT(pat)
+		assert.Error(t, err)
 	})
 
 	t.Run("Invalid PAT", func(t *testing.T) {

--- a/pkg/auth/tokenauthenticator_test.go
+++ b/pkg/auth/tokenauthenticator_test.go
@@ -96,6 +96,14 @@ func TestGetApiUrlFromPAT(t *testing.T) {
 		assert.Equal(t, "http://api.snyk.io", apiUrl)
 	})
 
+	t.Run("PAT without hostname in claims", func(t *testing.T) {
+		pat := createMockPAT(t, `{}`)
+		fmt.Println("pat", pat)
+		apiUrl, err := GetApiUrlFromPAT(pat)
+		assert.NoError(t, err)
+		assert.Equal(t, "http://api.snyk.io", apiUrl)
+	})
+
 	t.Run("Invalid PAT", func(t *testing.T) {
 		patTooManySegments := "snyk_test.12345678.payload.signature.extra"
 		apiUrl, err := GetApiUrlFromPAT(patTooManySegments)


### PR DESCRIPTION
We were not defaulting to the `SNYK_API` url, if claims were used that did not contain an `h` in the claims.