### PR TITLE
chore: add fingerprints to UFM SARIF output

### DIFF
--- a/internal/presenters/templates/ufm.sarif.tmpl
+++ b/internal/presenters/templates/ufm.sarif.tmpl
@@ -70,6 +70,7 @@
 				{{- $fix := buildFixFromIssue $issue }}
 				{{- $ignoreDetails := $issue.GetIgnoreDetails }}
 				{{- $problemID := $issue.GetProblemID }}
+				{{- $fingerPrintID := $issue.GetID }}
 				{{- if not $problemID }}{{ $problemID = $issue.GetID }}{{ end }}
 				{
 					"ruleId": {{ getQuotedString $problemID }},
@@ -112,6 +113,12 @@
 						}
 						{{- end }}
 					]
+					{{- if and (ne (printf "%s" $issue.GetFindingType) "sca") (ne (printf "%s" $issue.GetFindingType) "license") }},
+					"fingerprints": {
+						"identity": {{ getQuotedString $fingerPrintID }},
+						"snyk/asset/finding/v1": {{ getQuotedString $fingerPrintID }}
+					}
+					{{- end }}
 					{{- if $fix }},
 					"fixes": [
 						{

--- a/internal/presenters/testdata/ufm/secrets.sarif.json
+++ b/internal/presenters/testdata/ufm/secrets.sarif.json
@@ -83,7 +83,11 @@
 								}
 							}
 						}
-					]
+					],
+					"fingerprints": {
+						"identity": "99999999-8888-7777-6665-000000000000",
+						"snyk/asset/finding/v1": "99999999-8888-7777-6665-000000000000"
+					}
 				},
 				{
 					"ruleId": "generic-api-key-2",
@@ -106,6 +110,10 @@
 							}
 						}
 					],
+					"fingerprints": {
+						"identity": "99999999-8888-7777-6666-000000000000",
+						"snyk/asset/finding/v1": "99999999-8888-7777-6666-000000000000"
+					},
 					"suppressions": [
 						{
 							"guid": "31b96aa6-d218-4e5d-a9d6-d42c12ff6712",
@@ -136,6 +144,10 @@
 							}
 						}
 					],
+					"fingerprints": {
+						"identity": "bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee",
+						"snyk/asset/finding/v1": "bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee"
+					},
 					"suppressions": [
 						{
 							"guid": "90b2fe3f-f811-4447-8f75-e32545d753ea",


### PR DESCRIPTION
### Description

Adds `fingerprints` to the UFM SARIF output, per [SARIF v2.1.0 section 3.27.16](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790904), to provide stable identifiers for results. Each result includes two fingerprint entries: `identity` and `snyk/asset/finding/v1`, both using the issue ID.

Fingerprints are conditionally excluded for OSS issues (`sca` and `license` finding types) because their IDs are vulnerability/license identifiers rather than stable code-centric fingerprints suitable for result tracking.

**Relevant ticket:** [CLI-1328](https://snyksec.atlassian.net/browse/CLI-1328)

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.

[CLI-1328]: https://snyksec.atlassian.net/browse/CLI-1328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ