### PR TITLE
chore: wire up html rendering to output workflow

### DIFF
--- a/pkg/local_workflows/output_workflow/constants.go
+++ b/pkg/local_workflows/output_workflow/constants.go
@@ -7,6 +7,8 @@ const (
 	OUTPUT_CONFIG_KEY_JSON_FILE          = "json-file-output"
 	OUTPUT_CONFIG_KEY_SARIF              = "sarif"
 	OUTPUT_CONFIG_KEY_SARIF_FILE         = "sarif-file-output"
+	OUTPUT_CONFIG_KEY_HTML               = "html"
+	OUTPUT_CONFIG_KEY_HTML_FILE          = "html-file-output"
 	OUTPUT_CONFIG_TEMPLATE_FILE          = "internal_template_file"
 	OUTPUT_CONFIG_KEY_FILE_WRITERS       = "internal_output_file_writers"
 	OUTPUT_CONFIG_KEY_DEFAULT_WRITER_LUT = "internal_default_writer_mimetype_lut"
@@ -15,10 +17,12 @@ const (
 	DEFAULT_MIME_TYPE                    = presenters.DefaultMimeType
 	SARIF_MIME_TYPE                      = presenters.ApplicationSarifMimeType
 	JSON_MIME_TYPE                       = presenters.ApplicationJSONMimeType
+	HTML_MIME_TYPE                       = presenters.ApplicationHTMLMimeType
 )
 
 // DefaultTemplateFiles is an instance of TemplatePathsStruct with the template paths.
 var DefaultTemplateFiles = presenters.DefaultTemplateFiles
 var ApplicationSarifTemplates = presenters.ApplicationSarifTemplates
 var ApplicationSarifTemplatesUfm = presenters.ApplicationSarifTemplatesUfm
-var structuredContent = []string{SARIF_MIME_TYPE, JSON_MIME_TYPE}
+var ApplicationHTMLTemplatesUfm = presenters.ApplicationHTMLTemplatesUfm
+var structuredContent = []string{SARIF_MIME_TYPE, JSON_MIME_TYPE, HTML_MIME_TYPE}

--- a/pkg/local_workflows/output_workflow/other_tools_test.go
+++ b/pkg/local_workflows/output_workflow/other_tools_test.go
@@ -247,6 +247,14 @@ func Test_DefaultOutputIsStructured(t *testing.T) {
 		assert.True(t, result)
 	})
 
+	t.Run("returns true when html output is enabled", func(t *testing.T) {
+		config := configuration.NewWithOpts()
+		config.Set(OUTPUT_CONFIG_KEY_HTML, true)
+
+		result := DefaultOutputIsStructured(config)
+		assert.True(t, result)
+	})
+
 	t.Run("returns false when default output is used", func(t *testing.T) {
 		config := configuration.NewWithOpts()
 

--- a/pkg/local_workflows/output_workflow/ufm_tools.go
+++ b/pkg/local_workflows/output_workflow/ufm_tools.go
@@ -106,6 +106,10 @@ func HandleContentTypeUnifiedModel(input []workflow.Data, invocation workflow.In
 			mimetype:  DEFAULT_MIME_TYPE,
 			templates: presenters.DefaultTemplateFilesUfm,
 		},
+		{
+			mimetype:  HTML_MIME_TYPE,
+			templates: presenters.ApplicationHTMLTemplatesUfm,
+		},
 	}
 	writerMap := applyTemplatesToWriters(supportedMimeTypes, writers)
 

--- a/pkg/local_workflows/output_workflow/ufm_tools_test.go
+++ b/pkg/local_workflows/output_workflow/ufm_tools_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -19,6 +21,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )
 
+//nolint:unparam // path should be kept configurable
 func loadTestResults(t *testing.T, path string) []testapi.TestResult {
 	t.Helper()
 	testResultBytes, err := os.ReadFile(path)
@@ -180,5 +183,70 @@ func Test_HandleContentTypeUnifiedModel(t *testing.T) {
 			unwrapped := joinedErrs.Unwrap()
 			assert.Equal(t, 2, len(unwrapped))
 		}
+	})
+
+	t.Run("html and sarif file outputs are produced in the same run", func(t *testing.T) {
+		mockCtl := gomock.NewController(t)
+		defer mockCtl.Finish()
+
+		fileConfig := configuration.NewWithOpts()
+		expectedHTMLFile := filepath.Join(t.TempDir(), "report.html")
+		expectedSarifFile := filepath.Join(t.TempDir(), "report.sarif")
+		fileConfig.Set(OUTPUT_CONFIG_KEY_HTML_FILE, expectedHTMLFile)
+		fileConfig.Set(OUTPUT_CONFIG_KEY_SARIF_FILE, expectedSarifFile)
+		fileConfig.Set(configuration.MAX_THREADS, 10)
+
+		ctx := pkgMocks.NewMockInvocationContext(mockCtl)
+		ctx.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
+		ctx.EXPECT().GetConfiguration().Return(fileConfig).AnyTimes()
+		ctx.EXPECT().GetRuntimeInfo().Return(runtimeinfo.New(runtimeinfo.WithName("snyk-cli"), runtimeinfo.WithVersion("1.1301.0"))).AnyTimes()
+		ctx.EXPECT().Context().Return(t.Context()).AnyTimes()
+
+		results := loadTestResults(t, "../../../internal/presenters/testdata/ufm/secrets.testresult.json")
+		workflowData := ufm.CreateWorkflowDataFromTestResults(workflow.NewWorkflowIdentifier("test"), results)
+		input := []workflow.Data{workflowData}
+
+		writers := GetWritersFromConfiguration(fileConfig, &stubOutputDestination{})
+
+		remaining, err := HandleContentTypeUnifiedModel(input, ctx, writers)
+		assert.NoError(t, err)
+		assert.NotNil(t, remaining)
+
+		htmlBytes, err := os.ReadFile(expectedHTMLFile)
+		assert.NoError(t, err, "HTML file should have been written")
+		assert.Contains(t, strings.ToLower(string(htmlBytes)), "<!doctype html>")
+
+		sarifBytes, err := os.ReadFile(expectedSarifFile)
+		assert.NoError(t, err, "SARIF file should have been written")
+		assert.Contains(t, string(sarifBytes), "\"version\": \"2.1.0\"")
+	})
+
+	t.Run("html flag renders HTML to the default stdout writer", func(t *testing.T) {
+		mockCtl := gomock.NewController(t)
+		defer mockCtl.Finish()
+
+		stdoutConfig := configuration.NewWithOpts()
+		stdoutConfig.Set(OUTPUT_CONFIG_KEY_HTML, true)
+		stdoutConfig.Set(configuration.MAX_THREADS, 10)
+
+		ctx := pkgMocks.NewMockInvocationContext(mockCtl)
+		ctx.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
+		ctx.EXPECT().GetConfiguration().Return(stdoutConfig).AnyTimes()
+		ctx.EXPECT().GetRuntimeInfo().Return(runtimeinfo.New(runtimeinfo.WithName("snyk-cli"), runtimeinfo.WithVersion("1.1301.0"))).AnyTimes()
+		ctx.EXPECT().Context().Return(t.Context()).AnyTimes()
+
+		results := loadTestResults(t, "../../../internal/presenters/testdata/ufm/secrets.testresult.json")
+		workflowData := ufm.CreateWorkflowDataFromTestResults(workflow.NewWorkflowIdentifier("test"), results)
+		input := []workflow.Data{workflowData}
+
+		outputDestination := &stubOutputDestination{}
+		writers := GetWritersFromConfiguration(stdoutConfig, outputDestination)
+
+		remaining, err := HandleContentTypeUnifiedModel(input, ctx, writers)
+		assert.NoError(t, err)
+		assert.NotNil(t, remaining)
+
+		stdout := outputDestination.buffer.String()
+		assert.Contains(t, strings.ToLower(stdout), "<!doctype html>", "default writer should have received HTML output")
 	})
 }

--- a/pkg/local_workflows/output_workflow/writer.go
+++ b/pkg/local_workflows/output_workflow/writer.go
@@ -132,6 +132,12 @@ func GetWritersFromConfiguration(config configuration.Configuration, outputDesti
 			[]string{},
 			true,
 		},
+		{
+			OUTPUT_CONFIG_KEY_HTML_FILE,
+			HTML_MIME_TYPE,
+			[]string{},
+			true,
+		},
 	}
 
 	// use configured file writers if available
@@ -187,6 +193,10 @@ func getDefaultWriterMimeType(config configuration.Configuration) string {
 
 	if config.GetBool(OUTPUT_CONFIG_KEY_JSON) {
 		return JSON_MIME_TYPE
+	}
+
+	if config.GetBool(OUTPUT_CONFIG_KEY_HTML) {
+		return HTML_MIME_TYPE
 	}
 
 	return DEFAULT_MIME_TYPE

--- a/pkg/local_workflows/output_workflow/writer_test.go
+++ b/pkg/local_workflows/output_workflow/writer_test.go
@@ -1,0 +1,110 @@
+package output_workflow
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+)
+
+// stubOutputDestination is a minimal iUtils.OutputDestination for tests in
+// this package; stdout-style output goes to an in-memory buffer while file
+// operations hit the real filesystem (callers should use t.TempDir() paths).
+type stubOutputDestination struct {
+	buffer bytes.Buffer
+}
+
+func (s *stubOutputDestination) Println(a ...any) (n int, err error) {
+	return fmt.Fprintln(&s.buffer, a...)
+}
+
+func (s *stubOutputDestination) Remove(name string) error {
+	return os.Remove(name)
+}
+
+func (s *stubOutputDestination) WriteFile(filename string, data []byte, perm fs.FileMode) error {
+	return os.WriteFile(filename, data, perm)
+}
+
+func (s *stubOutputDestination) GetWriter() io.Writer {
+	return &s.buffer
+}
+
+func Test_GetWritersFromConfiguration_HTMLFileWriter(t *testing.T) {
+	t.Run("html-file-output set creates an HTML file writer", func(t *testing.T) {
+		config := configuration.NewWithOpts()
+		config.Set(OUTPUT_CONFIG_KEY_HTML_FILE, "/tmp/x.html")
+
+		writerMap := GetWritersFromConfiguration(config, &stubOutputDestination{})
+
+		htmlWriters := writerMap.PopWritersByMimetype(HTML_MIME_TYPE)
+		assert.Len(t, htmlWriters, 1)
+		assert.Equal(t, HTML_MIME_TYPE, htmlWriters[0].mimeType)
+		assert.Equal(t, OUTPUT_CONFIG_KEY_HTML_FILE, htmlWriters[0].name)
+	})
+
+	t.Run("html-file-output unset creates no HTML writer", func(t *testing.T) {
+		config := configuration.NewWithOpts()
+
+		writerMap := GetWritersFromConfiguration(config, &stubOutputDestination{})
+
+		htmlWriters := writerMap.PopWritersByMimetype(HTML_MIME_TYPE)
+		assert.Empty(t, htmlWriters)
+	})
+}
+
+func Test_getDefaultWriterMimeType(t *testing.T) {
+	testCases := []struct {
+		name             string
+		configKeys       []string
+		expectedMimeType string
+	}{
+		{
+			name:             "no flags set returns default",
+			configKeys:       nil,
+			expectedMimeType: DEFAULT_MIME_TYPE,
+		},
+		{
+			name:             "sarif",
+			configKeys:       []string{OUTPUT_CONFIG_KEY_SARIF},
+			expectedMimeType: SARIF_MIME_TYPE,
+		},
+		{
+			name:             "json",
+			configKeys:       []string{OUTPUT_CONFIG_KEY_JSON},
+			expectedMimeType: JSON_MIME_TYPE,
+		},
+		{
+			name:             "html",
+			configKeys:       []string{OUTPUT_CONFIG_KEY_HTML},
+			expectedMimeType: HTML_MIME_TYPE,
+		},
+		{
+			name:             "sarif takes precedence over html",
+			configKeys:       []string{OUTPUT_CONFIG_KEY_SARIF, OUTPUT_CONFIG_KEY_HTML},
+			expectedMimeType: SARIF_MIME_TYPE,
+		},
+		{
+			name:             "json takes precedence over html",
+			configKeys:       []string{OUTPUT_CONFIG_KEY_JSON, OUTPUT_CONFIG_KEY_HTML},
+			expectedMimeType: JSON_MIME_TYPE,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := configuration.NewWithOpts()
+			for _, key := range tc.configKeys {
+				config.Set(key, true)
+			}
+
+			assert.Equal(t, tc.expectedMimeType, getDefaultWriterMimeType(config))
+		})
+	}
+}


### PR DESCRIPTION
### Description

This PR wires up the HTML rendering from #625 to the output workflow.

### Checklist

- [ ] Tests added and all succeed (`make test`)
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.
