### PR TITLE
fix(configresolver): decode persisted Remote/LocalConfigField

### DIFF
--- a/pkg/configuration/configresolver/resolver.go
+++ b/pkg/configuration/configresolver/resolver.go
@@ -198,18 +198,26 @@ func (r *Resolver) resolveFolder(name, effectiveOrg, folderPath string) (any, Co
 }
 
 // remoteField retrieves a *RemoteConfigField stored at key, or nil if not present/wrong type.
+// Values persisted through JSON storage come back as map[string]interface{}, so we reconstruct
+// the struct from that map in that case. Keys match the lowercase json tags; viper also
+// lowercases map keys on Set.
 func (r *Resolver) remoteField(key string) *RemoteConfigField {
-	v := r.conf.Get(key)
-	if v == nil {
+	switch v := r.conf.Get(key).(type) {
+	case nil:
 		return nil
+	case *RemoteConfigField:
+		return v
+	case map[string]any:
+		locked, ok := v["islocked"].(bool)
+		if !ok {
+			//nolint:errcheck // zero-value fallback on type mismatch is intentional
+			locked, _ = v["isLocked"].(bool)
+		}
+		//nolint:errcheck // zero-value fallback on type mismatch is intentional
+		origin, _ := v["origin"].(string)
+		return &RemoteConfigField{Value: v["value"], IsLocked: locked, Origin: origin}
 	}
-
-	f, ok := v.(*RemoteConfigField)
-	if !ok {
-		return nil
-	}
-
-	return f
+	return nil
 }
 
 // remoteFolderField retrieves a *RemoteConfigField from the folder-level remote key, or nil.
@@ -231,16 +239,19 @@ func (r *Resolver) fallback(name string) (any, ConfigSource) {
 }
 
 // localField retrieves a *LocalConfigField stored at key, or nil if not present/wrong type.
+// Values persisted through JSON storage come back as map[string]interface{}, so we reconstruct
+// the struct from that map in that case. Keys match the lowercase json tags; viper also
+// lowercases map keys on Set.
 func (r *Resolver) localField(key string) *LocalConfigField {
-	v := r.conf.Get(key)
-	if v == nil {
+	switch v := r.conf.Get(key).(type) {
+	case nil:
 		return nil
+	case *LocalConfigField:
+		return v
+	case map[string]any:
+		//nolint:errcheck // zero-value fallback on type mismatch is intentional
+		changed, _ := v["changed"].(bool)
+		return &LocalConfigField{Value: v["value"], Changed: changed}
 	}
-
-	f, ok := v.(*LocalConfigField)
-	if !ok {
-		return nil
-	}
-
-	return f
+	return nil
 }

--- a/pkg/configuration/configresolver/resolver_test.go
+++ b/pkg/configuration/configresolver/resolver_test.go
@@ -706,6 +706,126 @@ func TestResolveBool_UserGlobalAsLocalConfigField(t *testing.T) {
 	assert.True(t, got, "ResolveBool must unwrap LocalConfigField.Value, not see the struct pointer")
 }
 
+// TestResolve_DeserializedMap covers the case where values stored in the configuration
+// have been round-tripped through JSON (e.g. loaded from on-disk config via viper) and
+// therefore come back as map[string]interface{} rather than the original struct pointer.
+// remoteField/localField must decode those maps back into *RemoteConfigField /
+// *LocalConfigField; otherwise precedence is silently broken.
+func TestResolve_DeserializedMap(t *testing.T) {
+	t.Run("machine remote from map (unlocked) is honored", func(t *testing.T) {
+		fs := newTestFlagSet()
+		conf := configuration.NewWithOpts()
+		conf.Set(configresolver.RemoteMachineKey("api_endpoint"), map[string]any{
+			"value":    "remote-ep",
+			"isLocked": false,
+			"origin":   "test",
+		})
+		r := newResolver(conf, fs)
+		val, src := r.Resolve("api_endpoint", "org1", "")
+		assert.Equal(t, "remote-ep", val)
+		assert.Equal(t, configresolver.ConfigSourceRemote, src)
+	})
+
+	t.Run("machine remote from map (locked) wins over user global", func(t *testing.T) {
+		fs := newTestFlagSet()
+		conf := configuration.NewWithOpts()
+		conf.Set(configresolver.RemoteMachineKey("api_endpoint"), map[string]any{
+			"value":    "locked-ep",
+			"isLocked": true,
+		})
+		conf.Set(configresolver.UserGlobalKey("api_endpoint"), &configresolver.LocalConfigField{Value: "user-ep", Changed: true})
+		r := newResolver(conf, fs)
+		val, src := r.Resolve("api_endpoint", "org1", "")
+		assert.Equal(t, "locked-ep", val)
+		assert.Equal(t, configresolver.ConfigSourceRemoteLocked, src)
+	})
+
+	t.Run("machine remote from map with uppercase keys (legacy payload) still decodes", func(t *testing.T) {
+		fs := newTestFlagSet()
+		conf := configuration.NewWithOpts()
+		conf.Set(configresolver.RemoteMachineKey("api_endpoint"), map[string]any{
+			"Value":    "legacy-ep",
+			"IsLocked": true,
+		})
+		r := newResolver(conf, fs)
+		val, src := r.Resolve("api_endpoint", "org1", "")
+		assert.Equal(t, "legacy-ep", val)
+		assert.Equal(t, configresolver.ConfigSourceRemoteLocked, src)
+	})
+
+	t.Run("user global from map is unwrapped (not returned as map)", func(t *testing.T) {
+		fs := newTestFlagSet()
+		conf := configuration.NewWithOpts()
+		conf.Set(configresolver.UserGlobalKey("api_endpoint"), map[string]any{
+			"value":   "user-ep",
+			"changed": true,
+		})
+		r := newResolver(conf, fs)
+		val, src := r.Resolve("api_endpoint", "org1", "")
+		assert.Equal(t, "user-ep", val)
+		assert.Equal(t, configresolver.ConfigSourceUserGlobal, src)
+	})
+
+	t.Run("user global from map with changed=false is ignored", func(t *testing.T) {
+		fs := newTestFlagSet()
+		conf := configuration.NewWithOpts()
+		conf.Set(configresolver.UserGlobalKey("api_endpoint"), map[string]any{
+			"value":   "ignored",
+			"changed": false,
+		})
+		conf.Set(configresolver.RemoteMachineKey("api_endpoint"), map[string]any{
+			"value":    "remote-ep",
+			"isLocked": false,
+		})
+		r := newResolver(conf, fs)
+		val, src := r.Resolve("api_endpoint", "org1", "")
+		assert.Equal(t, "remote-ep", val)
+		assert.Equal(t, configresolver.ConfigSourceRemote, src)
+	})
+
+	t.Run("folder user override from map wins over remote org", func(t *testing.T) {
+		fs := newTestFlagSet()
+		conf := configuration.NewWithOpts()
+		org := "org1"
+		folder := "/proj"
+		name := "reference_branch"
+		conf.Set(configresolver.RemoteOrgKey(org, name), map[string]any{
+			"value":    "main",
+			"isLocked": false,
+		})
+		conf.Set(configresolver.UserFolderKey(folder, name), map[string]any{
+			"value":   "my-branch",
+			"changed": true,
+		})
+		r := newResolver(conf, fs)
+		val, src := r.Resolve(name, org, folder)
+		assert.Equal(t, "my-branch", val)
+		assert.Equal(t, configresolver.ConfigSourceUserFolderOverride, src)
+	})
+
+	t.Run("IsLocked honored for remote map", func(t *testing.T) {
+		fs := newTestFlagSet()
+		conf := configuration.NewWithOpts()
+		conf.Set(configresolver.RemoteOrgKey("org1", "snyk_code_enabled"), map[string]any{
+			"value":    true,
+			"isLocked": true,
+		})
+		r := newResolver(conf, fs)
+		assert.True(t, r.IsLocked("snyk_code_enabled", "org1"))
+	})
+
+	t.Run("ResolveBool unwraps LocalConfigField from map", func(t *testing.T) {
+		fs := newTestFlagSet()
+		conf := configuration.NewWithOpts()
+		conf.Set(configresolver.UserGlobalKey("snyk_code_enabled"), map[string]any{
+			"value":   true,
+			"changed": true,
+		})
+		r := newResolver(conf, fs)
+		assert.True(t, r.ResolveBool("snyk_code_enabled", "org1", "/proj"))
+	})
+}
+
 func TestResolve_UserGlobalKeyDeleted(t *testing.T) {
 	fs := newTestFlagSet()
 	conf := configuration.NewWithOpts()


### PR DESCRIPTION
…589)

### Description

_Provide description of this PR and changes._

### Checklist

- [ ] Tests added and all succeed (`make test`)
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.
