### PR TITLE
feat(configuration): add GetDefaultValueFunc to Configuration interface

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -57,6 +57,7 @@ type Configuration interface {
 	AddFlagSet(flagset *pflag.FlagSet) error
 	AllKeys() []string
 	AddDefaultValue(key string, defaultValue DefaultValueFunction)
+	GetDefaultValueFunc(key string) DefaultValueFunction
 	AddAlternativeKeys(key string, altKeys []string)
 	GetAlternativeKeys(key string) []string
 	GetAllKeysThatContainValues(key string) []string
@@ -674,6 +675,15 @@ func (ev *extendedViper) AddDefaultValue(key string, defaultValue DefaultValueFu
 	defer ev.mutex.Unlock()
 
 	ev.defaultValues[key] = defaultValue
+}
+
+// GetDefaultValueFunc returns the DefaultValueFunction registered for key, or nil if none is registered.
+// This allows callers to capture the existing function before overwriting it with AddDefaultValue,
+// enabling layered/chained default-value behaviour.
+func (ev *extendedViper) GetDefaultValueFunc(key string) DefaultValueFunction {
+	ev.mutex.RLock()
+	defer ev.mutex.RUnlock()
+	return ev.defaultValues[key]
 }
 
 // AddAlternativeKeys adds alternative keys to the configuration.

--- a/pkg/mocks/configuration.go
+++ b/pkg/mocks/configuration.go
@@ -226,6 +226,20 @@ func (mr *MockConfigurationMockRecorder) GetBoolWithError(key interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBoolWithError", reflect.TypeOf((*MockConfiguration)(nil).GetBoolWithError), key)
 }
 
+// GetDefaultValueFunc mocks base method.
+func (m *MockConfiguration) GetDefaultValueFunc(key string) configuration.DefaultValueFunction {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDefaultValueFunc", key)
+	ret0, _ := ret[0].(configuration.DefaultValueFunction)
+	return ret0
+}
+
+// GetDefaultValueFunc indicates an expected call of GetDefaultValueFunc.
+func (mr *MockConfigurationMockRecorder) GetDefaultValueFunc(key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultValueFunc", reflect.TypeOf((*MockConfiguration)(nil).GetDefaultValueFunc), key)
+}
+
 // GetDuration mocks base method.
 func (m *MockConfiguration) GetDuration(key string) time.Duration {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary

- Adds `GetDefaultValueFunc(key string) DefaultValueFunction` to the `Configuration` interface and `extendedViper` implementation
- Regenerates the `MockConfiguration` mock
- Enables callers to capture an existing default-value function before overwriting it with `AddDefaultValue`, allowing layered/chained behaviour

## Motivation

Currently `AddDefaultValue` replaces the registered function for a key with no way to retrieve the prior one. This makes it impossible to build wrappers that guard (e.g. skip network calls when offline/unauthenticated) and then delegate to the original function. Without this, a wrapper permanently displaces the original GAF default func (e.g. `defaultFuncOrganization`), silently breaking org resolution for callers that go through `conf.GetString(configuration.ORGANIZATION)` when no cached value exists.

## Test plan

- [ ] `go test ./pkg/configuration/...` passes (180 tests, verified locally)
- [ ] `go build ./pkg/...` passes
- [ ] Mock regenerated via `go generate ./pkg/configuration/...`