### PR TITLE
fix: Fix incorrect behaviour of IsSet() for environment variables

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -409,6 +409,9 @@ func (ev *extendedViper) IsSet(key string) bool {
 	ev.mutex.RLock()
 	defer ev.mutex.RUnlock()
 
+	//nolint:errcheck // bindenv is actually best effort and we don't care about the error
+	_ = ev.bindEnv(key)
+
 	isSet := ev.viper.IsSet(key)
 	if !isSet {
 		for _, altKey := range ev.alternativeKeys[key] {

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -1060,3 +1060,12 @@ func Test_Configuration_AddKeyDependency_CircularDependency(t *testing.T) {
 	err = config.AddKeyDependency("key1", "key1")
 	assert.Error(t, err)
 }
+
+func Test_Configuration_IsSet(t *testing.T) {
+	key := "SNYK_TOKEN"
+	value := "value1"
+	config := NewWithOpts(WithSupportedEnvVarPrefixes("SNYK_"))
+	assert.False(t, config.IsSet(key))
+	t.Setenv(key, value)
+	assert.True(t, config.IsSet(key))
+}


### PR DESCRIPTION
This fix ensures that configuration.IsSet() works for environment variables as well.