### PR TITLE
fix(analytics): make AddExtension goroutine-safe

### DIFF
--- a/pkg/analytics/instrumentation_collector.go
+++ b/pkg/analytics/instrumentation_collector.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/snyk/go-application-framework/pkg/logging"
 	"os/user"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -63,6 +64,7 @@ type instrumentationCollectorImpl struct {
 	testSummary         json_schemas.TestSummary
 	targetId            string
 	instrumentationErr  []error
+	extensionMu         sync.Mutex
 	extension           map[string]interface{}
 }
 
@@ -134,6 +136,8 @@ func (ic *instrumentationCollectorImpl) AddError(err error) {
 }
 
 func (ic *instrumentationCollectorImpl) AddExtension(key string, value interface{}) {
+	ic.extensionMu.Lock()
+	defer ic.extensionMu.Unlock()
 	ic.extension[key] = value
 }
 

--- a/pkg/analytics/instrumentation_collector.go
+++ b/pkg/analytics/instrumentation_collector.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/snyk/go-application-framework/pkg/logging"
+	"maps"
 	"os/user"
 	"sync"
 	"time"
@@ -222,11 +223,15 @@ func (ic *instrumentationCollectorImpl) getV2Attributes() api.AnalyticsAttribute
 }
 
 func (ic *instrumentationCollectorImpl) getV2Interaction() api.Interaction {
+	ic.extensionMu.Lock()
+	extensionCopy := maps.Clone(ic.extension)
+	ic.extensionMu.Unlock()
+
 	stage := toInteractionStage(ic.stage)
 	return api.Interaction{
 		Categories:  &ic.category,
 		Errors:      toInteractionErrors(ic.instrumentationErr),
-		Extension:   &ic.extension,
+		Extension:   &extensionCopy,
 		Id:          ic.interactionId,
 		Results:     toInteractionResults(&ic.testSummary),
 		Stage:       &stage,

--- a/pkg/analytics/instrumentation_collector_test.go
+++ b/pkg/analytics/instrumentation_collector_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -275,6 +276,19 @@ func setupBaseCollector(t *testing.T) InstrumentationCollector {
 	ic.SetTimestamp(time.Date(2025, 1, 01, 0, 0, 0, 0, time.UTC))
 
 	return ic
+}
+
+func TestAddExtension_ConcurrentSafe(t *testing.T) {
+	ic := NewInstrumentationCollector()
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			ic.AddExtension(fmt.Sprintf("key%d", n), n)
+		}(i)
+	}
+	wg.Wait()
 }
 
 // Helper function to build the expected response object


### PR DESCRIPTION
## Summary

- `instrumentationCollectorImpl.AddExtension` wrote to `ic.extension` map with no mutex
- Concurrent calls from `featureflag.fetch` goroutines in snyk-ls caused `fatal error: concurrent map writes` and `WARNING: DATA RACE` in CI
- Add `extensionMu sync.Mutex` field, lock it in `AddExtension`
- Add `TestAddExtension_ConcurrentSafe` (100 concurrent goroutines under `-race`) to reproduce and prevent regression

## Root cause

`AddExtension` has been unsynchronised since introduction (commit `0eaffbc`, May 2024). snyk-ls's `featureflag.fetch` spawns N goroutines each calling `GetFeatureFlagValue` → GAF `defaultFuncOrganization` → `AddExtension` concurrently, triggering the race.

## Test plan

- [ ] `go test -race ./pkg/analytics/...` passes (was failing before fix)
- [ ] Existing analytics tests unaffected