### PR TITLE
feat: normalize remote repo URL before code scanning

### DIFF
--- a/pkg/local_workflows/code_workflow/native_workflow.go
+++ b/pkg/local_workflows/code_workflow/native_workflow.go
@@ -26,6 +26,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/networking"
 	"github.com/snyk/go-application-framework/pkg/ui"
 	"github.com/snyk/go-application-framework/pkg/utils"
+	"github.com/snyk/go-application-framework/pkg/utils/git"
 	sarif2 "github.com/snyk/go-application-framework/pkg/utils/sarif"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )
@@ -273,8 +274,10 @@ func determineAnalyzeInput(path string, config configuration.Configuration, logg
 		pathIsDirectory = true
 	}
 
+	remoteUrl := git.GetSanitizedRemoteUrl(config.GetString(configuration.FLAG_REMOTE_REPO_URL))
+
 	if !pathIsDirectory {
-		target, err := scan.NewRepositoryTarget(filepath.Dir(path), scan.WithRepositoryUrl(config.GetString(configuration.FLAG_REMOTE_REPO_URL)), scan.WithCommitId(config.GetString(ConfigurationCommitId)))
+		target, err := scan.NewRepositoryTarget(filepath.Dir(path), scan.WithRepositoryUrl(remoteUrl), scan.WithCommitId(config.GetString(ConfigurationCommitId)))
 		if err != nil {
 			logger.Warn().Err(err)
 		}
@@ -290,7 +293,7 @@ func determineAnalyzeInput(path string, config configuration.Configuration, logg
 		return target, files, nil
 	}
 
-	target, err := scan.NewRepositoryTarget(path, scan.WithRepositoryUrl(config.GetString(configuration.FLAG_REMOTE_REPO_URL)), scan.WithCommitId(config.GetString(ConfigurationCommitId)))
+	target, err := scan.NewRepositoryTarget(path, scan.WithRepositoryUrl(remoteUrl), scan.WithCommitId(config.GetString(ConfigurationCommitId)))
 	if err != nil {
 		logger.Warn().Err(err)
 	}

--- a/pkg/utils/git/git_test.go
+++ b/pkg/utils/git/git_test.go
@@ -134,3 +134,69 @@ func TestGetRemoteUrl_Priority(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "https://github.com/origin/repo.git", remoteUrl)
 }
+
+func TestGetSanitizedRemoteUrl(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "HTTPS URL",
+			input:    "https://github.com/user/repo.git",
+			expected: "http://github.com/user/repo.git",
+		},
+		{
+			name:     "HTTP URL",
+			input:    "http://github.com/user/repo.git",
+			expected: "http://github.com/user/repo.git",
+		},
+		{
+			name:     "SSH URL with protocol",
+			input:    "ssh://git@github.com/user/repo.git",
+			expected: "http://github.com/user/repo.git",
+		},
+		{
+			name:     "SCP-like syntax with user",
+			input:    "git@github.com:user/repo.git",
+			expected: "http://github.com/user/repo.git",
+		},
+		{
+			name:     "SCP-like syntax without user",
+			input:    "github.com:user/repo.git",
+			expected: "http://github.com/user/repo.git",
+		},
+		{
+			name:     "SCP-like syntax with different host",
+			input:    "git@gitlab.com:organization/project.git",
+			expected: "http://gitlab.com/organization/project.git",
+		},
+		{
+			name:     "HTTPS URL with port",
+			input:    "https://github.com:443/user/repo.git",
+			expected: "http://github.com:443/user/repo.git",
+		},
+		{
+			name:     "unsupported protocol",
+			input:    "ftp://example.com/repo.git",
+			expected: "ftp://example.com/repo.git",
+		},
+		{
+			name:     "plain path (no match)",
+			input:    "/path/to/repo",
+			expected: "/path/to/repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetSanitizedRemoteUrl(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Add GetSanitizedRemoteUrl function to convert git remote URLs to a consistent HTTP format. This handles SSH, HTTPS, and SCP-like syntax (e.g., git@github.com:org/repo.git) by normalizing them to http://{host}/{path} format.

Apply normalization in determineAnalyzeInput before passing the remote URL to scan.NewRepositoryTarget, ensuring consistent URL format for both file and directory scan paths.

- Add GetSanitizedRemoteUrl in pkg/utils/git/git.go
- Add comprehensive tests for URL normalization
- Apply normalization in native_workflow.go
- Add tests covering various URL formats in code workflow