### PR TITLE
chore: Add helper tool to generate and redact UFM test fixtures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,3 +193,85 @@ func MainWithErrorCode() int {
 As you can see, adding our extension to the CLI is as simple as calling the `engine.AddExtensionInitializer()` function and passing our extension's `Init()` in as a parameter.
 
 That's it!
+
+# UFM test fixtures
+
+The presenter tests in `internal/presenters/` compare rendered output against expected files stored under `internal/presenters/testdata/ufm/`. There are several workflows for keeping these up to date.
+
+## Generating a fixture (recommended)
+
+Use the helper target to run a scan, dump workflow payloads to disk, pick the latest `workflow.TestResult.*`, add a `.json` extension, and optionally redact in one flow:
+
+```bash
+# Defaults:
+# - SNYK_BIN=snyk
+# - OUT_DIR=./dumps
+# - DUMP_DIR=<OUT_DIR>/raw
+# - default scan: secrets test . (override with SCAN_CMD="...")
+# - REPORT=0 (set REPORT=1 to append --report, only for commands that support it)
+# - REDACT=1
+make generate-fixture \
+  PROJECT=/path/to/scanned-repo \
+  ORG=my-org \
+  NAME=secrets_with_report \
+  REPORT=1
+```
+
+Output files:
+
+- `./dumps/<name>.testresult.raw.json` (non-redacted dump copy)
+- `./dumps/<name>.testresult.json` (redacted, when `REDACT=1`)
+
+Useful overrides:
+
+```bash
+# Use a custom CLI binary and disable redaction
+make generate-fixture \
+  PROJECT=/path/to/scanned-repo \
+  ORG=my-org \
+  NAME=secrets_with_report \
+  SNYK_BIN=/path/to/snyk-macos-arm64 \
+  REDACT=0
+
+# Customize where dump files and final outputs are written
+make generate-fixture \
+  PROJECT=/path/to/scanned-repo \
+  ORG=my-org \
+  NAME=secrets_with_report \
+  DUMP_DIR=/tmp/my-dump-dir \
+  OUT_DIR=/tmp/my-fixtures
+```
+
+The dump command uses these internal settings by default:
+
+- `SNYK_TMP_PATH=<DUMP_DIR>`
+- `INTERNAL_IN_MEMORY_THRESHOLD_BYTES=1`
+- `INTERNAL_CLEANUP_GLOBAL_TEMP_DIR_ENABLED=false`
+
+If the printed command shows `snyk test .` instead of `snyk secrets test .`, your shell may have `SCAN_CMD` exported. Run `unset SCAN_CMD` or pass `SCAN_CMD="secrets test ."` explicitly.
+
+## Redacting a dump into a stable fixture
+
+To redact an existing dump file manually:
+
+```bash
+go run ./cmd/ufm-fixture-tool \
+  --input=./dumps/raw/workflow.TestResult.12345 \
+  --output=./internal/presenters/testdata/ufm/my_fixture.testresult.json
+
+# Or via make (OUTPUT is optional)
+make redact-fixture INPUT=./dumps/raw/workflow.TestResult.12345 OUTPUT=./path/to/fixture.testresult.json
+```
+
+If `OUTPUT` is omitted, the redaction tool writes `<input>_redacted.json` next to the input path.
+
+
+## Regenerating expected files from existing fixtures
+
+If you changed a presenter template and need to update the expected SARIF / human-readable output without re-fetching from the API:
+
+```bash
+make regenerate-expected
+```
+
+This runs the presenter tests with `UFM_REGEN=1`, which overwrites the expected files with the current presenter output and skips the comparison. Review the diff before committing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,9 @@
 # Contributing
+
 This repo is intended for internal (Snyk) contributions only at this time.
 
 # Creating a new extension
+
 The `go-application-framework` makes it easy to add functionality to the Snyk CLI by taking care of the orchestration, requirements, and state management when running the CLI; this all happens behind the scenes via the packages provided by the framework. It means we can focus on building the core business logic for our extension and not worry about much else.
 
 Creating a new extension using the `go-application-framework` can be done in three steps
@@ -11,15 +13,19 @@ Creating a new extension using the `go-application-framework` can be done in thr
 3. Initialise the extension when using the `go-application-framework`
 
 # Create the extension workflow
+
 The extension workflow is the main component of your extension, it should:
+
 1. Uniquely identify your workflow
 2. Initialise your workflow (registering the extension with the workflow engine should happen here)
 3. Have an entry point containing the extension business logic
 
 # Creating `snyk whoami`
+
 The `snyk whoami` command was created following the steps outlined above; the following outlines the extension implementation in detail.
 
 ## Uniquely identify your workflow
+
 Before we can start creating our extension workflow, we'll need to create our workflow identifier. An identifier is required by the workflow engine to identify our workflow. The workflow identifier should also contain the name of the new extension command.
 
 The framework's `workflow` package allows us to easily create an identifier in this format as follows:
@@ -34,6 +40,7 @@ var WORKFLOWID_WHOAMI workflow.Identifier = workflow.NewWorkflowIdentifier(workf
 ```
 
 ## Initialise your workflow
+
 Now that we have a workflow identifier, we can continue with the implementation of the workflow's initialiser via an `Init()` function.
 
 Here we want to initialise the extension workflow's configuration, as well as register the workflow with the workflow engine, which is passed to the function as a parameter.
@@ -52,15 +59,19 @@ func Init(engine workflow.Engine) error {
 ```
 
 ### Initialise configuration
+
 We use the `pflag` package in order to create POSIX/GNU-style --flags. The extension should support the `--json` flag, so we add it to the configuration via `whoAmIConfig.Bool()`.
 
 ### Mark experimental versions of an extension workflow
+
 There is a common pattern to mark workflows as experimental by using [MarkAsExperimental()](https://github.com/snyk/go-application-framework/blob/main/pkg/local_workflows/config_utils/experimental.go#L28) in order to indicate early non production ready versions of a workflow. In the CLI this will automatically reflect in a required argument `--experimental`, if not provided the CLI will show an error and not call the workflow.
 
 ### Register with the workflow engine
+
 Next we must register the extension with the workflow engine. The `workflow` package is used again here in, firstly to abstract away the engine/workflow registration logic via `engine.Register`, and again to configure the workflow's configuration via `workflow.ConfigurationOptionsFromFlagset`.
 
 ## Implement business logic via the workflow entry point
+
 Now we can define the business logic for our extension workflow. This can be done in an `entryPoint()` function, which has two parameters; `invocationContext` and `input []workflow.Data`.
 
 `invocationContext` is a `workflow.InvocationContext` type and it abstracts away much of the boilerplate required when implementing a new workflow, For example, it provides a wrapper around the `net/http` package via `GetNetWorkAccess()` and reduces its implementation mainly to supplying configuration parameters.
@@ -68,6 +79,7 @@ Now we can define the business logic for our extension workflow. This can be don
 `input` is a `workflow.Data` type and is the standardised data interface used by all extensions workflows.
 
 At a high level, the business logic for the extension workflow will be as follows:
+
 1. Get necessary objects from the invocation context
 2. Call the `/user/me` Snyk API endpoint
 3. Extract the `username` property from the API response
@@ -117,18 +129,23 @@ func entryPoint(invocationCtx workflow.InvocationContext, _ []workflow.Data) (ou
 ```
 
 ### Get necessary invocation context objects
+
 The first step is to retrieve the necessary objects the workflow requires.
+
 - `invocationCtx.GetConfiguration()` will return the configuration object; which contains, amongst other things, the flags set in our `Init()` function
 - `invocationCtx.GetLogger()` will return a logger instance passed to the workflow engine during setup
 - `invocationCtx.GetNetworkAccess().GetHttpClient()` returns a httpClient which we can use to make Snyk API requests
 
 ### Call the `/user/me` Snyk API endpoint
+
 The next step is to fetch the user info by calling the `/user/me` endpoint, The `fetchUserMe()` function makes the API request and returns the response body
 
 ### Extract the username property from the API response
+
 Next, we must parse the response and extract the `username` property. The `extractUser()` function handles this
 
 ### Return the username
+
 The last step is to return the username. The workflow engine expects a `[]]workflow.Data` type in the `entryPoint()` response, so we must create a response of this type. The `createWorkflowData()` function handles this
 
 ```go
@@ -145,11 +162,13 @@ func createWorkflowData(data interface{}, contentType string) workflow.Data {
 `workflow.NewData()` creates a `workflow.Data` instance. Note that `workflow.NewData()` requires a new type identifier, which we create using `workflow.NewTypeIdentifier()`
 
 ### Support `--json` flag
+
 As an additional functionality, we want to support the `--json` flag so that when we run `snyk whoami --json` we will return the full JSON payload from the `/user/me` endpoint
 
 Using the `config` object retrieved from `workflow.GetConfiguration()`, we can check if the flag is set using `config.GetBool("json")`, we can then return the full payload response using hte `createWorkflowData()` helper function
 
 # Initialise extension when using the `go-application-framework`
+
 The final step is to add the extension to the CLI, this is done in the [CLI](https://github.com/snyk/cli/blob/master/cliv2/cmd/cliv2/main.go) itself.
 
 ```go
@@ -186,10 +205,11 @@ func MainWithErrorCode() int {
 		debugLogger.Println("Failed to init Workflow Engine!", err)
 		return constants.SNYK_EXIT_CODE_ERROR
 	}
-  
+
   // ...
 }
 ```
+
 As you can see, adding our extension to the CLI is as simple as calling the `engine.AddExtensionInitializer()` function and passing our extension's `Init()` in as a parameter.
 
 That's it!
@@ -221,6 +241,8 @@ Output files:
 
 - `./dumps/<name>.testresult.raw.json` (non-redacted dump copy)
 - `./dumps/<name>.testresult.json` (redacted, when `REDACT=1`)
+
+Once you're happy with the redacted output, move it into `internal/presenters/testdata/ufm/` and reference it from a new case in `internal/presenters/presenter_ufm_test.go`.
 
 Useful overrides:
 
@@ -265,7 +287,6 @@ make redact-fixture INPUT=./dumps/raw/workflow.TestResult.12345 OUTPUT=./path/to
 
 If `OUTPUT` is omitted, the redaction tool writes `<input>_redacted.json` next to the input path.
 
-
 ## Regenerating expected files from existing fixtures
 
 If you changed a presenter template and need to update the expected SARIF / human-readable output without re-fetching from the API:
@@ -274,4 +295,4 @@ If you changed a presenter template and need to update the expected SARIF / huma
 make regenerate-expected
 ```
 
-This runs the presenter tests with `UFM_REGEN=1`, which overwrites the expected files with the current presenter output and skips the comparison. Review the diff before committing.
+This runs the presenter tests with `UFM_REGEN=1`, which overwrites the expected files with the current presenter output and skips the comparison. The same effect can be achieved by flipping the `regenerateExpectedFiles` constant at the top of `internal/presenters/presenter_ufm_test.go` to `true` and running the tests directly (handy when stepping through with a debugger). Review the diff before committing.

--- a/Makefile
+++ b/Makefile
@@ -60,15 +60,36 @@ update-local-findings:
 	@scripts/pull-down-test-api-spec.sh
 	@make generate
 
+# Default scan for fixture generation — override on the CLI: SCAN_CMD="test ."
+SNYK_FIXTURE_SCAN ?= secrets test .
+.PHONY: generate-fixture
+generate-fixture:
+	@PROJECT="$(PROJECT)" ORG="$(ORG)" NAME="$(NAME)" SNYK_BIN="$(SNYK_BIN)" DUMP_DIR="$(DUMP_DIR)" OUT_DIR="$(OUT_DIR)" SCAN_CMD="$(SCAN_CMD)" REPORT="$(REPORT)" REDACT="$(REDACT)" DEFAULT_SCAN_CMD="$(SNYK_FIXTURE_SCAN)" ./scripts/generate-fixture.sh
+
+.PHONY: redact-fixture
+redact-fixture:
+	@go run ./cmd/ufm-fixture-tool --input=$(INPUT) $(if $(OUTPUT),--output=$(OUTPUT),)
+
+.PHONY: regenerate-expected
+regenerate-expected:
+	@UFM_REGEN=1 go test ./internal/presenters/... -run 'Test_UfmPresenter' -count=1
+
 .PHONY: help
 help:
 	@echo "Main targets:"
-	@echo "$(LOG_PREFIX) tools                      Installs the tools required for development and testing"
+	@echo "$(LOG_PREFIX) tools                      Install linter and dev dependencies"
 	@echo "$(LOG_PREFIX) format"
 	@echo "$(LOG_PREFIX) lint"
 	@echo "$(LOG_PREFIX) build"
-	@echo "$(LOG_PREFIX) generate                   Regenerates generated files (e.g. mocks)"
+	@echo "$(LOG_PREFIX) generate                   Regenerate generated files (e.g. mocks)"
 	@echo "$(LOG_PREFIX) test"
-	@echo "$(LOG_PREFIX) testv                      Test versbosely"
+	@echo "$(LOG_PREFIX) testv                      Test verbosely"
+	@echo ""
+	@echo "Fixture targets:"
+	@echo "$(LOG_PREFIX) generate-fixture PROJECT=/path ORG=slug NAME=name [SNYK_BIN=snyk] [REPORT=1] [REDACT=1]"
+	@echo "$(LOG_PREFIX)   Optional: OUT_DIR=$(CURDIR)/dumps SNYK_FIXTURE_SCAN='secrets test .' SCAN_CMD='...'"
+	@echo "$(LOG_PREFIX) redact-fixture INPUT=path [OUTPUT=path]  Redact a workflow dump into a stable test fixture"
+	@echo "$(LOG_PREFIX) regenerate-expected        Regenerate expected SARIF + human-readable files from existing fixtures"
+	@echo ""
 	@echo "$(LOG_PREFIX) GOOS                       Specify Operating System to compile for (see golang GOOS, default=$(GOOS))"
 	@echo "$(LOG_PREFIX) GOARCH                     Specify Architecture to compile for (see golang GOARCH, default=$(GOARCH))"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,46 @@
 # go-application-framework
 
-A framework to support building client side application like the [Snyk CLI](https://github.com/snyk/cli) as well as Extensions for these applications.
+A framework to support building client-side applications like the [Snyk CLI](https://github.com/snyk/cli) as well as extensions for these applications.
+
+## Getting started
+
+This module is consumed as a dependency by downstream projects (e.g. the [Snyk CLI](https://github.com/snyk/cli)) via a `replace` directive in their `go.mod`. To work on it locally, point the consumer at your checkout:
+
+```
+replace github.com/snyk/go-application-framework => ../../go-application-framework
+```
+
+Then iterate with:
+
+```bash
+make test    # run the full test suite
+```
+
+Run `make help` to see all available targets.
+
+## Key packages
+
+| Package | Description |
+|---------|-------------|
+| `pkg/local_workflows/` | Workflow engine and output pipeline (SARIF, human-readable, etc.) |
+| `pkg/apiclients/testapi/` | Generated API client and data types for the Snyk Test API |
+| `pkg/utils/ufm/` | Unified Finding Model serialization (optimized `problemStore`/`_problemRefs` wire format) |
+| `internal/presenters/` | UFM presenters — Go templates that render `TestResult` data into SARIF and human-readable output |
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for extension authoring, UFM test fixture generation, and other contributor workflows.
+
+## Security
+
+For any security issues or concerns, see the [SECURITY.md](SECURITY.md) file in this repository.
+
+## Development
+
+```bash
+make format      # gofmt
+make lint        # golangci-lint
+make generate    # regenerate mocks and API clients
+make test        # unit tests with race detector
+make testv       # verbose test output
+```

--- a/cmd/ufm-fixture-tool/main.go
+++ b/cmd/ufm-fixture-tool/main.go
@@ -1,0 +1,59 @@
+// Command ufm-fixture-tool redacts a workflow data dump for use as a
+// deterministic test fixture. UUIDs, emails, and sensitive metadata
+// (including stable org-scoped URLs) are replaced with placeholders.
+//
+// Usage:
+//
+//	# Step 1 — dump workflow data to disk via built-in env vars:
+//	SNYK_TMP_PATH=./dump INTERNAL_IN_MEMORY_THRESHOLD_BYTES=1 INTERNAL_CLEANUP_GLOBAL_TEMP_DIR_ENABLED=false \
+//	  snyk secrets test . --report --org=my-org
+//
+//	# Step 2 — redact the dump into a fixture:
+//	go run ./cmd/ufm-fixture-tool --input=./dump/workflow.TestResult.12345 --output=my_fixture.testresult.json
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/snyk/go-application-framework/cmd/ufm-fixture-tool/redact"
+)
+
+func main() {
+	input := flag.String("input", "", "path to the workflow data dump file (required)")
+	output := flag.String("output", "", "path for the redacted output file (optional; defaults to <input>_redacted.json)")
+	flag.Parse()
+
+	if *input == "" {
+		fmt.Fprintln(os.Stderr, "error: --input is required (path to the dump file)")
+		os.Exit(1)
+	}
+	if *output == "" {
+		if strings.HasSuffix(*input, ".json") {
+			*output = strings.TrimSuffix(*input, ".json") + "_redacted.json"
+		} else {
+			*output = *input + "_redacted.json"
+		}
+	}
+
+	raw, err := os.ReadFile(*input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error reading input: %v\n", err)
+		os.Exit(1)
+	}
+
+	redacted, err := redact.Fixture(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error redacting: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := os.WriteFile(*output, redacted, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "error writing output: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("wrote %s (%d bytes)\n", *output, len(redacted))
+}

--- a/cmd/ufm-fixture-tool/redact/redact.go
+++ b/cmd/ufm-fixture-tool/redact/redact.go
@@ -1,6 +1,6 @@
 // Package redact normalises a raw UFM test-result JSON dump into a
-// deterministic fixture by replacing UUIDs, emails, and sensitive
-// metadata (including stable org-scoped URLs) with placeholders.
+// deterministic fixture by replacing UUIDs, emails, and Snyk org slugs
+// inside URLs with stable placeholders.
 package redact
 
 import (
@@ -12,22 +12,19 @@ import (
 	"github.com/snyk/go-application-framework/pkg/utils"
 )
 
-var uuidRE = regexp.MustCompile(
-	`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`,
-)
-
 const (
 	stableOrgSlug = "my-org"
-	stableEmail   = "user@example.com"
-
-	defaultReportBase = "https://app.snyk.io/org/" + stableOrgSlug + "/project"
-
-	// Stable metadata placeholders (keys are kept; real IDs/URLs are not echoed).
-	stableMetadataProjectID  = "00000000-0000-0000-0000-000000000000"
-	stableMetadataSnapshotID = "00000000-0000-0000-0000-000000000001"
+	stableEmail   = "user@snyk.com"
+	stableOrgURL  = "https://app.snyk.io/org/" + stableOrgSlug
 )
 
-// UUIDRemapper assigns deterministic UUIDs to every unique UUID encountered,
+var (
+	uuidRE       = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+	snykOrgURLRE = regexp.MustCompile(`https?://[a-z0-9.-]*\bsnyk\.io/org/[^/?#]+`)
+	emailRE      = regexp.MustCompile(`[A-Za-z0-9._%+-]+@[A-Za-z][A-Za-z0-9-]*(?:\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}`)
+)
+
+// UUIDRemapper assigns deterministic UUIDs to every unique UUID it sees,
 // in first-seen order.
 type UUIDRemapper struct {
 	mapping map[string]string
@@ -46,18 +43,9 @@ func (r *UUIDRemapper) Remap(value string) string {
 		return mapped
 	}
 	r.counter++
-	mapped := fmt.Sprintf("11112222-3333-4444-5555-%012x", r.counter)
+	mapped := fmt.Sprintf("00000000-0000-0000-0000-%012d", r.counter)
 	r.mapping[key] = mapped
 	return mapped
-}
-
-// mapKeyIsUUID reports whether s is exactly one RFC-4122-style UUID (JSON object
-// keys cannot contain multiple matches; this is used for maps like _problemRefs).
-func mapKeyIsUUID(s string) bool {
-	if len(s) != 36 {
-		return false
-	}
-	return uuidRE.FindString(s) == s
 }
 
 // Fixture normalises a raw UFM JSON array ([]testresult) and returns the
@@ -68,9 +56,7 @@ func Fixture(raw []byte) ([]byte, error) {
 		return nil, fmt.Errorf("expected top-level JSON array: %w", err)
 	}
 
-	ctx := walkContext{
-		remapper: NewUUIDRemapper(),
-	}
+	ctx := walkContext{remapper: NewUUIDRemapper()}
 	redacted := walk(data, &ctx)
 
 	out, err := json.MarshalIndent(redacted, "", "  ")
@@ -83,62 +69,33 @@ func Fixture(raw []byte) ([]byte, error) {
 
 type walkContext struct {
 	remapper *UUIDRemapper
-	// inMetadata is true while walking the object under the top-level "metadata" key.
-	inMetadata bool
 }
 
-func walk(node interface{}, ctx *walkContext) interface{} {
+func walk(node any, ctx *walkContext) any {
 	switch v := node.(type) {
-	case map[string]interface{}:
-		out := make(map[string]interface{}, len(v))
+	case map[string]any:
+		out := make(map[string]any, len(v))
 		for _, k := range utils.SortedMapKeys(v) {
-			val := v[k]
-			outKey := k
-			if mapKeyIsUUID(k) {
-				outKey = ctx.remapper.Remap(k)
-			}
-			if k == "email" {
-				out[outKey] = stableEmail
-				continue
-			}
-			if ctx.inMetadata {
-				switch k {
-				case "project-id":
-					out[outKey] = stableMetadataProjectID
-				case "snapshot-id":
-					out[outKey] = stableMetadataSnapshotID
-				case "project-page-link", "report-url":
-					out[outKey] = fmt.Sprintf("%s/%s", defaultReportBase, stableMetadataProjectID)
-				default:
-					out[outKey] = walk(val, ctx)
-				}
-				continue
-			}
-
-			if k == "metadata" {
-				if meta, ok := val.(map[string]interface{}); ok {
-					sub := *ctx
-					sub.inMetadata = true
-					out[outKey] = walk(meta, &sub)
-					continue
-				}
-			}
-			out[outKey] = walk(val, ctx)
+			redactedKey := redactString(k, ctx)
+			out[redactedKey] = walk(v[k], ctx)
 		}
 		return out
-
-	case []interface{}:
-		out := make([]interface{}, len(v))
+	case []any:
+		out := make([]any, len(v))
 		for i, item := range v {
 			out[i] = walk(item, ctx)
 		}
 		return out
-
 	case string:
-		s := uuidRE.ReplaceAllStringFunc(v, ctx.remapper.Remap)
-		return s
-
+		return redactString(v, ctx)
 	default:
 		return node
 	}
+}
+
+func redactString(s string, ctx *walkContext) string {
+	s = uuidRE.ReplaceAllStringFunc(s, ctx.remapper.Remap)
+	s = snykOrgURLRE.ReplaceAllString(s, stableOrgURL)
+	s = emailRE.ReplaceAllString(s, stableEmail)
+	return s
 }

--- a/cmd/ufm-fixture-tool/redact/redact.go
+++ b/cmd/ufm-fixture-tool/redact/redact.go
@@ -1,0 +1,144 @@
+// Package redact normalises a raw UFM test-result JSON dump into a
+// deterministic fixture by replacing UUIDs, emails, and sensitive
+// metadata (including stable org-scoped URLs) with placeholders.
+package redact
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/snyk/go-application-framework/pkg/utils"
+)
+
+var uuidRE = regexp.MustCompile(
+	`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`,
+)
+
+const (
+	stableOrgSlug = "my-org"
+	stableEmail   = "user@example.com"
+
+	defaultReportBase = "https://app.snyk.io/org/" + stableOrgSlug + "/project"
+
+	// Stable metadata placeholders (keys are kept; real IDs/URLs are not echoed).
+	stableMetadataProjectID  = "00000000-0000-0000-0000-000000000000"
+	stableMetadataSnapshotID = "00000000-0000-0000-0000-000000000001"
+)
+
+// UUIDRemapper assigns deterministic UUIDs to every unique UUID encountered,
+// in first-seen order.
+type UUIDRemapper struct {
+	mapping map[string]string
+	counter int
+}
+
+func NewUUIDRemapper() *UUIDRemapper {
+	return &UUIDRemapper{mapping: make(map[string]string)}
+}
+
+// Remap returns the stable replacement for the given UUID. If not yet seen,
+// a new deterministic UUID is generated.
+func (r *UUIDRemapper) Remap(value string) string {
+	key := strings.ToLower(value)
+	if mapped, ok := r.mapping[key]; ok {
+		return mapped
+	}
+	r.counter++
+	mapped := fmt.Sprintf("11112222-3333-4444-5555-%012x", r.counter)
+	r.mapping[key] = mapped
+	return mapped
+}
+
+// mapKeyIsUUID reports whether s is exactly one RFC-4122-style UUID (JSON object
+// keys cannot contain multiple matches; this is used for maps like _problemRefs).
+func mapKeyIsUUID(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	return uuidRE.FindString(s) == s
+}
+
+// Fixture normalises a raw UFM JSON array ([]testresult) and returns the
+// redacted bytes as indented JSON.
+func Fixture(raw []byte) ([]byte, error) {
+	var data []interface{}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return nil, fmt.Errorf("expected top-level JSON array: %w", err)
+	}
+
+	ctx := walkContext{
+		remapper: NewUUIDRemapper(),
+	}
+	redacted := walk(data, &ctx)
+
+	out, err := json.MarshalIndent(redacted, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal redacted data: %w", err)
+	}
+	out = append(out, '\n')
+	return out, nil
+}
+
+type walkContext struct {
+	remapper *UUIDRemapper
+	// inMetadata is true while walking the object under the top-level "metadata" key.
+	inMetadata bool
+}
+
+func walk(node interface{}, ctx *walkContext) interface{} {
+	switch v := node.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(v))
+		for _, k := range utils.SortedMapKeys(v) {
+			val := v[k]
+			outKey := k
+			if mapKeyIsUUID(k) {
+				outKey = ctx.remapper.Remap(k)
+			}
+			if k == "email" {
+				out[outKey] = stableEmail
+				continue
+			}
+			if ctx.inMetadata {
+				switch k {
+				case "project-id":
+					out[outKey] = stableMetadataProjectID
+				case "snapshot-id":
+					out[outKey] = stableMetadataSnapshotID
+				case "project-page-link", "report-url":
+					out[outKey] = fmt.Sprintf("%s/%s", defaultReportBase, stableMetadataProjectID)
+				default:
+					out[outKey] = walk(val, ctx)
+				}
+				continue
+			}
+
+			if k == "metadata" {
+				if meta, ok := val.(map[string]interface{}); ok {
+					sub := *ctx
+					sub.inMetadata = true
+					out[outKey] = walk(meta, &sub)
+					continue
+				}
+			}
+			out[outKey] = walk(val, ctx)
+		}
+		return out
+
+	case []interface{}:
+		out := make([]interface{}, len(v))
+		for i, item := range v {
+			out[i] = walk(item, ctx)
+		}
+		return out
+
+	case string:
+		s := uuidRE.ReplaceAllStringFunc(v, ctx.remapper.Remap)
+		return s
+
+	default:
+		return node
+	}
+}

--- a/cmd/ufm-fixture-tool/redact/redact_test.go
+++ b/cmd/ufm-fixture-tool/redact/redact_test.go
@@ -29,15 +29,12 @@ func TestFixture_UUIDs_are_deterministic(t *testing.T) {
 	first, err := Fixture([]byte(input))
 	require.NoError(t, err)
 
-	// Run 20 times — every run must produce byte-identical output.
 	for i := 1; i < 20; i++ {
 		out, err := Fixture([]byte(input))
 		require.NoError(t, err, "iteration %d", i)
 		assert.Equal(t, string(first), string(out), "iteration %d produced different output (non-deterministic)", i)
 	}
 
-	// Verify the exact sequential counter: array position 0 gets counter
-	// 1, position 1 gets counter 2, etc.
 	var result []map[string]interface{}
 	require.NoError(t, json.Unmarshal(first, &result))
 
@@ -45,7 +42,7 @@ func TestFixture_UUIDs_are_deterministic(t *testing.T) {
 	require.True(t, ok, `expected []interface{} at result[0]["uuids"]`)
 
 	for i, v := range uuids {
-		want := fmt.Sprintf("11112222-3333-4444-5555-%012x", i+1)
+		want := fmt.Sprintf("00000000-0000-0000-0000-%012d", i+1)
 		got, ok := v.(string)
 		require.True(t, ok, "uuids[%d]: expected string, got %T", i, v)
 		assert.Equal(t, want, got, "uuids[%d]", i)
@@ -63,8 +60,8 @@ func TestFixture_same_UUID_maps_to_same_replacement(t *testing.T) {
 	assert.Equal(t, result[0]["a"], result[0]["b"], "same source UUID should map to the same replacement")
 }
 
-func TestFixture_email_field_replaced(t *testing.T) {
-	input := `[{"email":"alice@example.com","author":"bob@example.com"}]`
+func TestFixture_emails_replaced_anywhere(t *testing.T) {
+	input := `[{"email":"alice@example.com","author":"bob@example.com","name":"set by carol@snyk.io"}]`
 	out, err := Fixture([]byte(input))
 	require.NoError(t, err)
 
@@ -72,7 +69,8 @@ func TestFixture_email_field_replaced(t *testing.T) {
 	require.NoError(t, json.Unmarshal(out, &result))
 
 	assert.Equal(t, stableEmail, result[0]["email"])
-	assert.Equal(t, "bob@example.com", result[0]["author"], "author is not the 'email' key, should pass through")
+	assert.Equal(t, stableEmail, result[0]["author"])
+	assert.Equal(t, "set by "+stableEmail, result[0]["name"])
 }
 
 func TestFixture_email_field_in_nested_object(t *testing.T) {
@@ -90,8 +88,55 @@ func TestFixture_email_field_in_nested_object(t *testing.T) {
 	assert.Equal(t, "Alice", user["name"], "non-email fields should pass through")
 }
 
-func TestFixture_UUIDs_in_URLs_remapped(t *testing.T) {
-	input := `[{"url":"https://app.snyk.io/org/foo/project/aaaaaaaa-1111-2222-3333-444444444444/report"}]`
+// Markdown descriptions for OSS findings often contain "package@1.2.3"
+// strings (sometimes with exotic version suffixes like Maven's `.RELEASE`,
+// pre-release tags, or build metadata). The email pattern match must skip
+// all of these — its domain anchor requires a leading letter, ruling out
+// digit-led version suffixes.
+func TestFixture_package_at_version_not_redacted(t *testing.T) {
+	cases := []string{
+		// Semver-ish: numeric TLD, never email-shaped.
+		"got@11.8.5",
+		"lodash@4.17.21",
+		"requests@2.31.0",
+		// Maven-style suffixes — all-alpha "TLD" looks like an email TLD.
+		"org.springframework.boot@2.7.0.RELEASE",
+		"com.fasterxml.jackson.core@2.13.0.Final",
+		"javax.inject@1.0.0.GA",
+		"org.hibernate@5.4.0.SR1",
+		// Pre-release / build-metadata tags.
+		"react@18.2.0-alpha",
+		"vue@3.0.0-rc.1",
+		"webpack@5.0.0-beta.1",
+		"libfoo@1.0.0-SNAPSHOT",
+		"gem@1.0.0+build.123",
+		// Architecture/platform suffixes.
+		"nokogiri@1.13.4-x86_64-linux",
+		// Operators / globs commonly seen in advisories.
+		"lodash@^4.17.21",
+		"package@~1.2.3",
+		"foo@1.x",
+		"@scope/package@1.0.0",
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			input := fmt.Sprintf(`[{"description":"Upgrade %s for the fix."}]`, c)
+			out, err := Fixture([]byte(input))
+			require.NoError(t, err)
+
+			var result []map[string]interface{}
+			require.NoError(t, json.Unmarshal(out, &result))
+
+			desc, ok := result[0]["description"].(string)
+			assert.True(t, ok)
+			assert.Contains(t, desc, c, "package@version must be left untouched, got %q", desc)
+			assert.NotContains(t, desc, stableEmail)
+		})
+	}
+}
+
+func TestFixture_UUIDs_in_strings_remapped(t *testing.T) {
+	input := `[{"url":"https://snyk.io/projects/aaaaaaaa-1111-2222-3333-444444444444/report"}]`
 	out, err := Fixture([]byte(input))
 	require.NoError(t, err)
 
@@ -99,14 +144,48 @@ func TestFixture_UUIDs_in_URLs_remapped(t *testing.T) {
 	require.NoError(t, json.Unmarshal(out, &result))
 
 	url, ok := result[0]["url"].(string)
-	require.True(t, ok, `expected string at result[0]["url"]`)
-
-	assert.NotEqual(t, input, url, "URL should have been transformed")
-	assert.False(t, strings.Contains(url, "aaaaaaaa-1111-2222-3333-444444444444"), "original UUID still present in URL")
+	assert.True(t, ok)
+	assert.NotContains(t, url, "aaaaaaaa-1111-2222-3333-444444444444", "original UUID still present")
+	matches := uuidRE.FindAllString(url, -1)
+	require.Len(t, matches, 1)
+	assert.True(t, strings.HasPrefix(matches[0], "00000000-0000-0000-0000-"), "expected placeholder UUID, got %q", matches[0])
 }
 
-func TestFixture_metadata_redacted(t *testing.T) {
-	input := `[{"metadata":{"project-id":"aaaaaaaa-1111-2222-3333-444444444444","snapshot-id":"bbbbbbbb-1111-2222-3333-444444444444","project-page-link":"https://example.com","report-url":"https://old","kept":"value"}}]`
+func TestFixture_snyk_org_slug_swapped(t *testing.T) {
+	// Covers every Snyk app subdomain (production, regional, internal envs)
+	// so the redacted fixture doesn't leak the originating org slug.
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"app", "https://app.snyk.io/org/real-org-slug/project", "https://app.snyk.io/org/my-org/project"},
+		{"dev", "https://app.dev.snyk.io/org/another-slug/project/x", "https://app.snyk.io/org/my-org/project/x"},
+		{"eu", "https://app.eu.snyk.io/org/eu-team/dashboard", "https://app.snyk.io/org/my-org/dashboard"},
+		{"path_only", "https://app.snyk.io/org/slug-with-dashes-123", "https://app.snyk.io/org/my-org"},
+		{"project_with_uuid", "https://app.dev.snyk.io/org/real-org/project/aaaaaaaa-1111-2222-3333-444444444444/report", "https://app.snyk.io/org/my-org/project/00000000-0000-0000-0000-000000000001/report"},
+		{"non_snyk_left_alone", "https://github.com/org/some-org/repo", "https://github.com/org/some-org/repo"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := fmt.Sprintf(`[{"link":%q}]`, tc.in)
+			out, err := Fixture([]byte(input))
+			require.NoError(t, err)
+
+			var result []map[string]interface{}
+			require.NoError(t, json.Unmarshal(out, &result))
+
+			link, ok := result[0]["link"].(string)
+			assert.True(t, ok)
+			assert.Equal(t, tc.want, link)
+		})
+	}
+}
+
+func TestFixture_metadata_project_id_remapped_as_uuid(t *testing.T) {
+	// project-id used to have a hard-coded placeholder. Now it's just a
+	// UUID-valued string and should be handled by the generic UUID remapper.
+	input := `[{"metadata":{"project-id":"aaaaaaaa-1111-2222-3333-444444444444","snapshot-id":"bbbbbbbb-1111-2222-3333-444444444444","report-url":"https://app.snyk.io/org/real-org/project/aaaaaaaa-1111-2222-3333-444444444444","kept":"value"}}]`
 	out, err := Fixture([]byte(input))
 	require.NoError(t, err)
 
@@ -114,29 +193,21 @@ func TestFixture_metadata_redacted(t *testing.T) {
 	require.NoError(t, json.Unmarshal(out, &result))
 
 	meta, ok := result[0]["metadata"].(map[string]interface{})
-	require.True(t, ok, `expected map at result[0]["metadata"]`)
+	assert.True(t, ok)
 
-	wantPage := fmt.Sprintf("https://app.snyk.io/org/my-org/project/%s", stableMetadataProjectID)
+	projectID, ok := meta["project-id"].(string)
+	assert.True(t, ok)
+	assert.True(t, strings.HasPrefix(projectID, "00000000-0000-0000-0000-"), "project-id should be remapped, got %q", projectID)
 
-	assert.Equal(t, stableMetadataProjectID, meta["project-id"])
-	assert.Equal(t, stableMetadataSnapshotID, meta["snapshot-id"])
-	assert.Equal(t, wantPage, meta["project-page-link"])
-	assert.Equal(t, wantPage, meta["report-url"])
-	assert.Equal(t, "value", meta["kept"])
-}
+	snapshotID, ok := meta["snapshot-id"].(string)
+	assert.True(t, ok)
+	assert.True(t, strings.HasPrefix(snapshotID, "00000000-0000-0000-0000-"), "snapshot-id should be remapped, got %q", snapshotID)
+	assert.NotEqual(t, projectID, snapshotID)
 
-func TestFixture_metadata_without_report_url(t *testing.T) {
-	input := `[{"metadata":{"kept":"value"}}]`
-	out, err := Fixture([]byte(input))
-	require.NoError(t, err)
-
-	var result []map[string]interface{}
-	require.NoError(t, json.Unmarshal(out, &result))
-
-	meta, ok := result[0]["metadata"].(map[string]interface{})
-	require.True(t, ok, `expected map at result[0]["metadata"]`)
-
-	assert.NotContains(t, meta, "report-url", "report-url should not be injected when absent from input")
+	reportURL, ok := meta["report-url"].(string)
+	assert.True(t, ok)
+	wantURL := "https://app.snyk.io/org/" + stableOrgSlug + "/project/" + projectID
+	assert.Equal(t, wantURL, reportURL, "URL keeps domain, swaps org slug, reuses remapped project-id")
 	assert.Equal(t, "value", meta["kept"])
 }
 
@@ -149,21 +220,21 @@ func TestFixture_nested_arrays(t *testing.T) {
 	require.NoError(t, json.Unmarshal(out, &result))
 
 	items, ok := result[0]["items"].([]interface{})
-	require.True(t, ok, `expected []interface{} at result[0]["items"]`)
+	assert.True(t, ok)
 	require.Len(t, items, 2)
 
 	item0, ok := items[0].(map[string]interface{})
-	require.True(t, ok, "expected map at items[0]")
+	assert.True(t, ok)
 	item1, ok := items[1].(map[string]interface{})
-	require.True(t, ok, "expected map at items[1]")
+	assert.True(t, ok)
 
 	id1, ok := item0["id"].(string)
-	require.True(t, ok, `expected string at items[0]["id"]`)
+	assert.True(t, ok)
 	id2, ok := item1["id"].(string)
-	require.True(t, ok, `expected string at items[1]["id"]`)
+	assert.True(t, ok)
 
-	assert.NotEqual(t, "aaaaaaaa-1111-2222-3333-444444444444", id1, "nested UUID should be remapped")
-	assert.NotEqual(t, "bbbbbbbb-1111-2222-3333-444444444444", id2, "nested UUID should be remapped")
+	assert.True(t, strings.HasPrefix(id1, "00000000-0000-0000-0000-"), "nested UUID should use placeholder prefix, got %q", id1)
+	assert.True(t, strings.HasPrefix(id2, "00000000-0000-0000-0000-"), "nested UUID should use placeholder prefix, got %q", id2)
 	assert.NotEqual(t, id1, id2, "different UUIDs should map to different replacements")
 }
 
@@ -188,35 +259,48 @@ func TestFixture_problem_ref_map_keys_share_UUID_mapping_with_values(t *testing.
 
 	root := result[0]
 	refs, ok := root["_problemRefs"].(map[string]interface{})
-	require.True(t, ok, "expected map at _problemRefs")
-
+	assert.True(t, ok)
 	problems, ok := root["problems"].([]interface{})
-	require.True(t, ok, "expected []interface{} at problems")
+	assert.True(t, ok)
 	require.Len(t, problems, 2)
 
 	p0, ok := problems[0].(map[string]interface{})
-	require.True(t, ok, "problems[0] should be an object")
+	assert.True(t, ok)
 	p1, ok := problems[1].(map[string]interface{})
-	require.True(t, ok, "problems[1] should be an object")
+	assert.True(t, ok)
 	id0, ok := p0["id"].(string)
-	require.True(t, ok, "problems[0].id should be a string")
+	assert.True(t, ok)
 	id1, ok := p1["id"].(string)
-	require.True(t, ok, "problems[1].id should be a string")
-	require.NotEmpty(t, id0, "problems[0].id")
-	require.NotEmpty(t, id1, "problems[1].id")
+	assert.True(t, ok)
+	require.NotEmpty(t, id0)
+	require.NotEmpty(t, id1)
 
 	assert.Contains(t, refs, id0, "_problemRefs should contain key matching first problem id")
 	assert.Contains(t, refs, id1, "_problemRefs should contain key matching second problem id")
 }
 
-func TestFixture_invalid_json(t *testing.T) {
-	_, err := Fixture([]byte(`not json`))
-	assert.Error(t, err)
-}
-
-func TestFixture_non_array_json(t *testing.T) {
-	_, err := Fixture([]byte(`{"key":"value"}`))
-	assert.Error(t, err)
+func TestFixture_input_validation(t *testing.T) {
+	cases := []struct {
+		name        string
+		input       string
+		wantOutput  string
+		wantErrText string
+	}{
+		{"invalid_json", "not json", "", "expected top-level JSON array"},
+		{"object_not_array", `{"key":"value"}`, "", "expected top-level JSON array"},
+		{"empty_array", `[]`, "[]\n", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := Fixture([]byte(tc.input))
+			if tc.wantErrText != "" {
+				assert.ErrorContains(t, err, tc.wantErrText)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantOutput, string(out))
+		})
+	}
 }
 
 func TestUUIDRemapper_incremental(t *testing.T) {
@@ -225,8 +309,8 @@ func TestUUIDRemapper_incremental(t *testing.T) {
 	b := r.Remap("bbbbbbbb-1111-2222-3333-444444444444")
 
 	assert.NotEqual(t, a, b, "different inputs should produce different outputs")
-	assert.Equal(t, "11112222-3333-4444-5555-000000000001", a)
-	assert.Equal(t, "11112222-3333-4444-5555-000000000002", b)
+	assert.Equal(t, "00000000-0000-0000-0000-000000000001", a)
+	assert.Equal(t, "00000000-0000-0000-0000-000000000002", b)
 
 	a2 := r.Remap("AAAAAAAA-1111-2222-3333-444444444444")
 	assert.Equal(t, a, a2, "case-insensitive lookup should return the same mapped UUID")

--- a/cmd/ufm-fixture-tool/redact/redact_test.go
+++ b/cmd/ufm-fixture-tool/redact/redact_test.go
@@ -1,0 +1,233 @@
+package redact
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFixture_UUIDs_are_deterministic(t *testing.T) {
+	// Pure array of UUIDs — no maps involved — so traversal order is
+	// fully governed by array indices, not Go's random map iteration.
+	input := `[{"uuids":[
+		"aaaaaaaa-0001-0001-0001-aaaaaaaaaaaa",
+		"aaaaaaaa-0002-0002-0002-aaaaaaaaaaaa",
+		"aaaaaaaa-0003-0003-0003-aaaaaaaaaaaa",
+		"aaaaaaaa-0004-0004-0004-aaaaaaaaaaaa",
+		"aaaaaaaa-0005-0005-0005-aaaaaaaaaaaa",
+		"aaaaaaaa-0006-0006-0006-aaaaaaaaaaaa",
+		"aaaaaaaa-0007-0007-0007-aaaaaaaaaaaa",
+		"aaaaaaaa-0008-0008-0008-aaaaaaaaaaaa",
+		"aaaaaaaa-0009-0009-0009-aaaaaaaaaaaa",
+		"aaaaaaaa-0010-0010-0010-aaaaaaaaaaaa"
+	]}]`
+
+	first, err := Fixture([]byte(input))
+	require.NoError(t, err)
+
+	// Run 20 times — every run must produce byte-identical output.
+	for i := 1; i < 20; i++ {
+		out, err := Fixture([]byte(input))
+		require.NoError(t, err, "iteration %d", i)
+		assert.Equal(t, string(first), string(out), "iteration %d produced different output (non-deterministic)", i)
+	}
+
+	// Verify the exact sequential counter: array position 0 gets counter
+	// 1, position 1 gets counter 2, etc.
+	var result []map[string]interface{}
+	require.NoError(t, json.Unmarshal(first, &result))
+
+	uuids, ok := result[0]["uuids"].([]interface{})
+	require.True(t, ok, `expected []interface{} at result[0]["uuids"]`)
+
+	for i, v := range uuids {
+		want := fmt.Sprintf("11112222-3333-4444-5555-%012x", i+1)
+		got, ok := v.(string)
+		require.True(t, ok, "uuids[%d]: expected string, got %T", i, v)
+		assert.Equal(t, want, got, "uuids[%d]", i)
+	}
+}
+
+func TestFixture_same_UUID_maps_to_same_replacement(t *testing.T) {
+	input := `[{"a":"aaaaaaaa-1111-2222-3333-444444444444","b":"aaaaaaaa-1111-2222-3333-444444444444"}]`
+	out, err := Fixture([]byte(input))
+	require.NoError(t, err)
+
+	var result []map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	assert.Equal(t, result[0]["a"], result[0]["b"], "same source UUID should map to the same replacement")
+}
+
+func TestFixture_email_field_replaced(t *testing.T) {
+	input := `[{"email":"alice@example.com","author":"bob@example.com"}]`
+	out, err := Fixture([]byte(input))
+	require.NoError(t, err)
+
+	var result []map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	assert.Equal(t, stableEmail, result[0]["email"])
+	assert.Equal(t, "bob@example.com", result[0]["author"], "author is not the 'email' key, should pass through")
+}
+
+func TestFixture_email_field_in_nested_object(t *testing.T) {
+	input := `[{"user":{"email":"deep@nested.com","name":"Alice"}}]`
+	out, err := Fixture([]byte(input))
+	require.NoError(t, err)
+
+	var result []map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	user, ok := result[0]["user"].(map[string]interface{})
+	require.True(t, ok, `expected map at result[0]["user"]`)
+
+	assert.Equal(t, stableEmail, user["email"])
+	assert.Equal(t, "Alice", user["name"], "non-email fields should pass through")
+}
+
+func TestFixture_UUIDs_in_URLs_remapped(t *testing.T) {
+	input := `[{"url":"https://app.snyk.io/org/foo/project/aaaaaaaa-1111-2222-3333-444444444444/report"}]`
+	out, err := Fixture([]byte(input))
+	require.NoError(t, err)
+
+	var result []map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	url, ok := result[0]["url"].(string)
+	require.True(t, ok, `expected string at result[0]["url"]`)
+
+	assert.NotEqual(t, input, url, "URL should have been transformed")
+	assert.False(t, strings.Contains(url, "aaaaaaaa-1111-2222-3333-444444444444"), "original UUID still present in URL")
+}
+
+func TestFixture_metadata_redacted(t *testing.T) {
+	input := `[{"metadata":{"project-id":"aaaaaaaa-1111-2222-3333-444444444444","snapshot-id":"bbbbbbbb-1111-2222-3333-444444444444","project-page-link":"https://example.com","report-url":"https://old","kept":"value"}}]`
+	out, err := Fixture([]byte(input))
+	require.NoError(t, err)
+
+	var result []map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	meta, ok := result[0]["metadata"].(map[string]interface{})
+	require.True(t, ok, `expected map at result[0]["metadata"]`)
+
+	wantPage := fmt.Sprintf("https://app.snyk.io/org/my-org/project/%s", stableMetadataProjectID)
+
+	assert.Equal(t, stableMetadataProjectID, meta["project-id"])
+	assert.Equal(t, stableMetadataSnapshotID, meta["snapshot-id"])
+	assert.Equal(t, wantPage, meta["project-page-link"])
+	assert.Equal(t, wantPage, meta["report-url"])
+	assert.Equal(t, "value", meta["kept"])
+}
+
+func TestFixture_metadata_without_report_url(t *testing.T) {
+	input := `[{"metadata":{"kept":"value"}}]`
+	out, err := Fixture([]byte(input))
+	require.NoError(t, err)
+
+	var result []map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	meta, ok := result[0]["metadata"].(map[string]interface{})
+	require.True(t, ok, `expected map at result[0]["metadata"]`)
+
+	assert.NotContains(t, meta, "report-url", "report-url should not be injected when absent from input")
+	assert.Equal(t, "value", meta["kept"])
+}
+
+func TestFixture_nested_arrays(t *testing.T) {
+	input := `[{"items":[{"id":"aaaaaaaa-1111-2222-3333-444444444444"},{"id":"bbbbbbbb-1111-2222-3333-444444444444"}]}]`
+	out, err := Fixture([]byte(input))
+	require.NoError(t, err)
+
+	var result []map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	items, ok := result[0]["items"].([]interface{})
+	require.True(t, ok, `expected []interface{} at result[0]["items"]`)
+	require.Len(t, items, 2)
+
+	item0, ok := items[0].(map[string]interface{})
+	require.True(t, ok, "expected map at items[0]")
+	item1, ok := items[1].(map[string]interface{})
+	require.True(t, ok, "expected map at items[1]")
+
+	id1, ok := item0["id"].(string)
+	require.True(t, ok, `expected string at items[0]["id"]`)
+	id2, ok := item1["id"].(string)
+	require.True(t, ok, `expected string at items[1]["id"]`)
+
+	assert.NotEqual(t, "aaaaaaaa-1111-2222-3333-444444444444", id1, "nested UUID should be remapped")
+	assert.NotEqual(t, "bbbbbbbb-1111-2222-3333-444444444444", id2, "nested UUID should be remapped")
+	assert.NotEqual(t, id1, id2, "different UUIDs should map to different replacements")
+}
+
+func TestFixture_problem_ref_map_keys_share_UUID_mapping_with_values(t *testing.T) {
+	// _problemRefs uses problem UUIDs as JSON object keys; the same UUID appears
+	// in problem "id" fields. Keys must go through the same remapper as values.
+	input := `[{
+		"_problemRefs": {
+			"aaaaaaaa-1111-2222-3333-444444444444": ["generic-secret"],
+			"bbbbbbbb-1111-2222-3333-444444444444": ["private-key"]
+		},
+		"problems": [
+			{"id": "aaaaaaaa-1111-2222-3333-444444444444"},
+			{"id": "bbbbbbbb-1111-2222-3333-444444444444"}
+		]
+	}]`
+	out, err := Fixture([]byte(input))
+	require.NoError(t, err)
+
+	var result []map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	root := result[0]
+	refs, ok := root["_problemRefs"].(map[string]interface{})
+	require.True(t, ok, "expected map at _problemRefs")
+
+	problems, ok := root["problems"].([]interface{})
+	require.True(t, ok, "expected []interface{} at problems")
+	require.Len(t, problems, 2)
+
+	p0, ok := problems[0].(map[string]interface{})
+	require.True(t, ok, "problems[0] should be an object")
+	p1, ok := problems[1].(map[string]interface{})
+	require.True(t, ok, "problems[1] should be an object")
+	id0, ok := p0["id"].(string)
+	require.True(t, ok, "problems[0].id should be a string")
+	id1, ok := p1["id"].(string)
+	require.True(t, ok, "problems[1].id should be a string")
+	require.NotEmpty(t, id0, "problems[0].id")
+	require.NotEmpty(t, id1, "problems[1].id")
+
+	assert.Contains(t, refs, id0, "_problemRefs should contain key matching first problem id")
+	assert.Contains(t, refs, id1, "_problemRefs should contain key matching second problem id")
+}
+
+func TestFixture_invalid_json(t *testing.T) {
+	_, err := Fixture([]byte(`not json`))
+	assert.Error(t, err)
+}
+
+func TestFixture_non_array_json(t *testing.T) {
+	_, err := Fixture([]byte(`{"key":"value"}`))
+	assert.Error(t, err)
+}
+
+func TestUUIDRemapper_incremental(t *testing.T) {
+	r := NewUUIDRemapper()
+	a := r.Remap("aaaaaaaa-1111-2222-3333-444444444444")
+	b := r.Remap("bbbbbbbb-1111-2222-3333-444444444444")
+
+	assert.NotEqual(t, a, b, "different inputs should produce different outputs")
+	assert.Equal(t, "11112222-3333-4444-5555-000000000001", a)
+	assert.Equal(t, "11112222-3333-4444-5555-000000000002", b)
+
+	a2 := r.Remap("AAAAAAAA-1111-2222-3333-444444444444")
+	assert.Equal(t, a, a2, "case-insensitive lookup should return the same mapped UUID")
+}

--- a/internal/presenters/presenter_ufm_test.go
+++ b/internal/presenters/presenter_ufm_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/snyk/go-application-framework/internal/presenters"
@@ -622,9 +623,7 @@ func Test_UfmPresenter_Sarif(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := os.Stat(tc.testResultPath); os.IsNotExist(err) {
-				t.Skipf("fixture not yet generated: %s (see README for dump+redact workflow)", tc.testResultPath)
-			}
+			require.FileExists(t, tc.testResultPath, "fixture missing — regenerate via `make generate-fixture` (see CONTRIBUTING.md)")
 
 			expectedSarifBytes, err := os.ReadFile(tc.expectedSarifPath)
 			if os.IsNotExist(err) && regenerateExpectedFiles {
@@ -1236,9 +1235,7 @@ func Test_UfmPresenter_HumanReadable(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := os.Stat(tc.testResultPath); os.IsNotExist(err) {
-				t.Skipf("fixture not yet generated: %s (see README for dump+redact workflow)", tc.testResultPath)
-			}
+			require.FileExists(t, tc.testResultPath, "fixture missing — regenerate via `make generate-fixture` (see CONTRIBUTING.md)")
 
 			expectedBytes, err := os.ReadFile(tc.expectedPath)
 			if os.IsNotExist(err) && regenerateExpectedFiles {

--- a/internal/presenters/presenter_ufm_test.go
+++ b/internal/presenters/presenter_ufm_test.go
@@ -27,6 +27,11 @@ import (
 	"github.com/snyk/go-application-framework/pkg/utils/ufm"
 )
 
+// regenerateExpectedFiles controls whether the test loops overwrite expected
+// files with the current presenter output instead of comparing.
+// Flip to true here, or set UFM_REGEN=1 env var.
+var regenerateExpectedFiles = os.Getenv("UFM_REGEN") == "1" || false
+
 func validateSarifData(t *testing.T, data []byte) {
 	t.Helper()
 
@@ -617,15 +622,22 @@ func Test_UfmPresenter_Sarif(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			if _, err := os.Stat(tc.testResultPath); os.IsNotExist(err) {
+				t.Skipf("fixture not yet generated: %s (see README for dump+redact workflow)", tc.testResultPath)
+			}
+
 			expectedSarifBytes, err := os.ReadFile(tc.expectedSarifPath)
-			assert.NoError(t, err)
+			if os.IsNotExist(err) && regenerateExpectedFiles {
+				expectedSarifBytes = nil
+			} else {
+				assert.NoError(t, err)
+			}
 
 			testResultBytes, err := os.ReadFile(tc.testResultPath)
 			assert.NoError(t, err)
 
 			testResult, err := ufm.NewSerializableTestResultFromBytes(testResultBytes)
 			assert.NoError(t, err)
-			// assert.Equal(t, 1, len(testResult))
 
 			config := configuration.NewWithOpts()
 
@@ -636,6 +648,13 @@ func Test_UfmPresenter_Sarif(t *testing.T) {
 			assert.NoError(t, err)
 
 			validateSarifData(t, writer.Bytes())
+
+			if regenerateExpectedFiles {
+				if writeErr := os.WriteFile(tc.expectedSarifPath, writer.Bytes(), 0o644); writeErr != nil {
+					t.Fatalf("failed to regenerate %s: %v", tc.expectedSarifPath, writeErr)
+				}
+				t.Skipf("regenerated %s", tc.expectedSarifPath)
+			}
 
 			// Normalize both expected and actual SARIF to ignore known gaps while testing implemented features
 			expectedNormalized := normalizeSarifForComparison(t, string(expectedSarifBytes), tc.ignoreSuppressions)
@@ -1217,8 +1236,16 @@ func Test_UfmPresenter_HumanReadable(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			if _, err := os.Stat(tc.testResultPath); os.IsNotExist(err) {
+				t.Skipf("fixture not yet generated: %s (see README for dump+redact workflow)", tc.testResultPath)
+			}
+
 			expectedBytes, err := os.ReadFile(tc.expectedPath)
-			assert.NoError(t, err)
+			if os.IsNotExist(err) && regenerateExpectedFiles {
+				expectedBytes = nil
+			} else {
+				assert.NoError(t, err)
+			}
 
 			testResultBytes, err := os.ReadFile(tc.testResultPath)
 			assert.NoError(t, err)
@@ -1240,6 +1267,14 @@ func Test_UfmPresenter_HumanReadable(t *testing.T) {
 			assert.NoError(t, err)
 
 			actualBytes := writer.Bytes()
+
+			if regenerateExpectedFiles {
+				if writeErr := os.WriteFile(tc.expectedPath, actualBytes, 0o644); writeErr != nil {
+					t.Fatalf("failed to regenerate %s: %v", tc.expectedPath, writeErr)
+				}
+				t.Skipf("regenerated %s", tc.expectedPath)
+			}
+
 			assert.NotEmpty(t, actualBytes)
 
 			assert.NotEmpty(t, expectedBytes)

--- a/pkg/utils/mapkeys.go
+++ b/pkg/utils/mapkeys.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"cmp"
+	"slices"
+)
+
+// SortedMapKeys returns the keys of m in ascending order.
+// Use it when deterministic iteration over a map is required (Go map iteration order is not defined),
+// for example after encoding/json decoding into map[K]V.
+func SortedMapKeys[K cmp.Ordered, V any](m map[K]V) []K {
+	keys := make([]K, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return keys
+}

--- a/pkg/utils/mapkeys_test.go
+++ b/pkg/utils/mapkeys_test.go
@@ -1,0 +1,77 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortedMapKeys(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		testCases := []struct {
+			name string
+			m    map[string]int
+			want []string
+		}{
+			{
+				name: "sorted_values",
+				m:    map[string]int{"b": 2, "a": 1, "c": 3},
+				want: []string{"a", "b", "c"},
+			},
+			{
+				name: "empty",
+				m:    map[string]int{},
+				want: []string{},
+			},
+			{
+				name: "single_key",
+				m:    map[string]int{"only": 1},
+				want: []string{"only"},
+			},
+			{
+				name: "keys_already_sorted",
+				m:    map[string]int{"a": 1, "b": 2, "c": 3},
+				want: []string{"a", "b", "c"},
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.Equal(t, tc.want, SortedMapKeys(tc.m))
+			})
+		}
+	})
+
+	t.Run("int", func(t *testing.T) {
+		testCases := []struct {
+			name string
+			m    map[int]string
+			want []int
+		}{
+			{
+				name: "sorted_values",
+				m:    map[int]string{3: "c", 1: "a", 2: "b"},
+				want: []int{1, 2, 3},
+			},
+			{
+				name: "empty",
+				m:    map[int]string{},
+				want: []int{},
+			},
+			{
+				name: "single_key",
+				m:    map[int]string{42: "x"},
+				want: []int{42},
+			},
+			{
+				name: "negative_and_positive",
+				m:    map[int]string{0: "z", -1: "a", 2: "b"},
+				want: []int{-1, 0, 2},
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.Equal(t, tc.want, SortedMapKeys(tc.m))
+			})
+		}
+	})
+}

--- a/scripts/generate-fixture.sh
+++ b/scripts/generate-fixture.sh
@@ -94,10 +94,9 @@ if [[ "${REDACT}" == "1" ]]; then
   echo ""
   printf "Redacting:\n"
   printf "  cd %q\n" "${REPO_ROOT}"
-  printf "  go run ./cmd/ufm-fixture-tool --input=%q --output=%qZ\n" "${raw_output}" "${redacted_output}"
+  printf "  go run ./cmd/ufm-fixture-tool --input=%q --output=%q\n" "${raw_output}" "${redacted_output}"
   (
     cd "${REPO_ROOT}"
     go run ./cmd/ufm-fixture-tool --input="${raw_output}" --output="${redacted_output}"
   )
 fi
-

--- a/scripts/generate-fixture.sh
+++ b/scripts/generate-fixture.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+PROJECT="${PROJECT:-}"
+ORG="${ORG:-}"
+NAME="${NAME:-}"
+
+SNYK_BIN="${SNYK_BIN:-snyk}"
+OUT_DIR="${OUT_DIR:-${REPO_ROOT}/dumps}"
+DUMP_DIR="${DUMP_DIR:-${OUT_DIR}/raw}"
+DEFAULT_SCAN_CMD="${DEFAULT_SCAN_CMD:-secrets test .}"
+SCAN_CMD="${SCAN_CMD:-${DEFAULT_SCAN_CMD}}"
+REPORT="${REPORT:-0}"
+REDACT="${REDACT:-1}"
+
+if [[ -z "${PROJECT}" ]]; then
+  echo "error: PROJECT is required" >&2
+  exit 1
+fi
+if [[ -z "${ORG}" ]]; then
+  echo "error: ORG is required" >&2
+  exit 1
+fi
+if [[ -z "${NAME}" ]]; then
+  echo "error: NAME is required" >&2
+  exit 1
+fi
+
+mkdir -p "${DUMP_DIR}" "${OUT_DIR}"
+
+read -r -a scan_args <<< "${SCAN_CMD}"
+if [[ "${REPORT}" == "1" ]]; then
+  scan_args+=("--report")
+fi
+scan_args+=("--org=${ORG}")
+
+echo "Generating fixture (${NAME})"
+echo "  OUT_DIR=${OUT_DIR}"
+echo "  DUMP_DIR=${DUMP_DIR} (SNYK_TMP_PATH)"
+echo "  working directory for scan: ${PROJECT}"
+echo ""
+printf "Running (equivalent):\n"
+printf "  cd %q\n" "${PROJECT}"
+printf "  SNYK_TMP_PATH=%q INTERNAL_IN_MEMORY_THRESHOLD_BYTES=1 INTERNAL_CLEANUP_GLOBAL_TEMP_DIR_ENABLED=false %q" "${DUMP_DIR}" "${SNYK_BIN}"
+for a in "${scan_args[@]}"; do
+	printf " %q" "${a}"
+done
+echo
+echo ""
+set +e
+(
+  cd "${PROJECT}"
+  SNYK_TMP_PATH="${DUMP_DIR}" \
+  INTERNAL_IN_MEMORY_THRESHOLD_BYTES=1 \
+  INTERNAL_CLEANUP_GLOBAL_TEMP_DIR_ENABLED=false \
+    "${SNYK_BIN}" "${scan_args[@]}"
+)
+snyk_exit=$?
+set -e
+
+# Exit 1 is expected when findings are detected.
+if [[ "${snyk_exit}" -ne 0 && "${snyk_exit}" -ne 1 ]]; then
+  echo "error: snyk command failed with exit code ${snyk_exit}" >&2
+  exit "${snyk_exit}"
+fi
+
+# GAF derives TEMP_DIR_PATH as <SNYK_TMP_PATH>/<cli-version>/tmp/pid<pid>, so
+# the dump file lives in a nested subdirectory rather than directly under
+# DUMP_DIR. Recurse and pick the newest match by mtime.
+latest_dump=""
+while IFS= read -r -d '' f; do
+  if [[ -z "${latest_dump}" || "${f}" -nt "${latest_dump}" ]]; then
+    latest_dump="${f}"
+  fi
+done < <(find "${DUMP_DIR}" -type f -name 'workflow.TestResult.*' -print0 2>/dev/null)
+
+if [[ -z "${latest_dump}" ]]; then
+  echo "error: no workflow.TestResult.* file found under ${DUMP_DIR}" >&2
+  echo "hint: ensure SNYK_TMP_PATH is honored by the CLI build and that the" >&2
+  echo "      scan workflow emits a []byte TestResult payload that exceeds" >&2
+  echo "      INTERNAL_IN_MEMORY_THRESHOLD_BYTES (=1)." >&2
+  exit 1
+fi
+
+raw_output="${OUT_DIR}/${NAME}.testresult.raw.json"
+cp "${latest_dump}" "${raw_output}"
+echo "wrote ${raw_output}"
+
+if [[ "${REDACT}" == "1" ]]; then
+  redacted_output="${OUT_DIR}/${NAME}.testresult.json"
+  echo ""
+  printf "Redacting:\n"
+  printf "  cd %q\n" "${REPO_ROOT}"
+  printf "  go run ./cmd/ufm-fixture-tool --input=%q --output=%qZ\n" "${raw_output}" "${redacted_output}"
+  (
+    cd "${REPO_ROOT}"
+    go run ./cmd/ufm-fixture-tool --input="${raw_output}" --output="${redacted_output}"
+  )
+fi
+


### PR DESCRIPTION
### Description

Adds tooling and a small engine enhancement to support generating and redacting UFM test fixtures from real scan output.

#### Fixture generation tooling (new)

- **`cmd/ufm-fixture-tool`** — Standalone CLI tool that redacts a raw workflow dump into a deterministic test fixture. Replaces UUIDs, timestamps, org slugs, and emails with stable placeholders. Usage: `go run ./cmd/ufm-fixture-tool --input=<dump>`.
- **`scripts/generate-fixture.sh`** — Runs a Snyk scan with spill env vars (`SNYK_TMP_PATH`, `INTERNAL_IN_MEMORY_THRESHOLD_BYTES=1`, `INTERNAL_CLEANUP_GLOBAL_TEMP_DIR_ENABLED=false`), finds the newest `workflow.TestResult.*` file under the dump directory (recursive, since spill files are nested under version/pid paths), and optionally redacts. (This requires a followup PR to fix a bug around the payload threshold and it's location)
- **`Makefile`** — New targets: `generate-fixture`, `redact-fixture`, `regenerate-expected`.

#### Tests & docs

- **`internal/presenters/presenter_ufm_test.go`** — Tests now skip gracefully when fixtures are missing (with a pointer to the README). Added `UFM_REGEN=1` mode that overwrites expected files with current presenter output.
- **`README.md` & `CONTRIBUTING.md`** — Rewritten with getting-started, key-packages overview, and full fixture generation/redaction/regeneration workflow documentation.

### Risk assessment

- All other changes are additive: new tooling, new tests, documentation outside the usage of GAF as a library.

### Checklist

- [x] Tests added and pass (`make test`)
- [x] Regenerated mocks (`make generate`)
- [x] Linted (`make lint`)
- [ ] Tested with the CLI  (Not necessary since this changes are not impacting the CLI, but we did test it out with a patched CLI build to ensure the fixtures are generated and redacted)