### PR TITLE
chore: Use context.Context from InvocationContext

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,15 +15,15 @@ import (
 //go:generate go tool github.com/golang/mock/mockgen -source=api.go -destination ../mocks/api.go -package mocks -self_package github.com/snyk/go-application-framework/pkg/api/
 
 type ApiClient interface {
-	GetDefaultOrgId() (orgID string, err error)
-	GetOrgIdFromSlug(slugName string) (string, error)
-	GetSlugFromOrgId(orgID string) (string, error)
-	GetOrganizations(limit int) (*contract.OrganizationsResponse, error)
+	GetDefaultOrgId(ctx context.Context) (orgID string, err error)
+	GetOrgIdFromSlug(ctx context.Context, slugName string) (string, error)
+	GetSlugFromOrgId(ctx context.Context, orgID string) (string, error)
+	GetOrganizations(ctx context.Context, limit int) (*contract.OrganizationsResponse, error)
 	Init(url string, client *http.Client)
-	GetFeatureFlag(flagname string, origId string) (bool, error)
-	GetUserMe() (string, error)
-	GetSelf() (contract.SelfResponse, error)
-	GetOrgSettings(orgId string) (*contract.OrgSettingsResponse, error)
+	GetFeatureFlag(ctx context.Context, flagname string, origId string) (bool, error)
+	GetUserMe(ctx context.Context) (string, error)
+	GetSelf(ctx context.Context) (contract.SelfResponse, error)
+	GetOrgSettings(ctx context.Context, orgId string) (*contract.OrgSettingsResponse, error)
 }
 
 var _ ApiClient = (*snykApiClient)(nil)
@@ -35,17 +36,18 @@ type snykApiClient struct {
 // GetSlugFromOrgId retrieves the organization slug associated with a given Snyk organization ID.
 //
 // Parameters:
+//   - ctx: Context for cancellation and timeout control.
 //   - orgID (string): The UUID of the organization.
 //
 // Returns:
 //   - The organization slug as a string.
 //   - An error object (if the organization is not found, or if API request or response
 //     parsing errors occur).
-func (a *snykApiClient) GetSlugFromOrgId(orgID string) (string, error) {
+func (a *snykApiClient) GetSlugFromOrgId(ctx context.Context, orgID string) (string, error) {
 	endpoint := "/rest/orgs/" + orgID
 	version := "2024-03-12"
 
-	body, err := clientGet(a, endpoint, &version)
+	body, err := clientGet(ctx, a, endpoint, &version)
 	if err != nil {
 		return "", err
 	}
@@ -62,17 +64,18 @@ func (a *snykApiClient) GetSlugFromOrgId(orgID string) (string, error) {
 // GetOrgIdFromSlug retrieves the organization ID associated with a given Snyk organization slug.
 //
 // Parameters:
+//   - ctx: Context for cancellation and timeout control.
 //   - slugName (string): The unique slug identifier of the organization.
 //
 // Returns:
 //   - The organization ID as a string.
 //   - An error object (if the organization is not found, or if API request or response
 //     parsing errors occur).
-func (a *snykApiClient) GetOrgIdFromSlug(slugName string) (string, error) {
+func (a *snykApiClient) GetOrgIdFromSlug(ctx context.Context, slugName string) (string, error) {
 	endpoint := "/rest/orgs"
 	version := "2024-03-12"
 
-	body, err := clientGet(a, endpoint, &version, "slug", slugName)
+	body, err := clientGet(ctx, a, endpoint, &version, "slug", slugName)
 	if err != nil {
 		return "", err
 	}
@@ -95,16 +98,17 @@ func (a *snykApiClient) GetOrgIdFromSlug(slugName string) (string, error) {
 // GetOrganizations retrieves organizations accessible to the authenticated user.
 //
 // Parameters:
+//   - ctx: Context for cancellation and timeout control.
 //   - limit: Maximum number of organizations to return
 //
 // Returns:
 //   - A pointer to OrganizationsResponse containing organizations.
 //   - An error object (if an error occurred during the API request or response parsing).
-func (a *snykApiClient) GetOrganizations(limit int) (*contract.OrganizationsResponse, error) {
+func (a *snykApiClient) GetOrganizations(ctx context.Context, limit int) (*contract.OrganizationsResponse, error) {
 	endpoint := "/rest/orgs"
 	version := "2024-10-15"
 
-	body, err := clientGet(a, endpoint, &version, "limit", fmt.Sprintf("%d", limit))
+	body, err := clientGet(ctx, a, endpoint, &version, "limit", fmt.Sprintf("%d", limit))
 	if err != nil {
 		return nil, err
 	}
@@ -120,11 +124,14 @@ func (a *snykApiClient) GetOrganizations(limit int) (*contract.OrganizationsResp
 
 // GetDefaultOrgId retrieves the default organization ID associated with the authenticated user.
 //
+// Parameters:
+//   - ctx: Context for cancellation and timeout control.
+//
 // Returns:
 //   - The user's default organization ID as a string.
 //   - An error object (if an error occurred while fetching user data).
-func (a *snykApiClient) GetDefaultOrgId() (string, error) {
-	selfData, err := a.GetSelf()
+func (a *snykApiClient) GetDefaultOrgId(ctx context.Context) (string, error) {
+	selfData, err := a.GetSelf(ctx)
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve org ID: %w", err)
 	}
@@ -134,11 +141,14 @@ func (a *snykApiClient) GetDefaultOrgId() (string, error) {
 
 // GetUserMe retrieves the username for the authenticated user from the Snyk API.
 //
+// Parameters:
+//   - ctx: Context for cancellation and timeout control.
+//
 // Returns:
 //   - The authenticated user's username as a string.
 //   - An error object (if an error occurred while fetching user data or extracting the username).
-func (a *snykApiClient) GetUserMe() (string, error) {
-	selfData, err := a.GetSelf()
+func (a *snykApiClient) GetUserMe(ctx context.Context) (string, error) {
+	selfData, err := a.GetSelf(ctx)
 	if err != nil {
 		return "", fmt.Errorf("error while fetching self data: %w", err) // Prioritize error
 	}
@@ -161,6 +171,7 @@ func (a *snykApiClient) GetUserMe() (string, error) {
 // GetFeatureFlag determines the state of a feature flag for the specified organization.
 //
 // Parameters:
+//   - ctx: Context for cancellation and timeout control.
 //   - flagname (string): The name of the feature flag to check.
 //   - orgId (string): The ID of the organization associated with the feature flag.
 //
@@ -168,7 +179,7 @@ func (a *snykApiClient) GetUserMe() (string, error) {
 //   - A boolean indicating if the feature flag is enabled (true) or disabled (false).
 //   - An error object (if an error occurred during the API request, response parsing,
 //     or if the organization ID is invalid).
-func (a *snykApiClient) GetFeatureFlag(flagname string, orgId string) (bool, error) {
+func (a *snykApiClient) GetFeatureFlag(ctx context.Context, flagname string, orgId string) (bool, error) {
 	const defaultResult = false
 
 	u := a.url + "/v1/cli-config/feature-flags/" + flagname + "?org=" + orgId
@@ -177,7 +188,12 @@ func (a *snykApiClient) GetFeatureFlag(flagname string, orgId string) (bool, err
 		return defaultResult, fmt.Errorf("failed to lookup feature flag with orgiId not set")
 	}
 
-	res, err := a.client.Get(u)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return defaultResult, fmt.Errorf("unable to create request: %w", err)
+	}
+
+	res, err := a.client.Do(req)
 	if err != nil {
 		return defaultResult, fmt.Errorf("unable to retrieve feature flag: %w", err)
 	}
@@ -204,14 +220,17 @@ func (a *snykApiClient) GetFeatureFlag(flagname string, orgId string) (bool, err
 
 // GetSelf retrieves the authenticated user's information from the Snyk API.
 //
+// Parameters:
+//   - ctx: Context for cancellation and timeout control.
+//
 // Returns:
 //   - A `contract.SelfResponse` struct containing the user's data.
 //   - An error object (if an error occurred during the API request or response parsing).
-func (a *snykApiClient) GetSelf() (contract.SelfResponse, error) {
+func (a *snykApiClient) GetSelf(ctx context.Context) (contract.SelfResponse, error) {
 	endpoint := "/rest/self"
 	var selfData contract.SelfResponse
 
-	body, err := clientGet(a, endpoint, nil)
+	body, err := clientGet(ctx, a, endpoint, nil)
 	if err != nil {
 		return selfData, err
 	}
@@ -223,10 +242,15 @@ func (a *snykApiClient) GetSelf() (contract.SelfResponse, error) {
 	return selfData, nil
 }
 
-func (a *snykApiClient) GetOrgSettings(orgId string) (*contract.OrgSettingsResponse, error) {
+func (a *snykApiClient) GetOrgSettings(ctx context.Context, orgId string) (*contract.OrgSettingsResponse, error) {
 	endpoint := fmt.Sprintf("%s/v1/org/%s/settings", a.url, url.QueryEscape(orgId))
 
-	res, err := a.client.Get(endpoint)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create request: %w", err)
+	}
+
+	res, err := a.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve org settings: %w", err)
 	}
@@ -250,6 +274,7 @@ func (a *snykApiClient) GetOrgSettings(orgId string) (*contract.OrgSettingsRespo
 // API versioning, and basic error checking.
 //
 // Parameters:
+//   - ctx: Context for cancellation and timeout control.
 //   - a (snykApiClient): A reference to the Snyk API client object.
 //   - endpoint (string): The endpoint path to be appended to the API base URL.
 //   - version (*string):  An optional pointer to a string specifying the desired API version.
@@ -264,8 +289,8 @@ func (a *snykApiClient) GetOrgSettings(orgId string) (*contract.OrgSettingsRespo
 //
 // Example:
 // apiVersion := "2022-01-12"
-// response, err := clientGet(myApiClient, "/organizations", &apiVersion, "limit", "50")
-func clientGet(a *snykApiClient, endpoint string, version *string, queryParams ...string) ([]byte, error) {
+// response, err := clientGet(ctx, myApiClient, "/organizations", &apiVersion, "limit", "50")
+func clientGet(ctx context.Context, a *snykApiClient, endpoint string, version *string, queryParams ...string) ([]byte, error) {
 	var apiVersion string = constants.SNYK_DEFAULT_API_VERSION
 	if version != nil && *version != "" {
 		apiVersion = *version
@@ -277,7 +302,12 @@ func clientGet(a *snykApiClient, endpoint string, version *string, queryParams .
 		return nil, err
 	}
 
-	res, err := a.client.Get(url.String())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := a.client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -25,7 +25,7 @@ func Test_GetDefaultOrgId_ReturnsCorrectOrgId(t *testing.T) {
 	client := api.NewApi(server.URL, http.DefaultClient)
 
 	// Act
-	orgId, err := client.GetDefaultOrgId()
+	orgId, err := client.GetDefaultOrgId(t.Context())
 	if err != nil {
 		t.Error(err)
 	}
@@ -46,7 +46,7 @@ func Test_GetSlugFromOrgId_ReturnsCorrectSlug(t *testing.T) {
 	client := api.NewApi(server.URL, http.DefaultClient)
 
 	// Act
-	actualSlug, err := client.GetSlugFromOrgId(orgID)
+	actualSlug, err := client.GetSlugFromOrgId(t.Context(), orgID)
 	if err != nil {
 		t.Error(err)
 	}
@@ -66,7 +66,7 @@ func Test_GetOrganizations_ReturnsOrganizations(t *testing.T) {
 	client := api.NewApi(server.URL, http.DefaultClient)
 
 	// Act
-	response, err := client.GetOrganizations(limit)
+	response, err := client.GetOrganizations(t.Context(), limit)
 	if err != nil {
 		t.Error(err)
 	}
@@ -93,7 +93,7 @@ func Test_GetOrgIdFromSlug_ReturnsCorrectOrgId(t *testing.T) {
 		apiClient := api.NewApi(server.URL, http.DefaultClient)
 
 		// Act
-		orgId, err := apiClient.GetOrgIdFromSlug(slugName)
+		orgId, err := apiClient.GetOrgIdFromSlug(t.Context(), slugName)
 		if err != nil {
 			t.Error(err)
 		}
@@ -115,11 +115,11 @@ func Test_GetFeatureFlag_false(t *testing.T) {
 	server := setupSingleReponseServer(t, "/v1/cli-config/feature-flags/"+featureFlagName+"?org="+org, featureFlagResponse)
 	client := api.NewApi(server.URL, http.DefaultClient)
 
-	actual, err := client.GetFeatureFlag(featureFlagName, org)
+	actual, err := client.GetFeatureFlag(t.Context(), featureFlagName, org)
 	assert.NoError(t, err)
 	assert.False(t, actual)
 
-	actual, err = client.GetFeatureFlag("unknownFF", org)
+	actual, err = client.GetFeatureFlag(t.Context(), "unknownFF", org)
 	assert.Error(t, err)
 	assert.False(t, actual)
 }
@@ -137,7 +137,7 @@ func Test_GetFeatureFlag_true(t *testing.T) {
 	server := setupSingleReponseServer(t, "/v1/cli-config/feature-flags/"+featureFlagName+"?org="+org, featureFlagResponse)
 	client := api.NewApi(server.URL, http.DefaultClient)
 
-	actual, err := client.GetFeatureFlag(featureFlagName, org)
+	actual, err := client.GetFeatureFlag(t.Context(), featureFlagName, org)
 	assert.NoError(t, err)
 	assert.True(t, actual)
 }

--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	http "net/http"
 	reflect "reflect"
 
@@ -36,123 +37,123 @@ func (m *MockApiClient) EXPECT() *MockApiClientMockRecorder {
 }
 
 // GetDefaultOrgId mocks base method.
-func (m *MockApiClient) GetDefaultOrgId() (string, error) {
+func (m *MockApiClient) GetDefaultOrgId(ctx context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDefaultOrgId")
+	ret := m.ctrl.Call(m, "GetDefaultOrgId", ctx)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDefaultOrgId indicates an expected call of GetDefaultOrgId.
-func (mr *MockApiClientMockRecorder) GetDefaultOrgId() *gomock.Call {
+func (mr *MockApiClientMockRecorder) GetDefaultOrgId(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultOrgId", reflect.TypeOf((*MockApiClient)(nil).GetDefaultOrgId))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultOrgId", reflect.TypeOf((*MockApiClient)(nil).GetDefaultOrgId), ctx)
 }
 
 // GetFeatureFlag mocks base method.
-func (m *MockApiClient) GetFeatureFlag(flagname, origId string) (bool, error) {
+func (m *MockApiClient) GetFeatureFlag(ctx context.Context, flagname, origId string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFeatureFlag", flagname, origId)
+	ret := m.ctrl.Call(m, "GetFeatureFlag", ctx, flagname, origId)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetFeatureFlag indicates an expected call of GetFeatureFlag.
-func (mr *MockApiClientMockRecorder) GetFeatureFlag(flagname, origId interface{}) *gomock.Call {
+func (mr *MockApiClientMockRecorder) GetFeatureFlag(ctx, flagname, origId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFeatureFlag", reflect.TypeOf((*MockApiClient)(nil).GetFeatureFlag), flagname, origId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFeatureFlag", reflect.TypeOf((*MockApiClient)(nil).GetFeatureFlag), ctx, flagname, origId)
 }
 
 // GetOrgIdFromSlug mocks base method.
-func (m *MockApiClient) GetOrgIdFromSlug(slugName string) (string, error) {
+func (m *MockApiClient) GetOrgIdFromSlug(ctx context.Context, slugName string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOrgIdFromSlug", slugName)
+	ret := m.ctrl.Call(m, "GetOrgIdFromSlug", ctx, slugName)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetOrgIdFromSlug indicates an expected call of GetOrgIdFromSlug.
-func (mr *MockApiClientMockRecorder) GetOrgIdFromSlug(slugName interface{}) *gomock.Call {
+func (mr *MockApiClientMockRecorder) GetOrgIdFromSlug(ctx, slugName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgIdFromSlug", reflect.TypeOf((*MockApiClient)(nil).GetOrgIdFromSlug), slugName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgIdFromSlug", reflect.TypeOf((*MockApiClient)(nil).GetOrgIdFromSlug), ctx, slugName)
 }
 
 // GetOrgSettings mocks base method.
-func (m *MockApiClient) GetOrgSettings(orgId string) (*contract.OrgSettingsResponse, error) {
+func (m *MockApiClient) GetOrgSettings(ctx context.Context, orgId string) (*contract.OrgSettingsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOrgSettings", orgId)
+	ret := m.ctrl.Call(m, "GetOrgSettings", ctx, orgId)
 	ret0, _ := ret[0].(*contract.OrgSettingsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetOrgSettings indicates an expected call of GetOrgSettings.
-func (mr *MockApiClientMockRecorder) GetOrgSettings(orgId interface{}) *gomock.Call {
+func (mr *MockApiClientMockRecorder) GetOrgSettings(ctx, orgId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgSettings", reflect.TypeOf((*MockApiClient)(nil).GetOrgSettings), orgId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgSettings", reflect.TypeOf((*MockApiClient)(nil).GetOrgSettings), ctx, orgId)
 }
 
 // GetOrganizations mocks base method.
-func (m *MockApiClient) GetOrganizations(limit int) (*contract.OrganizationsResponse, error) {
+func (m *MockApiClient) GetOrganizations(ctx context.Context, limit int) (*contract.OrganizationsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOrganizations", limit)
+	ret := m.ctrl.Call(m, "GetOrganizations", ctx, limit)
 	ret0, _ := ret[0].(*contract.OrganizationsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetOrganizations indicates an expected call of GetOrganizations.
-func (mr *MockApiClientMockRecorder) GetOrganizations(limit interface{}) *gomock.Call {
+func (mr *MockApiClientMockRecorder) GetOrganizations(ctx, limit interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrganizations", reflect.TypeOf((*MockApiClient)(nil).GetOrganizations), limit)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrganizations", reflect.TypeOf((*MockApiClient)(nil).GetOrganizations), ctx, limit)
 }
 
 // GetSelf mocks base method.
-func (m *MockApiClient) GetSelf() (contract.SelfResponse, error) {
+func (m *MockApiClient) GetSelf(ctx context.Context) (contract.SelfResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSelf")
+	ret := m.ctrl.Call(m, "GetSelf", ctx)
 	ret0, _ := ret[0].(contract.SelfResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSelf indicates an expected call of GetSelf.
-func (mr *MockApiClientMockRecorder) GetSelf() *gomock.Call {
+func (mr *MockApiClientMockRecorder) GetSelf(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSelf", reflect.TypeOf((*MockApiClient)(nil).GetSelf))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSelf", reflect.TypeOf((*MockApiClient)(nil).GetSelf), ctx)
 }
 
 // GetSlugFromOrgId mocks base method.
-func (m *MockApiClient) GetSlugFromOrgId(orgID string) (string, error) {
+func (m *MockApiClient) GetSlugFromOrgId(ctx context.Context, orgID string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSlugFromOrgId", orgID)
+	ret := m.ctrl.Call(m, "GetSlugFromOrgId", ctx, orgID)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSlugFromOrgId indicates an expected call of GetSlugFromOrgId.
-func (mr *MockApiClientMockRecorder) GetSlugFromOrgId(orgID interface{}) *gomock.Call {
+func (mr *MockApiClientMockRecorder) GetSlugFromOrgId(ctx, orgID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSlugFromOrgId", reflect.TypeOf((*MockApiClient)(nil).GetSlugFromOrgId), orgID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSlugFromOrgId", reflect.TypeOf((*MockApiClient)(nil).GetSlugFromOrgId), ctx, orgID)
 }
 
 // GetUserMe mocks base method.
-func (m *MockApiClient) GetUserMe() (string, error) {
+func (m *MockApiClient) GetUserMe(ctx context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserMe")
+	ret := m.ctrl.Call(m, "GetUserMe", ctx)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUserMe indicates an expected call of GetUserMe.
-func (mr *MockApiClientMockRecorder) GetUserMe() *gomock.Call {
+func (mr *MockApiClientMockRecorder) GetUserMe(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserMe", reflect.TypeOf((*MockApiClient)(nil).GetUserMe))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserMe", reflect.TypeOf((*MockApiClient)(nil).GetUserMe), ctx)
 }
 
 // Init mocks base method.

--- a/pkg/apiclients/ldx_sync_config/resolver.go
+++ b/pkg/apiclients/ldx_sync_config/resolver.go
@@ -57,7 +57,7 @@ func ResolveOrganization(config configuration.Configuration, engine workflow.Eng
 }
 
 // resolveOrgIdToUUID resolves a non-empty organization ID (UUID or slug) to a UUID
-func resolveOrgIdToUUID(orgId string, engine workflow.Engine, config configuration.Configuration) (*uuid.UUID, error) {
+func resolveOrgIdToUUID(ctx context.Context, orgId string, engine workflow.Engine, config configuration.Configuration) (*uuid.UUID, error) {
 	// Try to parse as UUID first to determine if it's a slug
 	parsedUUID, err := uuid.Parse(orgId)
 	if err == nil {
@@ -67,7 +67,7 @@ func resolveOrgIdToUUID(orgId string, engine workflow.Engine, config configurati
 
 	// Not a UUID, try to resolve as slug
 	apiClient := newApiClient(engine, config)
-	resolvedOrgId, err := apiClient.GetOrgIdFromSlug(orgId)
+	resolvedOrgId, err := apiClient.GetOrgIdFromSlug(ctx, orgId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve organization slug: %w", err)
 	}
@@ -106,7 +106,7 @@ func GetMergedConfigForFolder(ctx context.Context, engine workflow.Engine, dir s
 
 	if orgId != "" {
 		var orgUUID *uuid.UUID
-		orgUUID, err = resolveOrgIdToUUID(orgId, engine, config)
+		orgUUID, err = resolveOrgIdToUUID(ctx, orgId, engine, config)
 		if err != nil {
 			return LdxSyncConfigResult{Error: err}
 		}
@@ -182,7 +182,7 @@ func ResolveOrgFromUserConfig(engine workflow.Engine, cfgResult LdxSyncConfigRes
 }
 
 func getDefaultOrganization(apiClient api.ApiClient, logger *zerolog.Logger) (Organization, error) {
-	defaultOrgId, err := apiClient.GetDefaultOrgId()
+	defaultOrgId, err := apiClient.GetDefaultOrgId(context.Background())
 	if err != nil {
 		logger.Print("Failed to determine default value for \"ORGANIZATION\":", err)
 		return Organization{}, err

--- a/pkg/apiclients/ldx_sync_config/resolver_test.go
+++ b/pkg/apiclients/ldx_sync_config/resolver_test.go
@@ -41,8 +41,10 @@ func TestResolveOrgFromUserConfig(t *testing.T) {
 		cfgResult     LdxSyncConfigResult
 	}{
 		{
-			name:          "error in config result",
-			setupApiMock:  func(mock *api_mocks.MockApiClient) { mock.EXPECT().GetDefaultOrgId().Return("default-org", nil) },
+			name: "error in config result",
+			setupApiMock: func(mock *api_mocks.MockApiClient) {
+				mock.EXPECT().GetDefaultOrgId(gomock.Any()).Return("default-org", nil)
+			},
 			expectedOrgId: "default-org",
 			cfgResult:     LdxSyncConfigResult{Error: fmt.Errorf("no input directory specified")},
 		},
@@ -82,8 +84,10 @@ func TestResolveOrgFromUserConfig(t *testing.T) {
 			},
 		},
 		{
-			name:          "no preferred or default org, fallback to api",
-			setupApiMock:  func(mock *api_mocks.MockApiClient) { mock.EXPECT().GetDefaultOrgId().Return("default-org", nil) },
+			name: "no preferred or default org, fallback to api",
+			setupApiMock: func(mock *api_mocks.MockApiClient) {
+				mock.EXPECT().GetDefaultOrgId(gomock.Any()).Return("default-org", nil)
+			},
 			expectedOrgId: "default-org",
 			cfgResult: LdxSyncConfigResult{
 				Config: makeUserConfigResponse([]v20241015.Organization{
@@ -96,8 +100,10 @@ func TestResolveOrgFromUserConfig(t *testing.T) {
 			},
 		},
 		{
-			name:          "no organizations in response, fallback to API",
-			setupApiMock:  func(mock *api_mocks.MockApiClient) { mock.EXPECT().GetDefaultOrgId().Return("default-org", nil) },
+			name: "no organizations in response, fallback to API",
+			setupApiMock: func(mock *api_mocks.MockApiClient) {
+				mock.EXPECT().GetDefaultOrgId(gomock.Any()).Return("default-org", nil)
+			},
 			expectedOrgId: "default-org",
 			cfgResult: LdxSyncConfigResult{
 				Config:      makeUserConfigResponse([]v20241015.Organization{}),
@@ -106,8 +112,10 @@ func TestResolveOrgFromUserConfig(t *testing.T) {
 			},
 		},
 		{
-			name:          "nil organizations in response, fallback to API",
-			setupApiMock:  func(mock *api_mocks.MockApiClient) { mock.EXPECT().GetDefaultOrgId().Return("default-org", nil) },
+			name: "nil organizations in response, fallback to API",
+			setupApiMock: func(mock *api_mocks.MockApiClient) {
+				mock.EXPECT().GetDefaultOrgId(gomock.Any()).Return("default-org", nil)
+			},
 			expectedOrgId: "default-org",
 			cfgResult: LdxSyncConfigResult{
 				Config:      &v20241015.UserConfigResponse{},
@@ -116,32 +124,42 @@ func TestResolveOrgFromUserConfig(t *testing.T) {
 			},
 		},
 		{
-			name:          "API error, fallback to api",
-			setupApiMock:  func(mock *api_mocks.MockApiClient) { mock.EXPECT().GetDefaultOrgId().Return("default-org", nil) },
+			name: "API error, fallback to api",
+			setupApiMock: func(mock *api_mocks.MockApiClient) {
+				mock.EXPECT().GetDefaultOrgId(gomock.Any()).Return("default-org", nil)
+			},
 			expectedOrgId: "default-org",
 			cfgResult:     LdxSyncConfigResult{Error: errors.New("API error")},
 		},
 		{
-			name:          "API returns 404, fallback to api",
-			setupApiMock:  func(mock *api_mocks.MockApiClient) { mock.EXPECT().GetDefaultOrgId().Return("default-org", nil) },
+			name: "API returns 404, fallback to api",
+			setupApiMock: func(mock *api_mocks.MockApiClient) {
+				mock.EXPECT().GetDefaultOrgId(gomock.Any()).Return("default-org", nil)
+			},
 			expectedOrgId: "default-org",
 			cfgResult:     LdxSyncConfigResult{Error: fmt.Errorf("404 API error occurred")},
 		},
 		{
-			name:          "API returns 200 with no data, fallback to api",
-			setupApiMock:  func(mock *api_mocks.MockApiClient) { mock.EXPECT().GetDefaultOrgId().Return("default-org", nil) },
+			name: "API returns 200 with no data, fallback to api",
+			setupApiMock: func(mock *api_mocks.MockApiClient) {
+				mock.EXPECT().GetDefaultOrgId(gomock.Any()).Return("default-org", nil)
+			},
 			expectedOrgId: "default-org",
 			cfgResult:     LdxSyncConfigResult{Error: fmt.Errorf("no configuration data in response, status code: 200")},
 		},
 		{
-			name:          "git remote detection fails, fallback to api",
-			setupApiMock:  func(mock *api_mocks.MockApiClient) { mock.EXPECT().GetDefaultOrgId().Return("default-org", nil) },
+			name: "git remote detection fails, fallback to api",
+			setupApiMock: func(mock *api_mocks.MockApiClient) {
+				mock.EXPECT().GetDefaultOrgId(gomock.Any()).Return("default-org", nil)
+			},
 			expectedOrgId: "default-org",
 			cfgResult:     LdxSyncConfigResult{Error: fmt.Errorf("git remote detection failed: git command failed")},
 		},
 		{
-			name:          "client creation fails, fallback to api",
-			setupApiMock:  func(mock *api_mocks.MockApiClient) { mock.EXPECT().GetDefaultOrgId().Return("default-org", nil) },
+			name: "client creation fails, fallback to api",
+			setupApiMock: func(mock *api_mocks.MockApiClient) {
+				mock.EXPECT().GetDefaultOrgId(gomock.Any()).Return("default-org", nil)
+			},
 			expectedOrgId: "default-org",
 			cfgResult:     LdxSyncConfigResult{Error: fmt.Errorf("failed to create LDX-Sync client: client creation failed")},
 		},
@@ -192,7 +210,7 @@ func TestResolveOrgFromUserConfig(t *testing.T) {
 		{
 			name: "LDX fails, fallback to API default org fails",
 			setupApiMock: func(mock *api_mocks.MockApiClient) {
-				mock.EXPECT().GetDefaultOrgId().Return("", errors.New("api is down"))
+				mock.EXPECT().GetDefaultOrgId(gomock.Any()).Return("", errors.New("api is down"))
 			},
 			expectedOrgId: "",
 			expectedErr:   errors.New("api is down"),
@@ -303,7 +321,7 @@ func TestGetMergedConfigForFolder(t *testing.T) {
 			dir:   tempDir,
 			orgId: "invalid-org-id",
 			setupApiMock: func(mock *api_mocks.MockApiClient) {
-				mock.EXPECT().GetOrgIdFromSlug("invalid-org-id").Return("", fmt.Errorf("slug not found"))
+				mock.EXPECT().GetOrgIdFromSlug(gomock.Any(), "invalid-org-id").Return("", fmt.Errorf("slug not found"))
 			},
 			expectedError: "failed to resolve organization slug",
 		},
@@ -472,7 +490,7 @@ func TestGetMergedConfigForFolder(t *testing.T) {
 			dir:   tempDir,
 			orgId: "my-org-slug",
 			setupApiMock: func(mock *api_mocks.MockApiClient) {
-				mock.EXPECT().GetOrgIdFromSlug("my-org-slug").Return("123e4567-e89b-12d3-a456-426614174000", nil)
+				mock.EXPECT().GetOrgIdFromSlug(gomock.Any(), "my-org-slug").Return("123e4567-e89b-12d3-a456-426614174000", nil)
 			},
 			setupLdxMock: func(mock *ldx_mocks.MockClientWithResponsesInterface) {
 				mock.EXPECT().GetUserConfigWithResponse(

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"crypto/fips140"
 	"io"
 	"log"
@@ -46,7 +47,7 @@ func defaultFuncOrganizationSlug(engine workflow.Engine, config configuration.Co
 		if len(orgId) == 0 {
 			return existingValue, nil
 		}
-		slugName, err := apiClient.GetSlugFromOrgId(orgId)
+		slugName, err := apiClient.GetSlugFromOrgId(context.Background(), orgId)
 		if err != nil {
 			logger.Print("Failed to determine default value for \"ORGANIZATION_SLUG\":", err)
 		}
@@ -72,7 +73,7 @@ func defaultFuncOrganization(engine workflow.Engine, config configuration.Config
 			_, err := uuid.Parse(orgId)
 			isSlugName := err != nil
 			if isSlugName {
-				orgId, err = apiClient.GetOrgIdFromSlug(existingString)
+				orgId, err = apiClient.GetOrgIdFromSlug(context.Background(), existingString)
 				if err != nil {
 					logger.Print("Failed to determine default value for \"ORGANIZATION\":", err)
 				} else {
@@ -83,7 +84,7 @@ func defaultFuncOrganization(engine workflow.Engine, config configuration.Config
 			}
 		}
 
-		orgId, err := apiClient.GetDefaultOrgId()
+		orgId, err := apiClient.GetDefaultOrgId(context.Background())
 		if err != nil {
 			logger.Print("Failed to determine default value for \"ORGANIZATION\":", err)
 		}

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -348,8 +348,8 @@ func Test_initConfiguration_updateDefaultOrgId(t *testing.T) {
 
 	// mock assertion
 	mockApiClient.EXPECT().Init(gomock.Any(), gomock.Any()).AnyTimes()
-	mockApiClient.EXPECT().GetOrgIdFromSlug(orgName).Return(orgId, nil).AnyTimes()
-	mockApiClient.EXPECT().GetSlugFromOrgId(orgId).Return(orgName, nil).AnyTimes()
+	mockApiClient.EXPECT().GetOrgIdFromSlug(gomock.Any(), orgName).Return(orgId, nil).AnyTimes()
+	mockApiClient.EXPECT().GetSlugFromOrgId(gomock.Any(), orgId).Return(orgName, nil).AnyTimes()
 
 	config := configuration.NewInMemory()
 	engine := workflow.NewWorkFlowEngine(config)
@@ -376,8 +376,8 @@ func Test_initConfiguration_useDefaultOrg(t *testing.T) {
 
 	// mock assertion
 	mockApiClient.EXPECT().Init(gomock.Any(), gomock.Any()).AnyTimes()
-	mockApiClient.EXPECT().GetDefaultOrgId().Return(defaultOrgId, nil).AnyTimes()
-	mockApiClient.EXPECT().GetSlugFromOrgId(defaultOrgId).Return(defaultOrgSlug, nil).AnyTimes()
+	mockApiClient.EXPECT().GetDefaultOrgId(gomock.Any()).Return(defaultOrgId, nil).AnyTimes()
+	mockApiClient.EXPECT().GetSlugFromOrgId(gomock.Any(), defaultOrgId).Return(defaultOrgSlug, nil).AnyTimes()
 
 	config := configuration.NewInMemory()
 	engine := workflow.NewWorkFlowEngine(config)
@@ -400,8 +400,8 @@ func Test_initConfiguration_failDefaultOrgLookup(t *testing.T) {
 
 	// mock assertion
 	mockApiClient.EXPECT().Init(gomock.Any(), gomock.Any()).AnyTimes()
-	mockApiClient.EXPECT().GetDefaultOrgId().Return("", errors.New("error")).Times(2)
-	mockApiClient.EXPECT().GetDefaultOrgId().Return(orgId, nil).Times(1)
+	mockApiClient.EXPECT().GetDefaultOrgId(gomock.Any()).Return("", errors.New("error")).Times(2)
+	mockApiClient.EXPECT().GetDefaultOrgId(gomock.Any()).Return(orgId, nil).Times(1)
 
 	config := configuration.NewWithOpts(configuration.WithCachingEnabled(10 * time.Second))
 	engine := workflow.NewWorkFlowEngine(config)
@@ -434,9 +434,9 @@ func Test_initConfiguration_useDefaultOrgAsFallback(t *testing.T) {
 
 	// mock assertion
 	mockApiClient.EXPECT().Init(gomock.Any(), gomock.Any()).AnyTimes()
-	mockApiClient.EXPECT().GetOrgIdFromSlug(orgName).Return("", errors.New("Failed to fetch org id from slug")).AnyTimes()
-	mockApiClient.EXPECT().GetDefaultOrgId().Return(defaultOrgId, nil).AnyTimes()
-	mockApiClient.EXPECT().GetSlugFromOrgId(defaultOrgId).Return(orgName, nil).AnyTimes()
+	mockApiClient.EXPECT().GetOrgIdFromSlug(gomock.Any(), orgName).Return("", errors.New("Failed to fetch org id from slug")).AnyTimes()
+	mockApiClient.EXPECT().GetDefaultOrgId(gomock.Any()).Return(defaultOrgId, nil).AnyTimes()
+	mockApiClient.EXPECT().GetSlugFromOrgId(gomock.Any(), defaultOrgId).Return(orgName, nil).AnyTimes()
 
 	config := configuration.NewInMemory()
 	engine := workflow.NewWorkFlowEngine(config)
@@ -791,8 +791,8 @@ func Test_defaultFuncOrganizationSlug_UsesClonedConfig(t *testing.T) {
 
 	// mock assertions
 	mockApiClient.EXPECT().Init(gomock.Any(), gomock.Any()).AnyTimes()
-	mockApiClient.EXPECT().GetSlugFromOrgId(org1Id).Return(org1Slug, nil).AnyTimes()
-	mockApiClient.EXPECT().GetSlugFromOrgId(org2Id).Return(org2Slug, nil).AnyTimes()
+	mockApiClient.EXPECT().GetSlugFromOrgId(gomock.Any(), org1Id).Return(org1Slug, nil).AnyTimes()
+	mockApiClient.EXPECT().GetSlugFromOrgId(gomock.Any(), org2Id).Return(org2Slug, nil).AnyTimes()
 
 	config := configuration.NewInMemory()
 	engine := workflow.NewWorkFlowEngine(config)
@@ -833,7 +833,7 @@ func Test_defaultFuncOrganizationSlug_UsesClonedNetworkAccess(t *testing.T) {
 	mockApiClient := mocks.NewMockApiClient(ctrl)
 
 	mockApiClient.EXPECT().Init(gomock.Any(), gomock.Any()).AnyTimes()
-	mockApiClient.EXPECT().GetSlugFromOrgId(orgId).Return(orgSlug, nil).AnyTimes()
+	mockApiClient.EXPECT().GetSlugFromOrgId(gomock.Any(), orgId).Return(orgSlug, nil).AnyTimes()
 
 	config := configuration.NewInMemory()
 	config.Set(configuration.API_URL, globalAPIEndpoint)

--- a/pkg/local_workflows/config_utils/feature_flag.go
+++ b/pkg/local_workflows/config_utils/feature_flag.go
@@ -1,6 +1,7 @@
 package config_utils
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/snyk/go-application-framework/internal/api"
@@ -33,6 +34,6 @@ func GetFeatureFlagValue(featureFlagName string, config configuration.Configurat
 	url := config.GetString(configuration.API_URL)
 	org := config.GetString(configuration.ORGANIZATION)
 	apiClient := api.NewApi(url, httpClient)
-	result, err := apiClient.GetFeatureFlag(featureFlagName, org)
+	result, err := apiClient.GetFeatureFlag(context.Background(), featureFlagName, org)
 	return result, err
 }

--- a/pkg/local_workflows/connectivity_check_extension/connectivity/checker.go
+++ b/pkg/local_workflows/connectivity_check_extension/connectivity/checker.go
@@ -1,6 +1,7 @@
 package connectivity
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -118,12 +119,12 @@ func (c *Checker) CheckOrganizations(limit int) ([]Organization, error) {
 		return nil, nil
 	}
 
-	response, err := c.apiClient.GetOrganizations(limit)
+	response, err := c.apiClient.GetOrganizations(context.Background(), limit)
 	if err != nil {
 		return nil, err
 	}
 
-	defaultOrgId, err := c.apiClient.GetDefaultOrgId()
+	defaultOrgId, err := c.apiClient.GetDefaultOrgId(context.Background())
 	if err != nil {
 		// default org is optional, don't fail the entire operation
 		c.logger.Debug().Err(err).Msg("Failed to get default organization ID")

--- a/pkg/local_workflows/connectivity_check_extension/connectivity/checker_test.go
+++ b/pkg/local_workflows/connectivity_check_extension/connectivity/checker_test.go
@@ -602,8 +602,8 @@ func TestCheckConnectivityWithMaxOrgCount(t *testing.T) {
 		mockNA.EXPECT().GetUnauthorizedHttpClient().Return(httpClient).AnyTimes()
 
 		// Expect GetOrganizations to be called with limit from config
-		mockApiClient.EXPECT().GetOrganizations(25).Return(createTestOrgResponse(), nil)
-		mockApiClient.EXPECT().GetDefaultOrgId().Return("org-1", nil)
+		mockApiClient.EXPECT().GetOrganizations(gomock.Any(), 25).Return(createTestOrgResponse(), nil)
+		mockApiClient.EXPECT().GetDefaultOrgId(gomock.Any()).Return("org-1", nil)
 
 		// Create checker
 		checker := NewCheckerWithApiClient(mockNA, &logger, config, mockApiClient)
@@ -637,8 +637,8 @@ func TestCheckConnectivityWithMaxOrgCount(t *testing.T) {
 		mockNA.EXPECT().GetUnauthorizedHttpClient().Return(httpClient).AnyTimes()
 
 		// Expect GetOrganizations to be called with default limit of 100
-		mockApiClient.EXPECT().GetOrganizations(100).Return(createTestOrgResponse(), nil)
-		mockApiClient.EXPECT().GetDefaultOrgId().Return("org-1", nil)
+		mockApiClient.EXPECT().GetOrganizations(gomock.Any(), 100).Return(createTestOrgResponse(), nil)
+		mockApiClient.EXPECT().GetDefaultOrgId(gomock.Any()).Return("org-1", nil)
 
 		// Create checker
 		checker := NewCheckerWithApiClient(mockNA, &logger, config, mockApiClient)
@@ -673,8 +673,8 @@ func TestCheckConnectivityWithMaxOrgCount(t *testing.T) {
 		mockNA.EXPECT().GetUnauthorizedHttpClient().Return(httpClient).AnyTimes()
 
 		// Expect GetOrganizations to be called with default limit of 100 (since -5 is invalid)
-		mockApiClient.EXPECT().GetOrganizations(100).Return(createTestOrgResponse(), nil)
-		mockApiClient.EXPECT().GetDefaultOrgId().Return("org-1", nil)
+		mockApiClient.EXPECT().GetOrganizations(gomock.Any(), 100).Return(createTestOrgResponse(), nil)
+		mockApiClient.EXPECT().GetDefaultOrgId(gomock.Any()).Return("org-1", nil)
 
 		// Create checker
 		checker := NewCheckerWithApiClient(mockNA, &logger, config, mockApiClient)
@@ -755,8 +755,8 @@ func TestCheckOrganizations(t *testing.T) {
 		config.Set(configuration.AUTHENTICATION_TOKEN, "test-token")
 
 		// Set expectations
-		mockApiClient.EXPECT().GetOrganizations(100).Return(createTestOrgResponse(), nil)
-		mockApiClient.EXPECT().GetDefaultOrgId().Return("org-1", nil)
+		mockApiClient.EXPECT().GetOrganizations(gomock.Any(), 100).Return(createTestOrgResponse(), nil)
+		mockApiClient.EXPECT().GetDefaultOrgId(gomock.Any()).Return("org-1", nil)
 
 		// Create checker with mock API client
 		checker := NewCheckerWithApiClient(mockNA, &logger, config, mockApiClient)
@@ -788,8 +788,8 @@ func TestCheckOrganizations(t *testing.T) {
 		}
 
 		// Set expectations - GetDefaultOrgId returns an error
-		mockApiClient.EXPECT().GetOrganizations(100).Return(mockResponse, nil)
-		mockApiClient.EXPECT().GetDefaultOrgId().Return("", errors.New("failed to get default org"))
+		mockApiClient.EXPECT().GetOrganizations(gomock.Any(), 100).Return(mockResponse, nil)
+		mockApiClient.EXPECT().GetDefaultOrgId(gomock.Any()).Return("", errors.New("failed to get default org"))
 
 		// Create checker with mock API client
 		checker := NewCheckerWithApiClient(mockNA, &logger, config, mockApiClient)
@@ -838,7 +838,7 @@ func TestCheckOrganizations(t *testing.T) {
 		config.Set(configuration.AUTHENTICATION_TOKEN, "test-token")
 
 		// Set expectations for error case
-		mockApiClient.EXPECT().GetOrganizations(100).Return(nil, errors.New("API error"))
+		mockApiClient.EXPECT().GetOrganizations(gomock.Any(), 100).Return(nil, errors.New("API error"))
 
 		checker := NewCheckerWithApiClient(mockNA, &logger, config, mockApiClient)
 
@@ -872,8 +872,8 @@ func TestCheckOrganizations(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				// Set expectations with the specific limit
-				mockApiClient.EXPECT().GetOrganizations(tc.limit).Return(createTestOrgResponse(), nil)
-				mockApiClient.EXPECT().GetDefaultOrgId().Return("org-1", nil)
+				mockApiClient.EXPECT().GetOrganizations(gomock.Any(), tc.limit).Return(createTestOrgResponse(), nil)
+				mockApiClient.EXPECT().GetDefaultOrgId(gomock.Any()).Return("org-1", nil)
 
 				// Create checker with mock API client
 				checker := NewCheckerWithApiClient(mockNA, &logger, config, mockApiClient)
@@ -918,7 +918,7 @@ func TestCheckConnectivityHandlesOrgError(t *testing.T) {
 
 	// Mock GetOrganizations to return an error
 	expectedError := errors.New("organization fetch error")
-	mockApiClient.EXPECT().GetOrganizations(100).Return(nil, expectedError)
+	mockApiClient.EXPECT().GetOrganizations(gomock.Any(), 100).Return(nil, expectedError)
 
 	// Create checker with mocked API client
 	checker := NewCheckerWithApiClient(mockNA, &logger, config, mockApiClient)

--- a/pkg/local_workflows/ignore_workflow/config.go
+++ b/pkg/local_workflows/ignore_workflow/config.go
@@ -1,6 +1,7 @@
 package ignore_workflow
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -66,7 +67,7 @@ func getOrgIgnoreApprovalEnabled(engine workflow.Engine) configuration.DefaultVa
 
 		apiClient := api.NewApi(url, client)
 
-		settings, err := apiClient.GetOrgSettings(org)
+		settings, err := apiClient.GetOrgSettings(context.Background(), org)
 		if err != nil {
 			engine.GetLogger().Err(err).Msg("Failed to access settings.")
 			return nil, err

--- a/pkg/local_workflows/ignore_workflow/ignore_workflow.go
+++ b/pkg/local_workflows/ignore_workflow/ignore_workflow.go
@@ -348,7 +348,7 @@ func sendCreateIgnore(invocationCtx workflow.InvocationContext, input policyApi.
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithTimeout(context.Background(), policyApiTimeout)
+	ctx, cancelFunc := context.WithTimeout(invocationCtx.Context(), policyApiTimeout)
 	defer cancelFunc()
 
 	resp, err := client.CreateOrgPolicyWithApplicationVndAPIPlusJSONBody(ctx, orgUuid, &params, input)

--- a/pkg/local_workflows/ignore_workflow/ignore_workflow_test.go
+++ b/pkg/local_workflows/ignore_workflow/ignore_workflow_test.go
@@ -82,6 +82,7 @@ func setupMockIgnoreContext(t *testing.T, payload string, statusCode int) *mocks
 	invocationContextMock.EXPECT().GetEngine().Return(mockEngine).AnyTimes()
 	invocationContextMock.EXPECT().GetUserInterface().Return(mockUserInterface).AnyTimes()
 	invocationContextMock.EXPECT().GetWorkflowIdentifier().Return(workflow.NewWorkflowIdentifier(ignoreCreateWorkflowName)).AnyTimes()
+	invocationContextMock.EXPECT().Context().Return(t.Context()).AnyTimes()
 	networkAccessMock.EXPECT().GetHttpClient().Return(httpClient).AnyTimes()
 	mockData := []workflow.Data{workflow.NewData(
 		workflow.NewTypeIdentifier(localworkflows.WORKFLOWID_WHOAMI, "whoami"),
@@ -362,6 +363,7 @@ func setupInteractiveMockContext(t *testing.T, mockApiResponse string, mockApiSt
 	invocationContextMock.EXPECT().GetEngine().Return(mockEngine).AnyTimes()
 	invocationContextMock.EXPECT().GetUserInterface().Return(mockUserInterface).AnyTimes()
 	invocationContextMock.EXPECT().GetWorkflowIdentifier().Return(WORKFLOWID_IGNORE_CREATE).AnyTimes()
+	invocationContextMock.EXPECT().Context().Return(t.Context()).AnyTimes()
 	networkAccessMock.EXPECT().GetHttpClient().Return(httpClient).AnyTimes()
 
 	mockWhoamiData := []workflow.Data{workflow.NewData(

--- a/pkg/local_workflows/output_workflow/findings_model_tools.go
+++ b/pkg/local_workflows/output_workflow/findings_model_tools.go
@@ -1,7 +1,6 @@
 package output_workflow
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -117,7 +116,7 @@ func HandleContentTypeFindingsModel(input []workflow.Data, invocation workflow.I
 	writerMap := applyTemplatesToWriters(supportedMimeTypes, writers)
 
 	// iterate over all writers and render for each of them
-	ctx := context.Background()
+	ctx := invocation.Context()
 	availableThreads := semaphore.NewWeighted(threadCount)
 	for k, v := range writerMap {
 		err = availableThreads.Acquire(ctx, 1)

--- a/pkg/local_workflows/output_workflow/ufm_tools.go
+++ b/pkg/local_workflows/output_workflow/ufm_tools.go
@@ -1,7 +1,6 @@
 package output_workflow
 
 import (
-	"context"
 	"errors"
 	"sync"
 
@@ -111,7 +110,7 @@ func HandleContentTypeUnifiedModel(input []workflow.Data, invocation workflow.In
 	writerMap := applyTemplatesToWriters(supportedMimeTypes, writers)
 
 	// iterate over all writers and render for each of them
-	ctx := context.Background()
+	ctx := invocation.Context()
 	availableThreads := semaphore.NewWeighted(threadCount)
 	var errMu sync.Mutex
 	var errs []error

--- a/pkg/local_workflows/output_workflow/ufm_tools_test.go
+++ b/pkg/local_workflows/output_workflow/ufm_tools_test.go
@@ -112,6 +112,7 @@ func Test_HandleContentTypeUnifiedModel(t *testing.T) {
 		ctx.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
 		ctx.EXPECT().GetConfiguration().Return(config).AnyTimes()
 		ctx.EXPECT().GetRuntimeInfo().Return(runtimeinfo.New()).AnyTimes()
+		ctx.EXPECT().Context().Return(t.Context()).AnyTimes()
 
 		results := loadTestResults(t, "../../../internal/presenters/testdata/ufm/secrets.testresult.json")
 		workflowData := ufm.CreateWorkflowDataFromTestResults(workflow.NewWorkflowIdentifier("test"), results)
@@ -142,6 +143,7 @@ func Test_HandleContentTypeUnifiedModel(t *testing.T) {
 		ctx.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
 		ctx.EXPECT().GetConfiguration().Return(config).AnyTimes()
 		ctx.EXPECT().GetRuntimeInfo().Return(runtimeinfo.New()).AnyTimes()
+		ctx.EXPECT().Context().Return(t.Context()).AnyTimes()
 
 		results := loadTestResults(t, "../../../internal/presenters/testdata/ufm/secrets.testresult.json")
 		workflowData := ufm.CreateWorkflowDataFromTestResults(workflow.NewWorkflowIdentifier("test"), results)

--- a/pkg/local_workflows/output_workflow_test.go
+++ b/pkg/local_workflows/output_workflow_test.go
@@ -190,6 +190,7 @@ func setupTest(t *testing.T) *testSetup {
 	invocationContextMock.EXPECT().GetConfiguration().Return(config).AnyTimes()
 	invocationContextMock.EXPECT().GetEnhancedLogger().Return(logger).AnyTimes()
 	invocationContextMock.EXPECT().GetRuntimeInfo().Return(runtimeinfo.New(runtimeinfo.WithName("Random Application Name"), runtimeinfo.WithVersion("1.0.0"))).AnyTimes()
+	invocationContextMock.EXPECT().Context().Return(t.Context()).AnyTimes()
 
 	outputDestination := &testOutputDestination{writer: writer}
 
@@ -550,6 +551,7 @@ func Test_Output_outputWorkflowEntryPoint(t *testing.T) {
 				invocationContextMock.EXPECT().GetConfiguration().Return(config).AnyTimes()
 				invocationContextMock.EXPECT().GetEnhancedLogger().Return(logger).AnyTimes()
 				invocationContextMock.EXPECT().GetRuntimeInfo().Return(runtimeinfo.New(runtimeinfo.WithName("snyk-cli"), runtimeinfo.WithVersion("1.2.3"))).AnyTimes()
+				invocationContextMock.EXPECT().Context().Return(t.Context()).AnyTimes()
 
 				byteBuffer := &bytes.Buffer{}
 				outputDestination := &testOutputDestination{writer: byteBuffer, writeRealFiles: true}
@@ -628,6 +630,7 @@ func TestLocalFindingsHandling_renderFilesAndUI(t *testing.T) {
 	invocationContextMock.EXPECT().GetConfiguration().Return(config).AnyTimes()
 	invocationContextMock.EXPECT().GetEnhancedLogger().Return(logger).AnyTimes()
 	invocationContextMock.EXPECT().GetRuntimeInfo().Return(runtimeinfo.New(runtimeinfo.WithName("snyk-cli"), runtimeinfo.WithVersion("1.2.3"))).AnyTimes()
+	invocationContextMock.EXPECT().Context().Return(t.Context()).AnyTimes()
 
 	byteBuffer := &bytes.Buffer{}
 	outputDestination := &testOutputDestination{writer: byteBuffer, writeRealFiles: true}
@@ -687,6 +690,7 @@ func BenchmarkTransformationAndOutputWorkflow(b *testing.B) {
 	invocationContextMock.EXPECT().GetConfiguration().Return(config).AnyTimes()
 	invocationContextMock.EXPECT().GetEnhancedLogger().Return(logger).AnyTimes()
 	invocationContextMock.EXPECT().GetRuntimeInfo().Return(runtimeinfo.New(runtimeinfo.WithName("SnykCode"), runtimeinfo.WithVersion("1.0.0"))).AnyTimes()
+	invocationContextMock.EXPECT().Context().Return(t.Context()).AnyTimes()
 
 	outputDestination := &testOutputDestination{writer: writer}
 

--- a/pkg/local_workflows/report_analytics_workflow.go
+++ b/pkg/local_workflows/report_analytics_workflow.go
@@ -151,7 +151,8 @@ func callEndpoint(invocationCtx workflow.InvocationContext, input workflow.Data,
 		return fmt.Errorf("invalid payload type: %T", input.GetPayload())
 	}
 
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(byteData))
+	// Use context from invocation to respect timeout/cancellation
+	req, err := http.NewRequestWithContext(invocationCtx.Context(), http.MethodPost, url, bytes.NewBuffer(byteData))
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)
 	}

--- a/pkg/local_workflows/report_analytics_workflow_test.go
+++ b/pkg/local_workflows/report_analytics_workflow_test.go
@@ -46,6 +46,7 @@ func Test_ReportAnalytics_ReportAnalyticsEntryPoint_shouldReportV2AnalyticsPaylo
 	invocationContextMock.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
 	invocationContextMock.EXPECT().GetEngine().Return(engineMock).AnyTimes()
 	invocationContextMock.EXPECT().GetNetworkAccess().Return(networkAccessMock).AnyTimes()
+	invocationContextMock.EXPECT().Context().Return(t.Context()).AnyTimes()
 	networkAccessMock.EXPECT().GetHttpClient().Return(mockClient).AnyTimes()
 
 	_, err := reportAnalyticsEntrypoint(invocationContextMock, []workflow.Data{testPayload(requestPayload)})
@@ -84,6 +85,7 @@ func Test_ReportAnalytics_ReportAnalyticsEntryPoint_reportsHttpStatusError(t *te
 	invocationContextMock.EXPECT().GetConfiguration().Return(config).AnyTimes()
 	invocationContextMock.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
 	invocationContextMock.EXPECT().GetNetworkAccess().Return(networkAccessMock).AnyTimes()
+	invocationContextMock.EXPECT().Context().Return(t.Context()).AnyTimes()
 	networkAccessMock.EXPECT().GetHttpClient().Return(mockClient).AnyTimes()
 
 	_, err := reportAnalyticsEntrypoint(invocationContextMock, []workflow.Data{testPayload(requestPayload)})
@@ -112,6 +114,7 @@ func Test_ReportAnalytics_ReportAnalyticsEntryPoint_reportsHttpError(t *testing.
 	invocationContextMock.EXPECT().GetConfiguration().Return(config).AnyTimes()
 	invocationContextMock.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
 	invocationContextMock.EXPECT().GetNetworkAccess().Return(networkAccessMock).AnyTimes()
+	invocationContextMock.EXPECT().Context().Return(t.Context()).AnyTimes()
 	networkAccessMock.EXPECT().GetHttpClient().Return(mockClient).AnyTimes()
 
 	_, err := reportAnalyticsEntrypoint(invocationContextMock, []workflow.Data{testPayload(requestPayload)})
@@ -172,6 +175,7 @@ func Test_ReportAnalytics_ReportAnalyticsEntryPoint_usesCLIInput(t *testing.T) {
 	invocationContextMock.EXPECT().GetNetworkAccess().Return(networkAccessMock).AnyTimes()
 	invocationContextMock.EXPECT().GetEngine().Return(engineMock).AnyTimes()
 	invocationContextMock.EXPECT().GetRuntimeInfo().Return(runtimeinfo.New(runtimeinfo.WithName("snyk-cli"), runtimeinfo.WithVersion("1.1233.0"))).AnyTimes()
+	invocationContextMock.EXPECT().Context().Return(t.Context()).AnyTimes()
 	engineMock.EXPECT().GetWorkflows().AnyTimes()
 	networkAccessMock.EXPECT().GetHttpClient().Return(mockClient).AnyTimes()
 

--- a/pkg/local_workflows/whoami_workflow.go
+++ b/pkg/local_workflows/whoami_workflow.go
@@ -39,20 +39,21 @@ func InitWhoAmIWorkflow(engine workflow.Engine) error {
 // it can optionally return the full `/user/me` payload response if the json flag is set
 func whoAmIWorkflowEntryPoint(invocationCtx workflow.InvocationContext, _ []workflow.Data) (output []workflow.Data, err error) {
 	// get necessary objects from invocation context
+	ctx := invocationCtx.Context()
 	config := invocationCtx.GetConfiguration()
 	logger := invocationCtx.GetEnhancedLogger()
 	httpClient := invocationCtx.GetNetworkAccess().GetHttpClient()
 	url := config.GetString(configuration.API_URL)
 	var a = api.NewApi(url, httpClient)
 
-	userMe, err := a.GetUserMe()
+	userMe, err := a.GetUserMe(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching user data: %w", err)
 	}
 
 	// return full payload if json flag is set
 	if config.GetBool(jsonFlag) {
-		selfRes, err := a.GetSelf()
+		selfRes, err := a.GetSelf(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching user data: %w", err)
 		}

--- a/pkg/local_workflows/whoami_workflow_test.go
+++ b/pkg/local_workflows/whoami_workflow_test.go
@@ -2,6 +2,7 @@ package localworkflows
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -102,9 +103,10 @@ func setupMockContext(t *testing.T, payload string, json bool, statusCode int) *
 	})
 
 	// setup invocation context
-	invocationContextMock.EXPECT().GetConfiguration().Return(config)
-	invocationContextMock.EXPECT().GetEnhancedLogger().Return(&logger)
-	invocationContextMock.EXPECT().GetNetworkAccess().Return(networkAccessMock)
+	invocationContextMock.EXPECT().Context().Return(context.Background()).AnyTimes()
+	invocationContextMock.EXPECT().GetConfiguration().Return(config).AnyTimes()
+	invocationContextMock.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
+	invocationContextMock.EXPECT().GetNetworkAccess().Return(networkAccessMock).AnyTimes()
 	networkAccessMock.EXPECT().GetHttpClient().Return(httpClient).AnyTimes()
 
 	return invocationContextMock


### PR DESCRIPTION
### Description

This PR includes a couple of refactorings to make use of the context.Context instance provided by the InvocationContext. This requires extending a couple of interfaces.

To keep the changes incremental, it doesn't yet fully use the context and needs to fallback to context.Background() where the context is not directly available yet.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.
