### PR TITLE
fix: apply invocation config to workflow Data after callback

### DIFF
--- a/pkg/workflow/dataimpl.go
+++ b/pkg/workflow/dataimpl.go
@@ -66,10 +66,18 @@ func withPayload(payload *interface{}) Option {
 	}
 }
 
+// WithConfiguration copies IN_MEMORY_THRESHOLD_BYTES and TEMP_DIR_PATH from
+// config when each key resolves to a value (including AddDefaultValue). If
+// TEMP_DIR_PATH is absent, d.tempDirPath is left unchanged (typically ""), and
+// os.CreateTemp uses the process default temp directory.
 func WithConfiguration(config configuration.Configuration) Option {
 	return func(d *DataImpl) {
-		d.inMemoryThreshold = config.GetInt(configuration.IN_MEMORY_THRESHOLD_BYTES)
-		d.tempDirPath = config.GetString(configuration.TEMP_DIR_PATH)
+		if v := config.Get(configuration.IN_MEMORY_THRESHOLD_BYTES); v != nil {
+			d.inMemoryThreshold = config.GetInt(configuration.IN_MEMORY_THRESHOLD_BYTES)
+		}
+		if v := config.Get(configuration.TEMP_DIR_PATH); v != nil {
+			d.tempDirPath = config.GetString(configuration.TEMP_DIR_PATH)
+		}
 	}
 }
 
@@ -254,6 +262,28 @@ func (d *DataImpl) GetErrorList() []snyk_errors.Error {
 
 func (d *DataImpl) AddError(err snyk_errors.Error) {
 	d.errors = append(d.errors, err)
+}
+
+// applyConfiguration re-evaluates the payload location using the given
+// configuration. Field updates use the same rules as WithConfiguration.
+// If the payload is currently in memory and exceeds the
+// configured threshold, it is written to disk under the configured temp
+// directory. This allows the engine to apply its configuration to Data
+// objects that were created without WithConfiguration.
+func (d *DataImpl) applyConfiguration(config configuration.Configuration) {
+	if config.Get(configuration.IN_MEMORY_THRESHOLD_BYTES) == nil {
+		return
+	}
+
+	WithConfiguration(config)(d)
+
+	if d.payloadLocation.Type == InMemory && d.payload != nil {
+		d.payloadLocation = setPayloadLocation(d.identifier, d.inMemoryThreshold, d.tempDirPath, d.payload, d.logger)
+		if d.payloadLocation.Type == OnDisk {
+			d.logger.Debug().Msg("payload relocated to disk after applyConfiguration")
+			d.payload = nil
+		}
+	}
 }
 
 func setPayloadLocation(id Identifier, inMemoryThreshold int, tempDirPath string, payload interface{}, logger *zerolog.Logger) Location {

--- a/pkg/workflow/dataimpl_test.go
+++ b/pkg/workflow/dataimpl_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_NewDataFromInput(t *testing.T) {
@@ -192,6 +193,140 @@ func Test_NewData(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(actualFiles))
 		assert.Contains(t, actualFiles[0].Name(), expectedFileName)
+	})
+
+	t.Run("applyConfiguration relocates in-memory payload to disk", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		logger := zerolog.Nop()
+
+		id := NewTypeIdentifier(NewWorkflowIdentifier("cmd"), "applytest")
+		payloadBytes := []byte("payload that should end up on disk after applyConfiguration")
+
+		data := NewData(id, "application/octet-stream", payloadBytes, WithLogger(&logger))
+
+		// Without WithConfiguration, payload stays in memory (threshold defaults to -1)
+		di, ok := data.(*DataImpl)
+		require.True(t, ok)
+		assert.Equal(t, InMemory, di.payloadLocation.Type)
+		assert.NotNil(t, di.payload)
+
+		// Now apply a configuration with threshold=0 — everything spills to disk
+		cfg := configuration.NewInMemory()
+		cfg.Set(configuration.IN_MEMORY_THRESHOLD_BYTES, 0)
+		cfg.Set(configuration.TEMP_DIR_PATH, tmpDir)
+		di.applyConfiguration(cfg)
+
+		assert.Equal(t, OnDisk, di.payloadLocation.Type)
+		assert.Nil(t, di.payload)
+		assert.Contains(t, di.payloadLocation.Path, tmpDir)
+
+		// GetPayload still returns the original bytes
+		result := data.GetPayload()
+		assert.Equal(t, payloadBytes, result)
+	})
+
+	t.Run("applyConfiguration is no-op when threshold is disabled", func(t *testing.T) {
+		logger := zerolog.Nop()
+		id := NewTypeIdentifier(NewWorkflowIdentifier("cmd"), "noop")
+		payloadBytes := []byte("stays in memory")
+
+		data := NewData(id, "text/plain", payloadBytes, WithLogger(&logger))
+		di, ok := data.(*DataImpl)
+		require.True(t, ok)
+
+		cfg := configuration.NewInMemory()
+		cfg.Set(configuration.IN_MEMORY_THRESHOLD_BYTES, -1)
+		di.applyConfiguration(cfg)
+
+		assert.Equal(t, InMemory, di.payloadLocation.Type)
+		assert.NotNil(t, di.payload)
+	})
+
+	t.Run("applyConfiguration is no-op when threshold key is not set in config", func(t *testing.T) {
+		logger := zerolog.Nop()
+		id := NewTypeIdentifier(NewWorkflowIdentifier("cmd"), "unset")
+		payloadBytes := []byte("should stay in memory because key is unset")
+
+		data := NewData(id, "text/plain", payloadBytes, WithLogger(&logger))
+		di, ok := data.(*DataImpl)
+		require.True(t, ok)
+		assert.Equal(t, -1, di.inMemoryThreshold)
+
+		cfg := configuration.NewInMemory()
+		require.Nil(t, cfg.Get(configuration.IN_MEMORY_THRESHOLD_BYTES))
+		di.applyConfiguration(cfg)
+
+		assert.Equal(t, -1, di.inMemoryThreshold)
+		assert.Equal(t, InMemory, di.payloadLocation.Type)
+		assert.NotNil(t, di.payload)
+	})
+
+	t.Run("applyConfiguration uses AddDefaultValue when key is not Set", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		logger := zerolog.Nop()
+		id := NewTypeIdentifier(NewWorkflowIdentifier("cmd"), "adddefault")
+		payloadBytes := []byte("spill via default value functions")
+
+		data := NewData(id, "application/octet-stream", payloadBytes, WithLogger(&logger))
+		di, ok := data.(*DataImpl)
+		require.True(t, ok)
+
+		cfg := configuration.NewInMemory()
+		cfg.AddDefaultValue(configuration.IN_MEMORY_THRESHOLD_BYTES, configuration.StandardDefaultValueFunction(0))
+		cfg.AddDefaultValue(configuration.TEMP_DIR_PATH, configuration.StandardDefaultValueFunction(tmpDir))
+
+		assert.False(t, cfg.IsSet(configuration.IN_MEMORY_THRESHOLD_BYTES))
+		assert.False(t, cfg.IsSet(configuration.TEMP_DIR_PATH))
+		require.NotNil(t, cfg.Get(configuration.IN_MEMORY_THRESHOLD_BYTES))
+		require.NotNil(t, cfg.Get(configuration.TEMP_DIR_PATH))
+
+		di.applyConfiguration(cfg)
+
+		assert.Equal(t, OnDisk, di.payloadLocation.Type)
+		assert.Nil(t, di.payload)
+		assert.Contains(t, di.payloadLocation.Path, tmpDir)
+	})
+
+	t.Run("applyConfiguration with threshold only uses system temp when TEMP_DIR_PATH absent", func(t *testing.T) {
+		logger := zerolog.Nop()
+		id := NewTypeIdentifier(NewWorkflowIdentifier("cmd"), "notemp")
+		payloadBytes := []byte("spill with no temp path in config")
+
+		data := NewData(id, "application/octet-stream", payloadBytes, WithLogger(&logger))
+		di, ok := data.(*DataImpl)
+		require.True(t, ok)
+
+		cfg := configuration.NewInMemory()
+		cfg.Set(configuration.IN_MEMORY_THRESHOLD_BYTES, 0)
+		require.Nil(t, cfg.Get(configuration.TEMP_DIR_PATH))
+
+		di.applyConfiguration(cfg)
+
+		assert.Equal(t, OnDisk, di.payloadLocation.Type)
+		assert.Contains(t, di.payloadLocation.Path, os.TempDir())
+	})
+
+	t.Run("applyConfiguration is no-op when payload is already on disk", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		logger := zerolog.Nop()
+
+		cfg := configuration.NewInMemory()
+		cfg.Set(configuration.IN_MEMORY_THRESHOLD_BYTES, 0)
+		cfg.Set(configuration.TEMP_DIR_PATH, tmpDir)
+
+		id := NewTypeIdentifier(NewWorkflowIdentifier("cmd"), "alreadyondisk")
+		payloadBytes := []byte("on disk from the start")
+
+		data := NewData(id, "application/octet-stream", payloadBytes, WithConfiguration(cfg), WithLogger(&logger))
+		di, ok := data.(*DataImpl)
+		require.True(t, ok)
+		assert.Equal(t, OnDisk, di.payloadLocation.Type)
+		originalPath := di.payloadLocation.Path
+
+		// applyConfiguration again should not relocate
+		di.applyConfiguration(cfg)
+		assert.Equal(t, OnDisk, di.payloadLocation.Type)
+		assert.Equal(t, originalPath, di.payloadLocation.Path)
 	})
 
 	t.Run("when configuration is not provided, filesystem cache is not used", func(t *testing.T) {

--- a/pkg/workflow/engine_test.go
+++ b/pkg/workflow/engine_test.go
@@ -598,3 +598,42 @@ func Test_EngineImpl_InvokeWithContext_DefaultContext(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, receivedCtx)
 }
+
+func Test_Invoke_AppliesConfigurationToOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	config := configuration.New()
+	config.Set(configuration.IN_MEMORY_THRESHOLD_BYTES, 0)
+	config.Set(configuration.TEMP_DIR_PATH, tmpDir)
+
+	engine := NewWorkFlowEngine(config)
+
+	wfId := NewWorkflowIdentifier("threshold-test")
+	flagset := pflag.NewFlagSet("tt", pflag.ContinueOnError)
+
+	payload := []byte("this payload should be relocated to disk by the engine after Invoke")
+
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		// Create Data WITHOUT WithConfiguration — simulates what most callers do
+		id := NewTypeIdentifier(invocation.GetWorkflowIdentifier(), "testdata")
+		d := NewData(id, "application/octet-stream", payload)
+		return []Data{d}, nil
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, engine.Init())
+
+	output, err := engine.Invoke(wfId)
+	assert.NoError(t, err)
+	assert.Len(t, output, 1)
+
+	// The engine should have applied its config, relocating the payload to disk
+	di, ok := output[0].(*DataImpl)
+	assert.True(t, ok)
+	assert.Equal(t, OnDisk, di.payloadLocation.Type)
+	assert.Contains(t, di.payloadLocation.Path, tmpDir)
+	assert.Nil(t, di.payload)
+
+	// GetPayload still returns the original bytes from disk
+	result := output[0].GetPayload()
+	assert.Equal(t, payload, result)
+}

--- a/pkg/workflow/engineimpl.go
+++ b/pkg/workflow/engineimpl.go
@@ -338,6 +338,15 @@ func (e *EngineImpl) Invoke(
 			localLogger.Printf("Workflow Start")
 			output, err = callback(invocationCtx, options.input)
 			localLogger.Printf("Workflow End")
+
+			// Apply the engine's configuration to output data so that
+			// IN_MEMORY_THRESHOLD_BYTES and TEMP_DIR_PATH are respected
+			// even when workflows create Data without WithConfiguration.
+			for _, d := range output {
+				if di, ok := d.(*DataImpl); ok {
+					di.applyConfiguration(options.config)
+				}
+			}
 		}
 	} else {
 		err = fmt.Errorf("workflow '%v' not found", id)


### PR DESCRIPTION
### **User description**
### Description

Workflows can return `Data` created with `workflow.NewData` without `WithConfiguration`, so `IN_MEMORY_THRESHOLD_BYTES` and `TEMP_DIR_PATH` were not applied to those payloads.

After each workflow callback returns, `EngineImpl.Invoke` calls `applyConfiguration` on each `*DataImpl` in the output slice so in-memory payloads can spill to the configured temp directory when above threshold. `applyConfiguration` is package-private on `DataImpl` (same package as the engine) so it is not exported from the workflow package.

Adds tests in `dataimpl_test.go` for spill and no-op cases, and in `engine_test.go` for behavior after `Invoke`.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.
  
PR in CLI https://github.com/snyk/cli/pull/6792

### Where reviewers should start

- `pkg/workflow/dataimpl.go` — `applyConfiguration`
- `pkg/workflow/engineimpl.go` — post-process loop after `callback`

### Risk assessment

**Low.** Default production behavior is unchanged unless spill-related settings are enabled; when they are, returned `Data` placement aligns with engine configuration instead of leaving eligible payloads in memory.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Apply engine configuration to workflow output Data.

- Enable payload spilling based on engine settings.

- Introduce `DataImpl.applyConfiguration` method logic.

- Add comprehensive tests for configuration application.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  engine_invoke["EngineImpl.Invoke"] --> workflow_callback["Workflow Callback"];
  workflow_callback --> output_data["Output Data"];
  output_data --> post_processing_loop["Apply Config Loop"];
  post_processing_loop --> dataimpl_apply_config["DataImpl.applyConfiguration"];
  dataimpl_apply_config --> spill_to_disk["Payload Spills to Disk (if needed)"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dataimpl.go</strong><dd><code>Implement DataImpl configuration application logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/workflow/dataimpl.go

<ul><li>Modified <code>WithConfiguration</code> to conditionally apply threshold and temp <br>dir values.<br> <li> Introduced <code>applyConfiguration</code> method to relocate in-memory payloads to <br>disk based on configuration.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/606/changes#diff-1752c5ed22bf801a49fb09a0c131b3d5315cca0612ae39d0b43a503f37b17bfb">+32/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dataimpl_test.go</strong><dd><code>Add tests for DataImpl applyConfiguration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/workflow/dataimpl_test.go

<ul><li>Added several new test cases for <code>applyConfiguration</code>.<br> <li> Tests cover spill behavior, no-op scenarios, default values, and <br>missing temp directory paths.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/606/changes#diff-a282c7d1ff03bff6144f2fe2b46aeb71a92245dad129535e74546eedb7ee591b">+135/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>engine_test.go</strong><dd><code>Test engine Invoke output configuration application</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/workflow/engine_test.go

<ul><li>Added a new test <code>Test_Invoke_AppliesConfigurationToOutput</code>.<br> <li> Verifies that engine's invocation applies configuration to output <br>data, causing spills.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/606/changes#diff-95bcd88858f99e1bfecd015f2c3490e3072dbcb550ac8f7cb385b7462ae929cc">+39/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>engineimpl.go</strong><dd><code>Apply engine configuration to Invoke output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/workflow/engineimpl.go

<ul><li>Modified <code>Invoke</code> to iterate over workflow output <code>Data</code>.<br> <li> Calls <code>di.applyConfiguration(options.config)</code> on each <code>DataImpl</code> to apply <br>engine settings.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/606/changes#diff-672848374dc64d0b5059745d90ef50be714f0f3d9791ef4f6db7174eff68c460">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

