### PR TITLE
chore: add target file to UFM human readable summary

### DIFF
--- a/internal/presenters/templates/ufm.human.tmpl
+++ b/internal/presenters/templates/ufm.human.tmpl
@@ -98,6 +98,9 @@
 {{- define "testSummary"}}{{ "Test Summary" | bold }}
 {{- "\n" }}
 {{- $metadata := .GetMetadata }}
+{{- $testingSubject := getValueFromConfig "targetDirectory" }}
+{{- $targetFile := index $metadata "display-target-file" }}
+{{- if $targetFile }} {{- $testingSubject = $targetFile }} {{- end }}
 {{- $targetDirectory := index $metadata "target-directory" }}
 {{- if not $targetDirectory }}
 {{- $targetDirectory = getValueFromConfig "targetDirectory" }}
@@ -106,6 +109,9 @@
   Organization:      {{ getValueFromConfig "internal_org_slug" }}
   Test type:         {{ determineProductNameFromFindingTypes $findingTypes }}
   Project path:      {{ $targetDirectory }}
+  {{- if and $testingSubject (ne $testingSubject $targetDirectory) }}
+  Target file:       {{ $testingSubject }}
+  {{- end }}
 
 {{- range $findingType := $findingTypes }}
   {{- $issuesForType := getIssuesFromTestResult $ $findingType }}

--- a/internal/presenters/templates/ufm.human.tmpl
+++ b/internal/presenters/templates/ufm.human.tmpl
@@ -98,9 +98,7 @@
 {{- define "testSummary"}}{{ "Test Summary" | bold }}
 {{- "\n" }}
 {{- $metadata := .GetMetadata }}
-{{- $testingSubject := getValueFromConfig "targetDirectory" }}
 {{- $targetFile := index $metadata "display-target-file" }}
-{{- if $targetFile }} {{- $testingSubject = $targetFile }} {{- end }}
 {{- $targetDirectory := index $metadata "target-directory" }}
 {{- if not $targetDirectory }}
 {{- $targetDirectory = getValueFromConfig "targetDirectory" }}
@@ -109,8 +107,8 @@
   Organization:      {{ getValueFromConfig "internal_org_slug" }}
   Test type:         {{ determineProductNameFromFindingTypes $findingTypes }}
   Project path:      {{ $targetDirectory }}
-  {{- if and $testingSubject (ne $testingSubject $targetDirectory) }}
-  Target file:       {{ $testingSubject }}
+  {{- if $targetFile }}
+  Target file:       {{ $targetFile }}
   {{- end }}
 
 {{- range $findingType := $findingTypes }}

--- a/internal/presenters/testdata/ufm/cli.human.readable
+++ b/internal/presenters/testdata/ufm/cli.human.readable
@@ -118,6 +118,7 @@ Tested 552 dependencies for known issues, found 9 issues, 111 vulnerable paths.
 │   Organization:      My Org                             │
 │   Test type:         Software Composition Analysis      │
 │   Project path:      test-project                       │
+│   Target file:       package.json                       │
 │                                                         │
 │   Total security issues: 9                              │
 │   Ignored: [1m0[0m [[35m 0 CRITICAL [0m[31m 0 HIGH [0m[33m 0 MEDIUM [0m 0 LOW ]    │

--- a/internal/presenters/testdata/ufm/multi_project.human.readable
+++ b/internal/presenters/testdata/ufm/multi_project.human.readable
@@ -52,6 +52,7 @@ Tested 84 dependencies for known issues, found 6 issues, 9 vulnerable paths.
 │   Organization:      My Org                             │
 │   Test type:         Software Composition Analysis      │
 │   Project path:      multi-project                      │
+│   Target file:       dotnet/obj/project.assets.json     │
 │                                                         │
 │   Total security issues: 6                              │
 │   Ignored: [1m0[0m [[35m 0 CRITICAL [0m[31m 0 HIGH [0m[33m 0 MEDIUM [0m 0 LOW ]    │
@@ -247,6 +248,7 @@ Tested 23 dependencies for known issues, found 19 issues, 27 vulnerable paths.
 │   Organization:      My Org                               │
 │   Test type:         Software Composition Analysis        │
 │   Project path:      multi-project                        │
+│   Target file:       ghost/package.json                   │
 │                                                           │
 │   Total security issues: 19                               │
 │   Ignored: [1m0[0m [[35m 0 CRITICAL [0m[31m 0 HIGH [0m[33m 0 MEDIUM [0m 0 LOW ]      │
@@ -274,6 +276,7 @@ Tested 29 dependencies for known issues, found 1 issues, 1 vulnerable paths.
 │   Organization:      My Org                             │
 │   Test type:         Software Composition Analysis      │
 │   Project path:      multi-project                      │
+│   Target file:       golang/go.mod                      │
 │                                                         │
 │   Total security issues: 1                              │
 │   Ignored: [1m0[0m [[35m 0 CRITICAL [0m[31m 0 HIGH [0m[33m 0 MEDIUM [0m 0 LOW ]    │
@@ -294,6 +297,7 @@ Tested 4 dependencies for known issues, found 0 issues, 0 vulnerable paths.
 │   Organization:      My Org                 │
 │   Test type:         Other                  │
 │   Project path:      multi-project          │
+│   Target file:       maven/pom.xml          │
 │                                             │
 │   Total no findings type found issues: 0    │
 ╰─────────────────────────────────────────────╯
@@ -417,6 +421,7 @@ Tested 7 dependencies for known issues, found 11 issues, 22 vulnerable paths.
 │   Organization:      My Org                              │
 │   Test type:         Software Composition Analysis       │
 │   Project path:      multi-project                       │
+│   Target file:       not-python/requirements.txt         │
 │                                                          │
 │   Total security issues: 11                              │
 │   Ignored: [1m0[0m [[35m 0 CRITICAL [0m[31m 0 HIGH [0m[33m 0 MEDIUM [0m 0 LOW ]     │
@@ -542,6 +547,7 @@ Tested 7 dependencies for known issues, found 11 issues, 22 vulnerable paths.
 │   Organization:      My Org                              │
 │   Test type:         Software Composition Analysis       │
 │   Project path:      multi-project                       │
+│   Target file:       python/requirements.txt             │
 │                                                          │
 │   Total security issues: 11                              │
 │   Ignored: [1m0[0m [[35m 0 CRITICAL [0m[31m 0 HIGH [0m[33m 0 MEDIUM [0m 0 LOW ]     │
@@ -737,6 +743,7 @@ Tested 23 dependencies for known issues, found 19 issues, 27 vulnerable paths.
 │   Organization:      My Org                               │
 │   Test type:         Software Composition Analysis        │
 │   Project path:      multi-project                        │
+│   Target file:       tsc/package.json                     │
 │                                                           │
 │   Total security issues: 19                               │
 │   Ignored: [1m0[0m [[35m 0 CRITICAL [0m[31m 0 HIGH [0m[33m 0 MEDIUM [0m 0 LOW ]      │

--- a/internal/presenters/testdata/ufm/webgoat.ignore.human.readable
+++ b/internal/presenters/testdata/ufm/webgoat.ignore.human.readable
@@ -494,6 +494,7 @@ Tested 163 dependencies for known issues, found 42 issues, 42 vulnerable paths.
 │   Organization:      My Org                                    │
 │   Test type:         Software Composition Analysis             │
 │   Project path:      /Users/catalin.iuga/code/goofs/WebGoat    │
+│   Target file:       pom.xml                                   │
 │                                                                │
 │   Total security issues: 42                                    │
 │   Ignored: [1m4[0m [[35m 0 CRITICAL [0m[31m 2 HIGH [0m[33m 2 MEDIUM [0m 0 LOW ]           │


### PR DESCRIPTION
### Description

_This PR adds the `Target File` property to the human readable summary section of the UFM presenter._

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.
