### PR TITLE
fix: support for rendering multiple locations to SARIF

### DIFF
--- a/internal/presenters/funcs.go
+++ b/internal/presenters/funcs.go
@@ -271,7 +271,7 @@ func getSarifTemplateFuncMap() template.FuncMap {
 	fnMap["buildRuleHelpMarkdown"] = sarif.BuildHelpMarkdown
 	fnMap["buildRuleTags"] = sarif.BuildRuleTags
 	fnMap["getRuleCVSSScore"] = sarif.GetRuleCVSSScore
-	fnMap["buildLocationFromIssue"] = sarif.BuildLocation
+	fnMap["buildLocationsFromIssue"] = sarif.BuildLocations
 	fnMap["buildFixFromIssue"] = sarif.BuildFixFromIssue
 	fnMap["formatIssueMessage"] = sarif.FormatIssueMessage
 	return fnMap

--- a/internal/presenters/presenter_ufm_test.go
+++ b/internal/presenters/presenter_ufm_test.go
@@ -602,7 +602,7 @@ func Test_UfmPresenter_Sarif(t *testing.T) {
 			ignoreSuppressions: true,
 		},
 		{
-			name:               "secrets_duplicated_rules",
+			name:               "secrets_duplicated_rules_and_multiple_findings",
 			expectedSarifPath:  "testdata/ufm/secrets.duplicated-sarif-rules.sarif.json",
 			testResultPath:     "testdata/ufm/secrets.duplicated-sarif-rules.testresult.json",
 			ignoreSuppressions: true,

--- a/internal/presenters/templates/ufm.sarif.tmpl
+++ b/internal/presenters/templates/ufm.sarif.tmpl
@@ -63,11 +63,7 @@
 				{{- $targetFile := "" }}
 				{{- if $displayTargetFile }} {{- $targetFile = $displayTargetFile }} {{- end }}
 				{{- range $index, $issue := $issues }}
-				{{- $location := buildLocationFromIssue $issue $targetFile }}
-				{{- $physicalLoc := index $location "physicalLocation" }}
-				{{- $logicalLocs := index $location "logicalLocations" }}
-				{{- $region := index $physicalLoc "region" }}
-				{{- $artifactLocation := index $physicalLoc "artifactLocation" }}
+				{{- $locations := buildLocationsFromIssue $issue $targetFile }}
 				{{- $fix := buildFixFromIssue $issue }}
 				{{- $ignoreDetails := $issue.GetIgnoreDetails }}
 				{{- $problemID := $issue.GetProblemID }}
@@ -79,23 +75,26 @@
 						"text": {{ getQuotedString (formatIssueMessage $issue) }}
 					},
 					"locations": [
+						{{- range $locIndex, $location := $locations }}
+						{{- $logicalLocs := $location.LogicalLocations }}
+						{{- $physicalLoc := $location.PhysicalLocation }}
 						{{- if $location }}
 						{
 							{{- if $physicalLoc }}
 							"physicalLocation": {
 								"artifactLocation": {
-									"uri": {{ getQuotedString (index $artifactLocation "uri") }}
+									"uri": {{ getQuotedString $physicalLoc.ArtifactLocation.URI }}
 								},
 								"region": {
-									"startLine": {{ index $region "startLine" }}{{if index $region "startColumn"}},{{end}}
-									{{- if index $region "startColumn" }}
-									"startColumn": {{ index $region "startColumn" }}{{if index $region "endLine"}},{{end}}
+									"startLine": {{ $physicalLoc.Region.StartLine }}{{if $physicalLoc.Region.StartColumn}},{{end}}
+									{{- if $physicalLoc.Region.StartColumn }}
+									"startColumn": {{ $physicalLoc.Region.StartColumn }}{{if $physicalLoc.Region.EndLine}},{{end}}
 									{{- end }}
-									{{- if index $region "endLine" }}
-									"endLine": {{ index $region "endLine" }}{{if index $region "endColumn"}},{{end}}
+									{{- if $physicalLoc.Region.EndLine }}
+									"endLine": {{ $physicalLoc.Region.EndLine }}{{if $physicalLoc.Region.EndColumn}},{{end}}
 									{{- end }}
-									{{- if index $region "endColumn" }}
-									"endColumn": {{ index $region "endColumn" }}
+									{{- if $physicalLoc.Region.EndColumn }}
+									"endColumn": {{ $physicalLoc.Region.EndColumn }}
 									{{- end }}
 								}
 							}
@@ -105,12 +104,14 @@
 							"logicalLocations": [
 								{{- range $logLoc := $logicalLocs }}
 								{
-									"fullyQualifiedName": {{ getQuotedString (index $logLoc "fullyQualifiedName") }}
+									"fullyQualifiedName": {{ getQuotedString $logLoc.FullyQualifiedName }}
 								}
 								{{- end }}
 							]
 							{{- end }}
 						}
+						{{- end }}
+						{{if lt $locIndex (sub (len $locations) 1)}},{{end}}
 						{{- end }}
 					]
 					{{- if and (ne (printf "%s" $issue.GetFindingType) "sca") (ne (printf "%s" $issue.GetFindingType) "license") }},
@@ -121,6 +122,10 @@
 					{{- end }}
 					{{- if $fix }},
 					"fixes": [
+						{{- if gt (len $locations) 0 }}
+						{{- $firstLoc := index $locations 0 }}
+						{{- if $firstLoc.PhysicalLocation }}
+						{{- $firstPhysicalLoc := $firstLoc.PhysicalLocation }}
 						{
 							"description": {
 								"text": {{ getQuotedString (index $fix "description") }}
@@ -128,12 +133,12 @@
 							"artifactChanges": [
 								{
 									"artifactLocation": {
-										"uri": {{ getQuotedString (index $artifactLocation "uri") }}
+										"uri": {{ getQuotedString $firstPhysicalLoc.ArtifactLocation.URI }}
 									},
 									"replacements": [
 										{
 											"deletedRegion": {
-												"startLine": {{ index $region "startLine" }}
+												"startLine": {{ $firstPhysicalLoc.Region.StartLine }}
 											},
 											"insertedContent": {
 												"text": {{ getQuotedString (index $fix "packageVersion") }}
@@ -143,6 +148,8 @@
 								}
 							]
 						}
+						{{- end }}
+						{{- end }}
 					]
 					{{- end }}
 					{{- if $ignoreDetails }},
@@ -198,7 +205,7 @@
 					]
 					{{- end }}
 				}{{if lt $index $issuesSize}},{{end}}
-				{{- end}}
+				{{- end }}
 			],
 				{{- /* TODO: Add properties section for SAST (coverage) and upload results
 				"properties": {

--- a/internal/presenters/testdata/ufm/secrets.duplicated-sarif-rules.sarif.json
+++ b/internal/presenters/testdata/ufm/secrets.duplicated-sarif-rules.sarif.json
@@ -25,6 +25,32 @@
                   "startLine": 2
                 }
               }
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "generic/config.json"
+                },
+                "region": {
+                  "endColumn": 46,
+                  "endLine": 3,
+                  "startColumn": 14,
+                  "startLine": 3
+                }
+              }
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "generic/config.json"
+                },
+                "region": {
+                  "endColumn": 65,
+                  "endLine": 4,
+                  "startColumn": 33,
+                  "startLine": 4
+                }
+              }
             }
           ],
           "message": {
@@ -49,6 +75,19 @@
                   "endLine": 2,
                   "startColumn": 11,
                   "startLine": 2
+                }
+              }
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "generic/file with spaces"
+                },
+                "region": {
+                  "endColumn": 101,
+                  "endLine": 3,
+                  "startColumn": 13,
+                  "startLine": 3
                 }
               }
             }
@@ -101,6 +140,19 @@
                   "endLine": 2,
                   "startColumn": 11,
                   "startLine": 2
+                }
+              }
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "generic/secret"
+                },
+                "region": {
+                  "endColumn": 101,
+                  "endLine": 3,
+                  "startColumn": 13,
+                  "startLine": 3
                 }
               }
             }

--- a/pkg/utils/sarif/sarif.go
+++ b/pkg/utils/sarif/sarif.go
@@ -493,82 +493,204 @@ func appendDescriptionSection(sb *strings.Builder, issue testapi.Issue) {
 	}
 }
 
-// BuildLocation constructs a SARIF location object from issue data
-//
-//nolint:gocyclo // needs the global state for package name and version
-func BuildLocation(issue testapi.Issue, targetFile string) map[string]interface{} {
-	// Extract first finding from issue
+type regionData struct {
+	StartLine   int  `json:"startLine"`
+	StartColumn *int `json:"startColumn,omitempty"`
+	EndLine     *int `json:"endLine,omitempty"`
+	EndColumn   *int `json:"endColumn,omitempty"`
+}
+
+type artifactLocation struct {
+	URI string `json:"uri"`
+}
+
+type physicalLocation struct {
+	ArtifactLocation artifactLocation `json:"artifactLocation"`
+	Region           regionData       `json:"region"`
+}
+
+type logicalLocation struct {
+	FullyQualifiedName string `json:"fullyQualifiedName"`
+}
+
+type sarifLocation struct {
+	PhysicalLocation *physicalLocation `json:"physicalLocation,omitempty"`
+	LogicalLocations []logicalLocation `json:"logicalLocations,omitempty"`
+}
+
+// BuildLocations constructs SARIF location objects from issue finding data
+// Returns a slice of location objects, each containing physical and logical locations
+func BuildLocations(issue testapi.Issue, targetFile string) []sarifLocation {
+	packageName, packageVersion := getPackageNameAndVersionFromIssue(issue)
 	findings := issue.GetFindings()
+	findingType := issue.GetFindingType()
 	if len(findings) == 0 {
 		return nil
 	}
-	finding := findings[0]
 
-	// Default to line 1 for manifest files
-	uri := targetFile
-	region := map[string]interface{}{
-		"startLine": 1,
+	// SCA findings have only one location, so we can return it immediately
+	if findingType == testapi.FindingTypeSca {
+		scaFindingLocation := sarifLocation{
+			LogicalLocations: []logicalLocation{buildLogicalLocation(packageName, packageVersion)},
+		}
+		if targetFile != "" {
+			pLocation := buildPhysicalLocation(targetFile, regionData{StartLine: 1})
+			scaFindingLocation.PhysicalLocation = &pLocation
+		}
+		return []sarifLocation{scaFindingLocation}
 	}
 
-	packageName, packageVersion := getPackageNameAndVersionFromIssue(issue)
+	// track seen locations to prevent duplicates
+	var locations []sarifLocation
+	seen := make(map[string]bool)
 
-	// Try to extract actual file path and package version from locations
-	if finding.Attributes != nil && len(finding.Attributes.Locations) > 0 && uri == "" {
-		loc := finding.Attributes.Locations[0]
+	for _, finding := range findings {
+		sLocations := buildSarifLocations(*finding, targetFile, packageName, packageVersion)
 
-		// Try source location first
-		sourceLoc, err := loc.AsSourceLocation()
-		if err == nil && sourceLoc.FilePath != "" {
-			uri = sourceLoc.FilePath
-			region["startLine"] = sourceLoc.FromLine
-			if sourceLoc.FromColumn != nil {
-				region["startColumn"] = *sourceLoc.FromColumn
-			}
-			if sourceLoc.ToLine != nil {
-				region["endLine"] = *sourceLoc.ToLine
-			}
-			if sourceLoc.ToColumn != nil {
-				region["endColumn"] = *sourceLoc.ToColumn
-			}
-		}
+		for _, sLoc := range sLocations {
+			key := ""
 
-		pkgLoc, err := loc.AsPackageLocation()
-		if err == nil {
-			if pkgLoc.Package.Name != "" {
-				packageName = pkgLoc.Package.Name
+			if len(sLoc.LogicalLocations) > 0 {
+				key += fmt.Sprintf("log:%s", sLoc.LogicalLocations[0].FullyQualifiedName)
 			}
-			if pkgLoc.Package.Version != "" {
-				packageVersion = pkgLoc.Package.Version
+
+			if sLoc.PhysicalLocation != nil {
+				key += fmt.Sprintf("phys:%s:%d", sLoc.PhysicalLocation.ArtifactLocation.URI, sLoc.PhysicalLocation.Region.StartLine)
+				if sLoc.PhysicalLocation.Region.EndLine != nil {
+					key += fmt.Sprintf(":%d", *sLoc.PhysicalLocation.Region.EndLine)
+				}
+				if sLoc.PhysicalLocation.Region.StartColumn != nil {
+					key += fmt.Sprintf(":%d", *sLoc.PhysicalLocation.Region.StartColumn)
+				}
+				if sLoc.PhysicalLocation.Region.EndColumn != nil {
+					key += fmt.Sprintf(":%d", *sLoc.PhysicalLocation.Region.EndColumn)
+				}
+			}
+
+			if !seen[key] {
+				seen[key] = true
+				locations = append(locations, sLoc)
 			}
 		}
 	}
 
-	location := map[string]interface{}{}
+	return locations
+}
 
-	if len(uri) > 0 {
-		location["physicalLocation"] = map[string]interface{}{
-			"artifactLocation": map[string]interface{}{
-				"uri": uri,
-			},
-			"region": region,
+// buildSarifLocations extracts physical and logical locations from finding data
+// Returns a slice of location objects, each containing physical and logical locations
+func buildSarifLocations(finding testapi.FindingData, targetFile string, packageName string, packageVersion string) []sarifLocation {
+	var sLocations []sarifLocation
+
+	// try to extract actual file path and package version from locations
+	hasLocations := finding.Attributes != nil && len(finding.Attributes.Locations) > 0
+
+	if hasLocations && targetFile == "" {
+		for _, loc := range finding.Attributes.Locations {
+			sLoc := buildSarifLocationFromLoc(loc, packageName, packageVersion)
+			if sLoc.PhysicalLocation != nil {
+				sLocations = append(sLocations, sLoc)
+			}
 		}
+	}
+
+	// if no locations were generated
+	if len(sLocations) == 0 {
+		if fallback := buildFallbackSarifLocation(targetFile, packageName, packageVersion); fallback != nil {
+			sLocations = append(sLocations, *fallback)
+		}
+	}
+
+	return sLocations
+}
+
+// buildSarifLocationFromLoc extracts location data from a finding location
+// Returns a location object with physical and logical locations
+func buildSarifLocationFromLoc(loc testapi.FindingLocation, packageName string, packageVersion string) sarifLocation {
+	pName, pVersion := packageName, packageVersion
+
+	pkgLoc, err := loc.AsPackageLocation()
+	if err == nil {
+		if pkgLoc.Package.Name != "" {
+			pName = pkgLoc.Package.Name
+		}
+		if pkgLoc.Package.Version != "" {
+			pVersion = pkgLoc.Package.Version
+		}
+	}
+
+	if pName != "" || pVersion != "" {
+		return sarifLocation{LogicalLocations: []logicalLocation{buildLogicalLocation(pName, pVersion)}}
+	}
+
+	return buildSarifLocationFromSourceLoc(loc)
+}
+
+// buildSarifLocationFromSourceLoc extracts location data from a source location
+// Returns a location object with physical location only
+func buildSarifLocationFromSourceLoc(loc testapi.FindingLocation) sarifLocation {
+	region := regionData{StartLine: 1}
+
+	sourceLoc, err := loc.AsSourceLocation()
+	if err != nil || sourceLoc.FilePath == "" {
+		return sarifLocation{}
+	}
+
+	region.StartLine = sourceLoc.FromLine
+	if sourceLoc.FromColumn != nil {
+		region.StartColumn = sourceLoc.FromColumn
+	}
+	if sourceLoc.ToLine != nil {
+		region.EndLine = sourceLoc.ToLine
+	}
+	if sourceLoc.ToColumn != nil {
+		region.EndColumn = sourceLoc.ToColumn
+	}
+
+	pLocation := buildPhysicalLocation(sourceLoc.FilePath, region)
+	return sarifLocation{PhysicalLocation: &pLocation}
+}
+
+// buildFallbackSarifLocation creates a fallback location when no specific locations are found
+// Returns a location object with either physical or logical location, or nil if neither is provided
+func buildFallbackSarifLocation(targetFile string, packageName string, packageVersion string) *sarifLocation {
+	var pLoc *physicalLocation
+	var lLocs []logicalLocation
+
+	if len(targetFile) > 0 {
+		pLocation := buildPhysicalLocation(targetFile, regionData{StartLine: 1})
+		pLoc = &pLocation
 	}
 
 	if packageName != "" || packageVersion != "" {
-		location["logicalLocations"] = []interface{}{
-			map[string]interface{}{
-				"fullyQualifiedName": fmt.Sprintf("%s@%s", packageName, packageVersion),
-			},
-		}
+		lLocs = []logicalLocation{buildLogicalLocation(packageName, packageVersion)}
 	}
 
-	if len(location) > 0 {
-		return location
+	if pLoc != nil || len(lLocs) > 0 {
+		return &sarifLocation{PhysicalLocation: pLoc, LogicalLocations: lLocs}
 	}
-
 	return nil
 }
 
+// buildPhysicalLocation creates a physical location object with the given URI and region
+func buildPhysicalLocation(uri string, region regionData) physicalLocation {
+	return physicalLocation{
+		ArtifactLocation: artifactLocation{
+			URI: uri,
+		},
+		Region: region,
+	}
+}
+
+// buildLogicalLocation creates a logical location object with the given package name and version
+func buildLogicalLocation(packageName string, packageVersion string) logicalLocation {
+	return logicalLocation{
+		FullyQualifiedName: fmt.Sprintf("%s@%s", packageName, packageVersion),
+	}
+}
+
+// getPackageNameAndVersionFromIssue extracts package name and version from issue data
+// Returns the package name and version, or empty strings if not found
 func getPackageNameAndVersionFromIssue(issue testapi.Issue) (packageName, packageVersion string) {
 	if val, ok := issue.GetData(testapi.DataKeyComponentName); ok {
 		if str, ok := val.(string); ok {


### PR DESCRIPTION
### Description

_Provide description of this PR and changes._
This PR refactors the location building logic in sarif.go such that it now considers all possible locations for rendering instead of just the first one.

### Example output
#### Old
```
{
  "ruleId": "generic-secret",
  "level": "error",
  "message": {
    "text": "This file contains a high severity Generic Secret Key vulnerability."
  },
  "locations": [
    {
      "physicalLocation": {
        "artifactLocation": {
          "uri": ".gitleaksignore"
        },
        "region": {
          "startLine": 53,
          "startColumn": 1,
          "endLine": 53,
          "endColumn": 41
        }
      }
    }
  ],
  "fingerprints": {
    "identity": "53d6c119-b408-585a-9194-a451f33721a0",
    "snyk/asset/finding/v1": "53d6c119-b408-585a-9194-a451f33721a0"
  }
},
```
#### New
```
{
  "ruleId": "generic-secret",
  "level": "error",
  "message": {
    "text": "This file contains a high severity Generic Secret Key vulnerability."
  },
  "locations": [
    {
      "physicalLocation": {
        "artifactLocation": {
          "uri": ".gitleaksignore"
        },
        "region": {
          "startLine": 53,
          "startColumn": 1,
          "endLine": 53,
          "endColumn": 41
        }
      }
    },
    {
      "physicalLocation": {
        "artifactLocation": {
          "uri": ".gitleaksignore"
        },
        "region": {
          "startLine": 54,
          "startColumn": 1,
          "endLine": 54,
          "endColumn": 41
        }
      }
    },
    {
      "physicalLocation": {
        "artifactLocation": {
          "uri": ".gitleaksignore"
        },
        "region": {
          "startLine": 55,
          "startColumn": 1,
          "endLine": 55,
          "endColumn": 41
        }
      }
    },
    many more...
  ],
  "fingerprints": {
    "identity": "53d6c119-b408-585a-9194-a451f33721a0",
    "snyk/asset/finding/v1": "53d6c119-b408-585a-9194-a451f33721a0"
  }
},
```

### Checklist

- [x] Tests added and all succeed (`make test`)
- [ ] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.
