### PR TITLE
fix(workflow): synchronize GetLogger with SetLogger [IDE-2024]

### DIFF
--- a/pkg/workflow/engineimpl.go
+++ b/pkg/workflow/engineimpl.go
@@ -31,7 +31,7 @@ type EngineImpl struct {
 	ui                   ui.UserInterface
 	runtimeInfo          runtimeinfo.RuntimeInfo
 
-	mu                sync.Mutex
+	mu                sync.RWMutex
 	invocationCounter int
 }
 
@@ -73,6 +73,8 @@ func WithContext(ctx context.Context) EngineInvokeOption {
 }
 
 func (e *EngineImpl) GetLogger() *zerolog.Logger {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	return e.logger
 }
 


### PR DESCRIPTION
### Description

Fixes a data race between `EngineImpl.SetLogger` (which wrote `e.logger` under `mu`) and `EngineImpl.GetLogger` (which read `e.logger` without locking). The race showed up when snyk-ls ran CLI install with concurrent logging (for example async `logCliVersion`) alongside `config.SetupLogging`.

**Changes**

- Use `sync.RWMutex` instead of `sync.Mutex` on `EngineImpl`.
- Take `RLock` in `GetLogger` so reads pair with `SetLogger`'s exclusive `Lock`.

**Jira:** [IDE-2024](https://snyksec.atlassian.net/browse/IDE-2024)

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.


[IDE-2024]: https://snyksec.atlassian.net/browse/IDE-2024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ