### PR TITLE
fix: improve API endpoint regex [IDE-1896]

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -5,4 +5,4 @@ const SNYK_DEFAULT_API_VERSION = "2024-04-22"
 const SNYK_DEFAULT_IN_MEMORY_THRESHOLD_MB = 512 * 1024 * 1024
 const SNYK_DOCS_URL = "https://docs.snyk.io"
 const SNYK_DOCS_ERROR_CATALOG_PATH = "/scan-with-snyk/error-catalog"
-const SNYK_DEFAULT_ALLOWED_HOST_REGEXP = `^(https?://)?api(\.(.+))?\.(snyk|snykgov)\.io$`
+const SNYK_DEFAULT_ALLOWED_HOST_REGEXP = `^(https?:\/\/)?api(\.([a-z0-9._-]+))?\.(snyk|snykgov)\.io$`

--- a/pkg/auth/authHost_test.go
+++ b/pkg/auth/authHost_test.go
@@ -17,10 +17,17 @@ func Test_isValidAuthHost(t *testing.T) {
 		{"api.snyk.io", true},
 		{"api.snykgov.io", true},
 		{"api.pre-release.snykgov.io", true},
+		{"api.a.b.c.snyk.io", true},
 		{"snyk.io", false},
 		{"api.example.com", false},
 		{"api.snyk.evil.com", false},
 		{"evilsnykgov.io", false},
+		{"api.example.snyk.io.evil.com", false},
+		{"api.snyk.io.attacker.com", false},
+		{"api.snyk.io/haha", false},
+		{"api.attacker.io/haha.snyk.io", false},
+		{"token@api.snyk.io", false},
+		{"api.something api.snyk.io", false},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### Description

Ensure the endpoint is restricted to Snyk domains.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [ ] Regenerated mocks, etc. (`make generate`)
 - N/A
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.
  - http://github.com/snyk/cli/pull/6733
