### PR TITLE
fix(logging): base sanitisation of logs on known parameter values

### DIFF
--- a/pkg/instrumentation/categories.go
+++ b/pkg/instrumentation/categories.go
@@ -89,7 +89,7 @@ func determineCategoryFromArgs(args []string, knownCommands []string, flagsAllow
 }
 
 func DetermineCategory(args []string, engine workflow.Engine) []string {
-	knownCommands, knownFlags := getKnownCommandsAndFlags(engine)
+	knownCommands, knownFlags := GetKnownCommandsAndFlags(engine)
 	return determineCategoryFromArgs(args, knownCommands, knownFlags)
 }
 

--- a/pkg/instrumentation/instrumentation.go
+++ b/pkg/instrumentation/instrumentation.go
@@ -10,7 +10,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )
 
-func getKnownCommandsAndFlags(engine workflow.Engine) ([]string, []string) {
+func GetKnownCommandsAndFlags(engine workflow.Engine) ([]string, []string) {
 	knownCommands := KNOWN_COMMANDS
 	knownFlags := known_flags
 

--- a/pkg/instrumentation/instrumentation_test.go
+++ b/pkg/instrumentation/instrumentation_test.go
@@ -24,7 +24,7 @@ func Test_DetermineStage(t *testing.T) {
 func Test_GetKnownCommandsAndFlags(t *testing.T) {
 	config := configuration.NewInMemory()
 	engine := workflow.NewWorkFlowEngine(config)
-	actualCommands, actualFlags := getKnownCommandsAndFlags(engine)
+	actualCommands, actualFlags := GetKnownCommandsAndFlags(engine)
 	assert.Equal(t, KNOWN_COMMANDS, actualCommands)
 	assert.Equal(t, known_flags, actualFlags)
 }
@@ -52,7 +52,7 @@ func Test_GetKnownCommandsAndFlags_Extension(t *testing.T) {
 	assert.NotNil(t, entry)
 	assert.NoError(t, err)
 
-	actualCommands, actualFlags := getKnownCommandsAndFlags(engine)
+	actualCommands, actualFlags := GetKnownCommandsAndFlags(engine)
 	assert.Contains(t, actualCommands, command1)
 	assert.Contains(t, actualCommands, command2)
 	assert.Contains(t, actualFlags, "ever")

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -46,13 +46,20 @@ var SENSITIVE_FIELD_NAMES = []string{
 }
 
 type ScrubbingLogWriter interface {
+	// AddTerm takes a regex pattern to scrub
 	AddTerm(term string, matchGroup int)
+	// AddTermsToReplace takes exact strings to scrub
+	AddTermsToReplace(args []string)
 	RemoveTerm(term string)
 }
 
 type scrubStruct struct {
+	// the group to redact from the regex pattern if `regex` is populated, otherwise 0
 	groupToRedact int
-	regex         *regexp.Regexp
+	// the regex pattern to scrub
+	regex *regexp.Regexp
+	// the exact term to replace
+	replace string
 }
 
 type ScrubbingDict map[string]scrubStruct
@@ -86,16 +93,30 @@ func NewScrubbingIoWriter(writer io.Writer, scrubDict ScrubbingDict) io.Writer {
 	}
 }
 
+func (w *scrubbingIoWriter) AddTermsToReplace(terms []string) {
+	w.m.Lock()
+	defer w.m.Unlock()
+	for _, v := range terms {
+		addStaticTermToDict(v, w.scrubDict)
+	}
+}
+
 func (w *scrubbingIoWriter) AddTerm(term string, matchGroup int) {
 	// lock for dict readers and writers
 	w.m.Lock()
 	defer w.m.Unlock()
-	addTermToDict(term, matchGroup, w.scrubDict)
+	addRegexTermToDict(term, matchGroup, w.scrubDict)
 }
 
-func addTermToDict(term string, matchGroup int, dict ScrubbingDict) {
-	if term != "" {
-		dict[term] = scrubStruct{matchGroup, regexp.MustCompile(term)}
+func addStaticTermToDict(replaceTerm string, dict ScrubbingDict) {
+	if replaceTerm != "" {
+		dict[replaceTerm] = scrubStruct{0, nil, replaceTerm}
+	}
+}
+
+func addRegexTermToDict(regexTerm string, matchGroup int, dict ScrubbingDict) {
+	if regexTerm != "" {
+		dict[regexTerm] = scrubStruct{matchGroup, regexp.MustCompile(regexTerm), ""}
 	}
 }
 
@@ -108,16 +129,16 @@ func (w *scrubbingIoWriter) RemoveTerm(term string) {
 
 func GetScrubDictFromConfig(config configuration.Configuration) ScrubbingDict {
 	dict := getDefaultDict()
-	addTermToDict(config.GetString(configuration.AUTHENTICATION_TOKEN), 0, dict)
-	addTermToDict(config.GetString(configuration.AUTHENTICATION_BEARER_TOKEN), 0, dict)
-	addTermToDict(config.GetString(auth.PARAMETER_CLIENT_SECRET), 0, dict)
-	addTermToDict(config.GetString(auth.PARAMETER_CLIENT_ID), 0, dict)
+	addRegexTermToDict(config.GetString(configuration.AUTHENTICATION_TOKEN), 0, dict)
+	addRegexTermToDict(config.GetString(configuration.AUTHENTICATION_BEARER_TOKEN), 0, dict)
+	addRegexTermToDict(config.GetString(auth.PARAMETER_CLIENT_SECRET), 0, dict)
+	addRegexTermToDict(config.GetString(auth.PARAMETER_CLIENT_ID), 0, dict)
 	token, err := auth.GetOAuthToken(config)
 	if err != nil || token == nil {
 		return dict
 	}
-	addTermToDict(token.AccessToken, 0, dict)
-	addTermToDict(token.RefreshToken, 0, dict)
+	addRegexTermToDict(token.AccessToken, 0, dict)
+	addRegexTermToDict(token.RefreshToken, 0, dict)
 	return dict
 }
 
@@ -127,11 +148,19 @@ func getDefaultDict() ScrubbingDict {
 	return dict
 }
 
+func (w *scrubbingLevelWriter) AddTermsToReplace(terms []string) {
+	w.m.Lock()
+	defer w.m.Unlock()
+	for _, v := range terms {
+		addStaticTermToDict(v, w.scrubDict)
+	}
+}
+
 func (w *scrubbingLevelWriter) AddTerm(term string, matchGroup int) {
 	// lock for dict readers and writers
 	w.m.Lock()
 	defer w.m.Unlock()
-	addTermToDict(term, matchGroup, w.scrubDict)
+	addRegexTermToDict(term, matchGroup, w.scrubDict)
 }
 
 func (w *scrubbingLevelWriter) RemoveTerm(term string) {
@@ -230,7 +259,7 @@ func addMandatoryMasking(dict ScrubbingDict) ScrubbingDict {
 	u, err := user.Current()
 	if err == nil {
 		s = fmt.Sprintf(`\b%s\b`, regexp.QuoteMeta(u.Username))
-		addTermToDict(s, 0, dict)
+		addRegexTermToDict(s, 0, dict)
 	}
 
 	// The legacy CLI's snyk-config package prints the entire configuration in debug mode.
@@ -244,14 +273,6 @@ func addMandatoryMasking(dict ScrubbingDict) ScrubbingDict {
 	// JSON-formatted data, in general
 	kws := strings.Join(SENSITIVE_FIELD_NAMES, "|")
 	s = fmt.Sprintf(`(?i)"[^"]*(?<json_key>%s)[^"]*"\s*:\s*"(?<json_value>[^"]*)"`, kws)
-	dict[s] = scrubStruct{
-		groupToRedact: 2,
-		regex:         regexp.MustCompile(s),
-	}
-
-	// CLI argument mapping from the snyk-config debug logging
-	// I.e., if --argument=value is passed, it will be logged as { 'argument=value': true }
-	s = fmt.Sprintf(`(?im)(%s)[^=]*=(?P<value>.*)['"]`, kws)
 	dict[s] = scrubStruct{
 		groupToRedact: 2,
 		regex:         regexp.MustCompile(s),
@@ -285,13 +306,6 @@ func addMandatoryMasking(dict ScrubbingDict) ScrubbingDict {
 		regex:         regexp.MustCompile(s),
 	}
 
-	// Long-form, rest is covered by the JSON scrubbing above
-	s = fmt.Sprintf(`(?im)--(?<argument_key>[^=\s]*(?:%s)[^=\s]*)[\s=]['"]?(?<argument_value>\S*)['"]?`, kws)
-	dict[s] = scrubStruct{
-		groupToRedact: 2,
-		regex:         regexp.MustCompile(s),
-	}
-
 	return dict
 }
 
@@ -304,7 +318,6 @@ func (w *scrubbingLevelWriter) Write(p []byte) (int, error) {
 
 func scrub(p []byte, scrubDict ScrubbingDict) []byte {
 	s := string(p)
-
 	// The dictionary order is important here, as we want potentially overlapping regexes to be applied
 	// in a specific order every time. Since dictionaries are unordered, we sort the keys here.
 	keys := make([]string, 0, len(scrubDict))
@@ -314,6 +327,12 @@ func scrub(p []byte, scrubDict ScrubbingDict) []byte {
 	sort.Strings(keys)
 	for _, key := range keys {
 		entry := scrubDict[key]
+		// scrub from the replacement list first
+		if entry.replace != "" {
+			s = strings.ReplaceAll(s, entry.replace, SANITIZE_REPLACEMENT_STRING)
+			continue
+		}
+		// then scrub from the regex list
 		matches := entry.regex.FindAllStringSubmatch(s, -1)
 		for _, match := range matches {
 			if entry.groupToRedact >= len(match) || match[entry.groupToRedact] == "" {

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os/user"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -91,8 +92,8 @@ func TestScrubbingWriter_WriteLevel(t *testing.T) {
 
 func TestScrubbingIoWriter(t *testing.T) {
 	scrubDict := map[string]scrubStruct{
-		"token":  {0, regexp.MustCompile("token")},
-		"secret": {0, regexp.MustCompile("secret")},
+		"token":  {0, regexp.MustCompile("token"), ""},
+		"secret": {0, regexp.MustCompile("secret"), ""},
 	}
 
 	pattern := "%s for my account, including my %s"
@@ -165,9 +166,9 @@ func TestScrubbingIoWriter(t *testing.T) {
 func TestScrubFunction(t *testing.T) {
 	t.Run("scrub everything in dict", func(t *testing.T) {
 		dict := ScrubbingDict{
-			"secret":       {0, regexp.MustCompile("secret")},
-			"special":      {0, regexp.MustCompile("special")},
-			"be disclosed": {0, regexp.MustCompile("be disclosed")},
+			"secret":       {0, regexp.MustCompile("secret"), ""},
+			"special":      {0, regexp.MustCompile("special"), ""},
+			"be disclosed": {0, regexp.MustCompile("be disclosed"), ""},
 		}
 		input := "This is my secret message, which might not be special but definitely should not be disclosed."
 		expected := "This is my *** message, which might not be *** but definitely should not ***."
@@ -301,39 +302,6 @@ func TestAddDefaults(t *testing.T) {
 			expected: `_: [***],`,
 		},
 		{
-			name: "cli argument mapping from snyk-config debug logging",
-			input: `{
-				username: 'username-set',
-				'username=john.doe': true,
-				password: 'password-set',
-				'password=foobar': true,
-				'u=foobar': true,
-				'password-with-double-quotes=foo"bar': true,
-				"password-with-single-quotes=foo'bar": true,
-				'password-with-comma=foo,bar': true,
-				'my-password-with-spaces=foo bar': true,
-				'my-password-thats-solid=solid': true,
-				'p=foobar': true,
-				debug: true,
-				'log-level': 'trace'
-			}`,
-			expected: `{
-				username: 'username-set',
-				'username=***': true,
-				password: 'password-set',
-				'password=***': true,
-				'u=***': true,
-				'password-with-double-quotes=***': true,
-				"password-with-single-quotes=***": true,
-				'password-with-comma=***': true,
-				'my-password-with-spaces=***': true,
-				'my-password-thats-***=***': true,
-				'p=***': true,
-				debug: true,
-				'log-level': 'trace'
-			}`,
-		},
-		{
 			name: "username and password constellations passed in a JSON-ish structure with verbatim output from snyk-config",
 			input: `{
 				unrelated: dont-scrub,
@@ -381,53 +349,6 @@ func TestAddDefaults(t *testing.T) {
 			}`,
 		},
 		{
-			name: "CLI arguments logged to the debug logs (multi-line)",
-			input: `Arguments:[
-			container test gcr.io/distroless/nodejs:latest
-			--platform=linux/arm64
-			--unrelated-argument
-			--unrelated-argument-with-value "value"
-			--unrelated-argument-with-equals-sign="value"
-			-u john.doe
-			-p hunter2
-			--username john.doe
-			--password hunter2
-			--a-password-with-secret-in-the-value 'super-secret-password'
-			--a-password-with-an-equals-sign='hunter2'
-			--a-password-with-spaces='hun ter2'
-			--a-password-with-double-quotes='hun"ter2'
-			--a-password-with-single-quotes="hun'ter2"
-			--token "token"
-			--password-with-no-value
-			--another-unrelated-at-the-end
-			--log-level=trace
-			-d
-			--debug
-		]`,
-			expected: `Arguments:[
-			container test gcr.io/distroless/nodejs:latest
-			--platform=linux/arm64
-			--unrelated-argument
-			--unrelated-argument-with-value "value"
-			--unrelated-argument-with-equals-sign="value"
-			-u ***
-			-p ***
-			--username ***
-			--password ***
-			--a-password-with-secret-in-the-value '***
-			--a-password-with-an-equals-sign=***
-			--a-password-with-spaces=***
-			--a-password-with-double-quotes=***
-			--a-password-with-single-quotes=***
-			--token "***
-			--password-with-no-value
-			--another-unrelated-at-the-end
-			--log-level=trace
-			-d
-			--debug
-		]`,
-		},
-		{
 			name:     "CLI arguments logged to the debug logs (same line, short-form, no equals signs)",
 			input:    `container test gcr.io/distroless/nodejs:latest --platform=linux/arm64 --unrelated-argument --unrelated-argument-with-value "value" --unrelated-argument-with-equals-sign="value" -u john.doe -p hunter2 --log-level=trace`,
 			expected: `container test gcr.io/distroless/nodejs:latest --platform=linux/arm64 --unrelated-argument --unrelated-argument-with-value "value" --unrelated-argument-with-equals-sign="value" -u *** -p *** --log-level=trace`,
@@ -436,16 +357,6 @@ func TestAddDefaults(t *testing.T) {
 			name:     "CLI arguments logged to the debug logs (same line, short-form, with equals signs)",
 			input:    `container test gcr.io/distroless/nodejs:latest --platform=linux/arm64 --unrelated-argument --unrelated-argument-with-value "value" --unrelated-argument-with-equals-sign="value" -u=john.doe -p=hunter2 --log-level=trace`,
 			expected: `container test gcr.io/distroless/nodejs:latest --platform=linux/arm64 --unrelated-argument --unrelated-argument-with-value "value" --unrelated-argument-with-equals-sign="value" -u=*** -p=*** --log-level=trace`,
-		},
-		{
-			name:     "CLI arguments logged to the debug logs (same line, long-form, no equals signs)",
-			input:    `container test ubuntu:latest --username john.doe --password solidpassword -d`,
-			expected: `container test ubuntu:latest --username *** --password *** -d`,
-		},
-		{
-			name:     "CLI arguments logged to the debug logs (same line, long-form, with equals signs)",
-			input:    `container test ubuntu:latest --username=john.doe --password=solidpassword -d`,
-			expected: `container test ubuntu:latest --username=*** --password=*** -d`,
 		},
 	}
 	for _, test := range tests {
@@ -458,8 +369,8 @@ func TestAddDefaults(t *testing.T) {
 
 func TestScrubbingIoWriter_piecewise(t *testing.T) {
 	scrubDict := map[string]scrubStruct{
-		"token":    {0, regexp.MustCompile("token")},
-		"password": {0, regexp.MustCompile("password")},
+		"token":    {0, regexp.MustCompile("token"), ""},
+		"password": {0, regexp.MustCompile("password"), ""},
 	}
 
 	innerWriter := &mockWriter{
@@ -474,6 +385,104 @@ func TestScrubbingIoWriter_piecewise(t *testing.T) {
 	assert.Equal(t, len(input), n)
 	t.Log(string(innerWriter.written))
 	assert.Equal(t, string(expectedOutput), string(innerWriter.written))
+}
+
+func TestAddTermsToReplace(t *testing.T) {
+	tests := []struct {
+		name       string
+		termsToAdd []string
+		input      string
+		expected   string
+	}{
+		{
+			name:       "single term",
+			termsToAdd: []string{"secret123"},
+			input:      "This is my secret123 value",
+			expected:   "This is my *** value",
+		},
+		{
+			name:       "multiple terms",
+			termsToAdd: []string{"password", "token", "key"},
+			input:      "password is secret, token is hidden, key is protected",
+			expected:   "*** is secret, *** is hidden, *** is protected",
+		},
+		{
+			name:       "empty terms list",
+			termsToAdd: []string{},
+			input:      "nothing should be replaced here",
+			expected:   "nothing should be replaced here",
+		},
+		{
+			name:       "special characters in terms",
+			termsToAdd: []string{"user@domain.com", "file.txt", "super=secret?password"},
+			input:      "Email user@domain.com, file file.txt, and super=secret?password value",
+			expected:   "Email ***, file ***, and *** value",
+		},
+		{
+			name:       "terms with spaces",
+			termsToAdd: []string{"secret phrase", "multi word key"},
+			input:      "The secret phrase is hidden and multi word key is protected",
+			expected:   "The *** is hidden and *** is protected",
+		},
+		{
+			name:       "unicode characters",
+			termsToAdd: []string{"café", "naïve"},
+			input:      "The café is naïve about security",
+			expected:   "The *** is *** about security",
+		},
+		{
+			name:       "terms with newlines and tabs",
+			termsToAdd: []string{"line1\nline2", "tab\tseparated"},
+			input:      "First line1\nline2 then tab\tseparated values",
+			expected:   "First *** then *** values",
+		},
+		{
+			name:       "very long term",
+			termsToAdd: []string{strings.Repeat("X", 1000)},
+			input:      "Short text with " + strings.Repeat("X", 1000) + " long term",
+			expected:   "Short text with *** long term",
+		},
+		{
+			name:       "numeric terms",
+			termsToAdd: []string{"12345", "987.654"},
+			input:      "ID 12345 and value 987.654 are sensitive",
+			expected:   "ID *** and value *** are sensitive",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Run("IoWriter", func(t *testing.T) {
+				mockWriter := &mockWriter{}
+				writer := &scrubbingIoWriter{
+					writer:    mockWriter,
+					scrubDict: ScrubbingDict{},
+				}
+
+				writer.AddTermsToReplace(test.termsToAdd)
+
+				n, err := writer.Write([]byte(test.input))
+				assert.NoError(t, err)
+				assert.Equal(t, len(test.input), n)
+				assert.Equal(t, test.expected, string(mockWriter.written))
+			})
+
+			t.Run("LevelWriter", func(t *testing.T) {
+				mockWriter := &mockWriter{}
+				writer := &scrubbingLevelWriter{
+					writer:    mockWriter,
+					scrubDict: ScrubbingDict{},
+				}
+
+				writer.AddTermsToReplace(test.termsToAdd)
+
+				n, err := writer.WriteLevel(zerolog.InfoLevel, []byte(test.input))
+				assert.NoError(t, err)
+				assert.Equal(t, len(test.input), n)
+				assert.Equal(t, test.expected, string(mockWriter.written))
+			})
+		})
+	}
 }
 
 func TestSnykPATScrubbing(t *testing.T) {


### PR DESCRIPTION
This PR updates our log scrubbing implementation to a more layered approach. Where we initially only relied on regex pattern matching to scrub sensitive data from our logs, we will now also pass in known parameters for scrub processing.

Unknown parameters will be scrubbed, whilst known parameters are not.