### PR TITLE
feat: add runAutomationsDetailsId for SARIF output

### DIFF
--- a/internal/presenters/funcs.go
+++ b/internal/presenters/funcs.go
@@ -237,6 +237,12 @@ func getSarifTemplateFuncMap() template.FuncMap {
 	fnMap["SeverityToSarifLevel"] = func(s local_models.TypesFindingRatingSeverityValue) string {
 		return sarif.SeverityToSarifLevel(string(s))
 	}
+	fnMap["getAutomationDetailsId"] = func(projectName string) string {
+		if projectName != "" {
+			projectName = projectName + "/"
+		}
+		return fmt.Sprintf("Snyk/Code/%s%s", projectName, time.Now().UTC().Format(time.RFC3339))
+	}
 	fnMap["convertTypeToDriverName"] = sarif.ConvertTypeToDriverName
 	return fnMap
 }

--- a/internal/presenters/templates/local_finding.sarif.tmpl
+++ b/internal/presenters/templates/local_finding.sarif.tmpl
@@ -232,6 +232,9 @@
 						"reportUrl": "{{ .Links.report }}"
 					}
 					{{- end }}
+				},
+				"automationDetails": {
+					"id": "{{- getAutomationDetailsId (getValueFromConfig "project-name") }}"
 				}
 			}
 		{{- end}}


### PR DESCRIPTION
Updates the presenters to include the `runAutomationDetails` [id](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790776) field in the SARIF output for the native code implementation.