### PR TITLE
chore: cleans up TestResult interface

### DIFF
--- a/internal/presenters/templates/ufm.human.tmpl
+++ b/internal/presenters/templates/ufm.human.tmpl
@@ -97,7 +97,7 @@
 
 {{- define "testSummary"}}{{ "Test Summary" | bold }}
 {{- "\n" }}
-{{- $metadata := .GetMetadata }}
+{{- $metadata := .Get "metadata" }}
 {{- $targetFile := index $metadata "display-target-file" }}
 {{- $targetDirectory := index $metadata "target-directory" }}
 {{- if not $targetDirectory }}
@@ -118,7 +118,7 @@
 {{- end }} {{/* end testSummary */}}
 
 {{- define "resultHeader" }}
-   {{- $metadata := .GetMetadata }}
+   {{- $metadata := .Get "metadata" }}
    {{- $testingSubject := getValueFromConfig "targetDirectory" }}
    {{- $targetFile := index $metadata "display-target-file" }}
    {{- if $targetFile }} {{- $testingSubject = $targetFile }} {{- end }}

--- a/internal/presenters/templates/ufm.sarif.tmpl
+++ b/internal/presenters/templates/ufm.sarif.tmpl
@@ -8,7 +8,7 @@
 			{{- $findingType := index $findingTypes 0 }}
 			{{- $issues := getIssuesFromTestResult $result }}
 			{{- $issuesSize := sub (len $issues) 1 }}
-			{{- $metadata := $result.GetMetadata }}
+			{{- $metadata := $result.Get "metadata" }}
 			{
 				"tool": {
 					"driver" : {
@@ -59,7 +59,7 @@
 					}
 				},
 			"results": [
-				{{- $displayTargetFile := index $result.GetMetadata "display-target-file" }}
+				{{- $displayTargetFile := $result.GetMetadataValue "display-target-file" }}
 				{{- $targetFile := "" }}
 				{{- if $displayTargetFile }} {{- $targetFile = $displayTargetFile }} {{- end }}
 				{{- range $index, $issue := $issues }}

--- a/pkg/apiclients/mocks/testapi.go
+++ b/pkg/apiclients/mocks/testapi.go
@@ -53,6 +53,20 @@ func (mr *MockTestResultMockRecorder) Findings(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Findings", reflect.TypeOf((*MockTestResult)(nil).Findings), ctx)
 }
 
+// Get mocks base method.
+func (m *MockTestResult) Get(key testapi.TestResultKeys) interface{} {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", key)
+	ret0, _ := ret[0].(interface{})
+	return ret0
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockTestResultMockRecorder) Get(key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockTestResult)(nil).Get), key)
+}
+
 // GetBreachedPolicies mocks base method.
 func (m *MockTestResult) GetBreachedPolicies() *testapi.PolicyRefSet {
 	m.ctrl.T.Helper()

--- a/pkg/apiclients/testapi/testapi.go
+++ b/pkg/apiclients/testapi/testapi.go
@@ -20,6 +20,19 @@ import (
 
 //go:generate go tool github.com/golang/mock/mockgen -source=testapi.go -destination ../mocks/testapi.go -package mocks -imports testapi=github.com/snyk/go-application-framework/pkg/apiclients/testapi
 
+// TestResultKeys represents the keys for accessing test result data.
+type TestResultKeys string
+
+const (
+	TestResultTestSubject      TestResultKeys = "subject"
+	TestResultSubjectLocators  TestResultKeys = "subject_locators"
+	TestResultTestResources    TestResultKeys = "resources"
+	TestResultRawSummary       TestResultKeys = "raw_summary"
+	TestResultTestFacts        TestResultKeys = "test_facts"
+	TestResultBreachedPolicies TestResultKeys = "breached_policies"
+	TestResultMetadata         TestResultKeys = "metadata"
+)
+
 // config holds configuration for the test API client, set using ConfigOption functions.
 type config struct {
 	PollInterval          time.Duration // Default: 2000ms, Min: 1000ms
@@ -107,8 +120,14 @@ type TestResult interface {
 	GetTestID() *uuid.UUID
 	GetTestConfiguration() *TestConfiguration
 	GetCreatedAt() *time.Time
+
+	Get(key TestResultKeys) interface{}
+
+	// Deprecated: Use Get(testapi.TestResultTestSubject) instead.
 	GetTestSubject() *TestSubject
+	// Deprecated: Use Get(testapi.TestResultSubjectLocators) instead.
 	GetSubjectLocators() *[]TestSubjectLocator
+	// Deprecated: Use Get(testapi.TestResultTestResources) instead.
 	GetTestResources() *[]TestResource
 
 	GetExecutionState() TestExecutionStates
@@ -117,14 +136,18 @@ type TestResult interface {
 
 	GetPassFail() *PassFail
 	GetOutcomeReason() *TestOutcomeReason
+	// Deprecated: Use Get(testapi.TestResultBreachedPolicies) instead.
 	GetBreachedPolicies() *PolicyRefSet
 
 	GetEffectiveSummary() *FindingSummary
+	// Deprecated: Use Get(testapi.TestResultRawSummary) instead.
 	GetRawSummary() *FindingSummary
+	// Deprecated: Use Get(testapi.TestResultTestFacts) instead.
 	GetTestFacts() *[]TestFact
 
 	SetMetadata(key string, value interface{})
 	GetMetadataValue(key string) interface{}
+	// Deprecated: Use Get(testapi.TestResultMetadata) instead.
 	GetMetadata() map[string]interface{}
 
 	Findings(ctx context.Context) (resultFindings []FindingData, complete bool, err error)
@@ -255,6 +278,8 @@ func (r *testResult) GetPassFail() *PassFail { return r.PassFail }
 // GetOutcomeReason returns the reason for the test outcome.
 func (r *testResult) GetOutcomeReason() *TestOutcomeReason { return r.OutcomeReason }
 
+// Deprecated: Use Get(testapi.TestResultBreachedPolicies) instead
+//
 // GetBreachedPolicies returns the policies that were breached.
 func (r *testResult) GetBreachedPolicies() *PolicyRefSet { return r.BreachedPolicies }
 
@@ -264,21 +289,54 @@ func (r *testResult) GetTestConfiguration() *TestConfiguration { return r.TestCo
 // GetCreatedAt returns the creation timestamp of the test.
 func (r *testResult) GetCreatedAt() *time.Time { return r.CreatedAt }
 
+// Get returns a TestResult field value by key.
+// Returns nil if the key is not found.
+func (r *testResult) Get(key TestResultKeys) interface{} {
+	switch key {
+	case TestResultTestSubject:
+		return r.TestSubject
+	case TestResultSubjectLocators:
+		return r.SubjectLocators
+	case TestResultTestResources:
+		return r.TestResources
+	case TestResultRawSummary:
+		return r.RawSummary
+	case TestResultTestFacts:
+		return r.TestFacts
+	case TestResultBreachedPolicies:
+		return r.BreachedPolicies
+	case TestResultMetadata:
+		return r.metadata
+	default:
+		return nil
+	}
+}
+
+// Deprecated: Use Get(testapi.TestResultTestSubject) instead
+//
 // GetTestSubject returns the test subject.
 func (r *testResult) GetTestSubject() *TestSubject { return r.TestSubject }
 
+// Deprecated: Use Get(testapi.TestResultSubjectLocators) instead
+//
 // GetSubjectLocators returns the subject locators.
 func (r *testResult) GetSubjectLocators() *[]TestSubjectLocator { return r.SubjectLocators }
 
+// Deprecated: Use Get(testapi.TestResultTestResources) instead
+//
 // GetTestResources returns the test resources.
 func (r *testResult) GetTestResources() *[]TestResource { return r.TestResources }
 
 // GetEffectiveSummary returns the summary excluding suppressed findings.
 func (r *testResult) GetEffectiveSummary() *FindingSummary { return r.EffectiveSummary }
 
+// Deprecated: Use Get(testapi.TestResultRawSummary) instead
+//
 // GetRawSummary returns the summary including suppressed findings.
 func (r *testResult) GetRawSummary() *FindingSummary { return r.RawSummary }
 
+// Deprecated: Use Get(testapi.TestResultTestFacts) instead
+//
 // GetTestFacts returns the facts computed during test execution.
 func (r *testResult) GetTestFacts() *[]TestFact { return r.TestFacts }
 
@@ -287,6 +345,8 @@ func (r *testResult) SetMetadata(key string, value interface{}) {
 	r.metadata[key] = value
 }
 
+// Deprecated: Use Get(testapi.TestResultMetadata) instead
+//
 // GetMetadata returns the metadata for the given key.
 func (r *testResult) GetMetadata() map[string]interface{} {
 	return r.metadata

--- a/pkg/apiclients/testapi/testapi_test.go
+++ b/pkg/apiclients/testapi/testapi_test.go
@@ -1555,8 +1555,8 @@ func Test_Wait_Synchronous_Finished_With_ErrorsAndWarnings(t *testing.T) {
 		testData.ExpectedTestResources,
 		testData.ExpectedEffectiveSummary,
 		testData.ExpectedRawSummary)
-	require.NotNil(t, result.GetBreachedPolicies())
-	assert.Equal(t, expectedBreachedPolicies, result.GetBreachedPolicies())
+	require.NotNil(t, result.Get(testapi.TestResultBreachedPolicies))
+	assert.Equal(t, expectedBreachedPolicies, result.Get(testapi.TestResultBreachedPolicies))
 	assert.GreaterOrEqual(t, testData.PollCounter.Load(), int32(2), "Should have polled at least twice")
 }
 
@@ -1645,8 +1645,8 @@ func Test_Wait_WithResources_Synchronous_Finished_With_ErrorsAndWarnings(t *test
 		testData.ExpectedTestResources,
 		testData.ExpectedEffectiveSummary,
 		testData.ExpectedRawSummary)
-	require.NotNil(t, result.GetBreachedPolicies())
-	assert.Equal(t, expectedBreachedPolicies, result.GetBreachedPolicies())
+	require.NotNil(t, result.Get(testapi.TestResultBreachedPolicies))
+	assert.Equal(t, expectedBreachedPolicies, result.Get(testapi.TestResultBreachedPolicies))
 	assert.GreaterOrEqual(t, testData.PollCounter.Load(), int32(2), "Should have polled at least twice")
 }
 
@@ -1676,20 +1676,22 @@ func assertCommonTestResultFields(
 	assert.False(t, result.GetCreatedAt().IsZero())
 
 	if expectedSubject != nil {
-		require.NotNil(t, result.GetTestSubject())
-		assert.Equal(t, expectedSubject, result.GetTestSubject())
+		require.NotNil(t, result.Get(testapi.TestResultTestSubject))
+		assert.Equal(t, expectedSubject, result.Get(testapi.TestResultTestSubject))
 	}
 
 	if expectedResources != nil {
-		require.NotNil(t, result.GetTestResources())
-		assert.Equal(t, expectedResources, result.GetTestResources()) //test equals ignoring order
+		require.NotNil(t, result.Get(testapi.TestResultTestResources))
+		assert.Equal(t, expectedResources, result.Get(testapi.TestResultTestResources)) //test equals ignoring order
 	}
 
 	if expectedLocators != nil {
-		require.NotNil(t, result.GetSubjectLocators())
-		assert.Equal(t, *expectedLocators, *result.GetSubjectLocators())
+		require.NotNil(t, result.Get(testapi.TestResultSubjectLocators))
+		locators, ok := result.Get(testapi.TestResultSubjectLocators).(*[]testapi.TestSubjectLocator)
+		require.True(t, ok)
+		assert.Equal(t, *expectedLocators, *locators)
 	} else {
-		assert.Nil(t, result.GetSubjectLocators())
+		assert.Nil(t, result.Get(testapi.TestResultSubjectLocators))
 	}
 
 	if expectedEffectiveSummary != nil {
@@ -1700,10 +1702,10 @@ func assertCommonTestResultFields(
 	}
 
 	if expectedRawSummary != nil {
-		require.NotNil(t, result.GetRawSummary())
-		assert.Equal(t, expectedRawSummary, result.GetRawSummary())
+		require.NotNil(t, result.Get(testapi.TestResultRawSummary))
+		assert.Equal(t, expectedRawSummary, result.Get(testapi.TestResultRawSummary))
 	} else {
-		assert.Nil(t, result.GetRawSummary())
+		assert.Nil(t, result.Get(testapi.TestResultRawSummary))
 	}
 }
 
@@ -1866,7 +1868,7 @@ func assertTestOutcomeFail(t *testing.T, result testapi.TestResult, expectedTest
 	assert.Equal(t, expectedReason, *result.GetOutcomeReason())
 	assert.Nil(t, result.GetErrors())
 	assert.Nil(t, result.GetWarnings())
-	assert.Nil(t, result.GetBreachedPolicies())
+	assert.Nil(t, result.Get(testapi.TestResultBreachedPolicies))
 }
 
 // Helper function to assert that there are no findings.

--- a/pkg/utils/ufm/json_test_result.go
+++ b/pkg/utils/ufm/json_test_result.go
@@ -45,6 +45,28 @@ type jsonTestResult struct {
 	mutex sync.Mutex
 }
 
+// Get returns a TestResult field value by key.
+func (j *jsonTestResult) Get(key testapi.TestResultKeys) interface{} {
+	switch key {
+	case testapi.TestResultTestSubject:
+		return j.TestSubject
+	case testapi.TestResultSubjectLocators:
+		return j.SubjectLocators
+	case testapi.TestResultTestResources:
+		return j.TestResources
+	case testapi.TestResultRawSummary:
+		return j.RawSummary
+	case testapi.TestResultTestFacts:
+		return j.TestFacts
+	case testapi.TestResultBreachedPolicies:
+		return j.BreachedPolicies
+	case testapi.TestResultMetadata:
+		return j.Metadata
+	default:
+		return nil
+	}
+}
+
 // GetTestID returns the test ID.
 func (j *jsonTestResult) GetTestID() *uuid.UUID {
 	return j.TestID
@@ -60,16 +82,22 @@ func (j *jsonTestResult) GetCreatedAt() *time.Time {
 	return j.CreatedAt
 }
 
+// Deprecated: use Get(testapi.TestResultTestSubject) instead
+//
 // GetTestSubject returns the test subject.
 func (j *jsonTestResult) GetTestSubject() *testapi.TestSubject {
 	return j.TestSubject
 }
 
+// Deprecated: use Get(testapi.TestResultSubjectLocators) instead
+//
 // GetSubjectLocators returns the subject locators.
 func (j *jsonTestResult) GetSubjectLocators() *[]testapi.TestSubjectLocator {
 	return j.SubjectLocators
 }
 
+// Deprecated: use Get(testapi.TestResultTestResources) instead
+//
 // GetResources returns the test resources.
 func (j *jsonTestResult) GetTestResources() *[]testapi.TestResource {
 	return j.TestResources
@@ -110,11 +138,15 @@ func (j *jsonTestResult) GetEffectiveSummary() *testapi.FindingSummary {
 	return j.EffectiveSummary
 }
 
+// Deprecated: use Get(testapi.TestResultRawSummary) instead
+//
 // GetRawSummary returns the raw summary (including suppressed findings).
 func (j *jsonTestResult) GetRawSummary() *testapi.FindingSummary {
 	return j.RawSummary
 }
 
+// Deprecated: use Get(testapi.TestResultTestFacts) instead
+//
 // GetTestFacts returns the facts computed during test execution.
 func (j *jsonTestResult) GetTestFacts() *[]testapi.TestFact {
 	return j.TestFacts
@@ -129,6 +161,8 @@ func (j *jsonTestResult) SetMetadata(key string, value interface{}) {
 	j.Metadata[key] = value
 }
 
+// Deprecated: use Get(testapi.TestResultMetadata) instead
+//
 // GetMetadata returns the metadata for the given key.
 func (j *jsonTestResult) GetMetadata() map[string]interface{} {
 	return j.Metadata

--- a/pkg/utils/ufm/json_test_result_test.go
+++ b/pkg/utils/ufm/json_test_result_test.go
@@ -32,7 +32,6 @@ func TestNewSerializableTestResult(t *testing.T) {
 	mock.EXPECT().GetCreatedAt().Return(&createdAt).AnyTimes()
 	mock.EXPECT().GetTestSubject().Return(nil).AnyTimes()
 	mock.EXPECT().GetSubjectLocators().Return(nil).AnyTimes()
-	mock.EXPECT().GetTestResources().Return(nil).AnyTimes()
 	mock.EXPECT().GetExecutionState().Return(testapi.TestExecutionStatesFinished).AnyTimes()
 	mock.EXPECT().GetErrors().Return(nil).AnyTimes()
 	mock.EXPECT().GetWarnings().Return(nil).AnyTimes()

--- a/pkg/utils/ufm/ufm_workflow_helper_test.go
+++ b/pkg/utils/ufm/ufm_workflow_helper_test.go
@@ -32,7 +32,6 @@ func Test_CreateAndRetrieveDataFromUFM(t *testing.T) {
 	singleResult.EXPECT().GetCreatedAt().Return(nil).AnyTimes()
 	singleResult.EXPECT().GetTestSubject().Return(nil).AnyTimes()
 	singleResult.EXPECT().GetSubjectLocators().Return(nil).AnyTimes()
-	singleResult.EXPECT().GetTestResources().Return(nil).AnyTimes()
 	singleResult.EXPECT().GetExecutionState().Return(testapi.TestExecutionStatesFinished).AnyTimes()
 	singleResult.EXPECT().GetErrors().Return(nil).AnyTimes()
 	singleResult.EXPECT().GetWarnings().Return(nil).AnyTimes()


### PR DESCRIPTION
### Description

This PR updates the `testapi` `TestResult` interface by introducing a general `Get()` getter method and deprecating several specific getters from the interface. The `Get()` method will eventually replace the deprecated ones.

The outdated getters were deprecated instead of removed so as not to introduce a breaking change and block this PR from being merged. This would allow dependencies to update their implementations before we eventually remove the deprecated methods.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.
