### PR TITLE
feat: add StripGitCredentials and NormalizeGitURL [IDE-1915]

### DIFF
--- a/pkg/utils/git/git.go
+++ b/pkg/utils/git/git.go
@@ -2,6 +2,8 @@ package git
 
 import (
 	"fmt"
+	"net/url"
+	"strings"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
@@ -52,6 +54,138 @@ func RepoFromDir(inputDir string) (*git.Repository, *config.RemoteConfig, error)
 		return repo, nil, fmt.Errorf("no remote url found")
 	}
 	return repo, remoteConfig, nil
+}
+
+// StripGitCredentials removes userinfo (username, password, token) from a git URL.
+// For SCP-style URLs (user@host:path), the user@ portion is stripped since it may
+// contain tokens used as usernames. For scheme:// URLs, the standard userinfo is
+// removed. If url.Parse fails (e.g., malformed port), a pattern-based fallback
+// strips credentials from the raw string to prevent leakage.
+func StripGitCredentials(rawUrl string) string {
+	if rawUrl == "" {
+		return rawUrl
+	}
+
+	return stripGitCredentials(rawUrl, isSCPStyle(rawUrl))
+}
+
+func stripGitCredentials(rawUrl string, scpStyle bool) string {
+	if rawUrl == "" {
+		return rawUrl
+	}
+
+	// SCP-style URLs (user@host:path) — strip the user@ portion.
+	// The result is used for logging/API calls, not SSH connections,
+	// so removing the username is safe and prevents token-as-username leakage.
+	if scpStyle {
+		atIdx := strings.Index(rawUrl, "@")
+		colonIdx := strings.Index(rawUrl, ":")
+		if atIdx < 0 || colonIdx < 0 || atIdx > colonIdx {
+			return rawUrl
+		}
+		return rawUrl[atIdx+1:]
+	}
+
+	u, err := url.Parse(rawUrl)
+	if err != nil {
+		// url.Parse failed (e.g., invalid port) — fall back to pattern-based stripping
+		return stripCredentialsByPattern(rawUrl)
+	}
+
+	if u.User != nil {
+		u.User = nil
+		return u.String()
+	}
+
+	return rawUrl
+}
+
+// stripCredentialsByPattern removes user[:pass]@ from a URL string using pattern matching.
+// Used as a fallback when url.Parse fails on malformed URLs that still contain credentials.
+func stripCredentialsByPattern(rawUrl string) string {
+	schemeEnd := strings.Index(rawUrl, "://")
+	if schemeEnd < 0 {
+		return rawUrl
+	}
+	rest := rawUrl[schemeEnd+3:]
+
+	authorityEnd := strings.Index(rest, "/")
+	if authorityEnd < 0 {
+		authorityEnd = len(rest)
+	}
+	authority := rest[:authorityEnd]
+	atIdx := strings.LastIndex(authority, "@")
+	if atIdx < 0 {
+		return rawUrl
+	}
+
+	return rawUrl[:schemeEnd+3] + authority[atIdx+1:] + rest[authorityEnd:]
+}
+
+// NormalizeGitURL converts any git remote URL format (SSH, SCP-style, git://, http://)
+// into a consistent https:// URL with credentials removed and .git suffix stripped.
+// If the URL cannot be parsed, the credential-stripped input is returned as-is.
+func NormalizeGitURL(rawUrl string) string {
+	if rawUrl == "" {
+		return rawUrl
+	}
+
+	scpStyle := isSCPStyle(rawUrl)
+
+	// Handle SCP-style on the original input before credential stripping.
+	// StripGitCredentials turns user@host:path into host:path, which url.Parse
+	// would misinterpret as scheme:path. So we extract host and path directly.
+	if scpStyle {
+		atIdx := strings.Index(rawUrl, "@")
+		colonIdx := strings.Index(rawUrl, ":")
+		host := rawUrl[atIdx+1 : colonIdx]
+		path := strings.TrimSuffix(rawUrl[colonIdx+1:], ".git")
+		return "https://" + host + "/" + path
+	}
+
+	sanitized := stripGitCredentials(rawUrl, scpStyle)
+
+	u, err := url.Parse(sanitized)
+	if err != nil {
+		return sanitized
+	}
+
+	u.User = nil
+
+	switch u.Scheme {
+	case "ssh", "git+ssh", "ssh+git":
+		u.Scheme = "https"
+		// Strip SSH port — it's protocol-specific (e.g., 22, 7999) and doesn't map
+		// to the HTTPS port. HTTP/HTTPS ports are preserved in their respective cases
+		// because they represent the actual service port for that protocol.
+		u.Host = u.Hostname()
+		u.Path = strings.TrimSuffix(u.Path, ".git")
+		return u.String()
+	case "git", "http", "git+http":
+		u.Scheme = "https"
+		u.Path = strings.TrimSuffix(u.Path, ".git")
+		return u.String()
+	case "https", "git+https":
+		u.Scheme = "https"
+		u.Path = strings.TrimSuffix(u.Path, ".git")
+		return u.String()
+	default:
+		return sanitized
+	}
+}
+
+// isSCPStyle returns true if the URL uses SCP-style syntax (e.g., git@github.com:org/repo.git).
+// Detects user@host:path patterns without a scheme prefix ("://"), where userinfo
+// appears before the host/path separator ":".
+func isSCPStyle(rawUrl string) bool {
+	if strings.Contains(rawUrl, "://") {
+		return false
+	}
+
+	atIdx := strings.Index(rawUrl, "@")
+	colonIdx := strings.Index(rawUrl, ":")
+
+	return atIdx >= 0 && colonIdx >= 0 && atIdx < colonIdx
 }
 
 // GetRemoteUrl retrieves the appropriate remote URL for LDX-Sync resolution.

--- a/pkg/utils/git/git_test.go
+++ b/pkg/utils/git/git_test.go
@@ -9,6 +9,77 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestStripGitCredentials(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty string", "", ""},
+		{"https with user and password", "https://user:password@github.com/org/repo.git", "https://github.com/org/repo.git"},
+		{"https with oauth2 token", "https://oauth2:ghp_abc123@github.com/org/repo.git", "https://github.com/org/repo.git"},
+		{"https with username only", "https://user@github.com/org/repo.git", "https://github.com/org/repo.git"},
+		{"http with credentials", "http://user:pass@gitlab.com/org/repo", "http://gitlab.com/org/repo"},
+		{"malformed password with @ strips full userinfo", "https://user:p@ss@host:port8080/path", "https://host:port8080/path"},
+		{"ssh with userinfo", "ssh://git@github.com/org/repo.git", "ssh://github.com/org/repo.git"},
+		{"scp-style strips user", "git@github.com:org/repo.git", "github.com:org/repo.git"},
+		{"scp-style with token user", "TOKEN@host:org/repo.git", "host:org/repo.git"},
+		{"scp-style with deploy user", "deploy@gitlab.com:org/repo.git", "gitlab.com:org/repo.git"},
+		{"scp-style with @ in path keeps path @", "git@github.com:org/repo@v2.git", "github.com:org/repo@v2.git"},
+		{"scp-like without userinfo and @ in path unchanged", "github.com:org/repo@v2.git", "github.com:org/repo@v2.git"},
+		{"clean https unchanged", "https://github.com/org/repo.git", "https://github.com/org/repo.git"},
+		{"git protocol no credentials", "git://github.com/org/repo.git", "git://github.com/org/repo.git"},
+		{"malformed port with credentials", "https://user:pass@host:port8080/path", "https://host:port8080/path"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := StripGitCredentials(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNormalizeGitURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty string", "", ""},
+		{"scp-style", "git@github.com:org/repo.git", "https://github.com/org/repo"},
+		{"scp-style without .git suffix", "git@github.com:org/repo", "https://github.com/org/repo"},
+		{"ssh scheme", "ssh://git@github.com/org/repo.git", "https://github.com/org/repo"},
+		{"ssh scheme without .git suffix", "ssh://git@github.com/org/repo", "https://github.com/org/repo"},
+		{"git protocol", "git://github.com/org/repo.git", "https://github.com/org/repo"},
+		{"http to https", "http://github.com/org/repo.git", "https://github.com/org/repo"},
+		{"https with .git suffix", "https://github.com/org/repo.git", "https://github.com/org/repo"},
+		{"https already clean", "https://github.com/org/repo", "https://github.com/org/repo"},
+		{"https with credentials", "https://user:token@github.com/org/repo.git", "https://github.com/org/repo"},
+		{"http with credentials", "http://user:pass@gitlab.com/org/repo.git", "https://gitlab.com/org/repo"},
+		{"https with port", "https://github.com:8443/org/repo.git", "https://github.com:8443/org/repo"},
+		{"ssh with port", "ssh://git@github.com:22/org/repo.git", "https://github.com/org/repo"},
+		{"ssh with non-standard port", "ssh://git@bitbucket.example.com:7999/project/repo.git", "https://bitbucket.example.com/project/repo"},
+		{"git+ssh scheme", "git+ssh://git@github.com/org/repo.git", "https://github.com/org/repo"},
+		{"ssh+git scheme", "ssh+git://git@github.com/org/repo.git", "https://github.com/org/repo"},
+		{"git+http scheme", "git+http://github.com/org/repo.git", "https://github.com/org/repo"},
+		{"git+https scheme", "git+https://github.com/org/repo.git", "https://github.com/org/repo"},
+		{"gitlab subgroup scp-style", "git@gitlab.com:org/subgroup/repo.git", "https://gitlab.com/org/subgroup/repo"},
+		{"scp-style with token user", "TOKEN@host:org/repo.git", "https://host/org/repo"},
+		{"scp-style with deploy user", "deploy@gitlab.com:org/repo.git", "https://gitlab.com/org/repo"},
+		{"malformed password with @ strips credentials", "https://user:p@ss@host:port8080/org/repo.git", "https://host:port8080/org/repo.git"},
+		{"scp-like without userinfo and @ in path unchanged", "github.com:org/repo@v2.git", "github.com:org/repo@v2.git"},
+		{"file protocol passthrough", "file:///home/user/repo.git", "file:///home/user/repo.git"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NormalizeGitURL(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestGetRemoteUrl(t *testing.T) {
 	// Create a temporary directory
 	tempDir, err := os.MkdirTemp("", "git-test-*")


### PR DESCRIPTION
### **User description**
## Summary

- Adds `StripGitCredentials()` to remove userinfo (username/password/token) from git remote URLs, preventing credential leakage to APIs and logs
- Adds `NormalizeGitURL()` to convert any git URL format (SSH, SCP-style, git://, http://) into a consistent `https://` URL with credentials removed and `.git` suffix stripped
- Handles edge cases: SSH ports stripped during normalization, `git+ssh://`/`ssh+git://` schemes, GitLab subgroups, `file://` passthrough

## Test plan

- [x] 9 table-driven test cases for `StripGitCredentials` (empty, HTTPS with user:pass, OAuth tokens, username-only, HTTP creds, SSH userinfo, SCP-style passthrough, clean URLs, git protocol)
- [x] 18 table-driven test cases for `NormalizeGitURL` (all URL formats, SSH with ports, credential stripping, `git+ssh`/`ssh+git`, GitLab subgroups, `file://` passthrough)
- [x] All 6 existing tests continue to pass
- [x] `go vet` clean

___

### **PR Type**
enhancement, bug_fix


___

### **Description**
- Add Git URL sanitization functions.

- Remove sensitive credentials from URLs.

- Normalize diverse URL formats to HTTPS.

- Include extensive unit tests.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>git.go</strong><dd><code>Implement Git URL credential stripping and normalization.</code></dd></summary>
<hr>

pkg/utils/git/git.go

<ul><li>Adds <code>StripGitCredentials</code> to remove userinfo from Git URLs.<br> <li> Implements <code>NormalizeGitURL</code> to convert various URL formats to HTTPS.<br> <li> Introduces helper functions <code>isSCPStyle</code> and <code>stripCredentialsByPattern</code>.<br> <li> Handles edge cases for malformed URLs and SCP-style syntax.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/586/changes#diff-af8adb2f32344eb281e8436fafb1ea3b2b455a532b195f67cc245515f1e928a1">+134/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>git_test.go</strong><dd><code>Add comprehensive tests for Git URL sanitization.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/utils/git/git_test.go

<ul><li>Adds 17 new test cases for <code>StripGitCredentials</code>.<br> <li> Adds 24 new test cases for <code>NormalizeGitURL</code>.<br> <li> Covers numerous URL formats, schemes, and edge cases.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/586/changes#diff-8232e3bc8efc6284c4d55255fbef42ed5b93865b132e782d958a6bceaa7d9276">+71/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

