### PR TITLE
feat: make dot snyk excludes parameterisable

### DIFF
--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -50,9 +50,12 @@ func (s DotSnykExcludeSectionName) String() string {
 
 // DotSnykRule mirrors the relevant parts of a .snyk policy file. Exclude keys
 // its sections by name (e.g. "code", "global") so new sections are picked up by
-// decoding alone, without changes to this type.
+// decoding alone, without changes to this type. Section contents are kept as raw
+// yaml.Node values so each section can be decoded independently: only the
+// sections a caller opts into are decoded into rules, and a malformed section a
+// caller does not request cannot fail the decode of the whole file.
 type DotSnykRule struct {
-	Exclude map[DotSnykExcludeSectionName][]dotSnykExclude `yaml:"exclude"`
+	Exclude map[DotSnykExcludeSectionName]yaml.Node `yaml:"exclude"`
 }
 
 type FileFilterOption func(*FileFilter) error
@@ -215,10 +218,23 @@ func (fw *FileFilter) parseDotSnykFile(content []byte, filePath string) []string
 		return nil
 	}
 
-	// collect rules according to fw.dotSnykSections
+	// collect rules according to fw.dotSnykSections, decoding each requested
+	// section independently so a malformed section we don't care about (or a
+	// malformed sibling of one we do) cannot drop the sections we do apply.
 	var allRules []dotSnykExclude
 	for _, section := range fw.dotSnykSections {
-		allRules = append(allRules, rules.Exclude[section]...)
+		node, ok := rules.Exclude[section]
+		if !ok {
+			continue
+		}
+
+		var sectionRules []dotSnykExclude
+		if err := node.Decode(&sectionRules); err != nil {
+			fw.logger.Error().Msgf("parse .snyk section %q failed: %v", section, err)
+			continue
+		}
+
+		allRules = append(allRules, sectionRules...)
 	}
 
 	var globs []string

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -22,10 +23,50 @@ import (
 var defaultInvalidRules = []string{}
 
 type FileFilter struct {
-	path         string
-	defaultRules []string
-	logger       *zerolog.Logger
-	max_threads  int64
+	path            string
+	defaultRules    []string
+	logger          *zerolog.Logger
+	max_threads     int64
+	dotSnykSections []DotSnykExcludeSectionName
+}
+
+type DotSnykExcludeSectionName string
+
+const (
+	Global  DotSnykExcludeSectionName = "global"
+	Code    DotSnykExcludeSectionName = "code"
+	Secrets DotSnykExcludeSectionName = "secrets"
+)
+
+// dotSnykExcludeSectionNames lists every valid DotSnykExcludeSectionName value.
+var dotSnykExcludeSectionNames = []DotSnykExcludeSectionName{Global, Code, Secrets}
+
+// String implements fmt.Stringer.
+func (s DotSnykExcludeSectionName) String() string {
+	return string(s)
+}
+
+// IsValid reports whether s is one of the defined section names.
+func (s DotSnykExcludeSectionName) IsValid() bool {
+	return slices.Contains(dotSnykExcludeSectionNames, s)
+}
+
+// ParseDotSnykExcludeSectionName converts a string into a DotSnykExcludeSectionName,
+// returning an error if it does not match a defined section name.
+func ParseDotSnykExcludeSectionName(value string) (DotSnykExcludeSectionName, error) {
+	name := DotSnykExcludeSectionName(value)
+	if !name.IsValid() {
+		return "", fmt.Errorf("invalid .snyk exclude section name %q, must be one of %v", value, dotSnykExcludeSectionNames)
+	}
+	return name, nil
+}
+
+type DotSnykRule struct {
+	Exclude struct {
+		Code    []dotSnykExclude `yaml:"code"`
+		Global  []dotSnykExclude `yaml:"global"`
+		Secrets []dotSnykExclude `yaml:"secrets"`
+	} `yaml:"exclude"`
 }
 
 type FileFilterOption func(*FileFilter) error
@@ -41,12 +82,24 @@ func WithThreadNumber(maxThreadCount int) FileFilterOption {
 	}
 }
 
+// WithDotSnykSections sets which .snyk exclude sections (e.g. Global, Code,
+// Secrets) the FileFilter applies. It replaces the FileFilter's default
+// sections of Global and Code rather than adding to them. Passing an empty
+// slice disables all .snyk-based exclusions.
+func WithDotSnykSections(sections []DotSnykExcludeSectionName) FileFilterOption {
+	return func(filter *FileFilter) error {
+		filter.dotSnykSections = sections
+		return nil
+	}
+}
+
 func NewFileFilter(path string, logger *zerolog.Logger, options ...FileFilterOption) *FileFilter {
 	filter := &FileFilter{
-		path:         path,
-		defaultRules: []string{"**/.git/**"},
-		logger:       logger,
-		max_threads:  int64(runtime.NumCPU()),
+		path:            path,
+		defaultRules:    []string{"**/.git/**"},
+		logger:          logger,
+		max_threads:     int64(runtime.NumCPU()),
+		dotSnykSections: []DotSnykExcludeSectionName{Global, Code}, // init default with Global and Code to keep it backwards compatible
 	}
 
 	for _, option := range options {
@@ -169,13 +222,6 @@ func (fw *FileFilter) buildGlobs(ignoreFiles []string) ([]string, error) {
 
 // parseDotSnykFile builds a list of glob patterns from a given .snyk style file
 func (fw *FileFilter) parseDotSnykFile(content []byte, filePath string) []string {
-	type DotSnykRule struct {
-		Exclude struct {
-			Code   []dotSnykExclude `yaml:"code"`
-			Global []dotSnykExclude `yaml:"global"`
-		} `yaml:"exclude"`
-	}
-
 	var rules DotSnykRule
 	err := yaml.Unmarshal(content, &rules)
 	if err != nil {
@@ -183,8 +229,18 @@ func (fw *FileFilter) parseDotSnykFile(content []byte, filePath string) []string
 		return nil
 	}
 
-	// combine code and global rules
-	allRules := append(rules.Exclude.Code, rules.Exclude.Global...)
+	// collect rules according to fw.dotSnykSections
+	var allRules []dotSnykExclude
+	for _, section := range fw.dotSnykSections {
+		switch section {
+		case Global:
+			allRules = append(allRules, rules.Exclude.Global...)
+		case Code:
+			allRules = append(allRules, rules.Exclude.Code...)
+		case Secrets:
+			allRules = append(allRules, rules.Exclude.Secrets...)
+		}
+	}
 
 	var globs []string
 	for _, rule := range allRules {
@@ -376,10 +432,8 @@ func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string)
 	// `foo` => `**/foo/**`, `foo` (meaning: Ignore (root/sub) foo filesToFilter and dirs and their paths underneath.)
 
 	// If a rule is invalid, we skip it
-	for _, invalidRule := range invalidRules {
-		if strings.TrimSpace(rule) == invalidRule {
-			return globs
-		}
+	if slices.Contains(invalidRules, strings.TrimSpace(rule)) {
+		return globs
 	}
 
 	prefix := ""

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -31,16 +31,16 @@ type FileFilter struct {
 }
 
 // DotSnykExcludeSectionName is the name of an `exclude` section in a .snyk
-// file (e.g. "code", "global", "secrets", "iac"). It is a plain string so callers can
+// file (e.g. "code", "global", "secrets", "iac-drift"). It is a plain string so callers can
 // opt into sections this package doesn't define constants for without requiring
 // a code change here.
 type DotSnykExcludeSectionName string
 
 const (
-	Global  DotSnykExcludeSectionName = "global"
-	Code    DotSnykExcludeSectionName = "code"
-	Secrets DotSnykExcludeSectionName = "secrets"
-	Iac     DotSnykExcludeSectionName = "iac"
+	DotSnykExcludeGlobal   DotSnykExcludeSectionName = "global"
+	DotSnykExcludeCode     DotSnykExcludeSectionName = "code"
+	DotSnykExcludeSecrets  DotSnykExcludeSectionName = "secrets"
+	DotSnykExcludeIacDrift DotSnykExcludeSectionName = "iac-drift"
 )
 
 // String implements fmt.Stringer.
@@ -48,12 +48,12 @@ func (s DotSnykExcludeSectionName) String() string {
 	return string(s)
 }
 
-// DotSnykRule mirrors the relevant parts of a .snyk policy file. Exclude keys
-// its sections by name (e.g. "code", "global") so new sections are picked up by
-// decoding alone, without changes to this type. Section contents are kept as raw
-// yaml.Node values so each section can be decoded independently: only the
-// sections a caller opts into are decoded into rules, and a malformed section a
-// caller does not request cannot fail the decode of the whole file.
+// DotSnykRule mirrors the relevant parts of a .snyk policy file.
+// Exclude keys its sections by name (e.g. "code", "global") so new sections are picked up by
+// decoding alone, without changes to this type.
+// Only the sections a caller opts into are decoded into rules.
+// A malformed section a caller does not request is ignored.
+// A malformed section requested section is skipped.
 type DotSnykRule struct {
 	Exclude map[DotSnykExcludeSectionName]yaml.Node `yaml:"exclude"`
 }
@@ -71,9 +71,10 @@ func WithThreadNumber(maxThreadCount int) FileFilterOption {
 	}
 }
 
-// WithDotSnykSections sets which .snyk exclude sections (e.g. Code, Global,
-// Secrets) the FileFilter applies. It replaces the FileFilter's default
-// sections of Code and Global rather than adding to them. Passing an empty
+// WithDotSnykSections sets which .snyk exclude sections
+// (e.g. DotSnykExcludeCode, DotSnykExcludeGlobal, DotSnykExcludeSecrets, DotSnykExcludeIacDrift)
+// the FileFilter applies. It replaces the FileFilter's default
+// sections of DotSnykExcludeCode and DotSnykExcludeGlobal rather than adding to them. Passing an empty
 // slice disables all .snyk-based exclusions.
 func WithDotSnykSections(sections []DotSnykExcludeSectionName) FileFilterOption {
 	return func(filter *FileFilter) error {
@@ -88,7 +89,7 @@ func NewFileFilter(path string, logger *zerolog.Logger, options ...FileFilterOpt
 		defaultRules:    []string{"**/.git/**"},
 		logger:          logger,
 		max_threads:     int64(runtime.NumCPU()),
-		dotSnykSections: []DotSnykExcludeSectionName{Code, Global}, // init default with Code and Global to keep it backwards compatible
+		dotSnykSections: []DotSnykExcludeSectionName{DotSnykExcludeCode, DotSnykExcludeGlobal}, // init default with DotSnykExcludeCode and DotSnykExcludeGlobal to keep it backwards compatible
 	}
 
 	for _, option := range options {

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -30,43 +30,29 @@ type FileFilter struct {
 	dotSnykSections []DotSnykExcludeSectionName
 }
 
+// DotSnykExcludeSectionName is the name of an `exclude` section in a .snyk
+// file (e.g. "code", "global", "secrets", "iac"). It is a plain string so callers can
+// opt into sections this package doesn't define constants for without requiring
+// a code change here.
 type DotSnykExcludeSectionName string
 
 const (
 	Global  DotSnykExcludeSectionName = "global"
 	Code    DotSnykExcludeSectionName = "code"
 	Secrets DotSnykExcludeSectionName = "secrets"
+	Iac     DotSnykExcludeSectionName = "iac"
 )
-
-// dotSnykExcludeSectionNames lists every valid DotSnykExcludeSectionName value.
-var dotSnykExcludeSectionNames = []DotSnykExcludeSectionName{Global, Code, Secrets}
 
 // String implements fmt.Stringer.
 func (s DotSnykExcludeSectionName) String() string {
 	return string(s)
 }
 
-// IsValid reports whether s is one of the defined section names.
-func (s DotSnykExcludeSectionName) IsValid() bool {
-	return slices.Contains(dotSnykExcludeSectionNames, s)
-}
-
-// ParseDotSnykExcludeSectionName converts a string into a DotSnykExcludeSectionName,
-// returning an error if it does not match a defined section name.
-func ParseDotSnykExcludeSectionName(value string) (DotSnykExcludeSectionName, error) {
-	name := DotSnykExcludeSectionName(value)
-	if !name.IsValid() {
-		return "", fmt.Errorf("invalid .snyk exclude section name %q, must be one of %v", value, dotSnykExcludeSectionNames)
-	}
-	return name, nil
-}
-
+// DotSnykRule mirrors the relevant parts of a .snyk policy file. Exclude keys
+// its sections by name (e.g. "code", "global") so new sections are picked up by
+// decoding alone, without changes to this type.
 type DotSnykRule struct {
-	Exclude struct {
-		Code    []dotSnykExclude `yaml:"code"`
-		Global  []dotSnykExclude `yaml:"global"`
-		Secrets []dotSnykExclude `yaml:"secrets"`
-	} `yaml:"exclude"`
+	Exclude map[DotSnykExcludeSectionName][]dotSnykExclude `yaml:"exclude"`
 }
 
 type FileFilterOption func(*FileFilter) error
@@ -82,9 +68,9 @@ func WithThreadNumber(maxThreadCount int) FileFilterOption {
 	}
 }
 
-// WithDotSnykSections sets which .snyk exclude sections (e.g. Global, Code,
+// WithDotSnykSections sets which .snyk exclude sections (e.g. Code, Global,
 // Secrets) the FileFilter applies. It replaces the FileFilter's default
-// sections of Global and Code rather than adding to them. Passing an empty
+// sections of Code and Global rather than adding to them. Passing an empty
 // slice disables all .snyk-based exclusions.
 func WithDotSnykSections(sections []DotSnykExcludeSectionName) FileFilterOption {
 	return func(filter *FileFilter) error {
@@ -99,7 +85,7 @@ func NewFileFilter(path string, logger *zerolog.Logger, options ...FileFilterOpt
 		defaultRules:    []string{"**/.git/**"},
 		logger:          logger,
 		max_threads:     int64(runtime.NumCPU()),
-		dotSnykSections: []DotSnykExcludeSectionName{Global, Code}, // init default with Global and Code to keep it backwards compatible
+		dotSnykSections: []DotSnykExcludeSectionName{Code, Global}, // init default with Code and Global to keep it backwards compatible
 	}
 
 	for _, option := range options {
@@ -232,14 +218,7 @@ func (fw *FileFilter) parseDotSnykFile(content []byte, filePath string) []string
 	// collect rules according to fw.dotSnykSections
 	var allRules []dotSnykExclude
 	for _, section := range fw.dotSnykSections {
-		switch section {
-		case Global:
-			allRules = append(allRules, rules.Exclude.Global...)
-		case Code:
-			allRules = append(allRules, rules.Exclude.Code...)
-		case Secrets:
-			allRules = append(allRules, rules.Exclude.Secrets...)
-		}
+		allRules = append(allRules, rules.Exclude[section]...)
 	}
 
 	var globs []string

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -233,7 +233,7 @@ func TestFileFilter_GetRules_dotSnykSections(t *testing.T) {
     - %s
   secrets:
     - %s
-  iac:
+  newsection:
     - %s
 `, codeFile, globalFile, secretsFile, customFile)
 
@@ -273,7 +273,7 @@ func TestFileFilter_GetRules_dotSnykSections(t *testing.T) {
 		{
 			// no code change in file_filter.go is needed to support a new section
 			name:          "supports sections without a predefined constant",
-			options:       []FileFilterOption{WithDotSnykSections([]DotSnykExcludeSectionName{"iac"})},
+			options:       []FileFilterOption{WithDotSnykSections([]DotSnykExcludeSectionName{"newsection"})},
 			expectedFiles: []string{customFile},
 		},
 	}
@@ -310,6 +310,65 @@ func TestFileFilter_GetRules_dotSnykSections(t *testing.T) {
 		expectedRules := append(globsFor(codeFile), globsFor(globalFile)...)
 		assert.Equal(t, expectedRules, snykRules)
 	})
+}
+
+// TestFileFilter_GetRules_dotSnykMalformedSection verifies that .snyk exclude
+// sections are decoded independently: a section whose value is not a sequence
+// (e.g. a stray scalar) is malformed and must be skipped without dropping the
+// valid exclusions from other sections, and a malformed section a caller never
+// opts into must be ignored entirely. In every case the valid code exclusion
+// must survive.
+func TestFileFilter_GetRules_dotSnykMalformedSection(t *testing.T) {
+	tempDir := t.TempDir()
+	codeFile := "code.ts"
+	createFileInPath(t, filepath.Join(tempDir, codeFile), []byte{})
+
+	// The code section is valid; global and secrets are malformed (scalars where a
+	// sequence is expected).
+	snykContent := fmt.Sprintf(`exclude:
+  code:
+    - %s
+  global: not-a-list
+  secrets: not-a-list
+`, codeFile)
+	createFileInPath(t, filepath.Join(tempDir, ".snyk"), []byte(snykContent))
+
+	// globsFor returns the expected glob patterns for a given filename.
+	globsFor := func(file string) []string {
+		return []string{
+			fmt.Sprintf("%s/**/%s/**", filepath.ToSlash(tempDir), file),
+			fmt.Sprintf("%s/**/%s", filepath.ToSlash(tempDir), file),
+		}
+	}
+
+	tests := []struct {
+		name    string
+		options []FileFilterOption
+	}{
+		{
+			// code and global are both requested (the default); the malformed global
+			// is skipped while the valid code exclusion still applies.
+			name:    "malformed requested section is skipped, other requested sections still apply",
+			options: nil,
+		},
+		{
+			// only code is requested; the malformed secrets section is not parsed.
+			name:    "malformed non-requested section is ignored",
+			options: []FileFilterOption{WithDotSnykSections([]DotSnykExcludeSectionName{Code})},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fileFilter := NewFileFilter(tempDir, &log.Logger, test.options...)
+			actualRules, err := fileFilter.GetRules([]string{".snyk"})
+			assert.NoError(t, err)
+
+			expectedRules := append(globsFor(codeFile), fileFilter.defaultRules...)
+			assert.ElementsMatch(t, expectedRules, actualRules,
+				"a malformed section must not drop valid exclusions from other sections")
+		})
+	}
 }
 
 func TestFileFilter_GetFilteredFiles(t *testing.T) {

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -213,6 +213,105 @@ exclude:
 	})
 }
 
+func TestFileFilter_GetRules_dotSnykSections(t *testing.T) {
+	tempDir := t.TempDir()
+	codeFile := "code.ts"
+	globalFile := "global.ts"
+	secretsFile := "secrets.ts"
+	// customFile lives under a section this package defines no constant for, to
+	// exercise the map-based decode that lets callers opt into arbitrary sections.
+	customFile := "custom.ts"
+	createFileInPath(t, filepath.Join(tempDir, codeFile), []byte{})
+	createFileInPath(t, filepath.Join(tempDir, globalFile), []byte{})
+	createFileInPath(t, filepath.Join(tempDir, secretsFile), []byte{})
+	createFileInPath(t, filepath.Join(tempDir, customFile), []byte{})
+
+	snykContent := fmt.Sprintf(`exclude:
+  code:
+    - %s
+  global:
+    - %s
+  secrets:
+    - %s
+  iac:
+    - %s
+`, codeFile, globalFile, secretsFile, customFile)
+
+	// globsFor returns the expected glob patterns for a given filename.
+	globsFor := func(file string) []string {
+		return []string{
+			fmt.Sprintf("%s/**/%s/**", filepath.ToSlash(tempDir), file),
+			fmt.Sprintf("%s/**/%s", filepath.ToSlash(tempDir), file),
+		}
+	}
+
+	tests := []struct {
+		name          string
+		options       []FileFilterOption
+		expectedFiles []string
+	}{
+		{
+			name:          "defaults to code and global sections",
+			options:       nil,
+			expectedFiles: []string{codeFile, globalFile},
+		},
+		{
+			name:          "applies only the requested section",
+			options:       []FileFilterOption{WithDotSnykSections([]DotSnykExcludeSectionName{Secrets})},
+			expectedFiles: []string{secretsFile},
+		},
+		{
+			name:          "applies all sections when requested",
+			options:       []FileFilterOption{WithDotSnykSections([]DotSnykExcludeSectionName{Code, Global, Secrets})},
+			expectedFiles: []string{codeFile, globalFile, secretsFile},
+		},
+		{
+			name:          "empty slice disables all .snyk exclusions",
+			options:       []FileFilterOption{WithDotSnykSections([]DotSnykExcludeSectionName{})},
+			expectedFiles: []string{},
+		},
+		{
+			// no code change in file_filter.go is needed to support a new section
+			name:          "supports sections without a predefined constant",
+			options:       []FileFilterOption{WithDotSnykSections([]DotSnykExcludeSectionName{"iac"})},
+			expectedFiles: []string{customFile},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ignoreFile := filepath.Join(tempDir, ".snyk")
+			createFileInPath(t, ignoreFile, []byte(snykContent))
+
+			fileFilter := NewFileFilter(tempDir, &log.Logger, test.options...)
+			actualRules, err := fileFilter.GetRules([]string{".snyk"})
+			assert.NoError(t, err)
+
+			var expectedRules []string
+			for _, file := range test.expectedFiles {
+				expectedRules = append(expectedRules, globsFor(file)...)
+			}
+			expectedRules = append(expectedRules, fileFilter.defaultRules...)
+
+			assert.ElementsMatch(t, expectedRules, actualRules)
+		})
+	}
+
+	t.Run("preserves code-before-global ordering by default", func(t *testing.T) {
+		ignoreFile := filepath.Join(tempDir, ".snyk")
+		createFileInPath(t, ignoreFile, []byte(snykContent))
+
+		fileFilter := NewFileFilter(tempDir, &log.Logger)
+		actualRules, err := fileFilter.GetRules([]string{".snyk"})
+		assert.NoError(t, err)
+
+		// strip default rules to compare only the .snyk-derived globs
+		snykRules := actualRules[len(fileFilter.defaultRules):]
+		expectedRules := append(globsFor(codeFile), globsFor(globalFile)...)
+		assert.Equal(t, expectedRules, snykRules)
+	})
+}
+
 func TestFileFilter_GetFilteredFiles(t *testing.T) {
 	cases := testCases(t)
 	for _, testCase := range cases {

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -257,12 +257,12 @@ func TestFileFilter_GetRules_dotSnykSections(t *testing.T) {
 		},
 		{
 			name:          "applies only the requested section",
-			options:       []FileFilterOption{WithDotSnykSections([]DotSnykExcludeSectionName{Secrets})},
+			options:       []FileFilterOption{WithDotSnykSections([]DotSnykExcludeSectionName{DotSnykExcludeSecrets})},
 			expectedFiles: []string{secretsFile},
 		},
 		{
 			name:          "applies all sections when requested",
-			options:       []FileFilterOption{WithDotSnykSections([]DotSnykExcludeSectionName{Code, Global, Secrets})},
+			options:       []FileFilterOption{WithDotSnykSections([]DotSnykExcludeSectionName{DotSnykExcludeCode, DotSnykExcludeGlobal, DotSnykExcludeSecrets})},
 			expectedFiles: []string{codeFile, globalFile, secretsFile},
 		},
 		{
@@ -354,7 +354,7 @@ func TestFileFilter_GetRules_dotSnykMalformedSection(t *testing.T) {
 		{
 			// only code is requested; the malformed secrets section is not parsed.
 			name:    "malformed non-requested section is ignored",
-			options: []FileFilterOption{WithDotSnykSections([]DotSnykExcludeSectionName{Code})},
+			options: []FileFilterOption{WithDotSnykSections([]DotSnykExcludeSectionName{DotSnykExcludeCode})},
 		},
 	}
 


### PR DESCRIPTION
### Description

dotSnyk parsing had code hardcoded. In order to be able to reuse the functionality in the secrets extension, the Filter was made parameterizable with the .snyk exclude sections. 

It remains backwards compatible with the code sections as default.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which files are excluded when callers opt into different sections; wrong configuration could scan or skip paths unexpectedly, though defaults preserve existing behavior.
> 
> **Overview**
> **`FileFilter`** can now choose which `.snyk` `exclude` sections become ignore globs via **`WithDotSnykSections`**, so products like secrets can honor `secrets` (or custom section names) without hardcoding only `code` and `global`. Defaults stay **`code` + `global`** for backward compatibility; an empty slice turns off all `.snyk` exclusions.
> 
> Parsing uses a **map of YAML nodes** and **decodes each requested section separately**, so a bad section is logged and skipped instead of breaking other sections. **`parseIgnoreRuleToGlobs`** now uses **`slices.Contains`** for invalid-rule checks. Tests cover section selection, ordering, arbitrary section names, and malformed YAML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8b3797d89e9426d6136ef9d783c121ef0adfb67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->