### PR TITLE
chore(config): support string and stringslice conversion

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -148,6 +148,19 @@ func defaultInputDirectory() configuration.DefaultValueFunction {
 			return existingString, nil
 		}
 
+		existingStringSlice, isStringSlice := existingValue.([]string)
+		resultingSlice := []string{}
+		for _, s := range existingStringSlice {
+			if len(s) > 0 {
+				resultingSlice = append(resultingSlice, s)
+			}
+		}
+
+		if isStringSlice && len(resultingSlice) > 0 {
+			// Return the string value as-is (preserving any whitespace)
+			return resultingSlice, nil
+		}
+
 		// Fall back to current working directory for non-string types or empty strings
 		path, err := os.Getwd()
 		if err != nil {

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -697,8 +697,15 @@ func TestDefaultInputDirectory(t *testing.T) {
 			name:           "non-string type - slice",
 			existingValue:  []string{"path1", "path2"},
 			expectedError:  false,
-			expectedResult: nil, // Will fall back to current working directory
-			description:    "should handle non-string types gracefully and return current working directory",
+			expectedResult: []string{"path1", "path2"},
+			description:    "should handle non-string types gracefully and return the slice as there are multiple paths possible",
+		},
+		{
+			name:           "non-string type - slice with empty strings",
+			existingValue:  []string{"path1", "", "path2"},
+			expectedError:  false,
+			expectedResult: []string{"path1", "path2"},
+			description:    "should ignore empty strings in slices",
 		},
 		{
 			name:           "non-string type - map",
@@ -757,6 +764,8 @@ func TestDefaultInputDirectory(t *testing.T) {
 				assert.NotNil(t, result, tt.description)
 				if str, ok := result.(string); ok {
 					assert.NotEmpty(t, str, tt.description)
+				} else {
+					assert.Fail(t, "result is not a string", tt.description)
 				}
 			}
 		})

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -501,22 +501,28 @@ func (ev *extendedViper) GetStringWithError(key string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if s, ok := result.(string); ok {
-		return s, nil
+
+	switch v := result.(type) {
+	case string:
+		return v, nil
+	case []string:
+		if len(v) == 0 {
+			return "", nil
+		}
+
+		return v[0], nil
 	}
+
 	return "", fmt.Errorf("value for key %s is not a string", key)
 }
 
 // GetString returns a configuration value as string.
 func (ev *extendedViper) GetString(key string) string {
-	result := ev.Get(key)
-	if result == nil {
+	result, err := ev.GetStringWithError(key)
+	if err != nil {
 		return ""
 	}
-	if s, ok := result.(string); ok {
-		return s
-	}
-	return ""
+	return result
 }
 
 // GetBoolWithError returns a configuration value as bool.

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -943,6 +943,21 @@ func Test_toDuration(t *testing.T) {
 	}
 }
 
+func Test_Configuration_GetStringSliceString(t *testing.T) {
+	key := "key1"
+	expected := []string{"value1", "value2"}
+	config := NewWithOpts()
+	config.Set(key, expected)
+
+	// access slice as slice
+	actual := config.GetStringSlice(key)
+	assert.Equal(t, expected, actual)
+
+	// access slice as string
+	actualString := config.GetString(key)
+	assert.Equal(t, expected[0], actualString)
+}
+
 func Test_Configuration_AddKeyDependency_happy(t *testing.T) {
 	key1 := "key1"
 	key2 := "key2"


### PR DESCRIPTION
This PR adds support for single and multiple strings as `INPUT_DIRECTORY`. It remains the existing behaviour for consumers of `config.GetString(configuration.INPUT_DIRECTORY)` and adds the ability to get a list of directories via `config.GetStringSlice(configuration.INPUT_DIRECTORY)`

Besides the support in configuration.Configuration, `defaultInputDirectory` is adapted to validate the input for both types string and []string