### PR TITLE
feat: add handling for `X-RateLimit-Reset` header in retry middleware…

### DIFF
--- a/pkg/networking/middleware/response.go
+++ b/pkg/networking/middleware/response.go
@@ -134,7 +134,9 @@ func errFromStatusCode(code int) error {
 	case http.StatusInternalServerError:
 		return snyk.NewServerError("Internal server error.")
 	case http.StatusTooManyRequests:
-		return snyk.NewTooManyRequestsError("Too many requests.")
+		err := snyk.NewTooManyRequestsError("Too many requests.")
+		err.Level = "error"
+		return err
 	default:
 		return nil
 	}

--- a/pkg/networking/middleware/response.go
+++ b/pkg/networking/middleware/response.go
@@ -133,6 +133,8 @@ func errFromStatusCode(code int) error {
 		return snyk.NewBadRequestError("The request cannot be processed.")
 	case http.StatusInternalServerError:
 		return snyk.NewServerError("Internal server error.")
+	case http.StatusTooManyRequests:
+		return snyk.NewTooManyRequestsError("Too many requests.")
 	default:
 		return nil
 	}

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -133,13 +133,20 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 	backoffMethod.InitialInterval = time.Duration(retryAfterSeconds) * time.Second
 	finalResponse, finalError = backoff.Retry(req.Context(), op, backoff.WithBackOff(backoffMethod))
 
-	// if retries fail to resolve the issue, we need to unset the locally used error type to not return it from the RoundTripper
-	if errors.Is(finalError, errRetryNecessary) {
-		rm.logger.Warn().Msgf("Retry ultimately failed after %d attempts", actualAttempts)
-		finalError = nil
-	}
+	return finalResponse, rm.maskInternalRetryError(finalError, actualAttempts)
+}
 
-	return finalResponse, finalError
+// maskInternalRetryError strips sentinel errors used only inside the retry loop so callers receive the last HTTP response.
+func (rm RetryMiddleware) maskInternalRetryError(err error, actualAttempts int) error {
+	if errors.Is(err, errRetryNecessary) {
+		rm.logger.Warn().Msgf("Retry ultimately failed after %d attempts", actualAttempts)
+		return nil
+	}
+	if errors.Is(err, errRetryDelayMaxExceeded) {
+		rm.logger.Warn().Msg("Suggested retry delay from Retry-After or X-RateLimit-Reset exceeds maximum allowed wait; returning last HTTP response")
+		return nil
+	}
+	return err
 }
 
 func getMaxRetryAttempts(response *http.Response, maxAttempts int) int {

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -133,11 +133,12 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 	backoffMethod.InitialInterval = time.Duration(retryAfterSeconds) * time.Second
 	finalResponse, finalError = backoff.Retry(req.Context(), op, backoff.WithBackOff(backoffMethod))
 
-	return finalResponse, rm.maskInternalRetryError(finalError, actualAttempts)
+	finalError = rm.filterRetryError(finalError, actualAttempts)
+	return finalResponse, finalError
 }
 
-// maskInternalRetryError strips sentinel errors used only inside the retry loop so callers receive the last HTTP response.
-func (rm RetryMiddleware) maskInternalRetryError(err error, actualAttempts int) error {
+// filterRetryError strips sentinel errors used only inside the retry loop so callers receive the last HTTP response.
+func (rm RetryMiddleware) filterRetryError(err error, actualAttempts int) error {
 	if errors.Is(err, errRetryNecessary) {
 		rm.logger.Warn().Msgf("Retry ultimately failed after %d attempts", actualAttempts)
 		return nil

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -42,8 +42,7 @@ var statusCodesToRetryLUT = map[int]retryLogic{
 }
 
 var errRetryNecessary = errors.New("retry with backoff")
-var errRetryAfterHeaderError = errors.New("retry-after is too much in the future")
-var errXRateLimitResetHeaderError = errors.New("X-RateLimit-Reset is too far in the future")
+var errRetryDelayMaxExceeded = errors.New("suggested retry delay exceeds maximum allowed wait")
 
 type RetryMiddleware struct {
 	nextRoundtripper http.RoundTripper
@@ -177,7 +176,7 @@ func shouldRetry(response *http.Response, attempts int, maxAttempts int) error {
 
 			// if the fix retry delay is too big, we rather fail permanently than blocking too long
 			if fixRetryDelay > maxRetryAfter {
-				return backoff.Permanent(errRetryAfterHeaderError)
+				return backoff.Permanent(errRetryDelayMaxExceeded)
 			}
 		}
 
@@ -188,7 +187,7 @@ func shouldRetry(response *http.Response, attempts int, maxAttempts int) error {
 				fixRetryDelay = parseRetryDelay(headerXRateLimitResetValue)
 			}
 			if fixRetryDelay > maxRetryAfter {
-				return backoff.Permanent(errXRateLimitResetHeaderError)
+				return backoff.Permanent(errRetryDelayMaxExceeded)
 			}
 		}
 

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -43,6 +43,7 @@ var statusCodesToRetryLUT = map[int]retryLogic{
 
 var errRetryNecessary = errors.New("retry with backoff")
 var errRetryAfterHeaderError = errors.New("retry-after is too much in the future")
+var errXRateLimitResetHeaderError = errors.New("X-RateLimit-Reset is too far in the future")
 
 type RetryMiddleware struct {
 	nextRoundtripper http.RoundTripper
@@ -109,7 +110,7 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 			response.Header.Set(retryCountHeaderKey, fmt.Sprintf("%d", actualAttempts))
 		}
 
-		// errors from the next round tripper cannot not be retried
+		// errors from the next round tripper cannot be retried
 		if err != nil {
 			return response, backoff.Permanent(err)
 		}
@@ -172,12 +173,23 @@ func shouldRetry(response *http.Response, attempts int, maxAttempts int) error {
 
 		// try to read retry-after header if available
 		if headerRetryAfterValue := response.Header.Get("Retry-After"); len(headerRetryAfterValue) > 0 {
-			fixRetryDelay = parseRetryAfterHeader(headerRetryAfterValue)
+			fixRetryDelay = parseRetryDelay(headerRetryAfterValue)
+
+			// if the fix retry delay is too big, we rather fail permanently than blocking too long
+			if fixRetryDelay > maxRetryAfter {
+				return backoff.Permanent(errRetryAfterHeaderError)
+			}
 		}
 
-		// if the fix retry delay is too big, we rather fail permanently than blocking too long
-		if fixRetryDelay > maxRetryAfter {
-			return backoff.Permanent(errRetryAfterHeaderError)
+		if fixRetryDelay == 0 {
+			// try to read X-RateLimit-Reset header if available
+			// according to envoy docs: number of seconds until reset of the current time-window
+			if headerXRateLimitResetValue := response.Header.Get("X-RateLimit-Reset"); len(headerXRateLimitResetValue) > 0 {
+				fixRetryDelay = parseRetryDelay(headerXRateLimitResetValue)
+			}
+			if fixRetryDelay > maxRetryAfter {
+				return backoff.Permanent(errXRateLimitResetHeaderError)
+			}
 		}
 
 		// if a retry after is defined, this is the time to wait for
@@ -192,7 +204,7 @@ func shouldRetry(response *http.Response, attempts int, maxAttempts int) error {
 	return nil
 }
 
-func parseRetryAfterHeader(headerRetryAfterValue string) time.Duration {
+func parseRetryDelay(headerRetryAfterValue string) time.Duration {
 	// Retry-After: 1230
 	if tmp, err := strconv.ParseInt(headerRetryAfterValue, 10, 64); err == nil {
 		return time.Duration(tmp) * time.Second

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -141,7 +141,7 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 func (rm RetryMiddleware) filterRetryError(err error, actualAttempts int) error {
 	if errors.Is(err, errRetryNecessary) {
 		rm.logger.Warn().Msgf("Retry ultimately failed after %d attempts", actualAttempts)
-		return nil
+		return snyk.NewTooManyRequestsError(fmt.Sprintf("Retry ultimately failed after %d attempts", actualAttempts))
 	}
 	if errors.Is(err, errRetryDelayMaxExceeded) {
 		rm.logger.Warn().Msg("Suggested retry delay from Retry-After or X-RateLimit-Reset exceeds maximum allowed wait; returning last HTTP response")

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -198,13 +198,14 @@ func shouldRetry(response *http.Response, attempts int, maxAttempts int) error {
 			fixXRateLimitReset = parseRetryDelay(headerXRateLimitResetValue)
 		}
 
-		if max(fixRetryDelay, fixXRateLimitReset) > maxRetryAfter {
+		timeToWait := max(fixRetryDelay, fixXRateLimitReset)
+		if timeToWait > maxRetryAfter {
 			return backoff.Permanent(errRetryDelayMaxExceeded)
 		}
 
 		// if a retry after is defined, this is the time to wait for
-		if fixRetryDelay > 0 {
-			return &backoff.RetryAfterError{Duration: fixRetryDelay}
+		if timeToWait > 0 {
+			return &backoff.RetryAfterError{Duration: timeToWait}
 		}
 
 		// if no retry after is defined, the backoff strategy determines the time to wait for

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -137,15 +137,22 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 	return finalResponse, finalError
 }
 
-// filterRetryError maps sentinel retry-loop errors to catalog errors while callers still receive the last HTTP response.
+// filterRetryError hides implementation-only errors that mean “we stopped retrying
+// but the last HTTP response is still valid.”
+//
+// After backoff.Retry, err may be errRetryNecessary (retries exhausted or a 503
+// maintenance body that must not be retried) or errRetryDelayMaxExceeded
+// (Retry-After / X-RateLimit-Reset would exceed our max wait). We log those and
+// return nil so callers see no error alongside the last *http.Response. All other
+// errors are returned unchanged.
 func (rm RetryMiddleware) filterRetryError(err error, actualAttempts int) error {
 	if errors.Is(err, errRetryNecessary) {
 		rm.logger.Warn().Msgf("Retry ultimately failed after %d attempts", actualAttempts)
-		return snyk.NewTooManyRequestsError(fmt.Sprintf("Retry ultimately failed after %d attempts", actualAttempts))
+		return nil
 	}
 	if errors.Is(err, errRetryDelayMaxExceeded) {
 		rm.logger.Warn().Msg("Suggested retry delay from Retry-After or X-RateLimit-Reset exceeds maximum allowed wait; returning last HTTP response")
-		return snyk.NewTooManyRequestsError("Suggested retry delay from Retry-After or X-RateLimit-Reset exceeds maximum allowed wait")
+		return nil
 	}
 	return err
 }

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -141,7 +141,7 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 func (rm RetryMiddleware) filterRetryError(err error, actualAttempts int) error {
 	if errors.Is(err, errRetryNecessary) {
 		rm.logger.Warn().Msgf("Retry ultimately failed after %d attempts", actualAttempts)
-		return snyk.NewTooManyRequestsError(fmt.Sprintf("Retry ultimately failed after %d attempts", actualAttempts))
+		return nil
 	}
 	if errors.Is(err, errRetryDelayMaxExceeded) {
 		rm.logger.Warn().Msg("Suggested retry delay from Retry-After or X-RateLimit-Reset exceeds maximum allowed wait; returning last HTTP response")

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -188,11 +188,6 @@ func shouldRetry(response *http.Response, attempts int, maxAttempts int) error {
 		// try to read retry-after header if available
 		if headerRetryAfterValue := response.Header.Get("Retry-After"); len(headerRetryAfterValue) > 0 {
 			fixRetryDelay = parseRetryDelay(headerRetryAfterValue)
-
-			// if the fix retry delay is too big, we rather fail permanently than blocking too long
-			if fixRetryDelay > maxRetryAfter {
-				return backoff.Permanent(errRetryDelayMaxExceeded)
-			}
 		}
 
 		if fixRetryDelay == 0 {
@@ -201,9 +196,10 @@ func shouldRetry(response *http.Response, attempts int, maxAttempts int) error {
 			if headerXRateLimitResetValue := response.Header.Get("X-RateLimit-Reset"); len(headerXRateLimitResetValue) > 0 {
 				fixRetryDelay = parseRetryDelay(headerXRateLimitResetValue)
 			}
-			if fixRetryDelay > maxRetryAfter {
-				return backoff.Permanent(errRetryDelayMaxExceeded)
-			}
+		}
+
+		if fixRetryDelay > maxRetryAfter {
+			return backoff.Permanent(errRetryDelayMaxExceeded)
 		}
 
 		// if a retry after is defined, this is the time to wait for

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -190,15 +190,15 @@ func shouldRetry(response *http.Response, attempts int, maxAttempts int) error {
 			fixRetryDelay = parseRetryDelay(headerRetryAfterValue)
 		}
 
-		if fixRetryDelay == 0 {
-			// try to read X-RateLimit-Reset header if available
-			// according to envoy docs: number of seconds until reset of the current time-window
-			if headerXRateLimitResetValue := response.Header.Get("X-RateLimit-Reset"); len(headerXRateLimitResetValue) > 0 {
-				fixRetryDelay = parseRetryDelay(headerXRateLimitResetValue)
-			}
+		fixXRateLimitReset := time.Duration(0)
+
+		// try to read X-RateLimit-Reset header if available
+		// according to envoy docs: number of seconds until reset of the current time-window
+		if headerXRateLimitResetValue := response.Header.Get("X-RateLimit-Reset"); len(headerXRateLimitResetValue) > 0 {
+			fixXRateLimitReset = parseRetryDelay(headerXRateLimitResetValue)
 		}
 
-		if fixRetryDelay > maxRetryAfter {
+		if max(fixRetryDelay, fixXRateLimitReset) > maxRetryAfter {
 			return backoff.Permanent(errRetryDelayMaxExceeded)
 		}
 

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -137,15 +137,15 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 	return finalResponse, finalError
 }
 
-// filterRetryError strips sentinel errors used only inside the retry loop so callers receive the last HTTP response.
+// filterRetryError maps sentinel retry-loop errors to catalog errors while callers still receive the last HTTP response.
 func (rm RetryMiddleware) filterRetryError(err error, actualAttempts int) error {
 	if errors.Is(err, errRetryNecessary) {
 		rm.logger.Warn().Msgf("Retry ultimately failed after %d attempts", actualAttempts)
-		return nil
+		return snyk.NewTooManyRequestsError(fmt.Sprintf("Retry ultimately failed after %d attempts", actualAttempts))
 	}
 	if errors.Is(err, errRetryDelayMaxExceeded) {
 		rm.logger.Warn().Msg("Suggested retry delay from Retry-After or X-RateLimit-Reset exceeds maximum allowed wait; returning last HTTP response")
-		return nil
+		return snyk.NewTooManyRequestsError("Suggested retry delay from Retry-After or X-RateLimit-Reset exceeds maximum allowed wait")
 	}
 	return err
 }

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -196,6 +196,62 @@ func TestNewRetryMiddleware(t *testing.T) {
 		require.GreaterOrEqual(t, attemptCount, 2)
 	})
 
+	t.Run("429 with Retry-After beyond max wait returns response without leaking internal error", func(t *testing.T) {
+		const hugeRetryAfter = "126144000" // 4 years in seconds; exceeds maxRetryAfter
+
+		//nolint:unparam // error is always nil but signature must match http.RoundTripper
+		customRTFn := func(req *http.Request) (*http.Response, error) {
+			h := http.Header{}
+			h.Set("Retry-After", hugeRetryAfter)
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     h,
+				Request:    req,
+			}, nil
+		}
+
+		rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+		config := configuration.NewWithOpts()
+		config.Set(ConfigurationKeyRequestAttempts, 3)
+		config.Set(configurationKeyRetryAfter, 1)
+
+		sut := NewRetryMiddleware(config, &logger, rt)
+		resp, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+		require.Equal(t, hugeRetryAfter, resp.Header.Get("Retry-After"))
+	})
+
+	t.Run("429 with X-RateLimit-Reset beyond max wait returns response without leaking internal error", func(t *testing.T) {
+		const hugeReset = "126144000"
+
+		//nolint:unparam // error is always nil but signature must match http.RoundTripper
+		customRTFn := func(req *http.Request) (*http.Response, error) {
+			h := http.Header{}
+			h.Set("X-RateLimit-Reset", hugeReset)
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     h,
+				Request:    req,
+			}, nil
+		}
+
+		rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+		config := configuration.NewWithOpts()
+		config.Set(ConfigurationKeyRequestAttempts, 3)
+		config.Set(configurationKeyRetryAfter, 1)
+
+		sut := NewRetryMiddleware(config, &logger, rt)
+		resp, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+		require.Equal(t, hugeReset, resp.Header.Get("X-RateLimit-Reset"))
+	})
+
 	t.Run("Unhappy path, retries didn't resolve the issue", func(t *testing.T) {
 		var expectedAttempts = 3
 		failureRoundtripper := &failRoundtripper{

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -427,7 +427,7 @@ func Test_shouldRetry_rateLimitResetHeaders(t *testing.T) {
 				h.Set("X-RateLimit-Reset", "126144000")
 				return newResponse(http.StatusTooManyRequests, h)
 			}(),
-			expectedErrorIs: &backoff.PermanentError{Err: errRetryDelayMaxExceeded},
+			expectedErrorIs: errRetryDelayMaxExceeded,
 			attempts:        0,
 			maxAttempts:     1,
 		},
@@ -441,7 +441,7 @@ func Test_shouldRetry_rateLimitResetHeaders(t *testing.T) {
 
 			assert.NotNil(t, err)
 			if tt.expectedErrorIs != nil {
-				require.Equal(t, tt.expectedErrorIs.Error(), err.Error(), "Expected error to be of type %T, got %T (%v)", tt.expectedErrorIs, err, err)
+				require.True(t, errors.Is(err, tt.expectedErrorIs), `Expected error to be equal to "%v" (%T), got "%v" (%T)`, tt.expectedErrorIs, tt.expectedErrorIs, err, err)
 			}
 			if tt.expectedRetryable != nil {
 				var actualRetryableErr *backoff.RetryAfterError

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -282,7 +282,7 @@ func Test_shouldRetry(t *testing.T) {
 		{
 			name:            "Retryable status code (429) with Retry-After header too far in the future (4years)",
 			response:        newResponse(http.StatusTooManyRequests, http.Header{"Retry-After": []string{"126144000"}}),
-			expectedErrorIs: &backoff.PermanentError{Err: errRetryAfterHeaderError},
+			expectedErrorIs: &backoff.PermanentError{Err: errRetryDelayMaxExceeded},
 			attempts:        0,
 			maxAttempts:     1,
 		},
@@ -427,7 +427,7 @@ func Test_shouldRetry_rateLimitResetHeaders(t *testing.T) {
 				h.Set("X-RateLimit-Reset", "126144000")
 				return newResponse(http.StatusTooManyRequests, h)
 			}(),
-			expectedErrorIs: &backoff.PermanentError{Err: errXRateLimitResetHeaderError},
+			expectedErrorIs: &backoff.PermanentError{Err: errRetryDelayMaxExceeded},
 			attempts:        0,
 			maxAttempts:     1,
 		},

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/snyk/error-catalog-golang-public/snyk"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cenkalti/backoff/v5"
 
@@ -154,6 +155,45 @@ func TestNewRetryMiddleware(t *testing.T) {
 		assert.NotNil(t, response)
 		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
 		assert.Equal(t, fmt.Sprintf("%d", expectedAttempts), response.Header.Get(retryCountHeaderKey))
+	})
+
+	t.Run("Happy path, 429 with only X-Ratelimit-Reset then success", func(t *testing.T) {
+		attemptCount := 0
+
+		//nolint:unparam // error is always nil but signature must match http.RoundTripper
+		customRTFn := func(req *http.Request) (*http.Response, error) {
+			attemptCount++
+			headers := http.Header{}
+
+			switch attemptCount {
+			case 1:
+				headers.Set("X-Ratelimit-Reset", "0")
+				return &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Header:     headers,
+					Request:    req,
+				}, nil
+			default:
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     headers,
+					Request:    req,
+				}, nil
+			}
+		}
+
+		rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+		config := configuration.NewWithOpts()
+		config.Set(ConfigurationKeyRequestAttempts, 3)
+		config.Set(configurationKeyRetryAfter, 1)
+
+		sut := NewRetryMiddleware(config, &logger, rt)
+		resp, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.GreaterOrEqual(t, attemptCount, 2)
 	})
 
 	t.Run("Unhappy path, retries didn't resolve the issue", func(t *testing.T) {
@@ -346,7 +386,73 @@ func Test_shouldRetry(t *testing.T) {
 	}
 }
 
-func Test_parseRetryAfterHeader(t *testing.T) {
+func Test_shouldRetry_rateLimitResetHeaders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		response          *http.Response
+		expectedErrorIs   error
+		expectedRetryable *backoff.RetryAfterError
+		attempts          int
+		maxAttempts       int
+	}{
+		{
+			name: "Retryable status code (429) with only X-Ratelimit-Reset header",
+			response: func() *http.Response {
+				h := http.Header{}
+				h.Set("X-Ratelimit-Reset", "5")
+				return newResponse(http.StatusTooManyRequests, h)
+			}(),
+			expectedRetryable: &backoff.RetryAfterError{Duration: 5 * time.Second},
+			attempts:          0,
+			maxAttempts:       1,
+		},
+		{
+			name: "Retryable status code (429) Retry-After takes precedence over X-RateLimit-Reset",
+			response: func() *http.Response {
+				h := http.Header{}
+				h.Set("Retry-After", "3")
+				h.Set("X-RateLimit-Reset", "10")
+				return newResponse(http.StatusTooManyRequests, h)
+			}(),
+			expectedRetryable: &backoff.RetryAfterError{Duration: 3 * time.Second},
+			attempts:          0,
+			maxAttempts:       1,
+		},
+		{
+			name: "Retryable status code (429) with X-RateLimit-Reset header too far in the future (4years)",
+			response: func() *http.Response {
+				h := http.Header{}
+				h.Set("X-RateLimit-Reset", "126144000")
+				return newResponse(http.StatusTooManyRequests, h)
+			}(),
+			expectedErrorIs: &backoff.PermanentError{Err: errXRateLimitResetHeaderError},
+			attempts:        0,
+			maxAttempts:     1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := shouldRetry(tt.response, tt.attempts, tt.maxAttempts)
+
+			assert.NotNil(t, err)
+			if tt.expectedErrorIs != nil {
+				require.Equal(t, tt.expectedErrorIs.Error(), err.Error(), "Expected error to be of type %T, got %T (%v)", tt.expectedErrorIs, err, err)
+			}
+			if tt.expectedRetryable != nil {
+				var actualRetryableErr *backoff.RetryAfterError
+				require.ErrorAs(t, err, &actualRetryableErr)
+				require.Equal(t, tt.expectedRetryable, actualRetryableErr, "RetryAfter duration mismatch")
+			}
+		})
+	}
+}
+
+func Test_parseRetryDelay(t *testing.T) {
 	tests := []struct {
 		name   string
 		input  string
@@ -381,7 +487,7 @@ func Test_parseRetryAfterHeader(t *testing.T) {
 
 	for _, testcase := range tests {
 		t.Run(testcase.name, func(t *testing.T) {
-			actualOutput := parseRetryAfterHeader(testcase.input)
+			actualOutput := parseRetryDelay(testcase.input)
 			timeDistance := (testcase.output - actualOutput) / time.Second
 			t.Logf("Time distance: %v", timeDistance)
 			assert.Equal(t, 0.0, math.Abs(float64(timeDistance)))

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -113,7 +113,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 		sut := NewRetryMiddleware(config, &logger, failRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, response)
 
 		assert.Equal(t, 3, attemptCount, "Should use cached max attempts from first 429 response")
@@ -218,7 +218,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 		sut := NewRetryMiddleware(config, &logger, rt)
 		resp, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 		require.Equal(t, hugeRetryAfter, resp.Header.Get("Retry-After"))
@@ -246,7 +246,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 		sut := NewRetryMiddleware(config, &logger, rt)
 		resp, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 		require.Equal(t, hugeReset, resp.Header.Get("X-RateLimit-Reset"))
@@ -265,7 +265,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 
 		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, response)
 		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
 	})
@@ -283,7 +283,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 
 		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, response)
 		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
 	})
@@ -301,7 +301,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 
 		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, response)
 		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
 	})

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/snyk/error-catalog-golang-public/snyk"
+	snyk_errors "github.com/snyk/error-catalog-golang-public/snyk_errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -21,6 +22,14 @@ import (
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
 )
+
+func assertSNYK0001(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	var catalogErr snyk_errors.Error
+	require.True(t, errors.As(err, &catalogErr))
+	require.Equal(t, "SNYK-0001", catalogErr.ErrorCode)
+}
 
 // Helper to create a response
 func newResponse(statusCode int, headers http.Header) *http.Response {
@@ -113,7 +122,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 		sut := NewRetryMiddleware(config, &logger, failRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
 
-		assert.NoError(t, err)
+		assertSNYK0001(t, err)
 		assert.NotNil(t, response)
 
 		assert.Equal(t, 3, attemptCount, "Should use cached max attempts from first 429 response")
@@ -196,7 +205,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 		require.GreaterOrEqual(t, attemptCount, 2)
 	})
 
-	t.Run("429 with Retry-After beyond max wait returns response without leaking internal error", func(t *testing.T) {
+	t.Run("429 with Retry-After beyond max wait returns SNYK-0001 and last response", func(t *testing.T) {
 		const hugeRetryAfter = "126144000" // 4 years in seconds; exceeds maxRetryAfter
 
 		//nolint:unparam // error is always nil but signature must match http.RoundTripper
@@ -218,13 +227,13 @@ func TestNewRetryMiddleware(t *testing.T) {
 		sut := NewRetryMiddleware(config, &logger, rt)
 		resp, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
 
-		require.NoError(t, err)
+		assertSNYK0001(t, err)
 		require.NotNil(t, resp)
 		require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 		require.Equal(t, hugeRetryAfter, resp.Header.Get("Retry-After"))
 	})
 
-	t.Run("429 with X-RateLimit-Reset beyond max wait returns response without leaking internal error", func(t *testing.T) {
+	t.Run("429 with X-RateLimit-Reset beyond max wait returns SNYK-0001 and last response", func(t *testing.T) {
 		const hugeReset = "126144000"
 
 		//nolint:unparam // error is always nil but signature must match http.RoundTripper
@@ -246,7 +255,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 		sut := NewRetryMiddleware(config, &logger, rt)
 		resp, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
 
-		require.NoError(t, err)
+		assertSNYK0001(t, err)
 		require.NotNil(t, resp)
 		require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 		require.Equal(t, hugeReset, resp.Header.Get("X-RateLimit-Reset"))
@@ -265,7 +274,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 
 		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
-		assert.NoError(t, err)
+		assertSNYK0001(t, err)
 		assert.NotNil(t, response)
 		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
 	})
@@ -283,7 +292,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 
 		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
-		assert.NoError(t, err)
+		assertSNYK0001(t, err)
 		assert.NotNil(t, response)
 		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
 	})
@@ -301,7 +310,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 
 		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
-		assert.NoError(t, err)
+		assertSNYK0001(t, err)
 		assert.NotNil(t, response)
 		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
 	})

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/snyk/error-catalog-golang-public/snyk"
-	snyk_errors "github.com/snyk/error-catalog-golang-public/snyk_errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -22,14 +21,6 @@ import (
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
 )
-
-func assertSNYK0001(t *testing.T, err error) {
-	t.Helper()
-	require.Error(t, err)
-	var catalogErr snyk_errors.Error
-	require.True(t, errors.As(err, &catalogErr))
-	require.Equal(t, "SNYK-0001", catalogErr.ErrorCode)
-}
 
 // Helper to create a response
 func newResponse(statusCode int, headers http.Header) *http.Response {
@@ -122,7 +113,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 		sut := NewRetryMiddleware(config, &logger, failRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
 
-		assertSNYK0001(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, response)
 
 		assert.Equal(t, 3, attemptCount, "Should use cached max attempts from first 429 response")
@@ -227,7 +218,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 		sut := NewRetryMiddleware(config, &logger, rt)
 		resp, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
 
-		assertSNYK0001(t, err)
+		assert.Nil(t, err)
 		require.NotNil(t, resp)
 		require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 		require.Equal(t, hugeRetryAfter, resp.Header.Get("Retry-After"))
@@ -255,7 +246,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 		sut := NewRetryMiddleware(config, &logger, rt)
 		resp, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
 
-		assertSNYK0001(t, err)
+		assert.Nil(t, err)
 		require.NotNil(t, resp)
 		require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 		require.Equal(t, hugeReset, resp.Header.Get("X-RateLimit-Reset"))
@@ -274,7 +265,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 
 		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
-		assertSNYK0001(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, response)
 		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
 	})
@@ -292,7 +283,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 
 		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
-		assertSNYK0001(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, response)
 		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
 	})
@@ -310,7 +301,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 
 		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
-		assertSNYK0001(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, response)
 		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
 	})

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -122,7 +122,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 		sut := NewRetryMiddleware(config, &logger, failRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
 
-		assertSNYK0001(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, response)
 
 		assert.Equal(t, 3, attemptCount, "Should use cached max attempts from first 429 response")
@@ -274,7 +274,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 
 		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
-		assertSNYK0001(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, response)
 		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
 	})
@@ -292,7 +292,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 
 		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
-		assertSNYK0001(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, response)
 		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
 	})
@@ -310,7 +310,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 
 		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
-		assertSNYK0001(t, err)
+		assert.Nil(t, err)
 		assert.NotNil(t, response)
 		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
 	})

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -122,7 +122,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 		sut := NewRetryMiddleware(config, &logger, failRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
 
-		assert.Nil(t, err)
+		assertSNYK0001(t, err)
 		assert.NotNil(t, response)
 
 		assert.Equal(t, 3, attemptCount, "Should use cached max attempts from first 429 response")
@@ -274,7 +274,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 
 		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
-		assert.Nil(t, err)
+		assertSNYK0001(t, err)
 		assert.NotNil(t, response)
 		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
 	})
@@ -292,7 +292,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 
 		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
-		assert.Nil(t, err)
+		assertSNYK0001(t, err)
 		assert.NotNil(t, response)
 		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
 	})
@@ -310,7 +310,7 @@ func TestNewRetryMiddleware(t *testing.T) {
 
 		sut := NewRetryMiddleware(config, &logger, failureRoundtripper)
 		response, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(expectedBody)))
-		assert.Nil(t, err)
+		assertSNYK0001(t, err)
 		assert.NotNil(t, response)
 		assert.Equal(t, expectedAttempts, failureRoundtripper.actualCount)
 	})

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -472,7 +472,7 @@ func Test_shouldRetry_rateLimitResetHeaders(t *testing.T) {
 				h.Set("X-RateLimit-Reset", "10")
 				return newResponse(http.StatusTooManyRequests, h)
 			}(),
-			expectedRetryable: &backoff.RetryAfterError{Duration: 3 * time.Second},
+			expectedRetryable: &backoff.RetryAfterError{Duration: 10 * time.Second},
 			attempts:          0,
 			maxAttempts:       1,
 		},


### PR DESCRIPTION
### Description

X-RateLimit-Reset response header support.

When the user runs into rate limiting issues, Envoy returns a 429 response with this header. According to envoy docs and confirmed by platform team, it has numeric int format.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.


[CLI-1452]: https://snyksec.atlassian.net/browse/CLI-1452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ