### PR TITLE
fix: Honor environment variables for memory threshold when `WithConfiguration` is omitted

### DIFF
--- a/pkg/workflow/dataimpl.go
+++ b/pkg/workflow/dataimpl.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/snyk/go-application-framework/internal/constants"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 
 	"github.com/rs/zerolog"
@@ -109,11 +110,10 @@ func newDataWith(opts ...Option) Data {
 		logger: &zerolog.Logger{},
 	}
 
-	// Configure and initialize default value for memory threshold. We default to -1 AKA this feature is disabled.
-	// Needed for cases when we call NewData() without WithConfiguration() OR we do not configure IN…MEMORY_THRESHOLD_BYTES
-	// If we do not disable by default, we will get inconsistencies with things like the temp dir in workflows that do not use WithConfiguration()
-	c := configuration.NewInMemory()
-	c.Set(configuration.IN_MEMORY_THRESHOLD_BYTES, -1)
+	// Apply env-backed defaults when callers omit WithConfiguration so INTERNAL_IN_MEMORY_THRESHOLD_BYTES is honored.
+	c := configuration.NewWithOpts(configuration.WithAutomaticEnv())
+	c.AddDefaultValue(configuration.IN_MEMORY_THRESHOLD_BYTES,
+		configuration.StandardDefaultValueFunction(constants.SNYK_DEFAULT_IN_MEMORY_THRESHOLD_MB))
 	opts = append([]Option{WithConfiguration(c)}, opts...)
 
 	for _, opt := range opts {

--- a/pkg/workflow/dataimpl_test.go
+++ b/pkg/workflow/dataimpl_test.go
@@ -9,9 +9,18 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+	"github.com/snyk/go-application-framework/internal/constants"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/stretchr/testify/assert"
 )
+
+func payloadLocationType(data Data) PayloadLocation {
+	return PayloadLocation(reflect.ValueOf(data).Elem().FieldByName("payloadLocation").FieldByName("Type").Int())
+}
+
+func inMemoryThresholdBytes(data Data) int {
+	return int(reflect.ValueOf(data).Elem().FieldByName("inMemoryThreshold").Int())
+}
 
 func Test_NewDataFromInput(t *testing.T) {
 	expectedContentType := "application/json"
@@ -194,56 +203,90 @@ func Test_NewData(t *testing.T) {
 		assert.Contains(t, actualFiles[0].Name(), expectedFileName)
 	})
 
-	t.Run("when configuration is not provided, filesystem cache is not used", func(t *testing.T) {
-		expectedConfig := configuration.NewInMemory()
+	t.Run("when configuration is not provided, environment variables are honored", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("INTERNAL_IN_MEMORY_THRESHOLD_BYTES", "1")
+		t.Setenv("SNYK_TMP_PATH", tmpDir)
+
 		expectedLogger := zerolog.Logger{}
 		expectedContentType := "application/json"
-
-		expectedTempDir := path.Join(os.TempDir(), "dataImpl_test")
-		err := os.Mkdir(expectedTempDir, 0755)
-
-		// cleanup temp dir and files
-		defer func(path string) {
-			err = os.RemoveAll(path)
-			if err != nil {
-				fmt.Println("failed to remove temp dir: ", err)
-			}
-		}(expectedTempDir)
-		assert.NoError(t, err)
-
-		expectedConfig.Set(configuration.IN_MEMORY_THRESHOLD_BYTES, 1)
-		expectedConfig.Set(configuration.TEMP_DIR_PATH, expectedTempDir)
 		expectedIdentifier := NewTypeIdentifier(NewWorkflowIdentifier("mycommand"), "mydata")
 
-		dataWithConfig := NewData(
-			expectedIdentifier,
-			expectedContentType,
-			[]byte("put some data in here so that it is bigger than the expectedThreshold"),
-			WithConfiguration(expectedConfig),
-			WithLogger(&expectedLogger),
-			WithInputData(nil))
-
-		// assert that payload location is on disk
-		actualPayloadLocationWithConfig := reflect.ValueOf(dataWithConfig).Elem().FieldByName("payloadLocation").FieldByName("Type")
-		assert.Equal(t, int64(OnDisk), actualPayloadLocationWithConfig.Int())
-
-		// assert that payload location path is empty
-		actualPayloadLocationPathWithConfig := reflect.ValueOf(dataWithConfig).Elem().FieldByName("payloadLocation").FieldByName("Path")
-		assert.Contains(t, actualPayloadLocationPathWithConfig.String(), expectedTempDir)
-
-		dataNoConfig := NewData(
+		data := NewData(
 			expectedIdentifier,
 			expectedContentType,
 			[]byte("put some data in here so that it is bigger than the expectedThreshold"),
 			WithLogger(&expectedLogger),
 			WithInputData(nil))
 
-		// assert that payload location is in memory
-		actualPayloadLocationNoConfig := reflect.ValueOf(dataNoConfig).Elem().FieldByName("payloadLocation").FieldByName("Type")
-		assert.Equal(t, int64(InMemory), actualPayloadLocationNoConfig.Int())
+		assert.Equal(t, OnDisk, payloadLocationType(data))
 
-		// assert that payload location path is empty
-		actualPayloadLocationPathNoConfig := reflect.ValueOf(dataNoConfig).Elem().FieldByName("payloadLocation").FieldByName("Path")
-		assert.Equal(t, "", actualPayloadLocationPathNoConfig.String())
+		actualPayloadLocationPath := reflect.ValueOf(data).Elem().FieldByName("payloadLocation").FieldByName("Path")
+		assert.Contains(t, actualPayloadLocationPath.String(), tmpDir)
+	})
+
+	t.Run("when configuration is not provided, defaults to 512MB threshold", func(t *testing.T) {
+		t.Setenv("INTERNAL_IN_MEMORY_THRESHOLD_BYTES", "")
+		t.Setenv("SNYK_TMP_PATH", "")
+
+		data := NewData(
+			NewTypeIdentifier(NewWorkflowIdentifier("mycommand"), "mydata"),
+			"application/json",
+			[]byte("small payload"),
+			WithLogger(&zerolog.Logger{}),
+			WithInputData(nil))
+
+		assert.Equal(t, constants.SNYK_DEFAULT_IN_MEMORY_THRESHOLD_MB, inMemoryThresholdBytes(data))
+		assert.Equal(t, InMemory, payloadLocationType(data))
+	})
+
+	t.Run("caller WithConfiguration overrides env-backed default", func(t *testing.T) {
+		t.Setenv("INTERNAL_IN_MEMORY_THRESHOLD_BYTES", "1")
+
+		callerConfig := configuration.NewInMemory()
+		callerConfig.Set(configuration.IN_MEMORY_THRESHOLD_BYTES, -1)
+
+		data := NewData(
+			NewTypeIdentifier(NewWorkflowIdentifier("mycommand"), "mydata"),
+			"application/json",
+			[]byte("put some data in here so that it is bigger than the expectedThreshold"),
+			WithConfiguration(callerConfig),
+			WithLogger(&zerolog.Logger{}),
+			WithInputData(nil))
+
+		assert.Equal(t, -1, inMemoryThresholdBytes(data))
+		assert.Equal(t, InMemory, payloadLocationType(data))
+	})
+
+	t.Run("non-byte payload stays in memory when threshold exceeded", func(t *testing.T) {
+		t.Setenv("INTERNAL_IN_MEMORY_THRESHOLD_BYTES", "0")
+
+		data := NewData(
+			NewTypeIdentifier(NewWorkflowIdentifier("mycommand"), "mydata"),
+			"application/json",
+			"string payload is not spilled to disk",
+			WithLogger(&zerolog.Logger{}),
+			WithInputData(nil))
+
+		assert.Equal(t, InMemory, payloadLocationType(data))
+	})
+
+	t.Run("NewDataFromInput inherits env-backed defaults", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("INTERNAL_IN_MEMORY_THRESHOLD_BYTES", "1")
+		t.Setenv("SNYK_TMP_PATH", tmpDir)
+
+		input := NewData(
+			NewTypeIdentifier(NewWorkflowIdentifier("mycommand"), "inputdata"),
+			"application/json",
+			[]byte{})
+
+		data := NewDataFromInput(
+			input,
+			NewTypeIdentifier(NewWorkflowIdentifier("yourcommand"), "yourdata"),
+			"application/json",
+			[]byte("put some data in here so that it is bigger than the expectedThreshold"))
+
+		assert.Equal(t, OnDisk, payloadLocationType(data))
 	})
 }


### PR DESCRIPTION
### **User description**
### Description

_Provide description of this PR and changes._

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improve default configuration loading for Data.

- Prioritize environment variables for defaults.

- Enhance test coverage for configuration handling.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Env["Environment Variables (e.g. INTERNAL_IN_MEMORY_THRESHOLD_BYTES)"]
  Defaults["Default Configuration Values (e.g. 512MB)"]
  ExplicitConfig["Explicit Configuration (WithConfiguration)"]
  DataCreation["NewData() call"]
  DataImpl["DataImpl initialization"]

  Env -- "Used for defaults" --> DataCreation
  Defaults -- "Used for defaults" --> DataCreation
  ExplicitConfig -- "Overrides defaults" --> DataCreation
  DataCreation -- "Initializes" --> DataImpl
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dataimpl.go</strong><dd><code>Apply env-backed configuration defaults for Data initialization</code></dd></summary>
<hr>

pkg/workflow/dataimpl.go

<ul><li>Modified <code>NewData</code> to initialize <code>DataImpl</code> with configuration that <br>automatically loads environment variables.<br> <li> Introduced default values for <code>IN_MEMORY_THRESHOLD_BYTES</code> using <br><code>constants.SNYK_DEFAULT_IN_MEMORY_THRESHOLD_MB</code> when environment <br>variables are not explicitly set.<br> <li> Ensured that explicit <code>WithConfiguration</code> options provided by the caller <br>will override environment-backed defaults.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/627/changes#diff-1752c5ed22bf801a49fb09a0c131b3d5315cca0612ae39d0b43a503f37b17bfb">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dataimpl_test.go</strong><dd><code>Expand tests for Data configuration and environment variable handling</code></dd></summary>
<hr>

pkg/workflow/dataimpl_test.go

<ul><li>Added helper functions <code>payloadLocationType</code> and <code>inMemoryThresholdBytes</code> <br>for easier test assertions.<br> <li> Introduced new test cases to verify that environment variables are <br>honored when configuration is omitted.<br> <li> Added tests for default threshold values (512MB) and ensuring <br>caller-provided configuration overrides environment settings.<br> <li> Included tests for <code>NewDataFromInput</code> to ensure it also inherits <br>env-backed defaults.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/627/changes#diff-a282c7d1ff03bff6144f2fe2b46aeb71a92245dad129535e74546eedb7ee591b">+78/-35</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

### MANUAL TESTING

Local build.

```sh
⋊> ~/g/c/cliv2 on fix/CLI-1509 ⨯ export SNYK_TMP_PATH=/tmp/snyk-cli-1509-test
                                 export INTERNAL_IN_MEMORY_THRESHOLD_BYTES=1
                                 export INTERNAL_CLEANUP_GLOBAL_TEMP_DIR_ENABLED=false
                                 export SNYK_LOG_LEVEL=trace
⋊> ~/g/c/cliv2 on fix/CLI-1509 ⨯ echo $SNYK_TMP_PATH
/tmp/snyk-cli-1509-test
⋊> ~/g/c/cliv2 on fix/CLI-1509 ⨯ echo $SNYK_LOG_LEVEL
trace
⋊> ~/g/c/cliv2 on fix/CLI-1509 ⨯ export SNYK_TOKEN=(../binary-releases/snyk-macos-arm64 config get INTERNAL_OAUTH_TOKEN_STORAGE)
⋊> ~/g/c/cliv2 on fix/CLI-1509 ⨯ echo $SNYK_TOKEN 
...REDACTED
⋊> ~/g/c/cliv2 on fix/CLI-1509 ⨯ echo $SNYK_API
https://api.dev.snyk.io/
⋊> ~/g/c/cliv2 on fix/CLI-1509 ⨯ rm -rf "$SNYK_TMP_PATH" && mkdir -p "$SNYK_TMP_PATH"
⋊> ~/g/c/cliv2 on fix/CLI-1509 ⨯ ../binary-releases/snyk-macos-arm64 config get test --experimental --json
⋊> ~/g/c/cliv2 on fix/CLI-1509 ⨯ ls -la "$SNYK_TMP_PATH" 
                                 find "$SNYK_TMP_PATH" -name 'workflow.*'
total 8
drwxr-xr-x@  4 roberto  wheel  128 Jun 11 16:19 ./
drwxrwxrwt  22 root     wheel  704 Jun 11 16:18 ../
drwxr-xr-x@  3 roberto  wheel   96 Jun 11 16:19 1.1306.0-preview.08381bd4215281401cd4e12b20ee53f3926f562d.oss/
-rwxr-xr-x@  1 roberto  wheel  733 Jun 11 16:19 workflow.analytics.report.1992018518*
/tmp/snyk-cli-1509-test/workflow.analytics.report.1992018518
```

___

### RELATED

[There was a previous PR trying to approach this issue](https://github.com/snyk/go-application-framework/pull/606) which includes a quite similar approach: there `WithConfiguration()` checks if `IN_MEMORY_THRESHOLD_BYTES` has been set - if not, it assigns a value.

This PR just sets the same default value as during the app bootstrap (512 MB).