### PR TITLE
chore: Add redact CLI for UFM test-result fixtures

### DIFF
--- a/cmd/ufm-fixture-tool/main.go
+++ b/cmd/ufm-fixture-tool/main.go
@@ -1,0 +1,59 @@
+// Command ufm-fixture-tool redacts a workflow data dump for use as a
+// deterministic test fixture. UUIDs, emails, and sensitive metadata
+// (including stable org-scoped URLs) are replaced with placeholders.
+//
+// Usage:
+//
+//	# Step 1 — dump workflow data to disk via built-in env vars:
+//	SNYK_TMP_PATH=./dump INTERNAL_IN_MEMORY_THRESHOLD_BYTES=1 INTERNAL_CLEANUP_GLOBAL_TEMP_DIR_ENABLED=false \
+//	  snyk secrets test . --report --org=my-org
+//
+//	# Step 2 — redact the dump into a fixture:
+//	go run ./cmd/ufm-fixture-tool --input=./dump/workflow.TestResult.12345 --output=my_fixture.testresult.json
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/snyk/go-application-framework/cmd/ufm-fixture-tool/redact"
+)
+
+func main() {
+	input := flag.String("input", "", "path to the workflow data dump file (required)")
+	output := flag.String("output", "", "path for the redacted output file (optional; defaults to <input>_redacted.json)")
+	flag.Parse()
+
+	if *input == "" {
+		fmt.Fprintln(os.Stderr, "error: --input is required (path to the dump file)")
+		os.Exit(1)
+	}
+	if *output == "" {
+		if strings.HasSuffix(*input, ".json") {
+			*output = strings.TrimSuffix(*input, ".json") + "_redacted.json"
+		} else {
+			*output = *input + "_redacted.json"
+		}
+	}
+
+	raw, err := os.ReadFile(*input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error reading input: %v\n", err)
+		os.Exit(1)
+	}
+
+	redacted, err := redact.Fixture(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error redacting: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := os.WriteFile(*output, redacted, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "error writing output: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("wrote %s (%d bytes)\n", *output, len(redacted))
+}

--- a/cmd/ufm-fixture-tool/redact/redact.go
+++ b/cmd/ufm-fixture-tool/redact/redact.go
@@ -1,0 +1,144 @@
+// Package redact normalises a raw UFM test-result JSON dump into a
+// deterministic fixture by replacing UUIDs, emails, and sensitive
+// metadata (including stable org-scoped URLs) with placeholders.
+package redact
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/snyk/go-application-framework/pkg/utils"
+)
+
+var uuidRE = regexp.MustCompile(
+	`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`,
+)
+
+const (
+	stableOrgSlug = "my-org"
+	stableEmail   = "user@example.com"
+
+	defaultReportBase = "https://app.snyk.io/org/" + stableOrgSlug + "/project"
+
+	// Stable metadata placeholders (keys are kept; real IDs/URLs are not echoed).
+	stableMetadataProjectID  = "00000000-0000-0000-0000-000000000000"
+	stableMetadataSnapshotID = "00000000-0000-0000-0000-000000000001"
+)
+
+// UUIDRemapper assigns deterministic UUIDs to every unique UUID encountered,
+// in first-seen order.
+type UUIDRemapper struct {
+	mapping map[string]string
+	counter int
+}
+
+func NewUUIDRemapper() *UUIDRemapper {
+	return &UUIDRemapper{mapping: make(map[string]string)}
+}
+
+// Remap returns the stable replacement for the given UUID. If not yet seen,
+// a new deterministic UUID is generated.
+func (r *UUIDRemapper) Remap(value string) string {
+	key := strings.ToLower(value)
+	if mapped, ok := r.mapping[key]; ok {
+		return mapped
+	}
+	r.counter++
+	mapped := fmt.Sprintf("11112222-3333-4444-5555-%012x", r.counter)
+	r.mapping[key] = mapped
+	return mapped
+}
+
+// mapKeyIsUUID reports whether s is exactly one RFC-4122-style UUID (JSON object
+// keys cannot contain multiple matches; this is used for maps like _problemRefs).
+func mapKeyIsUUID(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	return uuidRE.FindString(s) == s
+}
+
+// Fixture normalises a raw UFM JSON array ([]testresult) and returns the
+// redacted bytes as indented JSON.
+func Fixture(raw []byte) ([]byte, error) {
+	var data []interface{}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return nil, fmt.Errorf("expected top-level JSON array: %w", err)
+	}
+
+	ctx := walkContext{
+		remapper: NewUUIDRemapper(),
+	}
+	redacted := walk(data, &ctx)
+
+	out, err := json.MarshalIndent(redacted, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal redacted data: %w", err)
+	}
+	out = append(out, '\n')
+	return out, nil
+}
+
+type walkContext struct {
+	remapper *UUIDRemapper
+	// inMetadata is true while walking the object under the top-level "metadata" key.
+	inMetadata bool
+}
+
+func walk(node interface{}, ctx *walkContext) interface{} {
+	switch v := node.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(v))
+		for _, k := range utils.SortedMapKeys(v) {
+			val := v[k]
+			outKey := k
+			if mapKeyIsUUID(k) {
+				outKey = ctx.remapper.Remap(k)
+			}
+			if k == "email" {
+				out[outKey] = stableEmail
+				continue
+			}
+			if ctx.inMetadata {
+				switch k {
+				case "project-id":
+					out[outKey] = stableMetadataProjectID
+				case "snapshot-id":
+					out[outKey] = stableMetadataSnapshotID
+				case "project-page-link", "report-url":
+					out[outKey] = fmt.Sprintf("%s/%s", defaultReportBase, stableMetadataProjectID)
+				default:
+					out[outKey] = walk(val, ctx)
+				}
+				continue
+			}
+
+			if k == "metadata" {
+				if meta, ok := val.(map[string]interface{}); ok {
+					sub := *ctx
+					sub.inMetadata = true
+					out[outKey] = walk(meta, &sub)
+					continue
+				}
+			}
+			out[outKey] = walk(val, ctx)
+		}
+		return out
+
+	case []interface{}:
+		out := make([]interface{}, len(v))
+		for i, item := range v {
+			out[i] = walk(item, ctx)
+		}
+		return out
+
+	case string:
+		s := uuidRE.ReplaceAllStringFunc(v, ctx.remapper.Remap)
+		return s
+
+	default:
+		return node
+	}
+}

--- a/cmd/ufm-fixture-tool/redact/redact_test.go
+++ b/cmd/ufm-fixture-tool/redact/redact_test.go
@@ -1,0 +1,233 @@
+package redact
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFixture_UUIDs_are_deterministic(t *testing.T) {
+	// Pure array of UUIDs — no maps involved — so traversal order is
+	// fully governed by array indices, not Go's random map iteration.
+	input := `[{"uuids":[
+		"aaaaaaaa-0001-0001-0001-aaaaaaaaaaaa",
+		"aaaaaaaa-0002-0002-0002-aaaaaaaaaaaa",
+		"aaaaaaaa-0003-0003-0003-aaaaaaaaaaaa",
+		"aaaaaaaa-0004-0004-0004-aaaaaaaaaaaa",
+		"aaaaaaaa-0005-0005-0005-aaaaaaaaaaaa",
+		"aaaaaaaa-0006-0006-0006-aaaaaaaaaaaa",
+		"aaaaaaaa-0007-0007-0007-aaaaaaaaaaaa",
+		"aaaaaaaa-0008-0008-0008-aaaaaaaaaaaa",
+		"aaaaaaaa-0009-0009-0009-aaaaaaaaaaaa",
+		"aaaaaaaa-0010-0010-0010-aaaaaaaaaaaa"
+	]}]`
+
+	first, err := Fixture([]byte(input))
+	require.NoError(t, err)
+
+	// Run 20 times — every run must produce byte-identical output.
+	for i := 1; i < 20; i++ {
+		out, err := Fixture([]byte(input))
+		require.NoError(t, err, "iteration %d", i)
+		assert.Equal(t, string(first), string(out), "iteration %d produced different output (non-deterministic)", i)
+	}
+
+	// Verify the exact sequential counter: array position 0 gets counter
+	// 1, position 1 gets counter 2, etc.
+	var result []map[string]interface{}
+	require.NoError(t, json.Unmarshal(first, &result))
+
+	uuids, ok := result[0]["uuids"].([]interface{})
+	require.True(t, ok, `expected []interface{} at result[0]["uuids"]`)
+
+	for i, v := range uuids {
+		want := fmt.Sprintf("11112222-3333-4444-5555-%012x", i+1)
+		got, ok := v.(string)
+		require.True(t, ok, "uuids[%d]: expected string, got %T", i, v)
+		assert.Equal(t, want, got, "uuids[%d]", i)
+	}
+}
+
+func TestFixture_same_UUID_maps_to_same_replacement(t *testing.T) {
+	input := `[{"a":"aaaaaaaa-1111-2222-3333-444444444444","b":"aaaaaaaa-1111-2222-3333-444444444444"}]`
+	out, err := Fixture([]byte(input))
+	require.NoError(t, err)
+
+	var result []map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	assert.Equal(t, result[0]["a"], result[0]["b"], "same source UUID should map to the same replacement")
+}
+
+func TestFixture_email_field_replaced(t *testing.T) {
+	input := `[{"email":"alice@example.com","author":"bob@example.com"}]`
+	out, err := Fixture([]byte(input))
+	require.NoError(t, err)
+
+	var result []map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	assert.Equal(t, stableEmail, result[0]["email"])
+	assert.Equal(t, "bob@example.com", result[0]["author"], "author is not the 'email' key, should pass through")
+}
+
+func TestFixture_email_field_in_nested_object(t *testing.T) {
+	input := `[{"user":{"email":"deep@nested.com","name":"Alice"}}]`
+	out, err := Fixture([]byte(input))
+	require.NoError(t, err)
+
+	var result []map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	user, ok := result[0]["user"].(map[string]interface{})
+	require.True(t, ok, `expected map at result[0]["user"]`)
+
+	assert.Equal(t, stableEmail, user["email"])
+	assert.Equal(t, "Alice", user["name"], "non-email fields should pass through")
+}
+
+func TestFixture_UUIDs_in_URLs_remapped(t *testing.T) {
+	input := `[{"url":"https://app.snyk.io/org/foo/project/aaaaaaaa-1111-2222-3333-444444444444/report"}]`
+	out, err := Fixture([]byte(input))
+	require.NoError(t, err)
+
+	var result []map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	url, ok := result[0]["url"].(string)
+	require.True(t, ok, `expected string at result[0]["url"]`)
+
+	assert.NotEqual(t, input, url, "URL should have been transformed")
+	assert.False(t, strings.Contains(url, "aaaaaaaa-1111-2222-3333-444444444444"), "original UUID still present in URL")
+}
+
+func TestFixture_metadata_redacted(t *testing.T) {
+	input := `[{"metadata":{"project-id":"aaaaaaaa-1111-2222-3333-444444444444","snapshot-id":"bbbbbbbb-1111-2222-3333-444444444444","project-page-link":"https://example.com","report-url":"https://old","kept":"value"}}]`
+	out, err := Fixture([]byte(input))
+	require.NoError(t, err)
+
+	var result []map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	meta, ok := result[0]["metadata"].(map[string]interface{})
+	require.True(t, ok, `expected map at result[0]["metadata"]`)
+
+	wantPage := fmt.Sprintf("https://app.snyk.io/org/my-org/project/%s", stableMetadataProjectID)
+
+	assert.Equal(t, stableMetadataProjectID, meta["project-id"])
+	assert.Equal(t, stableMetadataSnapshotID, meta["snapshot-id"])
+	assert.Equal(t, wantPage, meta["project-page-link"])
+	assert.Equal(t, wantPage, meta["report-url"])
+	assert.Equal(t, "value", meta["kept"])
+}
+
+func TestFixture_metadata_without_report_url(t *testing.T) {
+	input := `[{"metadata":{"kept":"value"}}]`
+	out, err := Fixture([]byte(input))
+	require.NoError(t, err)
+
+	var result []map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	meta, ok := result[0]["metadata"].(map[string]interface{})
+	require.True(t, ok, `expected map at result[0]["metadata"]`)
+
+	assert.NotContains(t, meta, "report-url", "report-url should not be injected when absent from input")
+	assert.Equal(t, "value", meta["kept"])
+}
+
+func TestFixture_nested_arrays(t *testing.T) {
+	input := `[{"items":[{"id":"aaaaaaaa-1111-2222-3333-444444444444"},{"id":"bbbbbbbb-1111-2222-3333-444444444444"}]}]`
+	out, err := Fixture([]byte(input))
+	require.NoError(t, err)
+
+	var result []map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	items, ok := result[0]["items"].([]interface{})
+	require.True(t, ok, `expected []interface{} at result[0]["items"]`)
+	require.Len(t, items, 2)
+
+	item0, ok := items[0].(map[string]interface{})
+	require.True(t, ok, "expected map at items[0]")
+	item1, ok := items[1].(map[string]interface{})
+	require.True(t, ok, "expected map at items[1]")
+
+	id1, ok := item0["id"].(string)
+	require.True(t, ok, `expected string at items[0]["id"]`)
+	id2, ok := item1["id"].(string)
+	require.True(t, ok, `expected string at items[1]["id"]`)
+
+	assert.NotEqual(t, "aaaaaaaa-1111-2222-3333-444444444444", id1, "nested UUID should be remapped")
+	assert.NotEqual(t, "bbbbbbbb-1111-2222-3333-444444444444", id2, "nested UUID should be remapped")
+	assert.NotEqual(t, id1, id2, "different UUIDs should map to different replacements")
+}
+
+func TestFixture_problem_ref_map_keys_share_UUID_mapping_with_values(t *testing.T) {
+	// _problemRefs uses problem UUIDs as JSON object keys; the same UUID appears
+	// in problem "id" fields. Keys must go through the same remapper as values.
+	input := `[{
+		"_problemRefs": {
+			"aaaaaaaa-1111-2222-3333-444444444444": ["generic-secret"],
+			"bbbbbbbb-1111-2222-3333-444444444444": ["private-key"]
+		},
+		"problems": [
+			{"id": "aaaaaaaa-1111-2222-3333-444444444444"},
+			{"id": "bbbbbbbb-1111-2222-3333-444444444444"}
+		]
+	}]`
+	out, err := Fixture([]byte(input))
+	require.NoError(t, err)
+
+	var result []map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	root := result[0]
+	refs, ok := root["_problemRefs"].(map[string]interface{})
+	require.True(t, ok, "expected map at _problemRefs")
+
+	problems, ok := root["problems"].([]interface{})
+	require.True(t, ok, "expected []interface{} at problems")
+	require.Len(t, problems, 2)
+
+	p0, ok := problems[0].(map[string]interface{})
+	require.True(t, ok, "problems[0] should be an object")
+	p1, ok := problems[1].(map[string]interface{})
+	require.True(t, ok, "problems[1] should be an object")
+	id0, ok := p0["id"].(string)
+	require.True(t, ok, "problems[0].id should be a string")
+	id1, ok := p1["id"].(string)
+	require.True(t, ok, "problems[1].id should be a string")
+	require.NotEmpty(t, id0, "problems[0].id")
+	require.NotEmpty(t, id1, "problems[1].id")
+
+	assert.Contains(t, refs, id0, "_problemRefs should contain key matching first problem id")
+	assert.Contains(t, refs, id1, "_problemRefs should contain key matching second problem id")
+}
+
+func TestFixture_invalid_json(t *testing.T) {
+	_, err := Fixture([]byte(`not json`))
+	assert.Error(t, err)
+}
+
+func TestFixture_non_array_json(t *testing.T) {
+	_, err := Fixture([]byte(`{"key":"value"}`))
+	assert.Error(t, err)
+}
+
+func TestUUIDRemapper_incremental(t *testing.T) {
+	r := NewUUIDRemapper()
+	a := r.Remap("aaaaaaaa-1111-2222-3333-444444444444")
+	b := r.Remap("bbbbbbbb-1111-2222-3333-444444444444")
+
+	assert.NotEqual(t, a, b, "different inputs should produce different outputs")
+	assert.Equal(t, "11112222-3333-4444-5555-000000000001", a)
+	assert.Equal(t, "11112222-3333-4444-5555-000000000002", b)
+
+	a2 := r.Remap("AAAAAAAA-1111-2222-3333-444444444444")
+	assert.Equal(t, a, a2, "case-insensitive lookup should return the same mapped UUID")
+}

--- a/pkg/utils/mapkeys.go
+++ b/pkg/utils/mapkeys.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"cmp"
+	"slices"
+)
+
+// SortedMapKeys returns the keys of m in ascending order.
+// Use it when deterministic iteration over a map is required (Go map iteration order is not defined),
+// for example after encoding/json decoding into map[K]V.
+func SortedMapKeys[K cmp.Ordered, V any](m map[K]V) []K {
+	keys := make([]K, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return keys
+}

--- a/pkg/utils/mapkeys_test.go
+++ b/pkg/utils/mapkeys_test.go
@@ -1,0 +1,77 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortedMapKeys(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		testCases := []struct {
+			name string
+			m    map[string]int
+			want []string
+		}{
+			{
+				name: "sorted_values",
+				m:    map[string]int{"b": 2, "a": 1, "c": 3},
+				want: []string{"a", "b", "c"},
+			},
+			{
+				name: "empty",
+				m:    map[string]int{},
+				want: []string{},
+			},
+			{
+				name: "single_key",
+				m:    map[string]int{"only": 1},
+				want: []string{"only"},
+			},
+			{
+				name: "keys_already_sorted",
+				m:    map[string]int{"a": 1, "b": 2, "c": 3},
+				want: []string{"a", "b", "c"},
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.Equal(t, tc.want, SortedMapKeys(tc.m))
+			})
+		}
+	})
+
+	t.Run("int", func(t *testing.T) {
+		testCases := []struct {
+			name string
+			m    map[int]string
+			want []int
+		}{
+			{
+				name: "sorted_values",
+				m:    map[int]string{3: "c", 1: "a", 2: "b"},
+				want: []int{1, 2, 3},
+			},
+			{
+				name: "empty",
+				m:    map[int]string{},
+				want: []int{},
+			},
+			{
+				name: "single_key",
+				m:    map[int]string{42: "x"},
+				want: []int{42},
+			},
+			{
+				name: "negative_and_positive",
+				m:    map[int]string{0: "z", -1: "a", 2: "b"},
+				want: []int{-1, 0, 2},
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.Equal(t, tc.want, SortedMapKeys(tc.m))
+			})
+		}
+	})
+}


### PR DESCRIPTION
### Description

Adds `cmd/ufm-fixture-tool` and `cmd/ufm-fixture-tool/redact`: deterministic normalization of UFM test-result JSON (`[]testresult` wire shape from workflow dumps). Replaces volatile values (UUIDs, org slug, emails in 'email' fields) with stable placeholders so output is comparable and safe to commit. It is not a generic redactor for arbitrary JSON; it is tailored to the UFM dump structure (including `metadata` handling). Includes table-driven tests for determinism, org and email handling, metadata, and embedded UUIDs. Usable standalone via `go run ./cmd/ufm-fixture-tool`.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.

### Where reviewers should start

- `cmd/ufm-fixture-tool/redact/redact.go`
- `cmd/ufm-fixture-tool/redact/redact_test.go`
- `cmd/ufm-fixture-tool/main.go`

### Risk assessment

**Low.** New command and package only; no changes to existing workflow or engine behavior.