### PR TITLE
feat: update ldx-sync API spec to reduced centralized config allowlist [IDE-1895]

### DIFF
--- a/pkg/apiclients/ldx_sync_config/ldx_sync/2024-10-15/ldx_sync.go
+++ b/pkg/apiclients/ldx_sync_config/ldx_sync/2024-10-15/ldx_sync.go
@@ -59,39 +59,27 @@ const (
 
 // Defines values for FolderSettingName.
 const (
-	AdditionalEnvironment FolderSettingName = "additional_environment"
-	AdditionalParameters  FolderSettingName = "additional_parameters"
-	PreAssignedOrgId      FolderSettingName = "pre_assigned_org_id"
-	ReferenceBranch       FolderSettingName = "reference_branch"
-	ReferenceFolder       FolderSettingName = "reference_folder"
+	PreAssignedOrgId FolderSettingName = "pre_assigned_org_id"
 )
 
 // Defines values for GlobalSettingName.
 const (
-	ApiEndpoint                         GlobalSettingName = "api_endpoint"
-	AuthenticationMethod                GlobalSettingName = "authentication_method"
-	AutoConfigureMcpServer              GlobalSettingName = "auto_configure_mcp_server"
-	AutomaticDownload                   GlobalSettingName = "automatic_download"
-	BinaryBaseUrl                       GlobalSettingName = "binary_base_url"
-	CliPath                             GlobalSettingName = "cli_path"
-	CliReleaseChannel                   GlobalSettingName = "cli_release_channel"
-	CodeEndpoint                        GlobalSettingName = "code_endpoint"
-	CveIds                              GlobalSettingName = "cve_ids"
-	CweIds                              GlobalSettingName = "cwe_ids"
-	EnabledProducts                     GlobalSettingName = "enabled_products"
-	EnabledSeverities                   GlobalSettingName = "enabled_severities"
-	IssueViewIgnoredIssues              GlobalSettingName = "issue_view_ignored_issues"
-	IssueViewOpenIssues                 GlobalSettingName = "issue_view_open_issues"
-	ProxyHttp                           GlobalSettingName = "proxy_http"
-	ProxyHttps                          GlobalSettingName = "proxy_https"
-	ProxyInsecure                       GlobalSettingName = "proxy_insecure"
-	ProxyNoProxy                        GlobalSettingName = "proxy_no_proxy"
-	RiskScoreThreshold                  GlobalSettingName = "risk_score_threshold"
-	RuleIds                             GlobalSettingName = "rule_ids"
-	ScanAutomatic                       GlobalSettingName = "scan_automatic"
-	ScanNetNew                          GlobalSettingName = "scan_net_new"
-	SecureAtInceptionExecutionFrequency GlobalSettingName = "secure_at_inception_execution_frequency"
-	TrustEnabled                        GlobalSettingName = "trust_enabled"
+	AutomaticDownload       GlobalSettingName = "automatic_download"
+	CliReleaseChannel       GlobalSettingName = "cli_release_channel"
+	IssueViewIgnoredIssues  GlobalSettingName = "issue_view_ignored_issues"
+	IssueViewOpenIssues     GlobalSettingName = "issue_view_open_issues"
+	ProductCodeEnabled      GlobalSettingName = "product_code_enabled"
+	ProductContainerEnabled GlobalSettingName = "product_container_enabled"
+	ProductIacEnabled       GlobalSettingName = "product_iac_enabled"
+	ProductOssEnabled       GlobalSettingName = "product_oss_enabled"
+	ProductSecretsEnabled   GlobalSettingName = "product_secrets_enabled"
+	RiskScoreThreshold      GlobalSettingName = "risk_score_threshold"
+	ScanAutomatic           GlobalSettingName = "scan_automatic"
+	ScanNetNew              GlobalSettingName = "scan_net_new"
+	SeverityCriticalEnabled GlobalSettingName = "severity_critical_enabled"
+	SeverityHighEnabled     GlobalSettingName = "severity_high_enabled"
+	SeverityLowEnabled      GlobalSettingName = "severity_low_enabled"
+	SeverityMediumEnabled   GlobalSettingName = "severity_medium_enabled"
 )
 
 // Defines values for SettingMetadataOrigin.
@@ -431,8 +419,7 @@ type FolderConfig struct {
 }
 
 // FolderConfigInput Input for creating a folder configuration.
-// All folder-level configuration (reference_branch, organization, etc.) should be
-// stored as settings, not as dedicated fields. This keeps the API flexible.
+// Folder-specific options (for example pre_assigned_org_id) are expressed as folder-level settings.
 type FolderConfigInput struct {
 	// FolderPath Path within the repository
 	FolderPath string `json:"folder_path"`
@@ -441,7 +428,7 @@ type FolderConfigInput struct {
 	RemoteUrl string `json:"remote_url"`
 
 	// Settings Folder-level settings (only FolderSettingName allowed). Distinct from global; no overlap.
-	// Examples: reference_branch, reference_folder, pre_assigned_org_id, additional_parameters, additional_environment.
+	// Example: pre_assigned_org_id.
 	Settings *[]FolderSettingInput `json:"settings,omitempty"`
 }
 

--- a/pkg/apiclients/ldx_sync_config/ldx_sync/2024-10-15/spec.yaml
+++ b/pkg/apiclients/ldx_sync_config/ldx_sync/2024-10-15/spec.yaml
@@ -753,8 +753,7 @@ components:
       additionalProperties: false
       description: |
         Input for creating a folder configuration.
-        All folder-level configuration (reference_branch, organization, etc.) should be
-        stored as settings, not as dedicated fields. This keeps the API flexible.
+        Folder-specific options (for example pre_assigned_org_id) are expressed as folder-level settings.
       properties:
         folder_path:
           description: Path within the repository
@@ -767,7 +766,7 @@ components:
         settings:
           description: |
             Folder-level settings (only FolderSettingName allowed). Distinct from global; no overlap.
-            Examples: reference_branch, reference_folder, pre_assigned_org_id, additional_parameters, additional_environment.
+            Example: pre_assigned_org_id.
           items:
             $ref: '#/components/schemas/FolderSettingInput'
           type: array
@@ -796,7 +795,7 @@ components:
           $ref: '#/components/schemas/FolderSettingName'
         value:
           description: Setting value (type depends on the setting; validated server-side)
-          example: main
+          example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
       required:
       - name
       - value
@@ -805,10 +804,6 @@ components:
       description: Setting names allowed at folder level only. Must not be used in
         top-level settings.
       enum:
-      - reference_folder
-      - reference_branch
-      - additional_parameters
-      - additional_environment
       - pre_assigned_org_id
       type: string
     GlobalSettingInput:
@@ -828,7 +823,7 @@ components:
           $ref: '#/components/schemas/GlobalSettingName'
         value:
           description: Setting value (type depends on the setting; validated server-side)
-          example: https://api.snyk.io
+          example: true
       required:
       - name
       - value
@@ -837,28 +832,20 @@ components:
       description: Setting names allowed at global level only. Must not be used in
         folder_configs[].settings.
       enum:
-      - api_endpoint
-      - code_endpoint
-      - authentication_method
-      - proxy_http
-      - proxy_https
-      - proxy_no_proxy
-      - proxy_insecure
-      - enabled_severities
+      - severity_critical_enabled
+      - severity_high_enabled
+      - severity_medium_enabled
+      - severity_low_enabled
       - risk_score_threshold
-      - cwe_ids
-      - cve_ids
-      - rule_ids
-      - enabled_products
+      - product_oss_enabled
+      - product_code_enabled
+      - product_iac_enabled
+      - product_container_enabled
+      - product_secrets_enabled
       - scan_automatic
       - scan_net_new
       - issue_view_open_issues
       - issue_view_ignored_issues
-      - auto_configure_mcp_server
-      - secure_at_inception_execution_frequency
-      - trust_enabled
-      - binary_base_url
-      - cli_path
       - automatic_download
       - cli_release_channel
       type: string


### PR DESCRIPTION
## Summary

- Syncs `spec.yaml` from ldx-sync `feat/IDE-1895_centralized-config-setting-allowlist` and regenerates the oapi-codegen client
- `GlobalSettingName` now uses individual boolean fields for products (`product_oss_enabled`, `product_code_enabled`, `product_iac_enabled`, `product_container_enabled`, `product_secrets_enabled`) and severities (`severity_critical_enabled`, `severity_high_enabled`, `severity_medium_enabled`, `severity_low_enabled`) instead of the former string-array `enabled_products`/`enabled_severities`
- Removes settings no longer managed via centralized config: `api_endpoint`, `code_endpoint`, `authentication_method`, `proxy_*`, `cwe/cve/rule_ids`, `auto_configure_mcp_server`, `secure_at_inception_execution_frequency`, `trust_enabled`, `binary_base_url`, `cli_path`
- `FolderSettingName` reduced to `pre_assigned_org_id` only (removed `reference_folder`, `reference_branch`, `additional_parameters`, `additional_environment`)

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] Full test suite passes (`go test ./...` — 47 packages, 0 failures)
- [ ] Verify downstream consumers (snyk-ls `feat/IDE-1816_split-products-and-filters`) compile against this GAF branch


Made with [Cursor](https://cursor.com)