### PR TITLE
fix: remove duplicate rules from SARIF output

### DIFF
--- a/internal/presenters/funcs.go
+++ b/internal/presenters/funcs.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"os"
 	"reflect"
 	"slices"
 	"strconv"
@@ -386,8 +387,38 @@ func getDefaultTemplateFuncMap(config configuration.Configuration, ri runtimeinf
 	defaultMap["getTargetId"] = func(path string) (string, error) {
 		return target.GetTargetId(path, target.AutoDetectedTargetId, target.WithConfiguredRepository(config))
 	}
+	defaultMap["deduplicateIssues"] = deduplicateIssues
 
 	return defaultMap
+}
+
+type issueDedupeKey string
+
+const (
+	DedupeByProblemID issueDedupeKey = "problemID"
+	DedupeByID        issueDedupeKey = "id"
+)
+
+// deduplicateIssues returns a subset of issues with unique keys, preserving order (first-wins).
+func deduplicateIssues(issues []testapi.Issue, key issueDedupeKey) []testapi.Issue {
+	seen := make(map[string]bool)
+	result := make([]testapi.Issue, 0, len(issues))
+	for _, issue := range issues {
+		var field string
+		switch key {
+		case DedupeByProblemID:
+			field = issue.GetProblemID()
+		case DedupeByID:
+			field = issue.GetID()
+		default:
+			fmt.Fprintf(os.Stderr, "warning: unsupported issueDedupeKey %q, skipping deduplication for issue\n", key)
+		}
+		if field != "" && !seen[field] {
+			seen[field] = true
+			result = append(result, issue)
+		}
+	}
+	return result
 }
 
 func convertTypeToIssueName(findingType testapi.FindingType) string {

--- a/internal/presenters/presenter_ufm_test.go
+++ b/internal/presenters/presenter_ufm_test.go
@@ -131,7 +131,11 @@ func sortByID(arr []interface{}) {
 	})
 }
 
-// sortByRuleID sorts an array of results by their "ruleId" field
+// sortByRuleID sorts results for stable comparison. Tiebreakers (in order):
+//  1. ruleId — primary key
+//  2. artifact URI — needed when multiple findings share the same rule but differ in file
+//  3. fingerprint identity — needed when findings share both rule and file (e.g. same secret
+//     rule detected at different locations in the same file)
 func sortByRuleID(arr []interface{}) {
 	sort.Slice(arr, func(i, j int) bool {
 		iMap, iOk := arr[i].(map[string]interface{})
@@ -141,8 +145,51 @@ func sortByRuleID(arr []interface{}) {
 		}
 		iID, _ := iMap["ruleId"].(string) //nolint:errcheck // test helper, ok to ignore
 		jID, _ := jMap["ruleId"].(string) //nolint:errcheck // test helper, ok to ignore
-		return iID < jID
+		if iID != jID {
+			return iID < jID
+		}
+		iURI := extractArtifactURI(iMap)
+		jURI := extractArtifactURI(jMap)
+		if iURI != jURI {
+			return iURI < jURI
+		}
+		return extractFingerprint(iMap) < extractFingerprint(jMap)
 	})
+}
+
+func extractFingerprint(result map[string]interface{}) string {
+	fps, ok := result["fingerprints"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	if id, ok := fps["identity"].(string); ok {
+		return id
+	}
+	return ""
+}
+
+func extractArtifactURI(result map[string]interface{}) string {
+	locations, ok := result["locations"].([]interface{})
+	if !ok || len(locations) == 0 {
+		return ""
+	}
+	loc, ok := locations[0].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	physLoc, ok := loc["physicalLocation"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	artLoc, ok := physLoc["artifactLocation"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	uri, ok := artLoc["uri"].(string)
+	if !ok {
+		return ""
+	}
+	return uri
 }
 
 // normalizeHelpContent removes help.markdown content to avoid comparing test data descriptions
@@ -552,6 +599,12 @@ func Test_UfmPresenter_Sarif(t *testing.T) {
 			name:               "secrets",
 			expectedSarifPath:  "testdata/ufm/secrets.0findings.sarif.json",
 			testResultPath:     "testdata/ufm/secrets.0findings.testresult.json",
+			ignoreSuppressions: true,
+		},
+		{
+			name:               "secrets_duplicated_rules",
+			expectedSarifPath:  "testdata/ufm/secrets.duplicated-sarif-rules.sarif.json",
+			testResultPath:     "testdata/ufm/secrets.duplicated-sarif-rules.testresult.json",
 			ignoreSuppressions: true,
 		},
 	}
@@ -1131,6 +1184,13 @@ func Test_UfmPresenter_HumanReadable(t *testing.T) {
 			expectedPath:      "testdata/ufm/multi_project.human.readable",
 			testResultPath:    "testdata/ufm/multi_project.testresult.json",
 			includeIgnores:    false,
+			severityThreshold: "",
+		},
+		{
+			name:              "secrets_duplicated_rules",
+			expectedPath:      "testdata/ufm/secrets.duplicated-sarif-rules.human.readable",
+			testResultPath:    "testdata/ufm/secrets.duplicated-sarif-rules.testresult.json",
+			includeIgnores:    true,
 			severityThreshold: "",
 		},
 	}

--- a/internal/presenters/templates/ufm.sarif.tmpl
+++ b/internal/presenters/templates/ufm.sarif.tmpl
@@ -17,11 +17,12 @@
 						"version" : "{{- getRuntimeInfo "version" }}",
 						"informationUri" : "https://docs.snyk.io/",
 						"rules" : [
-							{{- range $index, $issue := $issues }}
+							{{- $uniqueRules := deduplicateIssues $issues "problemID" }}
+							{{- $rulesSize := sub (len $uniqueRules) 1 }}
+							{{- range $index, $issue := $uniqueRules }}
 							{{- $tags := buildRuleTags $issue }}
 							{{- $cvssScore := getRuleCVSSScore $issue }}
 							{{- $problemID := $issue.GetProblemID }}
-							{{- if not $problemID }}{{ $problemID = $issue.GetID }}{{ end }}
 							{
 								"id": {{ getQuotedString $problemID }},
 								"shortDescription": {
@@ -46,7 +47,7 @@
 									"cvssv3_baseScore": {{ $cvssScore }},
 									"security-severity": {{ getQuotedString (printf "%.1f" $cvssScore) }}{{end}}
 								}
-							}{{if lt $index $issuesSize}},{{end}}
+							}{{if lt $index $rulesSize}},{{end}}
 							{{- end }}
 						]
 						{{- $dependencyCount := index $metadata "dependency-count" }}
@@ -71,7 +72,6 @@
 				{{- $ignoreDetails := $issue.GetIgnoreDetails }}
 				{{- $problemID := $issue.GetProblemID }}
 				{{- $fingerPrintID := $issue.GetID }}
-				{{- if not $problemID }}{{ $problemID = $issue.GetID }}{{ end }}
 				{
 					"ruleId": {{ getQuotedString $problemID }},
 					"level": {{ getQuotedString (severityToSarifLevel $issue.GetSeverity) }},

--- a/internal/presenters/testdata/ufm/secrets.duplicated-sarif-rules.human.readable
+++ b/internal/presenters/testdata/ufm/secrets.duplicated-sarif-rules.human.readable
@@ -1,0 +1,45 @@
+[1mTesting  () ...[0m
+
+[1mOpen Secrets issues: 5[0m
+
+ ✗ [31m[HIGH][0m [1mGeneric Secret Key[0m
+   Finding ID: 00000000-0000-0000-0000-000000000000
+   Info: Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.
+   Path: generic/file with spaces, line 2 to 2
+   Path: generic/file with spaces, line 3 to 3
+
+ ✗ [31m[HIGH][0m [1mGeneric Secret Key[0m
+   Finding ID: 00000000-0000-0000-0000-000000000001
+   Info: Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.
+   Path: generic/secret, line 2 to 2
+   Path: generic/secret, line 3 to 3
+
+ ✗ [31m[HIGH][0m [1mGeneric Secret Key[0m
+   Finding ID: 00000000-0000-0000-0000-000000000002
+   Info: Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.
+   Path: generic/config.json, line 2 to 2
+   Path: generic/config.json, line 3 to 3
+   Path: generic/config.json, line 4 to 4
+
+ ✗ [31m[HIGH][0m [1mGeneric Secret Key[0m
+   Finding ID: 00000000-0000-0000-0000-000000000003
+   Info: Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.
+   Path: generic/file with spaces, line 1 to 1
+
+ ✗ [31m[HIGH][0m [1mGeneric Secret Key[0m
+   Finding ID: 00000000-0000-0000-0000-000000000004
+   Info: Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.
+   Path: generic/secret, line 1 to 1
+
+╭─────────────────────────────────────────────────────────╮
+│ [1mTest Summary[0m                                            │
+│                                                         │
+│   Organization:      My Org                             │
+│   Test type:         Secret Detection                   │
+│   Project path:                                         │
+│                                                         │
+│   Total secrets issues: 5                               │
+│   Ignored: [1m0[0m [[35m 0 CRITICAL [0m[31m 0 HIGH [0m[33m 0 MEDIUM [0m 0 LOW ]    │
+│   Open   : [1m5[0m [[35m 0 CRITICAL [0m[31m 5 HIGH [0m[33m 0 MEDIUM [0m 0 LOW ]    │
+╰─────────────────────────────────────────────────────────╯
+

--- a/internal/presenters/testdata/ufm/secrets.duplicated-sarif-rules.sarif.json
+++ b/internal/presenters/testdata/ufm/secrets.duplicated-sarif-rules.sarif.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "automationDetails": {
+        "id": "Snyk/Secrets/0/*"
+      },
+      "results": [
+        {
+          "fingerprints": {
+            "identity": "00000000-0000-0000-0000-000000000002",
+            "snyk/asset/finding/v1": "00000000-0000-0000-0000-000000000002"
+          },
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "generic/config.json"
+                },
+                "region": {
+                  "endColumn": 48,
+                  "endLine": 2,
+                  "startColumn": 16,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "This file contains a high severity Generic Secret Key vulnerability."
+          },
+          "ruleId": "generic-secret"
+        },
+        {
+          "fingerprints": {
+            "identity": "00000000-0000-0000-0000-000000000000",
+            "snyk/asset/finding/v1": "00000000-0000-0000-0000-000000000000"
+          },
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "generic/file with spaces"
+                },
+                "region": {
+                  "endColumn": 99,
+                  "endLine": 2,
+                  "startColumn": 11,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "This file contains a high severity Generic Secret Key vulnerability."
+          },
+          "ruleId": "generic-secret"
+        },
+        {
+          "fingerprints": {
+            "identity": "00000000-0000-0000-0000-000000000003",
+            "snyk/asset/finding/v1": "00000000-0000-0000-0000-000000000003"
+          },
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "generic/file with spaces"
+                },
+                "region": {
+                  "endColumn": 29,
+                  "endLine": 1,
+                  "startColumn": 9,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "This file contains a high severity Generic Secret Key vulnerability."
+          },
+          "ruleId": "generic-secret"
+        },
+        {
+          "fingerprints": {
+            "identity": "00000000-0000-0000-0000-000000000001",
+            "snyk/asset/finding/v1": "00000000-0000-0000-0000-000000000001"
+          },
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "generic/secret"
+                },
+                "region": {
+                  "endColumn": 99,
+                  "endLine": 2,
+                  "startColumn": 11,
+                  "startLine": 2
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "This file contains a high severity Generic Secret Key vulnerability."
+          },
+          "ruleId": "generic-secret"
+        },
+        {
+          "fingerprints": {
+            "identity": "00000000-0000-0000-0000-000000000004",
+            "snyk/asset/finding/v1": "00000000-0000-0000-0000-000000000004"
+          },
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "generic/secret"
+                },
+                "region": {
+                  "endColumn": 29,
+                  "endLine": 1,
+                  "startColumn": 9,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "This file contains a high severity Generic Secret Key vulnerability."
+          },
+          "ruleId": "generic-secret"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://docs.snyk.io/",
+          "name": "Snyk Secrets",
+          "rules": [
+            {
+              "help": {
+                "markdown": "Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.",
+                "text": ""
+              },
+              "id": "generic-secret",
+              "properties": {
+                "tags": [
+                  "CWE-798",
+                  "security"
+                ]
+              },
+              "shortDescription": {
+                "text": "Generic Secret Key"
+              }
+            }
+          ],
+          "semanticVersion": "1.1301.0",
+          "version": "1.1301.0"
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/presenters/testdata/ufm/secrets.duplicated-sarif-rules.testresult.json
+++ b/internal/presenters/testdata/ufm/secrets.duplicated-sarif-rules.testresult.json
@@ -1,0 +1,231 @@
+[
+    {
+      "testId": "d558fcea-76d4-461b-bf6e-78ef547b4e18",
+      "testConfiguration": {
+        "local_policy": {
+          "fail_on_upgradable": false,
+          "severity_threshold": "low",
+          "suppress_pending_ignores": false
+        },
+        "project_environment": [],
+        "project_lifecycle": [],
+        "project_tags": [],
+        "scan_config": { "secrets": {} },
+        "timeout": { "outcome": "fail", "seconds": 1200 }
+      },
+      "createdAt": "2026-04-15T13:09:48.973061Z",
+      "executionState": "finished",
+      "passFail": "fail",
+      "outcomeReason": "policy_breach",
+      "effectiveSummary": {
+        "count": 5,
+        "count_by": {
+          "result_type": { "secret": 5 },
+          "severity": { "critical": 0, "high": 5, "low": 0, "medium": 0 }
+        }
+      },
+      "rawSummary": {
+        "count": 5,
+        "count_by": {
+          "result_type": { "secret": 5 },
+          "severity": { "critical": 0, "high": 5, "low": 0, "medium": 0 }
+        }
+      },
+      "findingsComplete": true,
+      "problemStore": {
+        "CWE-798": { "id": "CWE-798", "source": "cwe" },
+        "generic-secret": {
+          "categories": ["Security"],
+          "help": "Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.",
+          "id": "generic-secret",
+          "name": "Generic Secret Key",
+          "precision": "very-high",
+          "severity": "high",
+          "short_description": "Generic Secret Key",
+          "source": "secret",
+          "tags": ["type:secret-key", "provider:generic"]
+        }
+      },
+      "_problemRefs": {
+        "00000000-0000-0000-0000-000000000000": ["CWE-798", "generic-secret"],
+        "00000000-0000-0000-0000-000000000001": ["CWE-798", "generic-secret"],
+        "00000000-0000-0000-0000-000000000002": ["CWE-798", "generic-secret"],
+        "00000000-0000-0000-0000-000000000003": ["CWE-798", "generic-secret"],
+        "00000000-0000-0000-0000-000000000004": ["CWE-798", "generic-secret"]
+      },
+      "findings": [
+        {
+          "attributes": {
+            "cause_of_failure": false,
+            "description": "Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.",
+            "evidence": [],
+            "finding_type": "secret",
+            "key": "00000000-0000-0000-0000-000000000000",
+            "locations": [
+              {
+                "file_path": "generic/file with spaces",
+                "from_column": 11,
+                "from_line": 2,
+                "to_column": 99,
+                "to_line": 2,
+                "type": "source"
+              },
+              {
+                "file_path": "generic/file with spaces",
+                "from_column": 13,
+                "from_line": 3,
+                "to_column": 101,
+                "to_line": 3,
+                "type": "source"
+              }
+            ],
+            "policy_modifications": [],
+            "problems": null,
+            "rating": { "severity": "high" },
+            "risk": {},
+            "title": "Generic Secret Key"
+          },
+          "id": "00000000-0000-0000-0000-000000000000",
+          "links": {},
+          "relationships": {},
+          "type": "findings"
+        },
+        {
+          "attributes": {
+            "cause_of_failure": false,
+            "description": "Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.",
+            "evidence": [],
+            "finding_type": "secret",
+            "key": "00000000-0000-0000-0000-000000000001",
+            "locations": [
+              {
+                "file_path": "generic/secret",
+                "from_column": 11,
+                "from_line": 2,
+                "to_column": 99,
+                "to_line": 2,
+                "type": "source"
+              },
+              {
+                "file_path": "generic/secret",
+                "from_column": 13,
+                "from_line": 3,
+                "to_column": 101,
+                "to_line": 3,
+                "type": "source"
+              }
+            ],
+            "policy_modifications": [],
+            "problems": null,
+            "rating": { "severity": "high" },
+            "risk": {},
+            "title": "Generic Secret Key"
+          },
+          "id": "00000000-0000-0000-0000-000000000001",
+          "links": {},
+          "relationships": {},
+          "type": "findings"
+        },
+        {
+          "attributes": {
+            "cause_of_failure": false,
+            "description": "Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.",
+            "evidence": [],
+            "finding_type": "secret",
+            "key": "00000000-0000-0000-0000-000000000002",
+            "locations": [
+              {
+                "file_path": "generic/config.json",
+                "from_column": 16,
+                "from_line": 2,
+                "to_column": 48,
+                "to_line": 2,
+                "type": "source"
+              },
+              {
+                "file_path": "generic/config.json",
+                "from_column": 14,
+                "from_line": 3,
+                "to_column": 46,
+                "to_line": 3,
+                "type": "source"
+              },
+              {
+                "file_path": "generic/config.json",
+                "from_column": 33,
+                "from_line": 4,
+                "to_column": 65,
+                "to_line": 4,
+                "type": "source"
+              }
+            ],
+            "policy_modifications": [],
+            "problems": null,
+            "rating": { "severity": "high" },
+            "risk": {},
+            "title": "Generic Secret Key"
+          },
+          "id": "00000000-0000-0000-0000-000000000002",
+          "links": {},
+          "relationships": {},
+          "type": "findings"
+        },
+        {
+          "attributes": {
+            "cause_of_failure": false,
+            "description": "Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.",
+            "evidence": [],
+            "finding_type": "secret",
+            "key": "00000000-0000-0000-0000-000000000003",
+            "locations": [
+              {
+                "file_path": "generic/file with spaces",
+                "from_column": 9,
+                "from_line": 1,
+                "to_column": 29,
+                "to_line": 1,
+                "type": "source"
+              }
+            ],
+            "policy_modifications": [],
+            "problems": null,
+            "rating": { "severity": "high" },
+            "risk": {},
+            "title": "Generic Secret Key"
+          },
+          "id": "00000000-0000-0000-0000-000000000003",
+          "links": {},
+          "relationships": {},
+          "type": "findings"
+        },
+        {
+          "attributes": {
+            "cause_of_failure": false,
+            "description": "Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.",
+            "evidence": [],
+            "finding_type": "secret",
+            "key": "00000000-0000-0000-0000-000000000004",
+            "locations": [
+              {
+                "file_path": "generic/secret",
+                "from_column": 9,
+                "from_line": 1,
+                "to_column": 29,
+                "to_line": 1,
+                "type": "source"
+              }
+            ],
+            "policy_modifications": [],
+            "problems": null,
+            "rating": { "severity": "high" },
+            "risk": {},
+            "title": "Generic Secret Key"
+          },
+          "id": "00000000-0000-0000-0000-000000000004",
+          "links": {},
+          "relationships": {},
+          "type": "findings"
+        }
+      ]
+    }
+  ]


### PR DESCRIPTION
### Description

Deduplicates SARIF rules by problem ID in UFM output to fix duplicate rule entries. When multiple findings share the same problem ID (e.g., two `generic-api-key` secrets found in different files), the SARIF output previously emitted one rule per finding, producing duplicate rule IDs in the `rules` array. Per the [SARIF v2.1.0 spec](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html), rule IDs must be unique within the `rules` array.

The fix adds a `deduplicateIssuesByProblemID` template function that filters the issues list to one entry per unique problem ID (first-wins) for the `rules` loop only. The `results` loop is unchanged — all findings still appear as individual results referencing their shared rule.

**Relevant ticket:** [CLI-1344](https://snyksec.atlassian.net/browse/CLI-1344)

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.

[CLI-1344]: https://snyksec.atlassian.net/browse/CLI-1344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ