### PR TITLE
chore: Forwad context.Context between Invoke() calls

### DIFF
--- a/pkg/workflow/engine_test.go
+++ b/pkg/workflow/engine_test.go
@@ -531,11 +531,22 @@ func Test_EngineImpl_InvokeWithContext_CustomContext(t *testing.T) {
 	engine := NewWorkFlowEngine(config)
 
 	wfId := NewWorkflowIdentifier("ctxtest")
+	wfIdNested := NewWorkflowIdentifier("ctxtest-nested")
 	flagset := pflag.NewFlagSet("ctx", pflag.ContinueOnError)
 
 	var receivedCtx context.Context
+	// register entry workflow
 	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		output, localError := invocation.GetEngine().Invoke(wfIdNested)
 		receivedCtx = invocation.Context()
+		return output, localError
+	})
+	assert.NoError(t, err)
+
+	var receivedCtxNested context.Context
+	// register nested workflow
+	_, err = engine.Register(wfIdNested, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		receivedCtxNested = invocation.Context()
 		return nil, nil
 	})
 	assert.NoError(t, err)
@@ -556,8 +567,11 @@ func Test_EngineImpl_InvokeWithContext_CustomContext(t *testing.T) {
 	assert.NotNil(t, receivedCtx)
 	assert.Equal(t, testValue, receivedCtx.Value(testKey))
 
+	assert.NotNil(t, receivedCtxNested)
+	assert.Equal(t, testValue, receivedCtxNested.Value(testKey))
+
 	// Verify deadline is propagated
-	deadline, hasDeadline := receivedCtx.Deadline()
+	deadline, hasDeadline := receivedCtxNested.Deadline()
 	assert.True(t, hasDeadline, "context should have a deadline")
 	assert.False(t, deadline.IsZero(), "deadline should not be zero")
 }

--- a/pkg/workflow/engineimpl.go
+++ b/pkg/workflow/engineimpl.go
@@ -327,6 +327,7 @@ func (e *EngineImpl) Invoke(
 			localEngine := &engineWrapper{
 				WrappedEngine:                   e,
 				defaultInstrumentationCollector: options.ic,
+				defaultCtxFunc:                  options.ctxFunc,
 			}
 			e.mu.Unlock()
 

--- a/pkg/workflow/enginewrapper.go
+++ b/pkg/workflow/enginewrapper.go
@@ -1,6 +1,8 @@
 package workflow
 
 import (
+	"context"
+
 	"github.com/rs/zerolog"
 
 	"github.com/snyk/go-application-framework/pkg/analytics"
@@ -10,9 +12,12 @@ import (
 	"github.com/snyk/go-application-framework/pkg/ui"
 )
 
+// engineWrapper is used to cache values that are not global for an engine but for an Invoke Chain. This way values can be preserved
+// for subsequent invocations without explicitly specifying them
 type engineWrapper struct {
 	WrappedEngine                   Engine
 	defaultInstrumentationCollector analytics.InstrumentationCollector
+	defaultCtxFunc                  func() context.Context
 }
 
 var _ Engine = (*engineWrapper)(nil)
@@ -47,6 +52,11 @@ func (e *engineWrapper) Invoke(id Identifier, opts ...EngineInvokeOption) ([]Dat
 	// if no InstrumentationCollector is specified, and a default is available, the default be used
 	if options.ic == nil && e.defaultInstrumentationCollector != nil {
 		opts = append(opts, WithInstrumentationCollector(e.defaultInstrumentationCollector))
+	}
+
+	// if no context is specified, and a context is available, the default is used.
+	if options.ctxFunc == nil && e.defaultCtxFunc != nil {
+		opts = append(opts, WithContext(e.defaultCtxFunc()))
 	}
 
 	return e.WrappedEngine.Invoke(id, opts...)


### PR DESCRIPTION
### Description

This PR forwards a given context to nested invocations.

### Checklist

- [ ] Tests added and all succeed (`make test`)
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.
