### PR TITLE
chore: fix transitive dependencies being marked as directly upgradable

### DIFF
--- a/internal/presenters/funcs.go
+++ b/internal/presenters/funcs.go
@@ -286,6 +286,7 @@ func getCliTemplateFuncMap(tmpl *template.Template) template.FuncMap {
 	fnMap["colorBySeverity"] = renderInSeverityColor // 2-arg version from styles.go
 	fnMap["renderGreen"] = renderGreen
 	fnMap["renderGray"] = renderGray
+	fnMap["renderCyan"] = renderCyan
 	fnMap["bold"] = renderBold
 	fnMap["tip"] = func(s string) string {
 		return RenderTip(s + "\n")

--- a/internal/presenters/presenter_ufm_test.go
+++ b/internal/presenters/presenter_ufm_test.go
@@ -1114,6 +1114,13 @@ func Test_UfmPresenter_HumanReadable(t *testing.T) {
 	}{
 		{
 			name:              "cli",
+			expectedPath:      "testdata/ufm/cli.human.readable",
+			testResultPath:    "testdata/ufm/testresult_cli.json",
+			includeIgnores:    false,
+			severityThreshold: "",
+		},
+		{
+			name:              "webgoat",
 			expectedPath:      "testdata/ufm/webgoat.ignore.human.readable",
 			testResultPath:    "testdata/ufm/webgoat.ignore.testresult.json",
 			includeIgnores:    true,

--- a/internal/presenters/styles.go
+++ b/internal/presenters/styles.go
@@ -35,3 +35,8 @@ func renderGray(str string) string {
 	style := lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
 	return style.Render(str)
 }
+
+func renderCyan(str string) string {
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+	return style.Render(str)
+}

--- a/internal/presenters/templates/ufm.human.tmpl
+++ b/internal/presenters/templates/ufm.human.tmpl
@@ -183,11 +183,12 @@ Tested {{ int $dependencyCount }} dependencies for known issues, found {{ len $o
 {{- define "issueRemediationDetails" }}
     {{- $issue := . }}
     {{- $componentName := getIssueMetadata $issue "component-name" }}
+    {{- $componentVersion := getIssueMetadata $issue "component-version" }}
     {{- $severity := $issue.GetEffectiveSeverity }}
     {{- $title := colorBySeverity $severity ($issue.GetTitle | bold) }}
     {{- $severityBadge := colorBySeverity $severity (printf "[%s]" ($severity | toUpperCase)) }}
     {{- $url := printf "[https://security.snyk.io/vuln/%s]" $issue.GetID }}
-    {{- $pkgDisplay := $componentName | bold }}
+    {{- $pkgDisplay := printf "%s@%s" $componentName $componentVersion | bold }}
     {{- printf "  ✗ %s %s %s in %s" $title $severityBadge $url $pkgDisplay }}
     {{- "\n" }}
 
@@ -221,9 +222,9 @@ Tested {{ int $dependencyCount }} dependencies for known issues, found {{ len $o
                 {{- end }}
                 {{- if gt $pathCount 1 }}
                     {{- if eq (sub $pathCount 1) 1 }}
-                        {{- printf "    introduced by %s and %d other path\n" $pathStr (sub $pathCount 1) }}
+                        {{- printf "    introduced by %s and %s other path\n" $pathStr (print (sub $pathCount 1) | renderCyan) }}
                     {{- else }}
-                        {{- printf "    introduced by %s and %d other paths\n" $pathStr (sub $pathCount 1) }}
+                        {{- printf "    introduced by %s and %s other paths\n" $pathStr (print (sub $pathCount 1) | renderCyan) }}
                     {{- end }}
                 {{- else }}
                     {{- printf "    introduced by %s\n" $pathStr }}

--- a/internal/presenters/testdata/ufm/cli.human.readable
+++ b/internal/presenters/testdata/ufm/cli.human.readable
@@ -1,0 +1,131 @@
+[1mTesting  (package.json) ...[0m
+
+Tested 552 dependencies for known issues, found 9 issues, 111 vulnerable paths.
+
+[1mOpen Security issues: 9[0m
+
+ ✗ [LOW] [1mRegular Expression Denial of Service (ReDoS)[0m
+   Finding ID: SNYK-JS-BRACEEXPANSION-9789073
+   Info: https://snyk.io/vuln/SNYK-JS-BRACEEXPANSION-9789073
+   Introduced by: brace-expansion
+   Introduced through: snyk@1.0.0-monorepo > glob@7.2.3 > minimatch@3.1.2 > brace-expansion@1.1.11
+   Reachability: No Path Found
+
+ ✗ [33m[MEDIUM][0m [1mArbitrary Code Injection[0m
+   Finding ID: SNYK-JS-COOKIE-13271683
+   Info: https://snyk.io/vuln/SNYK-JS-COOKIE-13271683
+   Introduced by: cookie
+   Introduced through: snyk@1.0.0-monorepo > @sentry/node@7.34.0 > cookie@0.4.2
+   Reachability: No Path Found
+
+ ✗ [33m[MEDIUM][0m [1mRegular Expression Denial of Service (ReDoS)[0m
+   Finding ID: SNYK-JS-DEBUG-13283909
+   Info: https://snyk.io/vuln/SNYK-JS-DEBUG-13283909
+   Introduced by: debug
+   Introduced through: snyk@1.0.0-monorepo > debug@4.3.4
+   Reachability: No Path Found
+
+ ✗ [33m[MEDIUM][0m [1mAlternate solution to CWE-1333 | Inefficient Regular Expression Complexity[0m
+   Finding ID: SNYK-JS-DEBUG-14214893
+   Info: https://snyk.io/vuln/SNYK-JS-DEBUG-14214893
+   Introduced by: debug
+   Introduced through: snyk@1.0.0-monorepo > debug@4.3.4
+   Reachability: No Path Found
+
+ ✗ [33m[MEDIUM][0m [1mOpen Redirect[0m
+   Finding ID: SNYK-JS-GOT-2932019
+   Info: https://snyk.io/vuln/SNYK-JS-GOT-2932019
+   Introduced by: got
+   Introduced through: snyk@1.0.0-monorepo > snyk-nodejs-lockfile-parser@2.3.1 > @yarnpkg/core@4.4.1 > got@11.8.2
+   Reachability: No Path Found
+
+ ✗ [33m[MEDIUM][0m [1mRegular Expression Denial of Service (ReDoS)[0m
+   Finding ID: SNYK-JS-MARKED-2342073
+   Info: https://snyk.io/vuln/SNYK-JS-MARKED-2342073
+   Introduced by: marked
+   Introduced through: snyk@1.0.0-monorepo > marked@4.0.1
+   Reachability: Reachable
+
+ ✗ [33m[MEDIUM][0m [1mRegular Expression Denial of Service (ReDoS)[0m
+   Finding ID: SNYK-JS-MARKED-2342082
+   Info: https://snyk.io/vuln/SNYK-JS-MARKED-2342082
+   Introduced by: marked
+   Introduced through: snyk@1.0.0-monorepo > marked@4.0.1
+   Reachability: Reachable
+
+ ✗ [31m[HIGH][0m [1mDirectory Traversal[0m
+   Finding ID: SNYK-JS-ASYNC-12239908
+   Info: https://snyk.io/vuln/SNYK-JS-ASYNC-12239908
+   Introduced by: async
+   Introduced through: snyk@1.0.0-monorepo > snyk-config@5.2.0 > async@3.2.4
+   Reachability: No Path Found
+
+ ✗ [31m[HIGH][0m [1mDenial of Service (DoS)[0m
+   Finding ID: SNYK-JS-LODASH-12239302
+   Info: https://snyk.io/vuln/SNYK-JS-LODASH-12239302
+   Introduced by: lodash
+   Introduced through: snyk@1.0.0-monorepo > snyk-nodejs-plugin@1.4.4 > lodash@4.17.21
+   Reachability: No Path Found
+
+[32m[1mIssues to fix by upgrading:[0m[0m
+
+  Upgrade [1m@sentry/node@7.34.0[0m to [1m@sentry/node@7.94.1[0m to fix
+  ✗ [33m[1mArbitrary Code Injection[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-COOKIE-13271683] in [1mcookie[0m
+    introduced by snyk@1.0.0-monorepo > @sentry/node@7.34.0 > cookie@0.4.2
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-DEBUG-13283909] in [1mdebug[0m
+    introduced by snyk@1.0.0-monorepo > debug@4.3.4 and 40 other paths
+  ✗ [33m[1mAlternate solution to CWE-1333 | Inefficient Regular Expression Complexity[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-DEBUG-14214893] in [1mdebug[0m
+    introduced by snyk@1.0.0-monorepo > debug@4.3.4 and 40 other paths
+
+  Upgrade [1m@snyk/fix@1.0.0-monorepo[0m to [1m@snyk/fix@1.471.0[0m to fix
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-DEBUG-13283909] in [1mdebug[0m
+    introduced by snyk@1.0.0-monorepo > debug@4.3.4 and 40 other paths
+  ✗ [33m[1mAlternate solution to CWE-1333 | Inefficient Regular Expression Complexity[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-DEBUG-14214893] in [1mdebug[0m
+    introduced by snyk@1.0.0-monorepo > debug@4.3.4 and 40 other paths
+
+  Upgrade [1mglob@7.2.3[0m to [1mglob@9.0.0[0m to fix
+  ✗ [1mRegular Expression Denial of Service (ReDoS)[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-BRACEEXPANSION-9789073] in [1mbrace-expansion[0m
+    introduced by snyk@1.0.0-monorepo > glob@7.2.3 > minimatch@3.1.2 > brace-expansion@1.1.11 and 7 other paths
+
+  Upgrade [1mmarked@4.0.1[0m to [1mmarked@4.0.10[0m to fix
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-MARKED-2342073] in [1mmarked[0m
+    introduced by snyk@1.0.0-monorepo > marked@4.0.1
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-MARKED-2342082] in [1mmarked[0m
+    introduced by snyk@1.0.0-monorepo > marked@4.0.1
+
+  Upgrade [1mrimraf@2.7.1[0m to [1mrimraf@4.3.1[0m to fix
+  ✗ [1mRegular Expression Denial of Service (ReDoS)[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-BRACEEXPANSION-9789073] in [1mbrace-expansion[0m
+    introduced by snyk@1.0.0-monorepo > glob@7.2.3 > minimatch@3.1.2 > brace-expansion@1.1.11 and 7 other paths
+
+  Upgrade [1msnyk-go-plugin@1.23.0[0m to [1msnyk-go-plugin@1.24.0[0m to fix
+  ✗ [1mRegular Expression Denial of Service (ReDoS)[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-BRACEEXPANSION-9789073] in [1mbrace-expansion[0m
+    introduced by snyk@1.0.0-monorepo > glob@7.2.3 > minimatch@3.1.2 > brace-expansion@1.1.11 and 7 other paths
+
+  Upgrade [1msnyk-resolve-deps@4.8.0[0m to [1msnyk-resolve-deps@4.9.1[0m to fix
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-DEBUG-13283909] in [1mdebug[0m
+    introduced by snyk@1.0.0-monorepo > debug@4.3.4 and 40 other paths
+  ✗ [33m[1mAlternate solution to CWE-1333 | Inefficient Regular Expression Complexity[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-DEBUG-14214893] in [1mdebug[0m
+    introduced by snyk@1.0.0-monorepo > debug@4.3.4 and 40 other paths
+
+[90m[1mIssues with no direct upgrade or patch:[0m[0m
+  ✗ [1mRegular Expression Denial of Service (ReDoS)[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-BRACEEXPANSION-9789073] in [1mbrace-expansion[0m
+    introduced by snyk@1.0.0-monorepo > glob@7.2.3 > minimatch@3.1.2 > brace-expansion@1.1.11 and 7 other paths
+  This issue was fixed in: [1m1.1.12, 2.0.2, 3.0.1, 4.0.1[0m
+
+╭─────────────────────────────────────────────────────────╮
+│ [1mTest Summary[0m                                            │
+│                                                         │
+│   Organization:      My Org                             │
+│   Test type:         Software Composition Analysis      │
+│   Project path:      test-project                       │
+│                                                         │
+│   Total security issues: 9                              │
+│   Ignored: [1m0[0m [[35m 0 CRITICAL [0m[31m 0 HIGH [0m[33m 0 MEDIUM [0m 0 LOW ]    │
+│   Open   : [1m9[0m [[35m 0 CRITICAL [0m[31m 2 HIGH [0m[33m 6 MEDIUM [0m 1 LOW ]    │
+╰─────────────────────────────────────────────────────────╯
+
+
+💡 Tip
+
+   To view ignored issues, use the --include-ignores option.
+                                                            

--- a/internal/presenters/testdata/ufm/cli.human.readable
+++ b/internal/presenters/testdata/ufm/cli.human.readable
@@ -70,46 +70,46 @@ Tested 552 dependencies for known issues, found 9 issues, 111 vulnerable paths.
 [32m[1mIssues to fix by upgrading:[0m[0m
 
   Upgrade [1m@sentry/node@7.34.0[0m to [1m@sentry/node@7.94.1[0m to fix
-  ✗ [33m[1mArbitrary Code Injection[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-COOKIE-13271683] in [1mcookie[0m
+  ✗ [33m[1mArbitrary Code Injection[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-COOKIE-13271683] in [1mcookie@0.4.2[0m
     introduced by snyk@1.0.0-monorepo > @sentry/node@7.34.0 > cookie@0.4.2
-  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-DEBUG-13283909] in [1mdebug[0m
-    introduced by snyk@1.0.0-monorepo > debug@4.3.4 and 40 other paths
-  ✗ [33m[1mAlternate solution to CWE-1333 | Inefficient Regular Expression Complexity[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-DEBUG-14214893] in [1mdebug[0m
-    introduced by snyk@1.0.0-monorepo > debug@4.3.4 and 40 other paths
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-DEBUG-13283909] in [1mdebug@4.3.4[0m
+    introduced by snyk@1.0.0-monorepo > debug@4.3.4 and [36m40[0m other paths
+  ✗ [33m[1mAlternate solution to CWE-1333 | Inefficient Regular Expression Complexity[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-DEBUG-14214893] in [1mdebug@4.3.4[0m
+    introduced by snyk@1.0.0-monorepo > debug@4.3.4 and [36m40[0m other paths
 
   Upgrade [1m@snyk/fix@1.0.0-monorepo[0m to [1m@snyk/fix@1.471.0[0m to fix
-  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-DEBUG-13283909] in [1mdebug[0m
-    introduced by snyk@1.0.0-monorepo > debug@4.3.4 and 40 other paths
-  ✗ [33m[1mAlternate solution to CWE-1333 | Inefficient Regular Expression Complexity[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-DEBUG-14214893] in [1mdebug[0m
-    introduced by snyk@1.0.0-monorepo > debug@4.3.4 and 40 other paths
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-DEBUG-13283909] in [1mdebug@4.3.4[0m
+    introduced by snyk@1.0.0-monorepo > debug@4.3.4 and [36m40[0m other paths
+  ✗ [33m[1mAlternate solution to CWE-1333 | Inefficient Regular Expression Complexity[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-DEBUG-14214893] in [1mdebug@4.3.4[0m
+    introduced by snyk@1.0.0-monorepo > debug@4.3.4 and [36m40[0m other paths
 
   Upgrade [1mglob@7.2.3[0m to [1mglob@9.0.0[0m to fix
-  ✗ [1mRegular Expression Denial of Service (ReDoS)[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-BRACEEXPANSION-9789073] in [1mbrace-expansion[0m
-    introduced by snyk@1.0.0-monorepo > glob@7.2.3 > minimatch@3.1.2 > brace-expansion@1.1.11 and 7 other paths
+  ✗ [1mRegular Expression Denial of Service (ReDoS)[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-BRACEEXPANSION-9789073] in [1mbrace-expansion@1.1.11[0m
+    introduced by snyk@1.0.0-monorepo > glob@7.2.3 > minimatch@3.1.2 > brace-expansion@1.1.11 and [36m7[0m other paths
 
   Upgrade [1mmarked@4.0.1[0m to [1mmarked@4.0.10[0m to fix
-  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-MARKED-2342073] in [1mmarked[0m
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-MARKED-2342073] in [1mmarked@4.0.1[0m
     introduced by snyk@1.0.0-monorepo > marked@4.0.1
-  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-MARKED-2342082] in [1mmarked[0m
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-MARKED-2342082] in [1mmarked@4.0.1[0m
     introduced by snyk@1.0.0-monorepo > marked@4.0.1
 
   Upgrade [1mrimraf@2.7.1[0m to [1mrimraf@4.3.1[0m to fix
-  ✗ [1mRegular Expression Denial of Service (ReDoS)[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-BRACEEXPANSION-9789073] in [1mbrace-expansion[0m
-    introduced by snyk@1.0.0-monorepo > glob@7.2.3 > minimatch@3.1.2 > brace-expansion@1.1.11 and 7 other paths
+  ✗ [1mRegular Expression Denial of Service (ReDoS)[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-BRACEEXPANSION-9789073] in [1mbrace-expansion@1.1.11[0m
+    introduced by snyk@1.0.0-monorepo > glob@7.2.3 > minimatch@3.1.2 > brace-expansion@1.1.11 and [36m7[0m other paths
 
   Upgrade [1msnyk-go-plugin@1.23.0[0m to [1msnyk-go-plugin@1.24.0[0m to fix
-  ✗ [1mRegular Expression Denial of Service (ReDoS)[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-BRACEEXPANSION-9789073] in [1mbrace-expansion[0m
-    introduced by snyk@1.0.0-monorepo > glob@7.2.3 > minimatch@3.1.2 > brace-expansion@1.1.11 and 7 other paths
+  ✗ [1mRegular Expression Denial of Service (ReDoS)[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-BRACEEXPANSION-9789073] in [1mbrace-expansion@1.1.11[0m
+    introduced by snyk@1.0.0-monorepo > glob@7.2.3 > minimatch@3.1.2 > brace-expansion@1.1.11 and [36m7[0m other paths
 
   Upgrade [1msnyk-resolve-deps@4.8.0[0m to [1msnyk-resolve-deps@4.9.1[0m to fix
-  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-DEBUG-13283909] in [1mdebug[0m
-    introduced by snyk@1.0.0-monorepo > debug@4.3.4 and 40 other paths
-  ✗ [33m[1mAlternate solution to CWE-1333 | Inefficient Regular Expression Complexity[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-DEBUG-14214893] in [1mdebug[0m
-    introduced by snyk@1.0.0-monorepo > debug@4.3.4 and 40 other paths
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-DEBUG-13283909] in [1mdebug@4.3.4[0m
+    introduced by snyk@1.0.0-monorepo > debug@4.3.4 and [36m40[0m other paths
+  ✗ [33m[1mAlternate solution to CWE-1333 | Inefficient Regular Expression Complexity[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-DEBUG-14214893] in [1mdebug@4.3.4[0m
+    introduced by snyk@1.0.0-monorepo > debug@4.3.4 and [36m40[0m other paths
 
 [90m[1mIssues with no direct upgrade or patch:[0m[0m
-  ✗ [1mRegular Expression Denial of Service (ReDoS)[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-BRACEEXPANSION-9789073] in [1mbrace-expansion[0m
-    introduced by snyk@1.0.0-monorepo > glob@7.2.3 > minimatch@3.1.2 > brace-expansion@1.1.11 and 7 other paths
+  ✗ [1mRegular Expression Denial of Service (ReDoS)[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-BRACEEXPANSION-9789073] in [1mbrace-expansion@1.1.11[0m
+    introduced by snyk@1.0.0-monorepo > glob@7.2.3 > minimatch@3.1.2 > brace-expansion@1.1.11 and [36m7[0m other paths
   This issue was fixed in: [1m1.1.12, 2.0.2, 3.0.1, 4.0.1[0m
 
 ╭─────────────────────────────────────────────────────────╮

--- a/internal/presenters/testdata/ufm/multi_project.human.readable
+++ b/internal/presenters/testdata/ufm/multi_project.human.readable
@@ -202,43 +202,43 @@ Tested 23 dependencies for known issues, found 19 issues, 27 vulnerable paths.
 [32m[1mIssues to fix by upgrading:[0m[0m
 
   Upgrade [1mexpress@4.0.0[0m to [1mexpress@4.21.2[0m to fix
-  ✗ [1mCross-site Scripting[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-SEND-7926862] in [1msend[0m
-    introduced by package.json@ > express@4.0.0 > send@0.2.0 and 1 other path
-  ✗ [1mCross-site Scripting[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-SERVESTATIC-7926865] in [1mserve-static[0m
+  ✗ [1mCross-site Scripting[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-SEND-7926862] in [1msend@0.2.0[0m
+    introduced by package.json@ > express@4.0.0 > send@0.2.0 and [36m1[0m other path
+  ✗ [1mCross-site Scripting[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-SERVESTATIC-7926865] in [1mserve-static@1.0.1[0m
     introduced by package.json@ > express@4.0.0 > serve-static@1.0.1
-  ✗ [1mRegular Expression Denial of Service (ReDoS)[0m [LOW] [https://security.snyk.io/vuln/npm:mime:20170907] in [1mmime[0m
-    introduced by package.json@ > express@4.0.0 > accepts@1.0.0 > mime@1.2.11 and 3 other paths
-  ✗ [1mOpen Redirect[0m [LOW] [https://security.snyk.io/vuln/npm:serve-static:20150113] in [1mserve-static[0m
+  ✗ [1mRegular Expression Denial of Service (ReDoS)[0m [LOW] [https://security.snyk.io/vuln/npm:mime:20170907] in [1mmime@1.2.11[0m
+    introduced by package.json@ > express@4.0.0 > accepts@1.0.0 > mime@1.2.11 and [36m3[0m other paths
+  ✗ [1mOpen Redirect[0m [LOW] [https://security.snyk.io/vuln/npm:serve-static:20150113] in [1mserve-static@1.0.1[0m
     introduced by package.json@ > express@4.0.0 > serve-static@1.0.1
-  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-COOKIE-8163060] in [1mcookie[0m
+  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-COOKIE-8163060] in [1mcookie@0.1.0[0m
     introduced by package.json@ > express@4.0.0 > cookie@0.1.0
-  ✗ [33m[1mOpen Redirect[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-EXPRESS-6474509] in [1mexpress[0m
+  ✗ [33m[1mOpen Redirect[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-EXPRESS-6474509] in [1mexpress@4.0.0[0m
     introduced by package.json@ > express@4.0.0
-  ✗ [33m[1mCross-site Scripting[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-EXPRESS-7926867] in [1mexpress[0m
+  ✗ [33m[1mCross-site Scripting[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-EXPRESS-7926867] in [1mexpress@4.0.0[0m
     introduced by package.json@ > express@4.0.0
-  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-PATHTOREGEXP-7925106] in [1mpath-to-regexp[0m
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-PATHTOREGEXP-7925106] in [1mpath-to-regexp@0.1.2[0m
     introduced by package.json@ > express@4.0.0 > path-to-regexp@0.1.2
-  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-PATHTOREGEXP-8482416] in [1mpath-to-regexp[0m
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-PATHTOREGEXP-8482416] in [1mpath-to-regexp@0.1.2[0m
     introduced by package.json@ > express@4.0.0 > path-to-regexp@0.1.2
-  ✗ [33m[1mNon-Constant Time String Comparison[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:cookie-signature:20160804] in [1mcookie-signature[0m
+  ✗ [33m[1mNon-Constant Time String Comparison[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:cookie-signature:20160804] in [1mcookie-signature@1.0.3[0m
     introduced by package.json@ > express@4.0.0 > cookie-signature@1.0.3
-  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:express:20140912] in [1mexpress[0m
+  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:express:20140912] in [1mexpress@4.0.0[0m
     introduced by package.json@ > express@4.0.0
-  ✗ [33m[1mDenial of Service (DoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:qs:20140806-1] in [1mqs[0m
+  ✗ [33m[1mDenial of Service (DoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:qs:20140806-1] in [1mqs@0.6.6[0m
     introduced by package.json@ > express@4.0.0 > qs@0.6.6
-  ✗ [33m[1mDirectory Traversal[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:send:20140912] in [1msend[0m
-    introduced by package.json@ > express@4.0.0 > send@0.2.0 and 1 other path
-  ✗ [33m[1mRoot Path Disclosure[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:send:20151103] in [1msend[0m
-    introduced by package.json@ > express@4.0.0 > send@0.2.0 and 1 other path
-  ✗ [31m[1mPrototype Poisoning[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JS-QS-3153490] in [1mqs[0m
+  ✗ [33m[1mDirectory Traversal[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:send:20140912] in [1msend@0.2.0[0m
+    introduced by package.json@ > express@4.0.0 > send@0.2.0 and [36m1[0m other path
+  ✗ [33m[1mRoot Path Disclosure[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:send:20151103] in [1msend@0.2.0[0m
+    introduced by package.json@ > express@4.0.0 > send@0.2.0 and [36m1[0m other path
+  ✗ [31m[1mPrototype Poisoning[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JS-QS-3153490] in [1mqs@0.6.6[0m
     introduced by package.json@ > express@4.0.0 > qs@0.6.6
-  ✗ [31m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:fresh:20170908] in [1mfresh[0m
-    introduced by package.json@ > express@4.0.0 > fresh@0.2.2 and 2 other paths
-  ✗ [31m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:negotiator:20160616] in [1mnegotiator[0m
+  ✗ [31m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:fresh:20170908] in [1mfresh@0.2.2[0m
+    introduced by package.json@ > express@4.0.0 > fresh@0.2.2 and [36m2[0m other paths
+  ✗ [31m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:negotiator:20160616] in [1mnegotiator@0.3.0[0m
     introduced by package.json@ > express@4.0.0 > accepts@1.0.0 > negotiator@0.3.0
-  ✗ [31m[1mDenial of Service (DoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:qs:20140806] in [1mqs[0m
+  ✗ [31m[1mDenial of Service (DoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:qs:20140806] in [1mqs@0.6.6[0m
     introduced by package.json@ > express@4.0.0 > qs@0.6.6
-  ✗ [31m[1mPrototype Override Protection Bypass[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:qs:20170213] in [1mqs[0m
+  ✗ [31m[1mPrototype Override Protection Bypass[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:qs:20170213] in [1mqs@0.6.6[0m
     introduced by package.json@ > express@4.0.0 > qs@0.6.6
 
 ╭───────────────────────────────────────────────────────────╮
@@ -386,30 +386,30 @@ Tested 7 dependencies for known issues, found 11 issues, 22 vulnerable paths.
 [32m[1mIssues to fix by upgrading:[0m[0m
 
   Upgrade [1mjinja2@2.7.2[0m to [1mjinja2@3.1.6[0m to fix
-  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-1012994] in [1mjinja2[0m
-    introduced by not-python@0.0.0 > jinja2@2.7.2 and 1 other path
-  ✗ [33m[1mSandbox Escape[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-174126] in [1mjinja2[0m
-    introduced by not-python@0.0.0 > jinja2@2.7.2 and 1 other path
-  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-6150717] in [1mjinja2[0m
-    introduced by not-python@0.0.0 > jinja2@2.7.2 and 1 other path
-  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-6809379] in [1mjinja2[0m
-    introduced by not-python@0.0.0 > jinja2@2.7.2 and 1 other path
-  ✗ [33m[1mTemplate Injection[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-8548181] in [1mjinja2[0m
-    introduced by not-python@0.0.0 > jinja2@2.7.2 and 1 other path
-  ✗ [33m[1mImproper Neutralization[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-8548987] in [1mjinja2[0m
-    introduced by not-python@0.0.0 > jinja2@2.7.2 and 1 other path
-  ✗ [33m[1mTemplate Injection[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-9292516] in [1mjinja2[0m
-    introduced by not-python@0.0.0 > jinja2@2.7.2 and 1 other path
-  ✗ [31m[1mSandbox Bypass[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-455616] in [1mjinja2[0m
-    introduced by not-python@0.0.0 > jinja2@2.7.2 and 1 other path
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-1012994] in [1mjinja2@2.7.2[0m
+    introduced by not-python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mSandbox Escape[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-174126] in [1mjinja2@2.7.2[0m
+    introduced by not-python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-6150717] in [1mjinja2@2.7.2[0m
+    introduced by not-python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-6809379] in [1mjinja2@2.7.2[0m
+    introduced by not-python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mTemplate Injection[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-8548181] in [1mjinja2@2.7.2[0m
+    introduced by not-python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mImproper Neutralization[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-8548987] in [1mjinja2@2.7.2[0m
+    introduced by not-python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mTemplate Injection[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-9292516] in [1mjinja2@2.7.2[0m
+    introduced by not-python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [31m[1mSandbox Bypass[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-455616] in [1mjinja2@2.7.2[0m
+    introduced by not-python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
 
   Upgrade [1mwerkzeug@3.0.1[0m to [1mwerkzeug@3.0.6[0m to fix
-  ✗ [33m[1mDirectory Traversal[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309091] in [1mwerkzeug[0m
-    introduced by not-python@0.0.0 > werkzeug@3.0.1 and 1 other path
-  ✗ [33m[1mAllocation of Resources Without Limits or Throttling[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309092] in [1mwerkzeug[0m
-    introduced by not-python@0.0.0 > werkzeug@3.0.1 and 1 other path
-  ✗ [31m[1mRemote Code Execution (RCE)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-6808933] in [1mwerkzeug[0m
-    introduced by not-python@0.0.0 > werkzeug@3.0.1 and 1 other path
+  ✗ [33m[1mDirectory Traversal[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309091] in [1mwerkzeug@3.0.1[0m
+    introduced by not-python@0.0.0 > werkzeug@3.0.1 and [36m1[0m other path
+  ✗ [33m[1mAllocation of Resources Without Limits or Throttling[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309092] in [1mwerkzeug@3.0.1[0m
+    introduced by not-python@0.0.0 > werkzeug@3.0.1 and [36m1[0m other path
+  ✗ [31m[1mRemote Code Execution (RCE)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-6808933] in [1mwerkzeug@3.0.1[0m
+    introduced by not-python@0.0.0 > werkzeug@3.0.1 and [36m1[0m other path
 
 ╭──────────────────────────────────────────────────────────╮
 │ [1mTest Summary[0m                                             │
@@ -511,30 +511,30 @@ Tested 7 dependencies for known issues, found 11 issues, 22 vulnerable paths.
 [32m[1mIssues to fix by upgrading:[0m[0m
 
   Upgrade [1mjinja2@2.7.2[0m to [1mjinja2@3.1.6[0m to fix
-  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-1012994] in [1mjinja2[0m
-    introduced by python@0.0.0 > jinja2@2.7.2 and 1 other path
-  ✗ [33m[1mSandbox Escape[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-174126] in [1mjinja2[0m
-    introduced by python@0.0.0 > jinja2@2.7.2 and 1 other path
-  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-6150717] in [1mjinja2[0m
-    introduced by python@0.0.0 > jinja2@2.7.2 and 1 other path
-  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-6809379] in [1mjinja2[0m
-    introduced by python@0.0.0 > jinja2@2.7.2 and 1 other path
-  ✗ [33m[1mTemplate Injection[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-8548181] in [1mjinja2[0m
-    introduced by python@0.0.0 > jinja2@2.7.2 and 1 other path
-  ✗ [33m[1mImproper Neutralization[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-8548987] in [1mjinja2[0m
-    introduced by python@0.0.0 > jinja2@2.7.2 and 1 other path
-  ✗ [33m[1mTemplate Injection[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-9292516] in [1mjinja2[0m
-    introduced by python@0.0.0 > jinja2@2.7.2 and 1 other path
-  ✗ [31m[1mSandbox Bypass[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-455616] in [1mjinja2[0m
-    introduced by python@0.0.0 > jinja2@2.7.2 and 1 other path
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-1012994] in [1mjinja2@2.7.2[0m
+    introduced by python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mSandbox Escape[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-174126] in [1mjinja2@2.7.2[0m
+    introduced by python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-6150717] in [1mjinja2@2.7.2[0m
+    introduced by python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-6809379] in [1mjinja2@2.7.2[0m
+    introduced by python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mTemplate Injection[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-8548181] in [1mjinja2@2.7.2[0m
+    introduced by python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mImproper Neutralization[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-8548987] in [1mjinja2@2.7.2[0m
+    introduced by python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mTemplate Injection[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-9292516] in [1mjinja2@2.7.2[0m
+    introduced by python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [31m[1mSandbox Bypass[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-455616] in [1mjinja2@2.7.2[0m
+    introduced by python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
 
   Upgrade [1mwerkzeug@3.0.1[0m to [1mwerkzeug@3.0.6[0m to fix
-  ✗ [33m[1mDirectory Traversal[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309091] in [1mwerkzeug[0m
-    introduced by python@0.0.0 > werkzeug@3.0.1 and 1 other path
-  ✗ [33m[1mAllocation of Resources Without Limits or Throttling[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309092] in [1mwerkzeug[0m
-    introduced by python@0.0.0 > werkzeug@3.0.1 and 1 other path
-  ✗ [31m[1mRemote Code Execution (RCE)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-6808933] in [1mwerkzeug[0m
-    introduced by python@0.0.0 > werkzeug@3.0.1 and 1 other path
+  ✗ [33m[1mDirectory Traversal[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309091] in [1mwerkzeug@3.0.1[0m
+    introduced by python@0.0.0 > werkzeug@3.0.1 and [36m1[0m other path
+  ✗ [33m[1mAllocation of Resources Without Limits or Throttling[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309092] in [1mwerkzeug@3.0.1[0m
+    introduced by python@0.0.0 > werkzeug@3.0.1 and [36m1[0m other path
+  ✗ [31m[1mRemote Code Execution (RCE)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-6808933] in [1mwerkzeug@3.0.1[0m
+    introduced by python@0.0.0 > werkzeug@3.0.1 and [36m1[0m other path
 
 ╭──────────────────────────────────────────────────────────╮
 │ [1mTest Summary[0m                                             │
@@ -692,43 +692,43 @@ Tested 23 dependencies for known issues, found 19 issues, 27 vulnerable paths.
 [32m[1mIssues to fix by upgrading:[0m[0m
 
   Upgrade [1mexpress@4.0.0[0m to [1mexpress@4.21.2[0m to fix
-  ✗ [1mCross-site Scripting[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-SEND-7926862] in [1msend[0m
-    introduced by tsc@1.0.0 > express@4.0.0 > send@0.2.0 and 1 other path
-  ✗ [1mCross-site Scripting[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-SERVESTATIC-7926865] in [1mserve-static[0m
+  ✗ [1mCross-site Scripting[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-SEND-7926862] in [1msend@0.2.0[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > send@0.2.0 and [36m1[0m other path
+  ✗ [1mCross-site Scripting[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-SERVESTATIC-7926865] in [1mserve-static@1.0.1[0m
     introduced by tsc@1.0.0 > express@4.0.0 > serve-static@1.0.1
-  ✗ [1mRegular Expression Denial of Service (ReDoS)[0m [LOW] [https://security.snyk.io/vuln/npm:mime:20170907] in [1mmime[0m
-    introduced by tsc@1.0.0 > express@4.0.0 > accepts@1.0.0 > mime@1.2.11 and 3 other paths
-  ✗ [1mOpen Redirect[0m [LOW] [https://security.snyk.io/vuln/npm:serve-static:20150113] in [1mserve-static[0m
+  ✗ [1mRegular Expression Denial of Service (ReDoS)[0m [LOW] [https://security.snyk.io/vuln/npm:mime:20170907] in [1mmime@1.2.11[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > accepts@1.0.0 > mime@1.2.11 and [36m3[0m other paths
+  ✗ [1mOpen Redirect[0m [LOW] [https://security.snyk.io/vuln/npm:serve-static:20150113] in [1mserve-static@1.0.1[0m
     introduced by tsc@1.0.0 > express@4.0.0 > serve-static@1.0.1
-  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-COOKIE-8163060] in [1mcookie[0m
+  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-COOKIE-8163060] in [1mcookie@0.1.0[0m
     introduced by tsc@1.0.0 > express@4.0.0 > cookie@0.1.0
-  ✗ [33m[1mOpen Redirect[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-EXPRESS-6474509] in [1mexpress[0m
+  ✗ [33m[1mOpen Redirect[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-EXPRESS-6474509] in [1mexpress@4.0.0[0m
     introduced by tsc@1.0.0 > express@4.0.0
-  ✗ [33m[1mCross-site Scripting[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-EXPRESS-7926867] in [1mexpress[0m
+  ✗ [33m[1mCross-site Scripting[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-EXPRESS-7926867] in [1mexpress@4.0.0[0m
     introduced by tsc@1.0.0 > express@4.0.0
-  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-PATHTOREGEXP-7925106] in [1mpath-to-regexp[0m
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-PATHTOREGEXP-7925106] in [1mpath-to-regexp@0.1.2[0m
     introduced by tsc@1.0.0 > express@4.0.0 > path-to-regexp@0.1.2
-  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-PATHTOREGEXP-8482416] in [1mpath-to-regexp[0m
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-PATHTOREGEXP-8482416] in [1mpath-to-regexp@0.1.2[0m
     introduced by tsc@1.0.0 > express@4.0.0 > path-to-regexp@0.1.2
-  ✗ [33m[1mNon-Constant Time String Comparison[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:cookie-signature:20160804] in [1mcookie-signature[0m
+  ✗ [33m[1mNon-Constant Time String Comparison[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:cookie-signature:20160804] in [1mcookie-signature@1.0.3[0m
     introduced by tsc@1.0.0 > express@4.0.0 > cookie-signature@1.0.3
-  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:express:20140912] in [1mexpress[0m
+  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:express:20140912] in [1mexpress@4.0.0[0m
     introduced by tsc@1.0.0 > express@4.0.0
-  ✗ [33m[1mDenial of Service (DoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:qs:20140806-1] in [1mqs[0m
+  ✗ [33m[1mDenial of Service (DoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:qs:20140806-1] in [1mqs@0.6.6[0m
     introduced by tsc@1.0.0 > express@4.0.0 > qs@0.6.6
-  ✗ [33m[1mDirectory Traversal[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:send:20140912] in [1msend[0m
-    introduced by tsc@1.0.0 > express@4.0.0 > send@0.2.0 and 1 other path
-  ✗ [33m[1mRoot Path Disclosure[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:send:20151103] in [1msend[0m
-    introduced by tsc@1.0.0 > express@4.0.0 > send@0.2.0 and 1 other path
-  ✗ [31m[1mPrototype Poisoning[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JS-QS-3153490] in [1mqs[0m
+  ✗ [33m[1mDirectory Traversal[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:send:20140912] in [1msend@0.2.0[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > send@0.2.0 and [36m1[0m other path
+  ✗ [33m[1mRoot Path Disclosure[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:send:20151103] in [1msend@0.2.0[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > send@0.2.0 and [36m1[0m other path
+  ✗ [31m[1mPrototype Poisoning[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JS-QS-3153490] in [1mqs@0.6.6[0m
     introduced by tsc@1.0.0 > express@4.0.0 > qs@0.6.6
-  ✗ [31m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:fresh:20170908] in [1mfresh[0m
-    introduced by tsc@1.0.0 > express@4.0.0 > fresh@0.2.2 and 2 other paths
-  ✗ [31m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:negotiator:20160616] in [1mnegotiator[0m
+  ✗ [31m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:fresh:20170908] in [1mfresh@0.2.2[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > fresh@0.2.2 and [36m2[0m other paths
+  ✗ [31m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:negotiator:20160616] in [1mnegotiator@0.3.0[0m
     introduced by tsc@1.0.0 > express@4.0.0 > accepts@1.0.0 > negotiator@0.3.0
-  ✗ [31m[1mDenial of Service (DoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:qs:20140806] in [1mqs[0m
+  ✗ [31m[1mDenial of Service (DoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:qs:20140806] in [1mqs@0.6.6[0m
     introduced by tsc@1.0.0 > express@4.0.0 > qs@0.6.6
-  ✗ [31m[1mPrototype Override Protection Bypass[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:qs:20170213] in [1mqs[0m
+  ✗ [31m[1mPrototype Override Protection Bypass[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:qs:20170213] in [1mqs@0.6.6[0m
     introduced by tsc@1.0.0 > express@4.0.0 > qs@0.6.6
 
 ╭───────────────────────────────────────────────────────────╮

--- a/internal/presenters/testdata/ufm/testresult_cli.json
+++ b/internal/presenters/testdata/ufm/testresult_cli.json
@@ -1197,7 +1197,7 @@
               "attributes": {
                 "action": {
                   "package_name": "debug",
-                  "type": "upgrade_package",
+                  "format": "upgrade_package_advice",
                   "upgrade_paths": [
                     {
                       "dependency_path": [
@@ -1434,7 +1434,7 @@
               "attributes": {
                 "action": {
                   "package_name": "debug",
-                  "type": "upgrade_package",
+                  "format": "upgrade_package_advice",
                   "upgrade_paths": [
                     {
                       "dependency_path": [
@@ -1915,7 +1915,7 @@
               "attributes": {
                 "action": {
                   "package_name": "brace-expansion",
-                  "type": "upgrade_package",
+                  "format": "upgrade_package_advice",
                   "upgrade_paths": [
                     {
                       "dependency_path": [
@@ -2154,7 +2154,7 @@
               "attributes": {
                 "action": {
                   "package_name": "marked",
-                  "type": "upgrade_package",
+                  "format": "upgrade_package_advice",
                   "upgrade_paths": [
                     {
                       "dependency_path": [
@@ -3087,7 +3087,7 @@
               "attributes": {
                 "action": {
                   "package_name": "debug",
-                  "type": "upgrade_package",
+                  "format": "upgrade_package_advice",
                   "upgrade_paths": [
                     {
                       "dependency_path": [
@@ -3320,7 +3320,7 @@
               "attributes": {
                 "action": {
                   "package_name": "debug",
-                  "type": "upgrade_package",
+                  "format": "upgrade_package_advice",
                   "upgrade_paths": [
                     {
                       "dependency_path": [
@@ -3785,7 +3785,7 @@
               "attributes": {
                 "action": {
                   "package_name": "cookie",
-                  "type": "upgrade_package",
+                  "format": "upgrade_package_advice",
                   "upgrade_paths": [
                     {
                       "dependency_path": [
@@ -3954,7 +3954,7 @@
               "attributes": {
                 "action": {
                   "package_name": "marked",
-                  "type": "upgrade_package",
+                  "format": "upgrade_package_advice",
                   "upgrade_paths": [
                     {
                       "dependency_path": [

--- a/internal/presenters/testdata/ufm/webgoat.ignore.human.readable
+++ b/internal/presenters/testdata/ufm/webgoat.ignore.human.readable
@@ -365,87 +365,87 @@ Tested 163 dependencies for known issues, found 42 issues, 42 vulnerable paths.
 [32m[1mIssues to fix by upgrading:[0m[0m
 
   Upgrade [1mcom.thoughtworks.xstream:xstream@1.4.5[0m to [1mcom.thoughtworks.xstream:xstream@1.4.21[0m to fix
-  ✗ [33m[1mArbitrary File Deletion[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1051966] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [33m[1mArbitrary File Deletion[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1051966] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [33m[1mServer-Side Request Forgery (SSRF)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1051967] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [33m[1mServer-Side Request Forgery (SSRF)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1051967] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088328] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088328] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088329] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088329] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088331] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088331] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088332] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088332] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088333] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088333] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088334] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088334] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088335] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088335] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088336] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088336] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088338] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088338] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1294540] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [33m[1mDeserialization of Untrusted Data[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1294540] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [33m[1mDenial of Service (DoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569189] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [33m[1mDenial of Service (DoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569189] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [33m[1mDenial of Service (DoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-3091180] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [33m[1mDenial of Service (DoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-3091180] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [33m[1mDenial of Service (DoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-3182897] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [33m[1mDenial of Service (DoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-3182897] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [33m[1mInsecure XML deserialization[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-460764] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [33m[1mInsecure XML deserialization[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-460764] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [31m[1mDeserialization of Untrusted Data[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1040458] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [31m[1mDeserialization of Untrusted Data[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1040458] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [31m[1mDeserialization of Untrusted Data[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088337] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [31m[1mDeserialization of Untrusted Data[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088337] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569176] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569176] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569177] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569177] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569178] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569178] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569179] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569179] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569180] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569180] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569181] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569181] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569182] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569182] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [31m[1mRemote Code Execution (RCE)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569183] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [31m[1mRemote Code Execution (RCE)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569183] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569185] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569185] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569186] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569186] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569187] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [31m[1mArbitrary Code Execution[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569187] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [31m[1mDeserialization of Untrusted Data[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569190] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [31m[1mDeserialization of Untrusted Data[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569190] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [31m[1mServer-Side Request Forgery (SSRF)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569191] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [31m[1mServer-Side Request Forgery (SSRF)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569191] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [31m[1mDenial of Service (DoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-2388977] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [31m[1mDenial of Service (DoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-2388977] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [31m[1mXML External Entity (XXE) Injection[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-30385] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [31m[1mXML External Entity (XXE) Injection[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-30385] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [31m[1mDenial of Service (DoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-31394] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [31m[1mDenial of Service (DoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-31394] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
-  ✗ [31m[1mDeserialization of Untrusted Data[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-8352924] in [1mcom.thoughtworks.xstream:xstream[0m
+  ✗ [31m[1mDeserialization of Untrusted Data[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-8352924] in [1mcom.thoughtworks.xstream:xstream@1.4.5[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > com.thoughtworks.xstream:xstream@1.4.5
 
   Upgrade [1morg.apache.commons:commons-lang3@3.14.0[0m to [1morg.apache.commons:commons-lang3@3.18.0[0m to fix
-  ✗ [31m[1mUncontrolled Recursion[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-10734078] in [1morg.apache.commons:commons-lang3[0m
+  ✗ [31m[1mUncontrolled Recursion[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-10734078] in [1morg.apache.commons:commons-lang3@3.14.0[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > org.apache.commons:commons-lang3@3.14.0
 
   Upgrade [1morg.springframework.boot:spring-boot-starter-validation@3.5.6[0m to [1morg.springframework.boot:spring-boot-starter-validation@3.5.7[0m to fix
-  ✗ [33m[1mExternal Initialization of Trusted Variables or Data Stores[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-13169722] in [1mch.qos.logback:logback-core[0m
+  ✗ [33m[1mExternal Initialization of Trusted Variables or Data Stores[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-13169722] in [1mch.qos.logback:logback-core@1.5.18[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > org.springframework.boot:spring-boot-starter-validation@3.5.6 > org.springframework.boot:spring-boot-starter@3.5.6 > org.springframework.boot:spring-boot-starter-logging@3.5.6 > ch.qos.logback:logback-classic@1.5.18 > ch.qos.logback:logback-core@1.5.18
 
 [90m[1mIssues with no direct upgrade or patch:[0m[0m
-  ✗ [31m[1mDenial of Service (DoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-ORGJRUBY-10557730] in [1morg.jruby:jruby-stdlib[0m
+  ✗ [31m[1mDenial of Service (DoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JAVA-ORGJRUBY-10557730] in [1morg.jruby:jruby-stdlib@10.0.0.1[0m
     introduced by org.owasp.webgoat:webgoat@2025.4-SNAPSHOT > org.asciidoctor:asciidoctorj@3.0.0 > org.jruby:jruby@10.0.0.1 > org.jruby:jruby-stdlib@10.0.0.1
 
 [1mOpen License issues: 4[0m

--- a/internal/ufm_helpers/remediation.go
+++ b/internal/ufm_helpers/remediation.go
@@ -92,6 +92,7 @@ func GetRemediationSummary(issues []testapi.Issue) *RemediationSummary {
 		summary.Pins = append(summary.Pins, pins...)
 	}
 
+	// Filter out unresolved issues that are already covered by a pin.
 	summary.Unresolved = filterUnresolvedCoveredByPins(summary.Unresolved, summary.Pins)
 
 	sort.Slice(summary.Upgrades, func(i, j int) bool {
@@ -173,6 +174,7 @@ func processUpgradeAdvice(issue testapi.Issue, advice testapi.UpgradePackageAdvi
 		}
 
 		for _, depPath := range paths {
+			// If the upgrade path does not match the dependency path, skip it.
 			if len(depPath) < 2 || !pathsMatch(upgradePath.DependencyPath, depPath) {
 				continue
 			}
@@ -180,6 +182,8 @@ func processUpgradeAdvice(issue testapi.Issue, advice testapi.UpgradePackageAdvi
 			fromPkg := depPath[1]
 			toPkg := upgradePath.DependencyPath[1]
 
+			// If the advised upgrade leaves the direct dependency at the exact same package version,
+			// the fix is transitive-only, so we skip it since it's not a direct upgrade the user can apply.
 			if fromPkg.Name == toPkg.Name && fromPkg.Version == toPkg.Version {
 				continue
 			}
@@ -192,10 +196,12 @@ func processUpgradeAdvice(issue testapi.Issue, advice testapi.UpgradePackageAdvi
 		}
 	}
 
+	// If no paths matched, the issue is not resolved.
 	if matchedPaths == 0 {
 		return false
 	}
 
+	// If the number of matched paths is less than the number of vulnerable paths, the issue is partially resolved.
 	hasUnmatchedPaths := matchedPaths < len(paths)
 	return outcome == testapi.FullyResolved || !hasUnmatchedPaths
 }
@@ -224,12 +230,14 @@ func processPinAdvice(issue testapi.Issue, advice testapi.PinPackageAdvice, pinM
 
 	existingPins, exists := pinMap[key]
 	if exists {
+		// 1. Ensure all pins for this package point to the highest recommended target version.
 		for _, pin := range existingPins {
 			if compareVersions(toPkg.Version, pin.ToPackage.Version) > 0 {
 				pin.ToPackage.Version = toPkg.Version
 			}
 		}
 
+		// 2. Check if we already have a pin group for this specific vulnerable version.
 		versionFound := false
 		for _, pin := range existingPins {
 			if pin.FromPackage.Version == vulnerablePkg.Version {
@@ -241,6 +249,7 @@ func processPinAdvice(issue testapi.Issue, advice testapi.PinPackageAdvice, pinM
 			}
 		}
 
+		// 3. If no pin group exists for this vulnerable version, create one using the highest known target version.
 		if !versionFound {
 			highestToVersion := toPkg.Version
 			for _, pin := range existingPins {
@@ -297,6 +306,7 @@ func pathsMatch(upgradePath, depPath []testapi.Package) bool {
 	if len(upgradePath) > len(depPath) {
 		return false
 	}
+
 	for i, pkg := range upgradePath {
 		if pkg.Name != depPath[i].Name {
 			return false

--- a/internal/ufm_helpers/remediation.go
+++ b/internal/ufm_helpers/remediation.go
@@ -346,14 +346,14 @@ func filterUnresolvedCoveredByPins(unresolved []testapi.Issue, pins []*PinGroup)
 		return unresolved
 	}
 
-	pinnedIssueIDs := map[string]struct{}{}
+	pinnedIssueIDs := make(map[string]bool)
 	for _, pin := range pins {
 		for _, fixedIssue := range pin.FixedIssues {
 			issueID := fixedIssue.GetID()
 			if issueID == "" {
 				continue
 			}
-			pinnedIssueIDs[issueID] = struct{}{}
+			pinnedIssueIDs[issueID] = true
 		}
 	}
 
@@ -363,7 +363,7 @@ func filterUnresolvedCoveredByPins(unresolved []testapi.Issue, pins []*PinGroup)
 
 	filtered := make([]testapi.Issue, 0, len(unresolved))
 	for _, issue := range unresolved {
-		if _, coveredByPin := pinnedIssueIDs[issue.GetID()]; coveredByPin {
+		if pinnedIssueIDs[issue.GetID()] {
 			continue
 		}
 		filtered = append(filtered, issue)

--- a/internal/ufm_helpers/remediation.go
+++ b/internal/ufm_helpers/remediation.go
@@ -92,6 +92,8 @@ func GetRemediationSummary(issues []testapi.Issue) *RemediationSummary {
 		summary.Pins = append(summary.Pins, pins...)
 	}
 
+	summary.Unresolved = filterUnresolvedCoveredByPins(summary.Unresolved, summary.Pins)
+
 	sort.Slice(summary.Upgrades, func(i, j int) bool {
 		return summary.Upgrades[i].FromPackage.Name < summary.Upgrades[j].FromPackage.Name
 	})
@@ -175,14 +177,23 @@ func processUpgradeAdvice(issue testapi.Issue, advice testapi.UpgradePackageAdvi
 				continue
 			}
 
-			matchedPaths++
 			fromPkg := depPath[1]
 			toPkg := upgradePath.DependencyPath[1]
+
+			if fromPkg.Name == toPkg.Name && fromPkg.Version == toPkg.Version {
+				continue
+			}
+
+			matchedPaths++
 			key := fmt.Sprintf("%s@%s", fromPkg.Name, fromPkg.Version)
 
 			addOrUpdateUpgradeGroup(upgradeMap, key, fromPkg, toPkg, issue)
 			break
 		}
+	}
+
+	if matchedPaths == 0 {
+		return false
 	}
 
 	hasUnmatchedPaths := matchedPaths < len(paths)
@@ -318,4 +329,35 @@ func compareVersions(v1, v2 string) int {
 		v2 = "v" + v2
 	}
 	return semver.Compare(v1, v2)
+}
+
+func filterUnresolvedCoveredByPins(unresolved []testapi.Issue, pins []*PinGroup) []testapi.Issue {
+	if len(unresolved) == 0 || len(pins) == 0 {
+		return unresolved
+	}
+
+	pinnedIssueIDs := map[string]struct{}{}
+	for _, pin := range pins {
+		for _, fixedIssue := range pin.FixedIssues {
+			issueID := fixedIssue.GetID()
+			if issueID == "" {
+				continue
+			}
+			pinnedIssueIDs[issueID] = struct{}{}
+		}
+	}
+
+	if len(pinnedIssueIDs) == 0 {
+		return unresolved
+	}
+
+	filtered := make([]testapi.Issue, 0, len(unresolved))
+	for _, issue := range unresolved {
+		if _, coveredByPin := pinnedIssueIDs[issue.GetID()]; coveredByPin {
+			continue
+		}
+		filtered = append(filtered, issue)
+	}
+
+	return filtered
 }

--- a/internal/ufm_helpers/remediation_test.go
+++ b/internal/ufm_helpers/remediation_test.go
@@ -489,6 +489,69 @@ func TestGetRemediationSummary(t *testing.T) {
 	})
 }
 
+func TestRemediationSummary_HasMethods(t *testing.T) {
+	summary := &RemediationSummary{}
+	require.False(t, summary.HasUpgrades())
+	require.False(t, summary.HasPins())
+	require.False(t, summary.HasUnresolved())
+
+	summary.Upgrades = []*UpgradeGroup{{
+		FromPackage: testapi.Package{Name: "pkg", Version: "1.0"},
+		ToPackage:   testapi.Package{Name: "pkg", Version: "2.0"},
+		FixedIssues: []testapi.Issue{newTestIssue(t, "VULN", "pkg@1.0.0")},
+	}}
+	require.True(t, summary.HasUpgrades())
+
+	summary.Pins = []*PinGroup{{
+		FromPackage: testapi.Package{Name: "pkg", Version: "1.0"},
+		ToPackage:   testapi.Package{Name: "pkg", Version: "2.0"},
+		FixedIssues: []testapi.Issue{newTestIssue(t, "VULN", "pkg@1.0.0")},
+	}}
+	require.True(t, summary.HasPins())
+
+	summary.Unresolved = []testapi.Issue{newTestIssue(t, "VULN", "pkg@1.0.0")}
+	require.True(t, summary.HasUnresolved())
+}
+
+func TestGetDirectPackageTargets(t *testing.T) {
+	t.Run("nil attributes", func(t *testing.T) {
+		name, version := GetDirectPackageUpgradeTarget(nil)
+		require.Empty(t, name)
+		require.Empty(t, version)
+
+		name, version = GetDirectPackagePinTarget(nil)
+		require.Empty(t, name)
+		require.Empty(t, version)
+	})
+
+	t.Run("empty action", func(t *testing.T) {
+		attrs := &testapi.FixAttributes{}
+		name, version := GetDirectPackageUpgradeTarget(attrs)
+		require.Empty(t, name)
+		require.Empty(t, version)
+
+		name, version = GetDirectPackagePinTarget(attrs)
+		require.Empty(t, name)
+		require.Empty(t, version)
+	})
+
+	t.Run("upgrade target", func(t *testing.T) {
+		issue := newTestIssue(t, "VULN", "pkg@1.0.0", withUpgradeFix(t, testapi.FullyResolved, []string{"root@1.0", "direct@2.0", "pkg@1.1"}))
+		attrs := GetFixAttributes(issue)
+		name, version := GetDirectPackageUpgradeTarget(attrs)
+		require.Equal(t, "direct", name)
+		require.Equal(t, "2.0", version)
+	})
+
+	t.Run("pin target", func(t *testing.T) {
+		issue := newTestIssue(t, "VULN", "pkg@1.0.0", withPinFix(t, testapi.FullyResolved, "pkg", "1.1"))
+		attrs := GetFixAttributes(issue)
+		name, version := GetDirectPackagePinTarget(attrs)
+		require.Equal(t, "pkg", name)
+		require.Equal(t, "1.1", version)
+	})
+}
+
 // Test helpers
 
 type issueOption func(*testapi.FindingData)

--- a/internal/ufm_helpers/remediation_test.go
+++ b/internal/ufm_helpers/remediation_test.go
@@ -355,9 +355,51 @@ func TestGetRemediationSummary(t *testing.T) {
 			require.Len(t, summary.Upgrades[0].FixedIssues, 1)
 			require.Empty(t, summary.Pins)
 		})
+
+		t.Run("upgrade matching should continue after same-version direct dep path", func(t *testing.T) {
+			issues := []testapi.Issue{
+				newTestIssue(t, "VULN_ID", "vulnerable@1.0.0",
+					// First path has the same direct dependency version as the target upgrade path.
+					// If matching stops here, the valid upgrade on the second path is missed.
+					withDepPaths(t, "root@1.0.0", "direct@1.2.3", "vulnerable@1.0.0"),
+					withDepPaths(t, "root@1.0.0", "direct@1.0.0", "vulnerable@1.0.0"),
+					withUpgradeFix(t, testapi.PartiallyResolved,
+						[]string{"root@1.0.0", "direct@1.2.3", "vulnerable@1.0.1"},
+					),
+				),
+			}
+
+			summary := GetRemediationSummary(issues)
+
+			require.Len(t, summary.Upgrades, 1, "should capture upgrade from the second matching path")
+			require.Equal(t, "direct", summary.Upgrades[0].FromPackage.Name)
+			require.Equal(t, "1.0.0", summary.Upgrades[0].FromPackage.Version)
+			require.Equal(t, "1.2.3", summary.Upgrades[0].ToPackage.Version)
+			require.Empty(t, summary.Pins)
+			require.Len(t, summary.Unresolved, 1, "partially resolved upgrade should remain unresolved for unmatched paths")
+		})
 	})
 
 	t.Run("unresolved", func(t *testing.T) {
+		t.Run("unresolved issues covered by pin remediation are filtered out by issue ID", func(t *testing.T) {
+			issues := []testapi.Issue{
+				newTestIssue(t, "VULN_ID", "vulnerable@1.0.0",
+					withDepPaths(t, "root@1.0.0", "direct@1.0.0", "vulnerable@1.0.0"),
+					withPinFix(t, testapi.PartiallyResolved, "vulnerable", "1.0.1"),
+				),
+				newTestIssue(t, "VULN_ID", "vulnerable@2.0.0",
+					withDepPaths(t, "root@1.0.0", "direct@2.0.0", "vulnerable@2.0.0"),
+					withUnresolvedFix(),
+				),
+			}
+
+			summary := GetRemediationSummary(issues)
+
+			require.Len(t, summary.Pins, 1)
+			require.Empty(t, summary.Upgrades)
+			require.Empty(t, summary.Unresolved, "same issue ID should be removed from unresolved when covered by pin")
+		})
+
 		t.Run("an issue containing an unresolved fix action returns valid summary", func(t *testing.T) {
 			issues := []testapi.Issue{
 				newTestIssue(t, "VULN_ID", "vulnerable@1.0.0",
@@ -371,6 +413,78 @@ func TestGetRemediationSummary(t *testing.T) {
 			require.Empty(t, summary.Upgrades)
 			require.Empty(t, summary.Pins)
 			require.Len(t, summary.Unresolved, 1)
+		})
+
+		t.Run("upgrade path where only transitive dep changes is treated as unresolved (PartiallyResolved)", func(t *testing.T) {
+			issues := []testapi.Issue{
+				newTestIssue(t, "VULN_ID", "vulnerable@1.0.0",
+					withDepPaths(t, "root@1.0.0", "direct@1.0.0", "vulnerable@1.0.0"),
+					withUpgradeFix(t, testapi.PartiallyResolved, []string{"root@1.0.0", "direct@1.0.0", "vulnerable@1.0.1"}),
+				),
+			}
+
+			summary := GetRemediationSummary(issues)
+
+			require.Empty(t, summary.Upgrades, "transitive-only fix should not appear as a direct upgrade")
+			require.Empty(t, summary.Pins)
+			require.Len(t, summary.Unresolved, 1)
+		})
+
+		t.Run("upgrade path where only transitive dep changes is treated as unresolved (FullyResolved)", func(t *testing.T) {
+			issues := []testapi.Issue{
+				newTestIssue(t, "VULN_ID", "vulnerable@1.0.0",
+					withDepPaths(t, "root@1.0.0", "direct@1.0.0", "vulnerable@1.0.0"),
+					withUpgradeFix(t, testapi.FullyResolved, []string{"root@1.0.0", "direct@1.0.0", "vulnerable@1.0.1"}),
+				),
+			}
+
+			summary := GetRemediationSummary(issues)
+
+			require.Empty(t, summary.Upgrades, "transitive-only fix should not appear as a direct upgrade")
+			require.Empty(t, summary.Pins)
+			require.Len(t, summary.Unresolved, 1, "should be unresolved even with FullyResolved outcome when no direct dep changes")
+		})
+
+		t.Run("multiple same-version upgrade paths with FullyResolved goes to unresolved", func(t *testing.T) {
+			issues := []testapi.Issue{
+				newTestIssue(t, "VULN_ID", "vulnerable@1.0.0",
+					withDepPaths(t, "root@1.0.0", "direct-1@1.0.0", "vulnerable@1.0.0"),
+					withDepPaths(t, "root@1.0.0", "direct-2@2.0.0", "vulnerable@1.0.0"),
+					withDepPaths(t, "root@1.0.0", "direct-3@3.0.0", "vulnerable@1.0.0"),
+					withUpgradeFix(t, testapi.FullyResolved,
+						[]string{"root@1.0.0", "direct-1@1.0.0", "vulnerable@1.0.1"},
+						[]string{"root@1.0.0", "direct-2@2.0.0", "vulnerable@1.0.1"},
+						[]string{"root@1.0.0", "direct-3@3.0.0", "vulnerable@1.0.1"},
+					),
+				),
+			}
+
+			summary := GetRemediationSummary(issues)
+
+			require.Empty(t, summary.Upgrades, "all paths are transitive-only, no direct upgrades")
+			require.Empty(t, summary.Pins)
+			require.Len(t, summary.Unresolved, 1, "issue must be unresolved when all paths are transitive-only")
+		})
+
+		t.Run("mixed paths with real upgrade and transitive-only fix results in both upgrade and unresolved", func(t *testing.T) {
+			issues := []testapi.Issue{
+				newTestIssue(t, "VULN_ID", "vulnerable@1.0.0",
+					withDepPaths(t, "root@1.0.0", "direct-1@1.0.0", "vulnerable@1.0.0"),
+					withDepPaths(t, "root@1.0.0", "direct-2@2.0.0", "vulnerable@1.0.0"),
+					withUpgradeFix(t, testapi.PartiallyResolved,
+						[]string{"root@1.0.0", "direct-1@1.2.3", "vulnerable@1.0.1"},
+						[]string{"root@1.0.0", "direct-2@2.0.0", "vulnerable@1.0.1"},
+					),
+				),
+			}
+
+			summary := GetRemediationSummary(issues)
+
+			require.Len(t, summary.Upgrades, 1, "real direct upgrade should be present")
+			require.Equal(t, "direct-1", summary.Upgrades[0].FromPackage.Name)
+			require.Equal(t, "1.2.3", summary.Upgrades[0].ToPackage.Version)
+			require.Empty(t, summary.Pins)
+			require.Len(t, summary.Unresolved, 1, "issue should also be unresolved due to transitive-only path")
 		})
 	})
 }

--- a/internal/ufm_helpers/remediation_test.go
+++ b/internal/ufm_helpers/remediation_test.go
@@ -400,6 +400,26 @@ func TestGetRemediationSummary(t *testing.T) {
 			require.Empty(t, summary.Unresolved, "same issue ID should be removed from unresolved when covered by pin")
 		})
 
+		t.Run("unresolved issues NOT covered by pin remediation remain unresolved", func(t *testing.T) {
+			issues := []testapi.Issue{
+				newTestIssue(t, "VULN_ID_1", "vulnerable@1.0.0",
+					withDepPaths(t, "root@1.0.0", "direct@1.0.0", "vulnerable@1.0.0"),
+					withPinFix(t, testapi.PartiallyResolved, "vulnerable", "1.0.1"),
+				),
+				newTestIssue(t, "VULN_ID_2", "vulnerable@2.0.0",
+					withDepPaths(t, "root@1.0.0", "direct@2.0.0", "vulnerable@2.0.0"),
+					withUnresolvedFix(),
+				),
+			}
+
+			summary := GetRemediationSummary(issues)
+
+			require.Len(t, summary.Pins, 1)
+			require.Empty(t, summary.Upgrades)
+			require.Len(t, summary.Unresolved, 1, "different issue ID should remain in unresolved")
+			require.Equal(t, "VULN_ID_2", summary.Unresolved[0].GetID())
+		})
+
 		t.Run("an issue containing an unresolved fix action returns valid summary", func(t *testing.T) {
 			issues := []testapi.Issue{
 				newTestIssue(t, "VULN_ID", "vulnerable@1.0.0",


### PR DESCRIPTION
### Description

In certain cases the Remediation Summary would count transitive dependency upgrades as directly upgradable. This would results in incorrect upgrade advice (e.g. `Upgrade from x@1.2.3 to x@1.2.3` - since the actual upgrade would be inside for a nested dependency).

The changes should allign the remediation summary building with the legacy implementation that can be found [here](https://github.com/snyk/cli/blob/b144a8f10b03f298e23bae08c04e3fa4a787faca/src/lib/formatters/remediation-based-format-issues.ts#L27). In terms of tests, I added a few more cases to the remedation testing logic to get the coverage to 85%, but I also slightly updated the `testresults_cli.json` to the newer TestAPI structure in order to add it as a test case for the human readable output.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [ ] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
