### PR TITLE
fix: isolate test environment from external variables

### DIFF
--- a/pkg/configtest/env.go
+++ b/pkg/configtest/env.go
@@ -2,13 +2,13 @@ package configtest
 
 import "testing"
 
-// APIURLViperEnvironmentKey is the AutomaticEnv name for configuration.API_URL (viper key "snyk_api").
+// snykAPIKey is the AutomaticEnv name for configuration.API_URL (viper key "snyk_api").
 // Keep aligned with pkg/configuration/constants.go.
-const APIURLViperEnvironmentKey = "SNYK_API"
+const snykAPIKey = "SNYK_API"
 
 // KnownLeakEnvironmentKeys is cleared when [IsolateEnvironmentForTest] is called with no arguments.
 var KnownLeakEnvironmentKeys = []string{
-	APIURLViperEnvironmentKey,
+	snykAPIKey,
 }
 
 // IsolateEnvironmentForTest runs t.Setenv(k, "") for each key. With no keys it clears [KnownLeakEnvironmentKeys].

--- a/pkg/configtest/env.go
+++ b/pkg/configtest/env.go
@@ -1,6 +1,8 @@
 package configtest
 
-import "testing"
+import (
+	"testing"
+)
 
 // snykAPIKey is the AutomaticEnv name for configuration.API_URL (viper key "snyk_api").
 // Keep aligned with pkg/configuration/constants.go.
@@ -11,8 +13,10 @@ var KnownLeakEnvironmentKeys = []string{
 	snykAPIKey,
 }
 
-// IsolateEnvironmentForTest runs t.Setenv(k, "") for each key. With no keys it clears [KnownLeakEnvironmentKeys].
-// With keys, only those are cleared (not merged with defaults). Empty keys are skipped.
+// IsolateEnvironmentForTest clears environment variables for a test using t.Setenv(k, "").
+// If no keys are provided, it clears the variables listed in [KnownLeakEnvironmentKeys].
+// If explicit keys are provided, they OVERRIDE the default behavior: only the specified keys are cleared,
+// and they are NOT merged with [KnownLeakEnvironmentKeys]. Empty keys are skipped.
 func IsolateEnvironmentForTest(t *testing.T, keys ...string) {
 	t.Helper()
 	toClear := keys

--- a/pkg/configtest/env.go
+++ b/pkg/configtest/env.go
@@ -1,0 +1,28 @@
+package configtest
+
+import "testing"
+
+// APIURLViperEnvironmentKey is the AutomaticEnv name for configuration.API_URL (viper key "snyk_api").
+// Keep aligned with pkg/configuration/constants.go.
+const APIURLViperEnvironmentKey = "SNYK_API"
+
+// KnownLeakEnvironmentKeys is cleared when [IsolateEnvironmentForTest] is called with no arguments.
+var KnownLeakEnvironmentKeys = []string{
+	APIURLViperEnvironmentKey,
+}
+
+// IsolateEnvironmentForTest runs t.Setenv(k, "") for each key. With no keys it clears [KnownLeakEnvironmentKeys].
+// With keys, only those are cleared (not merged with defaults). Empty keys are skipped.
+func IsolateEnvironmentForTest(t *testing.T, keys ...string) {
+	t.Helper()
+	toClear := keys
+	if len(toClear) == 0 {
+		toClear = KnownLeakEnvironmentKeys
+	}
+	for _, k := range toClear {
+		if k == "" {
+			continue
+		}
+		t.Setenv(k, "")
+	}
+}

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/patrickmn/go-cache"
+	"github.com/snyk/go-application-framework/pkg/configtest"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 )
@@ -269,6 +270,8 @@ func Test_ConfigurationGet_Url(t *testing.T) {
 }
 
 func Test_ConfigurationGet_StringSlice(t *testing.T) {
+	configtest.IsolateEnvironmentForTest(t)
+
 	config := New()
 
 	expectedDefault := []string{}

--- a/pkg/local_workflows/report_analytics_workflow_test.go
+++ b/pkg/local_workflows/report_analytics_workflow_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/go-application-framework/pkg/analytics"
+	"github.com/snyk/go-application-framework/pkg/configtest"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	testutils "github.com/snyk/go-application-framework/pkg/local_workflows/test_utils"
 	"github.com/snyk/go-application-framework/pkg/mocks"
@@ -320,6 +321,7 @@ func testInitReportAnalyticsWorkflow(ctrl *gomock.Controller) error {
 
 func testGetMockHTTPClient(t *testing.T, orgId string, requestPayload string) *http.Client {
 	t.Helper()
+	configtest.IsolateEnvironmentForTest(t)
 	mockClient := testutils.NewTestClient(func(req *http.Request) *http.Response {
 		// Test request parameters
 		require.Equal(t, "/hidden/orgs/"+orgId+"/analytics?version=2024-03-07~experimental", req.URL.String())

--- a/pkg/local_workflows/whoami_workflow_test.go
+++ b/pkg/local_workflows/whoami_workflow_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/snyk/go-application-framework/pkg/configtest"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	testutils "github.com/snyk/go-application-framework/pkg/local_workflows/test_utils"
 	"github.com/snyk/go-application-framework/pkg/mocks"
@@ -77,6 +78,8 @@ const missingFieldsPayload string = `{
 func setupMockContext(t *testing.T, payload string, json bool, statusCode int) *mocks.MockInvocationContext {
 	// This method is a helper
 	t.Helper()
+
+	configtest.IsolateEnvironmentForTest(t)
 
 	// setup
 	logger := zerolog.Logger{}

--- a/pkg/networking/networking_test.go
+++ b/pkg/networking/networking_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/snyk/error-catalog-golang-public/cli"
 	"github.com/snyk/error-catalog-golang-public/snyk"
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+	"github.com/snyk/go-application-framework/pkg/configtest"
 	"github.com/snyk/go-httpauth/pkg/httpauth"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
@@ -449,6 +450,8 @@ func Test_UserAgentInfo_Complete(t *testing.T) {
 }
 
 func TestNetworkImpl_Clone(t *testing.T) {
+	configtest.IsolateEnvironmentForTest(t)
+
 	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	network := NewNetworkAccess(config)
 


### PR DESCRIPTION
### Description

This PR adds an extendable mechanism to ignore environment variables in unit tests.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.
