### PR TITLE
chore: forward project and snapshot id to local findings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.34.0
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
-	github.com/snyk/code-client-go v1.21.3
+	github.com/snyk/code-client-go v1.22.4-0.20250917144443-635b798a8dc9
 	github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
-github.com/snyk/code-client-go v1.21.3 h1:2+HPXCA9FGn3gaI1Jw1C4Ifn/NRAbSnmohFUvz4GC4I=
-github.com/snyk/code-client-go v1.21.3/go.mod h1:WH6lNkJc785hfXmwhixxWHix3O6z+1zwz40oK8vl/zg=
+github.com/snyk/code-client-go v1.22.4-0.20250917144443-635b798a8dc9 h1:s3b8/4Grw6ihJmQk8rsj1Rl2o8psGB9fXy+1CEA9cHw=
+github.com/snyk/code-client-go v1.22.4-0.20250917144443-635b798a8dc9/go.mod h1:Jx3Jpo8kHlqHjhGa7a0ROQzPu+X15TBN0zRD+wNcUds=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250812140843-a01d75260003 h1:qeXih9sVe/WvhccE3MfEgglnSVKN1xTQBcsA/N96Kzo=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250812140843-a01d75260003/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=

--- a/internal/presenters/templates/local_finding.sarif.tmpl
+++ b/internal/presenters/templates/local_finding.sarif.tmpl
@@ -225,6 +225,13 @@
 						}{{if lt $coverageIndex $coverageSize}},{{end}}
 						{{- end }}
 					]
+					{{- if .Links.report }},
+					"uploadResult": {
+						"projectId": "{{ .Links.projectid }}",
+						"snapshotId": "{{ .Links.snapshotid }}",
+						"reportUrl": "{{ .Links.report }}"
+					}
+					{{- end }}
 				}
 			}
 		{{- end}}

--- a/pkg/local_workflows/code_workflow/native_workflow.go
+++ b/pkg/local_workflows/code_workflow/native_workflow.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"os"
 	"path"
@@ -161,10 +160,8 @@ func EntryPointNative(invocationCtx workflow.InvocationContext, opts ...Optional
 			return nil, lfError
 		}
 
-		// if available add a report link to the findings
-		if resultMetaData != nil && len(resultMetaData.WebUiUrl) > 0 {
-			localFindings.Links[local_models.LINKS_KEY_REPORT] = fmt.Sprintf("%s%s", config.GetString(configuration.WEB_APP_URL), resultMetaData.WebUiUrl)
-		}
+		// translate metadata to findings
+		local_models.TranslateMetadataToLocalFindingModel(resultMetaData, &localFindings, config)
 
 		targetId, targetIdError := instrumentation.GetTargetId(config.GetString(configuration.INPUT_DIRECTORY), instrumentation.AutoDetectedTargetId, instrumentation.WithConfiguredRepository(config))
 		if targetIdError != nil {

--- a/pkg/local_workflows/local_models/transform.go
+++ b/pkg/local_workflows/local_models/transform.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/snyk/code-client-go/sarif"
+	"github.com/snyk/code-client-go/scan"
+	"github.com/snyk/go-application-framework/pkg/configuration"
 	sarif2 "github.com/snyk/go-application-framework/pkg/utils/sarif"
 
 	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
@@ -266,4 +268,21 @@ func UpdateFindingSummary(findingsModel *LocalFinding) {
 	}
 
 	findingsModel.Summary.Counts = updatedFindingCounts
+}
+
+func TranslateMetadataToLocalFindingModel(resultMetaData *scan.ResultMetaData, localFindings *LocalFinding, config configuration.Configuration) {
+	// if available add a report url to the findings
+	if resultMetaData != nil && len(resultMetaData.WebUiUrl) > 0 {
+		localFindings.Links[LINKS_KEY_REPORT] = fmt.Sprintf("%s%s", config.GetString(configuration.WEB_APP_URL), resultMetaData.WebUiUrl)
+	}
+
+	// if available add a project id to the findings
+	if resultMetaData != nil && len(resultMetaData.ProjectId) > 0 {
+		localFindings.Links["projectid"] = resultMetaData.ProjectId
+	}
+
+	// if available add a project id to the findings
+	if resultMetaData != nil && len(resultMetaData.SnapshotId) > 0 {
+		localFindings.Links["snapshotid"] = resultMetaData.SnapshotId
+	}
 }

--- a/pkg/local_workflows/output_workflow_test.go
+++ b/pkg/local_workflows/output_workflow_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/rs/zerolog"
 	"github.com/snyk/code-client-go/sarif"
+	"github.com/snyk/code-client-go/scan"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/xeipuuv/gojsonschema"
@@ -389,6 +390,13 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 		apiResponse := "testdata/sarif-snyk-goof-ignores.api.response.json"
 		localFinding, err := sarifToLocalFinding(t, apiResponse, "/mypath")
 		assert.Nil(t, err)
+
+		resultMetaData := &scan.ResultMetaData{
+			WebUiUrl:   "https://app.snyk.io/org/test/project/123",
+			ProjectId:  "123",
+			SnapshotId: "456",
+		}
+		local_models.TranslateMetadataToLocalFindingModel(resultMetaData, localFinding, config)
 
 		workflowIdentifier := workflow.NewTypeIdentifier(WORKFLOWID_OUTPUT_WORKFLOW, "output")
 

--- a/pkg/local_workflows/testdata/sarif-snyk-goof-ignores.json
+++ b/pkg/local_workflows/testdata/sarif-snyk-goof-ignores.json
@@ -3268,7 +3268,12 @@
             "lang": "JavaScript",
             "type": "SUPPORTED"
           }
-        ]
+        ],
+        "uploadResult": {
+          "projectId": "123",
+          "snapshotId": "456",
+          "reportUrl": "https://app.snyk.io/org/test/project/123"
+        }
       }
     }
   ]


### PR DESCRIPTION
This PR updates code-client-go to use additional result metadata and render it in the sarif results.