### PR TITLE
fix: Buffer request body for retry overrides, close intermediate response bodies

### DIFF
--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -240,14 +240,16 @@ func ensureGetBodyExists(req *http.Request) (io.ReadCloser, func() (io.ReadClose
 		return req.Body, req.GetBody, nil, nil
 	}
 
+	// body can be rewound
 	if rs, ok := req.Body.(io.ReadSeeker); ok {
-		wrapped := &noCloseSeekBody{ReadSeeker: rs, realCloser: req.Body}
-		return wrapped, func() (io.ReadCloser, error) {
+		body := &noCloseSeekBody{ReadSeeker: rs, realCloser: req.Body}
+		getBody := func() (io.ReadCloser, error) {
 			if _, seekErr := rs.Seek(0, io.SeekStart); seekErr != nil {
 				return nil, seekErr
 			}
-			return wrapped, nil
-		}, wrapped.RealClose, nil
+			return body, nil
+		}
+		return body, getBody, body.RealClose, nil
 	}
 
 	bodyBytes, readErr := io.ReadAll(req.Body)

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -79,7 +79,6 @@ type noCloseSeekBody struct {
 	realCloser io.Closer
 }
 
-func (b *noCloseSeekBody) Read(p []byte) (int, error) { return b.ReadSeeker.Read(p) }
 func (b *noCloseSeekBody) Close() error               { return nil }
 func (b *noCloseSeekBody) RealClose() error {
 	if b.realCloser != nil {
@@ -115,6 +114,7 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 	var retryAfterSeconds = defaultRetryAfterSeconds
 	var actualAttempts int = 0
 	var cachedMaxRetries *int = nil // Per-request cached max retries
+	var prevRespBody io.ReadCloser  // original response body from prior attempt, for drain+close
 
 	if tmp := rm.config.GetInt(ConfigurationKeyRequestAttempts); tmp > 0 {
 		maxAttempts = tmp
@@ -140,6 +140,15 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	op := func() (*http.Response, error) {
 		actualAttempts++
+
+		// Close the previous response body before retrying to avoid leaking
+		// connections.  This matches stdlib's Client.do which drains+closes
+		// intermediate responses between attempts.
+		if prevRespBody != nil {
+			_, _ = io.Copy(io.Discard, prevRespBody)
+			_ = prevRespBody.Close()
+			prevRespBody = nil
+		}
 
 		// create a local copy of the request
 		localRequest := *req
@@ -177,8 +186,10 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 
 		// depending on the response determine if we should retry
+		origBody := response.Body // capture before shouldRetry may replace it (e.g. getErrorList for 503)
 		if retryError := shouldRetry(response, actualAttempts, *cachedMaxRetries); retryError != nil {
 			rm.logger.Debug().Msgf("Retrying request, reason: %v", retryError)
+			prevRespBody = origBody
 			return response, &RetryAttemptError{
 				StatusCode:  response.StatusCode,
 				Attempt:     actualAttempts,
@@ -199,6 +210,13 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 			rm.notifyRetry(reqCtx, err, duration)
 		}),
 	)
+
+	// Ensure any intermediate body is closed if the loop exited before the
+	// next op() call could clean it up (e.g. context cancellation).
+	if prevRespBody != nil && (finalResponse == nil || prevRespBody != finalResponse.Body) {
+		_, _ = io.Copy(io.Discard, prevRespBody)
+		_ = prevRespBody.Close()
+	}
 
 	finalError = rm.filterRetryError(finalError, actualAttempts)
 	return finalResponse, finalError

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -108,20 +108,13 @@ func NewRetryMiddleware(config configuration.Configuration, logger *zerolog.Logg
 	return rm
 }
 
-func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) { //nolint:gocyclo // complexity inherent to sequential retry logic with per-status-code overrides
+func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 	var finalResponse *http.Response
 	var finalError error
-	var localBodyBuffer []byte
 	var maxAttempts = defaultMaxAttemptsCount
 	var retryAfterSeconds = defaultRetryAfterSeconds
 	var actualAttempts int = 0
 	var cachedMaxRetries *int = nil // Per-request cached max retries
-	var deferredBodyClose func() error
-	defer func() {
-		if deferredBodyClose != nil {
-			_ = deferredBodyClose()
-		}
-	}()
 
 	if tmp := rm.config.GetInt(ConfigurationKeyRequestAttempts); tmp > 0 {
 		maxAttempts = tmp
@@ -131,46 +124,15 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 		retryAfterSeconds = tmp
 	}
 
-	// If a body is available, ensure it can be replayed across retries.
-	// Per-status-code overrides (e.g. 429 → 3 attempts) can trigger retries
-	// regardless of the configured maxAttempts, so the body must be available for reuse.
-	//
-	// Three strategies, in order of preference:
-	//  1. GetBody already set (e.g. http.NewRequest with *bytes.Reader) → use it as-is.
-	//  2. Body implements io.ReadSeeker → wrap to suppress Close, Seek(0) to rewind.
-	//  3. Fallback: io.ReadAll into memory buffer.
-	if req.Body != nil && req.Body != http.NoBody && req.GetBody == nil {
-		if rs, ok := req.Body.(io.ReadSeeker); ok {
-			// Seekable body: wrap to prevent the transport from closing the
-			// underlying stream, and rewind with Seek(0) between retries.
-			wrapped := &noCloseSeekBody{ReadSeeker: rs, realCloser: req.Body}
-			deferredBodyClose = wrapped.RealClose
-			req.Body = wrapped
-			req.GetBody = func() (io.ReadCloser, error) {
-				if _, err := rs.Seek(0, io.SeekStart); err != nil {
-					return nil, err
-				}
-				return wrapped, nil
-			}
-		} else {
-			// Non-seekable: buffer into memory so retries can replay the body.
-			var localBufferError error
-			localBodyBuffer, localBufferError = io.ReadAll(req.Body)
-			closeError := req.Body.Close()
-
-			if localBufferError != nil {
-				return nil, localBufferError
-			}
-			if closeError != nil {
-				return nil, closeError
-			}
-
-			req.Body = io.NopCloser(bytes.NewBuffer(localBodyBuffer))
-			req.GetBody = func() (io.ReadCloser, error) {
-				return io.NopCloser(bytes.NewBuffer(localBodyBuffer)), nil
-			}
-		}
+	getBody, cleanup, err := ensureGetBodyExists(req)
+	if err != nil {
+		return nil, err
 	}
+	defer func() {
+		if cleanup != nil {
+			_ = cleanup()
+		}
+	}()
 
 	op := func() (*http.Response, error) {
 		actualAttempts++
@@ -178,19 +140,17 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 		// create a local copy of the request
 		localRequest := *req
 
-		// for requests with a body, when retrying we create a new copy of the original body via GetBody
-		if actualAttempts > 1 && req.GetBody != nil {
-			// On retry attempts, obtain a fresh body via GetBody.
-			// The first attempt uses the original req.Body so the transport
-			// can read and close it per the http.RoundTripper contract.
-			body, err := req.GetBody()
+		// for requests with a body, obtain a (fresh) copy via getBody
+		if getBody != nil {
+			body, err := getBody()
 			if err != nil {
 				return nil, backoff.Permanent(err)
 			}
 			if body == nil {
-				return nil, backoff.Permanent(fmt.Errorf("GetBody returned nil reader"))
+				return nil, backoff.Permanent(fmt.Errorf("getBody returned nil reader"))
 			}
 			localRequest.Body = body
+			localRequest.GetBody = getBody
 		}
 
 		// try to send request
@@ -238,6 +198,47 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	finalError = rm.filterRetryError(finalError, actualAttempts)
 	return finalResponse, finalError
+}
+
+// ensureGetBodyExists returns a getBody function that produces a fresh body
+// reader for each retry attempt, and an optional cleanup function that must be
+// called after the retry loop. The original request is not modified.
+//
+// Three strategies, in order of preference:
+//  1. GetBody already set (e.g. http.NewRequest with *bytes.Reader) → return it.
+//  2. Body implements io.ReadSeeker → wrap to suppress Close, Seek(0) to rewind.
+//  3. Fallback: io.ReadAll into memory buffer.
+func ensureGetBodyExists(req *http.Request) (getBody func() (io.ReadCloser, error), cleanup func() error, err error) {
+	if req.Body == nil || req.Body == http.NoBody {
+		return nil, nil, nil
+	}
+
+	if req.GetBody != nil {
+		return req.GetBody, nil, nil
+	}
+
+	if rs, ok := req.Body.(io.ReadSeeker); ok {
+		wrapped := &noCloseSeekBody{ReadSeeker: rs, realCloser: req.Body}
+		return func() (io.ReadCloser, error) {
+			if _, seekErr := rs.Seek(0, io.SeekStart); seekErr != nil {
+				return nil, seekErr
+			}
+			return wrapped, nil
+		}, wrapped.RealClose, nil
+	}
+
+	bodyBytes, readErr := io.ReadAll(req.Body)
+	closeErr := req.Body.Close()
+	if readErr != nil {
+		return nil, nil, readErr
+	}
+	if closeErr != nil {
+		return nil, nil, closeErr
+	}
+
+	return func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewBuffer(bodyBytes)), nil
+	}, nil, nil
 }
 
 func (rm RetryMiddleware) notifyRetry(ctx context.Context, err error, duration time.Duration) {

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -152,6 +152,9 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 			if err != nil {
 				return nil, backoff.Permanent(err)
 			}
+			if body == nil {
+				return nil, backoff.Permanent(fmt.Errorf("GetBody returned nil reader"))
+			}
 			localRequest.Body = body
 		}
 

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -186,17 +186,13 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 
 		// depending on the response determine if we should retry
-		origBody := response.Body // capture before shouldRetry may replace it (e.g. getErrorList for 503)
 		if retryError := shouldRetry(response, actualAttempts, *cachedMaxRetries); retryError != nil {
 			rm.logger.Debug().Msgf("Retrying request, reason: %v", retryError)
 
-			// Close origBody when a retry will follow (non-permanent) OR when
-			// getErrorList replaced response.Body (permanent 503). Skip only when
-			// the caller still owns the same body reference (non-503 permanent).
+			// When doing a retry, we need to drain and close the RESPONSE body, to ensure that the resources are freed
 			var permErr *backoff.PermanentError
-			bodyWasReplaced := origBody != response.Body
-			if !errors.As(retryError, &permErr) || bodyWasReplaced {
-				drainAndClose(origBody)
+			if !errors.As(retryError, &permErr) {
+				drainAndClose(response.Body)
 			}
 
 			return response, &RetryAttemptError{

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -190,10 +190,12 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 		if retryError := shouldRetry(response, actualAttempts, *cachedMaxRetries); retryError != nil {
 			rm.logger.Debug().Msgf("Retrying request, reason: %v", retryError)
 
-			// Only track the body for cleanup when an actual retry will follow.
-			// Permanent errors mean this is the final response — the caller owns its body.
+			// Close origBody when a retry will follow (non-permanent) OR when
+			// getErrorList replaced response.Body (permanent 503). Skip only when
+			// the caller still owns the same body reference (non-503 permanent).
 			var permErr *backoff.PermanentError
-			if !errors.As(retryError, &permErr) {
+			bodyWasReplaced := origBody != response.Body
+			if !errors.As(retryError, &permErr) || bodyWasReplaced {
 				drainAndClose(origBody)
 			}
 
@@ -227,7 +229,7 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 //   - getBody: function that produces a fresh reader on retries (may be nil)
 //   - cleanup: called after the retry loop to release resources (may be nil)
 //
-// The original request is not modified.
+// The caller is expected to assign body/getBody onto the request.
 //
 // Three strategies, in order of preference:
 //  1. GetBody already set (e.g. http.NewRequest with *bytes.Reader) → return as-is.

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -108,10 +108,14 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 		retryAfterSeconds = tmp
 	}
 
-	// if a body is available, create a local copy to be able to use it multiple times.
-	// Always buffer: per-status-code overrides (e.g. 429 → 3 attempts) can trigger retries
+	// If a body is available, ensure it can be replayed across retries.
+	// Per-status-code overrides (e.g. 429 → 3 attempts) can trigger retries
 	// regardless of the configured maxAttempts, so the body must be available for reuse.
-	if req.Body != nil && req.Body != http.NoBody {
+	//
+	// When the caller already provides GetBody (e.g. http.NewRequest with *bytes.Reader,
+	// *bytes.Buffer, or *strings.Reader), we skip the redundant copy to avoid doubling
+	// memory usage for large payloads like file uploads.
+	if req.Body != nil && req.Body != http.NoBody && req.GetBody == nil {
 		// possible optimization for large request bodies to not buffer in memory but in filesystem
 		var localBufferError error
 		localBodyBuffer, localBufferError = io.ReadAll(req.Body)
@@ -140,6 +144,12 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 			localRequest.GetBody = func() (io.ReadCloser, error) {
 				return io.NopCloser(bytes.NewBuffer(localBodyBuffer)), nil
 			}
+		} else if req.GetBody != nil {
+			body, err := req.GetBody()
+			if err != nil {
+				return nil, backoff.Permanent(err)
+			}
+			localRequest.Body = body
 		}
 
 		// try to send request

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -124,7 +124,6 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 	var retryAfterSeconds = defaultRetryAfterSeconds
 	var actualAttempts int = 0
 	var cachedMaxRetries *int = nil // Per-request cached max retries
-	var prevRespBody io.ReadCloser  // original response body from prior attempt, for drain+close
 
 	if tmp := rm.config.GetInt(ConfigurationKeyRequestAttempts); tmp > 0 {
 		maxAttempts = tmp
@@ -150,14 +149,6 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	op := func() (*http.Response, error) {
 		actualAttempts++
-
-		// Close the previous response body before retrying to avoid leaking
-		// connections.  This matches stdlib's Client.do which drains+closes
-		// intermediate responses between attempts.
-		if prevRespBody != nil {
-			drainAndClose(prevRespBody)
-			prevRespBody = nil
-		}
 
 		// create a local copy of the request
 		localRequest := *req
@@ -203,7 +194,7 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 			// Permanent errors mean this is the final response — the caller owns its body.
 			var permErr *backoff.PermanentError
 			if !errors.As(retryError, &permErr) {
-				prevRespBody = origBody
+				drainAndClose(origBody)
 			}
 
 			return response, &RetryAttemptError{
@@ -226,11 +217,6 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 			rm.notifyRetry(reqCtx, err, duration)
 		}),
 	)
-
-	// Ensure any intermediate body is closed if the loop exited before the
-	// next op() call could clean it up (e.g. context cancellation).
-	drainAndClose(prevRespBody)
-	prevRespBody = nil
 
 	finalError = rm.filterRetryError(finalError, actualAttempts)
 	return finalResponse, finalError

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -87,6 +87,16 @@ func (b *noCloseSeekBody) RealClose() error {
 	return nil
 }
 
+// drainAndClose fully reads any remaining bytes from the body and then closes
+// it, enabling the underlying TCP connection to be reused by the transport.
+func drainAndClose(body io.ReadCloser) {
+	if body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, body)
+	_ = body.Close()
+}
+
 type RetryMiddlewareOption func(*RetryMiddleware)
 
 func WithErrorHandler(handler networktypes.ErrorHandlerFunc) RetryMiddlewareOption {
@@ -145,8 +155,7 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 		// connections.  This matches stdlib's Client.do which drains+closes
 		// intermediate responses between attempts.
 		if prevRespBody != nil {
-			_, _ = io.Copy(io.Discard, prevRespBody)
-			_ = prevRespBody.Close()
+			drainAndClose(prevRespBody)
 			prevRespBody = nil
 		}
 
@@ -189,7 +198,14 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 		origBody := response.Body // capture before shouldRetry may replace it (e.g. getErrorList for 503)
 		if retryError := shouldRetry(response, actualAttempts, *cachedMaxRetries); retryError != nil {
 			rm.logger.Debug().Msgf("Retrying request, reason: %v", retryError)
-			prevRespBody = origBody
+
+			// Only track the body for cleanup when an actual retry will follow.
+			// Permanent errors mean this is the final response — the caller owns its body.
+			var permErr *backoff.PermanentError
+			if !errors.As(retryError, &permErr) {
+				prevRespBody = origBody
+			}
+
 			return response, &RetryAttemptError{
 				StatusCode:  response.StatusCode,
 				Attempt:     actualAttempts,
@@ -213,10 +229,8 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// Ensure any intermediate body is closed if the loop exited before the
 	// next op() call could clean it up (e.g. context cancellation).
-	if prevRespBody != nil && (finalResponse == nil || prevRespBody != finalResponse.Body) {
-		_, _ = io.Copy(io.Discard, prevRespBody)
-		_ = prevRespBody.Close()
-	}
+	drainAndClose(prevRespBody)
+	prevRespBody = nil
 
 	finalError = rm.filterRetryError(finalError, actualAttempts)
 	return finalResponse, finalError

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -108,7 +108,7 @@ func NewRetryMiddleware(config configuration.Configuration, logger *zerolog.Logg
 	return rm
 }
 
-func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
+func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) { //nolint:gocyclo // complexity from sequential retry logic with per-status-code overrides
 	var finalResponse *http.Response
 	var finalError error
 	var maxAttempts = defaultMaxAttemptsCount
@@ -124,13 +124,17 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 		retryAfterSeconds = tmp
 	}
 
-	getBody, cleanup, err := ensureGetBodyExists(req)
+	body, getBody, cleanup, err := ensureGetBodyExists(req)
 	if err != nil {
 		return nil, err
 	}
+	req.Body = body
+	if getBody != nil {
+		req.GetBody = getBody
+	}
 	defer func() {
 		if cleanup != nil {
-			_ = cleanup()
+			_ = cleanup() //nolint:errcheck // best-effort cleanup, nothing to do on error
 		}
 	}()
 
@@ -140,21 +144,21 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 		// create a local copy of the request
 		localRequest := *req
 
-		// for requests with a body, obtain a (fresh) copy via getBody
-		if getBody != nil {
-			body, err := getBody()
-			if err != nil {
-				return nil, backoff.Permanent(err)
+		// on retries, obtain a fresh body; the first attempt uses the
+		// original req.Body carried over by the shallow copy above
+		if actualAttempts > 1 && req.GetBody != nil {
+			freshBody, getBodyErr := req.GetBody()
+			if getBodyErr != nil {
+				return nil, backoff.Permanent(getBodyErr)
 			}
-			if body == nil {
-				return nil, backoff.Permanent(fmt.Errorf("getBody returned nil reader"))
+			if freshBody == nil {
+				return nil, backoff.Permanent(fmt.Errorf("GetBody returned nil reader"))
 			}
-			localRequest.Body = body
-			localRequest.GetBody = getBody
+			localRequest.Body = freshBody
 		}
 
 		// try to send request
-		response, err := rm.nextRoundtripper.RoundTrip(&localRequest)
+		response, rtErr := rm.nextRoundtripper.RoundTrip(&localRequest)
 
 		// keep track of actual retry attempts for monitoring/logging
 		if response != nil && response.Header != nil && actualAttempts > 1 {
@@ -162,8 +166,8 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 
 		// errors from the next round tripper cannot be retried
-		if err != nil {
-			return response, backoff.Permanent(err)
+		if rtErr != nil {
+			return response, backoff.Permanent(rtErr)
 		}
 
 		// Cache max retry attempts for the current request
@@ -200,26 +204,29 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 	return finalResponse, finalError
 }
 
-// ensureGetBodyExists returns a getBody function that produces a fresh body
-// reader for each retry attempt, and an optional cleanup function that must be
-// called after the retry loop. The original request is not modified.
+// ensureGetBodyExists inspects the request body and returns:
+//   - body:    replacement Body for the first attempt (may be the original)
+//   - getBody: function that produces a fresh reader on retries (may be nil)
+//   - cleanup: called after the retry loop to release resources (may be nil)
+//
+// The original request is not modified.
 //
 // Three strategies, in order of preference:
-//  1. GetBody already set (e.g. http.NewRequest with *bytes.Reader) → return it.
+//  1. GetBody already set (e.g. http.NewRequest with *bytes.Reader) → return as-is.
 //  2. Body implements io.ReadSeeker → wrap to suppress Close, Seek(0) to rewind.
 //  3. Fallback: io.ReadAll into memory buffer.
-func ensureGetBodyExists(req *http.Request) (getBody func() (io.ReadCloser, error), cleanup func() error, err error) {
+func ensureGetBodyExists(req *http.Request) (io.ReadCloser, func() (io.ReadCloser, error), func() error, error) {
 	if req.Body == nil || req.Body == http.NoBody {
-		return nil, nil, nil
+		return req.Body, nil, nil, nil
 	}
 
 	if req.GetBody != nil {
-		return req.GetBody, nil, nil
+		return req.Body, req.GetBody, nil, nil
 	}
 
 	if rs, ok := req.Body.(io.ReadSeeker); ok {
 		wrapped := &noCloseSeekBody{ReadSeeker: rs, realCloser: req.Body}
-		return func() (io.ReadCloser, error) {
+		return wrapped, func() (io.ReadCloser, error) {
 			if _, seekErr := rs.Seek(0, io.SeekStart); seekErr != nil {
 				return nil, seekErr
 			}
@@ -230,15 +237,17 @@ func ensureGetBodyExists(req *http.Request) (getBody func() (io.ReadCloser, erro
 	bodyBytes, readErr := io.ReadAll(req.Body)
 	closeErr := req.Body.Close()
 	if readErr != nil {
-		return nil, nil, readErr
+		return nil, nil, nil, readErr
 	}
 	if closeErr != nil {
-		return nil, nil, closeErr
+		return nil, nil, nil, closeErr
 	}
 
-	return func() (io.ReadCloser, error) {
+	newGetBody := func() (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewBuffer(bodyBytes)), nil
-	}, nil, nil
+	}
+	firstBody, firstBodyErr := newGetBody()
+	return firstBody, newGetBody, nil, firstBodyErr
 }
 
 func (rm RetryMiddleware) notifyRetry(ctx context.Context, err error, duration time.Duration) {

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -144,7 +144,10 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 			localRequest.GetBody = func() (io.ReadCloser, error) {
 				return io.NopCloser(bytes.NewBuffer(localBodyBuffer)), nil
 			}
-		} else if req.GetBody != nil {
+		} else if req.GetBody != nil && actualAttempts > 1 {
+			// On retry attempts, obtain a fresh body via GetBody.
+			// The first attempt uses the original req.Body so the transport
+			// can read and close it per the http.RoundTripper contract.
 			body, err := req.GetBody()
 			if err != nil {
 				return nil, backoff.Permanent(err)

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -71,6 +71,23 @@ type RetryMiddleware struct {
 	errorHandler     networktypes.ErrorHandlerFunc
 }
 
+// noCloseSeekBody wraps an io.ReadSeeker so that Close is suppressed during
+// retries.  The underlying stream stays open and is rewound with Seek(0)
+// instead of being copied into memory.  Call RealClose after the retry loop.
+type noCloseSeekBody struct {
+	io.ReadSeeker
+	realCloser io.Closer
+}
+
+func (b *noCloseSeekBody) Read(p []byte) (int, error) { return b.ReadSeeker.Read(p) }
+func (b *noCloseSeekBody) Close() error               { return nil }
+func (b *noCloseSeekBody) RealClose() error {
+	if b.realCloser != nil {
+		return b.realCloser.Close()
+	}
+	return nil
+}
+
 type RetryMiddlewareOption func(*RetryMiddleware)
 
 func WithErrorHandler(handler networktypes.ErrorHandlerFunc) RetryMiddlewareOption {
@@ -99,6 +116,12 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 	var retryAfterSeconds = defaultRetryAfterSeconds
 	var actualAttempts int = 0
 	var cachedMaxRetries *int = nil // Per-request cached max retries
+	var deferredBodyClose func() error
+	defer func() {
+		if deferredBodyClose != nil {
+			_ = deferredBodyClose()
+		}
+	}()
 
 	if tmp := rm.config.GetInt(ConfigurationKeyRequestAttempts); tmp > 0 {
 		maxAttempts = tmp
@@ -112,25 +135,40 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Per-status-code overrides (e.g. 429 → 3 attempts) can trigger retries
 	// regardless of the configured maxAttempts, so the body must be available for reuse.
 	//
-	// When the caller already provides GetBody (e.g. http.NewRequest with *bytes.Reader,
-	// *bytes.Buffer, or *strings.Reader), we skip the redundant copy to avoid doubling
-	// memory usage for large payloads like file uploads.
+	// Three strategies, in order of preference:
+	//  1. GetBody already set (e.g. http.NewRequest with *bytes.Reader) → use it as-is.
+	//  2. Body implements io.ReadSeeker → wrap to suppress Close, Seek(0) to rewind.
+	//  3. Fallback: io.ReadAll into memory buffer.
 	if req.Body != nil && req.Body != http.NoBody && req.GetBody == nil {
-		// possible optimization for large request bodies to not buffer in memory but in filesystem
-		var localBufferError error
-		localBodyBuffer, localBufferError = io.ReadAll(req.Body)
-		closeError := req.Body.Close()
+		if rs, ok := req.Body.(io.ReadSeeker); ok {
+			// Seekable body: wrap to prevent the transport from closing the
+			// underlying stream, and rewind with Seek(0) between retries.
+			wrapped := &noCloseSeekBody{ReadSeeker: rs, realCloser: req.Body}
+			deferredBodyClose = wrapped.RealClose
+			req.Body = wrapped
+			req.GetBody = func() (io.ReadCloser, error) {
+				if _, err := rs.Seek(0, io.SeekStart); err != nil {
+					return nil, err
+				}
+				return wrapped, nil
+			}
+		} else {
+			// Non-seekable: buffer into memory so retries can replay the body.
+			var localBufferError error
+			localBodyBuffer, localBufferError = io.ReadAll(req.Body)
+			closeError := req.Body.Close()
 
-		if localBufferError != nil {
-			return nil, localBufferError
-		}
-		if closeError != nil {
-			return nil, closeError
-		}
+			if localBufferError != nil {
+				return nil, localBufferError
+			}
+			if closeError != nil {
+				return nil, closeError
+			}
 
-		req.Body = io.NopCloser(bytes.NewBuffer(localBodyBuffer))
-		req.GetBody = func() (io.ReadCloser, error) {
-			return io.NopCloser(bytes.NewBuffer(localBodyBuffer)), nil
+			req.Body = io.NopCloser(bytes.NewBuffer(localBodyBuffer))
+			req.GetBody = func() (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewBuffer(localBodyBuffer)), nil
+			}
 		}
 	}
 
@@ -139,12 +177,9 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 
 		// create a local copy of the request
 		localRequest := *req
-		if len(localBodyBuffer) > 0 {
-			localRequest.Body = io.NopCloser(bytes.NewBuffer(localBodyBuffer))
-			localRequest.GetBody = func() (io.ReadCloser, error) {
-				return io.NopCloser(bytes.NewBuffer(localBodyBuffer)), nil
-			}
-		} else if req.GetBody != nil && actualAttempts > 1 {
+
+		// for requests with a body, when retrying we create a new copy of the original body via GetBody
+		if actualAttempts > 1 && req.GetBody != nil {
 			// On retry attempts, obtain a fresh body via GetBody.
 			// The first attempt uses the original req.Body so the transport
 			// can read and close it per the http.RoundTripper contract.

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -79,7 +79,7 @@ type noCloseSeekBody struct {
 	realCloser io.Closer
 }
 
-func (b *noCloseSeekBody) Close() error               { return nil }
+func (b *noCloseSeekBody) Close() error { return nil }
 func (b *noCloseSeekBody) RealClose() error {
 	if b.realCloser != nil {
 		return b.realCloser.Close()
@@ -93,7 +93,7 @@ func drainAndClose(body io.ReadCloser) {
 	if body == nil {
 		return
 	}
-	_, _ = io.Copy(io.Discard, body)
+	_, _ = io.Copy(io.Discard, body) //nolint:errcheck // best-effort drain for connection reuse
 	_ = body.Close()
 }
 

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -91,7 +91,7 @@ func NewRetryMiddleware(config configuration.Configuration, logger *zerolog.Logg
 	return rm
 }
 
-func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
+func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) { //nolint:gocyclo // complexity inherent to sequential retry logic with per-status-code overrides
 	var finalResponse *http.Response
 	var finalError error
 	var localBodyBuffer []byte

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -108,8 +108,10 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 		retryAfterSeconds = tmp
 	}
 
-	// if a body is available, create a local copy to be able to use it multiple times
-	if req.Body != nil && req.Body != http.NoBody && maxAttempts > 1 {
+	// if a body is available, create a local copy to be able to use it multiple times.
+	// Always buffer: per-status-code overrides (e.g. 429 → 3 attempts) can trigger retries
+	// regardless of the configured maxAttempts, so the body must be available for reuse.
+	if req.Body != nil && req.Body != http.NoBody {
 		// possible optimization for large request bodies to not buffer in memory but in filesystem
 		var localBufferError error
 		localBodyBuffer, localBufferError = io.ReadAll(req.Body)

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -854,6 +854,15 @@ func TestRetryMiddleware_429_POST_BodyPreservedAcrossRetries(t *testing.T) {
 		require.NoError(t, err)
 		bodiesReceived = append(bodiesReceived, body)
 
+		// Verify GetBody also returns the full payload (used by HTTP/2 retries)
+		require.NotNil(t, req.GetBody, "Attempt %d: GetBody must be set", attemptCount)
+		getBodyReader, err := req.GetBody()
+		require.NoError(t, err, "Attempt %d: GetBody() must not error", attemptCount)
+		getBodyBytes, err := io.ReadAll(getBodyReader)
+		require.NoError(t, err)
+		assert.Equal(t, expectedBody, getBodyBytes,
+			"Attempt %d: GetBody() must return full body", attemptCount)
+
 		headers := http.Header{}
 		if attemptCount < 3 {
 			return &http.Response{

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -1176,7 +1176,7 @@ func TestRetryMiddleware_IntermediateResponseBodyClosed(t *testing.T) {
 }
 
 // TestRetryMiddleware_ContextCancellation_BodyClosed verifies that when the
-// context is cancelled between retry attempts, the last intermediate response
+// context is canceled between retry attempts, the last intermediate response
 // body is still closed (via the post-loop cleanup).
 func TestRetryMiddleware_ContextCancellation_BodyClosed(t *testing.T) {
 	logger := zerolog.Nop()
@@ -1221,8 +1221,10 @@ func TestRetryMiddleware_ContextCancellation_BodyClosed(t *testing.T) {
 
 	sut := NewRetryMiddleware(config, &logger, rt)
 
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com/", nil)
-	_, _ = sut.RoundTrip(req)
+	req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com/", nil)
+	require.NoError(t, reqErr)
+	_, err := sut.RoundTrip(req)
+	require.Error(t, err, "Expected context cancellation error")
 
 	assert.Equal(t, 1, attemptCount, "Only one attempt before context cancellation")
 

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -1031,7 +1031,7 @@ func TestRetryMiddleware_GetBodyNil_BuffersBody(t *testing.T) {
 }
 
 // TestRetryMiddleware_SeekableBody_NoBuffer verifies that when the request body
-// is a real *os.File (implements io.ReadSeeker + io.Closer, not recognised by
+// is a real *os.File (implements io.ReadSeeker + io.Closer, not recognized by
 // http.NewRequest for GetBody), the middleware rewinds via Seek instead of
 // copying into a memory buffer, and defers the real Close.
 func TestRetryMiddleware_SeekableBody_NoBuffer(t *testing.T) {
@@ -1053,9 +1053,9 @@ func TestRetryMiddleware_SeekableBody_NoBuffer(t *testing.T) {
 	customRTFn := func(req *http.Request) (*http.Response, error) {
 		attemptCount++
 
-		body, err := io.ReadAll(req.Body)
-		require.NoError(t, err)
-		bodiesReceived = append(bodiesReceived, body)
+		readBody, readErr := io.ReadAll(req.Body)
+		require.NoError(t, readErr)
+		bodiesReceived = append(bodiesReceived, readBody)
 
 		// Close should be a no-op (suppressed by the wrapper)
 		require.NoError(t, req.Body.Close())
@@ -1083,7 +1083,7 @@ func TestRetryMiddleware_SeekableBody_NoBuffer(t *testing.T) {
 	sut := NewRetryMiddleware(config, &logger, rt)
 
 	// *os.File implements io.ReadSeeker + io.Closer but is not one of the
-	// types http.NewRequest recognises, so GetBody stays nil.
+	// types http.NewRequest recognizes, so GetBody stays nil.
 	req, err := http.NewRequest(http.MethodPost, "http://example.com/api/v1/upload", tmpFile)
 	require.NoError(t, err)
 	require.Nil(t, req.GetBody, "precondition: GetBody must be nil for *os.File body")

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -1106,6 +1106,210 @@ func TestRetryMiddleware_SeekableBody_NoBuffer(t *testing.T) {
 	assert.ErrorIs(t, err, os.ErrClosed, "file must be closed after retry loop finishes")
 }
 
+// TestRetryMiddleware_IntermediateResponseBodyClosed verifies that response bodies
+// from failed attempts are closed before the next retry fires.  Without this,
+// connections are leaked (one per retry) against real servers because the
+// transport cannot recycle the connection until the body is drained+closed.
+func TestRetryMiddleware_IntermediateResponseBodyClosed(t *testing.T) {
+	logger := zerolog.Nop()
+
+	type trackedBody struct {
+		closed bool
+		mu     sync.Mutex
+	}
+
+	var intermediateBody trackedBody
+
+	attemptCount := 0
+	//nolint:unparam // error is always nil but signature must match http.RoundTripper
+	customRTFn := func(req *http.Request) (*http.Response, error) {
+		attemptCount++
+		headers := http.Header{}
+
+		if attemptCount == 1 {
+			// First attempt: return 503 with a body that tracks Close()
+			body := io.NopCloser(bytes.NewReader([]byte("service unavailable")))
+			trackingBody := &trackingReadCloser{
+				ReadCloser: body,
+				onClose: func() {
+					intermediateBody.mu.Lock()
+					intermediateBody.closed = true
+					intermediateBody.mu.Unlock()
+				},
+			}
+			return &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Header:     headers,
+				Body:       trackingBody,
+				Request:    req,
+			}, nil
+		}
+
+		// Second attempt: success
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     headers,
+			Body:       io.NopCloser(bytes.NewReader([]byte("ok"))),
+			Request:    req,
+		}, nil
+	}
+
+	rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+	config := configuration.NewWithOpts()
+	config.Set(ConfigurationKeyRequestAttempts, 3)
+	config.Set(configurationKeyRetryAfter, 1)
+
+	sut := NewRetryMiddleware(config, &logger, rt)
+	resp, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, attemptCount, "Should retry once then succeed")
+
+	// The intermediate (503) response body MUST have been closed before the
+	// second attempt, matching stdlib's Client.do behavior.
+	intermediateBody.mu.Lock()
+	defer intermediateBody.mu.Unlock()
+	assert.True(t, intermediateBody.closed,
+		"Intermediate response body must be closed between retries to avoid leaking connections")
+}
+
+// TestRetryMiddleware_ContextCancellation_BodyClosed verifies that when the
+// context is cancelled between retry attempts, the last intermediate response
+// body is still closed (via the post-loop cleanup).
+func TestRetryMiddleware_ContextCancellation_BodyClosed(t *testing.T) {
+	logger := zerolog.Nop()
+
+	var mu sync.Mutex
+	bodyClosed := false
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	attemptCount := 0
+	//nolint:unparam // error is always nil but signature must match http.RoundTripper
+	customRTFn := func(req *http.Request) (*http.Response, error) {
+		attemptCount++
+		headers := http.Header{}
+
+		body := io.NopCloser(bytes.NewReader([]byte("error")))
+		trackingBody := &trackingReadCloser{
+			ReadCloser: body,
+			onClose: func() {
+				mu.Lock()
+				bodyClosed = true
+				mu.Unlock()
+			},
+		}
+
+		// Cancel context after first attempt so the retry loop exits
+		// before a second op() call can close the body.
+		cancel()
+
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Header:     headers,
+			Body:       trackingBody,
+			Request:    req,
+		}, nil
+	}
+
+	rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+	config := configuration.NewWithOpts()
+	config.Set(ConfigurationKeyRequestAttempts, 5)
+	config.Set(configurationKeyRetryAfter, 1)
+
+	sut := NewRetryMiddleware(config, &logger, rt)
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com/", nil)
+	_, _ = sut.RoundTrip(req)
+
+	assert.Equal(t, 1, attemptCount, "Only one attempt before context cancellation")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.True(t, bodyClosed,
+		"Intermediate body must be closed even when context cancellation stops the retry loop")
+}
+
+// TestRetryMiddleware_MultipleIntermediateResponseBodiesClosed verifies that ALL
+// intermediate response bodies are closed when multiple retries occur, not just
+// the first one.
+func TestRetryMiddleware_MultipleIntermediateResponseBodiesClosed(t *testing.T) {
+	logger := zerolog.Nop()
+
+	var mu sync.Mutex
+	closedBodies := map[int]bool{}
+
+	attemptCount := 0
+	//nolint:unparam // error is always nil but signature must match http.RoundTripper
+	customRTFn := func(req *http.Request) (*http.Response, error) {
+		attemptCount++
+		headers := http.Header{}
+		currentAttempt := attemptCount
+
+		if currentAttempt <= 3 {
+			// Attempts 1-3: return 503 with a body that tracks Close()
+			body := io.NopCloser(bytes.NewReader([]byte(fmt.Sprintf("error attempt %d", currentAttempt))))
+			trackingBody := &trackingReadCloser{
+				ReadCloser: body,
+				onClose: func() {
+					mu.Lock()
+					closedBodies[currentAttempt] = true
+					mu.Unlock()
+				},
+			}
+			return &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Header:     headers,
+				Body:       trackingBody,
+				Request:    req,
+			}, nil
+		}
+
+		// Attempt 4: success
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     headers,
+			Body:       io.NopCloser(bytes.NewReader([]byte("ok"))),
+			Request:    req,
+		}, nil
+	}
+
+	rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+	config := configuration.NewWithOpts()
+	config.Set(ConfigurationKeyRequestAttempts, 5)
+	config.Set(configurationKeyRetryAfter, 1)
+
+	sut := NewRetryMiddleware(config, &logger, rt)
+	resp, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 4, attemptCount, "Should retry 3 times then succeed on 4th")
+
+	mu.Lock()
+	defer mu.Unlock()
+	for attempt := 1; attempt <= 3; attempt++ {
+		assert.True(t, closedBodies[attempt],
+			"Response body from attempt %d must be closed between retries", attempt)
+	}
+}
+
+// trackingReadCloser wraps an io.ReadCloser and calls onClose when Close is invoked.
+type trackingReadCloser struct {
+	io.ReadCloser
+	onClose func()
+}
+
+func (t *trackingReadCloser) Close() error {
+	if t.onClose != nil {
+		t.onClose()
+	}
+	return t.ReadCloser.Close()
+}
+
 // setupRetryMiddleware wires RetryMiddleware with a counting transport and the given config.
 func setupRetryMiddleware(
 	t *testing.T,

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -906,6 +906,127 @@ func TestRetryMiddleware_429_POST_BodyPreservedAcrossRetries(t *testing.T) {
 	}
 }
 
+// TestRetryMiddleware_GetBodyPreset_SkipsBuffering verifies that when the request
+// already has GetBody set (e.g. body created via bytes.NewReader), the middleware
+// does NOT perform a redundant io.ReadAll copy, and retries still replay the body
+// correctly via GetBody.
+func TestRetryMiddleware_GetBodyPreset_SkipsBuffering(t *testing.T) {
+	expectedBody := []byte(`{"large":"payload that should not be copied"}`)
+	logger := zerolog.Nop()
+
+	var bodiesReceived [][]byte
+	attemptCount := 0
+
+	//nolint:unparam // error is always nil but signature must match http.RoundTripper
+	customRTFn := func(req *http.Request) (*http.Response, error) {
+		attemptCount++
+
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		bodiesReceived = append(bodiesReceived, body)
+
+		headers := http.Header{}
+		if attemptCount < 2 {
+			return &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Header:     headers,
+				Request:    req,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     headers,
+			Request:    req,
+		}, nil
+	}
+
+	rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+	config := configuration.NewWithOpts()
+	config.Set(ConfigurationKeyRequestAttempts, 3)
+	config.Set(configurationKeyRetryAfter, 1)
+
+	sut := NewRetryMiddleware(config, &logger, rt)
+
+	// bytes.NewReader causes http.NewRequest to set GetBody automatically
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/upload", bytes.NewReader(expectedBody))
+	require.NotNil(t, req.GetBody, "precondition: GetBody must be set by http.NewRequest for *bytes.Reader")
+
+	response, err := sut.RoundTrip(req)
+
+	assert.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, 2, attemptCount, "Should retry once then succeed")
+
+	require.Len(t, bodiesReceived, 2)
+	for i, body := range bodiesReceived {
+		assert.Equal(t, expectedBody, body,
+			"Attempt %d: body must be correctly replayed via GetBody", i+1)
+	}
+}
+
+// TestRetryMiddleware_GetBodyNil_BuffersBody verifies that when the request body
+// does NOT have GetBody set (e.g. wrapped in io.NopCloser), the middleware falls
+// back to io.ReadAll buffering and retries still work.
+func TestRetryMiddleware_GetBodyNil_BuffersBody(t *testing.T) {
+	expectedBody := []byte(`{"wrapped":"body without GetBody"}`)
+	logger := zerolog.Nop()
+
+	var bodiesReceived [][]byte
+	attemptCount := 0
+
+	//nolint:unparam // error is always nil but signature must match http.RoundTripper
+	customRTFn := func(req *http.Request) (*http.Response, error) {
+		attemptCount++
+
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		bodiesReceived = append(bodiesReceived, body)
+
+		// After middleware buffering, GetBody should be set
+		require.NotNil(t, req.GetBody, "Attempt %d: GetBody must be set after middleware buffering", attemptCount)
+
+		headers := http.Header{}
+		if attemptCount < 2 {
+			return &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Header:     headers,
+				Request:    req,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     headers,
+			Request:    req,
+		}, nil
+	}
+
+	rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+	config := configuration.NewWithOpts()
+	config.Set(ConfigurationKeyRequestAttempts, 3)
+	config.Set(configurationKeyRetryAfter, 1)
+
+	sut := NewRetryMiddleware(config, &logger, rt)
+
+	// Wrap body in NopCloser so that http.NewRequest does NOT set GetBody
+	req, err := http.NewRequest(http.MethodPost, "http://example.com/api", io.NopCloser(bytes.NewBuffer(expectedBody)))
+	require.NoError(t, err)
+	require.Nil(t, req.GetBody, "precondition: GetBody must be nil for NopCloser-wrapped body")
+
+	response, err := sut.RoundTrip(req)
+
+	assert.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, 2, attemptCount, "Should retry once then succeed")
+
+	require.Len(t, bodiesReceived, 2)
+	for i, body := range bodiesReceived {
+		assert.Equal(t, expectedBody, body,
+			"Attempt %d: body must be preserved via middleware buffering", i+1)
+	}
+}
+
 // setupRetryMiddleware wires RetryMiddleware with a counting transport and the given config.
 func setupRetryMiddleware(
 	t *testing.T,

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -1029,28 +1030,21 @@ func TestRetryMiddleware_GetBodyNil_BuffersBody(t *testing.T) {
 	}
 }
 
-// seekableBody is a test helper that implements io.ReadSeeker + io.Closer,
-// allowing the retry middleware to detect it as seekable and avoid io.ReadAll.
-type seekableBody struct {
-	*bytes.Reader
-	closed bool
-}
-
-func newSeekableBody(data []byte) *seekableBody {
-	return &seekableBody{Reader: bytes.NewReader(data)}
-}
-
-func (s *seekableBody) Close() error {
-	s.closed = true
-	return nil
-}
-
 // TestRetryMiddleware_SeekableBody_NoBuffer verifies that when the request body
-// implements io.ReadSeeker (and GetBody is nil), the middleware rewinds via Seek
-// instead of copying into a memory buffer, and defers the real Close.
+// is a real *os.File (implements io.ReadSeeker + io.Closer, not recognised by
+// http.NewRequest for GetBody), the middleware rewinds via Seek instead of
+// copying into a memory buffer, and defers the real Close.
 func TestRetryMiddleware_SeekableBody_NoBuffer(t *testing.T) {
 	expectedBody := []byte(`{"seekable":"rewindable body, no buffer needed"}`)
 	logger := zerolog.Nop()
+
+	// Write payload to a temp file so the request body is a real *os.File.
+	tmpFile, err := os.CreateTemp(t.TempDir(), "seekable-body-*")
+	require.NoError(t, err)
+	_, err = tmpFile.Write(expectedBody)
+	require.NoError(t, err)
+	_, err = tmpFile.Seek(0, io.SeekStart)
+	require.NoError(t, err)
 
 	var bodiesReceived [][]byte
 	attemptCount := 0
@@ -1088,11 +1082,11 @@ func TestRetryMiddleware_SeekableBody_NoBuffer(t *testing.T) {
 
 	sut := NewRetryMiddleware(config, &logger, rt)
 
-	seekBody := newSeekableBody(expectedBody)
-	req, err := http.NewRequest(http.MethodPost, "http://example.com/api/v1/upload", seekBody)
+	// *os.File implements io.ReadSeeker + io.Closer but is not one of the
+	// types http.NewRequest recognises, so GetBody stays nil.
+	req, err := http.NewRequest(http.MethodPost, "http://example.com/api/v1/upload", tmpFile)
 	require.NoError(t, err)
-	// seekableBody is not one of the types http.NewRequest recognises, so GetBody is nil
-	require.Nil(t, req.GetBody, "precondition: GetBody must be nil for custom ReadSeeker body")
+	require.Nil(t, req.GetBody, "precondition: GetBody must be nil for *os.File body")
 
 	response, err := sut.RoundTrip(req)
 
@@ -1107,8 +1101,9 @@ func TestRetryMiddleware_SeekableBody_NoBuffer(t *testing.T) {
 			"Attempt %d: body must be correctly replayed via Seek", i+1)
 	}
 
-	// The deferred RealClose should have been called after RoundTrip returned
-	assert.True(t, seekBody.closed, "Real Close must be called after retry loop finishes")
+	// The deferred RealClose should have closed the file after RoundTrip returned.
+	_, err = tmpFile.Read(make([]byte, 1))
+	assert.ErrorIs(t, err, os.ErrClosed, "file must be closed after retry loop finishes")
 }
 
 // setupRetryMiddleware wires RetryMiddleware with a counting transport and the given config.

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -55,7 +55,7 @@ type failRoundtripper struct {
 	t           *testing.T
 }
 
-// getBodyRetryRoundTripper returns 503 on the first trip and 200 thereafter, asserting
+// getBodyRetryRoundTripper returns 429 on the first trip and 200 thereafter, asserting
 // GetBody returns the full body on every invocation.
 type getBodyRetryRoundTripper struct {
 	t            *testing.T
@@ -441,7 +441,7 @@ func Test_shouldRetry(t *testing.T) {
 			maxAttempts:       1,
 		},
 		{
-			name:            "Retryable status code (503) with invalid Retry-After header",
+			name:            "Retryable status code (429) with invalid Retry-After header",
 			response:        newResponse(http.StatusServiceUnavailable, http.Header{"Retry-After": []string{"abc"}}),
 			expectedErrorIs: errRetryNecessary, // retryDelaySecs will be 0
 			attempts:        0,
@@ -490,7 +490,7 @@ func Test_shouldRetry(t *testing.T) {
 			maxAttempts:     1,
 		},
 		{
-			name: "Retryable status code (503) with maintenance window error",
+			name: "Retryable status code (429) with maintenance window error",
 			response: func() *http.Response {
 				resp := newResponse(http.StatusServiceUnavailable, http.Header{"Retry-After": []string{"5"}})
 				var buf bytes.Buffer
@@ -1127,7 +1127,7 @@ func TestRetryMiddleware_IntermediateResponseBodyClosed(t *testing.T) {
 		headers := http.Header{}
 
 		if attemptCount == 1 {
-			// First attempt: return 503 with a body that tracks Close()
+			// First attempt: return 429 with a body that tracks Close()
 			body := io.NopCloser(bytes.NewReader([]byte("too much")))
 			trackingBody := &trackingReadCloser{
 				ReadCloser: body,
@@ -1167,7 +1167,7 @@ func TestRetryMiddleware_IntermediateResponseBodyClosed(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, 2, attemptCount, "Should retry once then succeed")
 
-	// The intermediate (503) response body MUST have been closed before the
+	// The intermediate (429) response body MUST have been closed before the
 	// second attempt, matching stdlib's Client.do behavior.
 	intermediateBody.mu.Lock()
 	defer intermediateBody.mu.Unlock()
@@ -1234,7 +1234,7 @@ func TestRetryMiddleware_ContextCancellation_BodyClosed(t *testing.T) {
 		"Intermediate body must be closed even when context cancellation stops the retry loop")
 }
 
-// TestRetryMiddleware_503Permanent_OriginalBodyClosed verifies that when a 503
+// TestRetryMiddleware_503Permanent_OriginalBodyClosed verifies that when a 429
 // response causes a permanent stop (retries exhausted), the original transport
 // body is still closed even though getErrorList replaced response.Body with a
 // buffer.  Without this, the TCP connection leaks because the transport body
@@ -1249,7 +1249,7 @@ func TestRetryMiddleware_503Permanent_OriginalBodyClosed(t *testing.T) {
 	customRTFn := func(req *http.Request) (*http.Response, error) {
 		headers := http.Header{}
 
-		// Return a 503 (non-maintenance) with a tracking body.
+		// Return a 429 (non-maintenance) with a tracking body.
 		// Since maxAttempts=1, shouldRetry will return Permanent on the first attempt.
 		body := io.NopCloser(bytes.NewReader([]byte("service unavailable")))
 		trackingBody := &trackingReadCloser{
@@ -1270,7 +1270,7 @@ func TestRetryMiddleware_503Permanent_OriginalBodyClosed(t *testing.T) {
 
 	rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
 	config := configuration.NewWithOpts()
-	config.Set(ConfigurationKeyRequestAttempts, 1) // maxAttempts=1 → permanent stop on first 503
+	config.Set(ConfigurationKeyRequestAttempts, 1) // maxAttempts=1 → permanent stop on first 429
 	config.Set(configurationKeyRetryAfter, 1)
 
 	sut := NewRetryMiddleware(config, &logger, rt)
@@ -1280,12 +1280,12 @@ func TestRetryMiddleware_503Permanent_OriginalBodyClosed(t *testing.T) {
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 
-	// The original transport body must be closed even on permanent 503, because
+	// The original transport body must be closed even on permanent 429, because
 	// getErrorList consumed it (ReadAll) and replaced response.Body with a buffer.
 	mu.Lock()
 	defer mu.Unlock()
 	assert.True(t, bodyClosed,
-		"Original response body must be closed on permanent 503 to avoid leaking connections")
+		"Original response body must be closed on permanent 429 to avoid leaking connections")
 }
 
 // TestRetryMiddleware_MultipleIntermediateResponseBodiesClosed verifies that ALL
@@ -1305,7 +1305,7 @@ func TestRetryMiddleware_MultipleIntermediateResponseBodiesClosed(t *testing.T) 
 		currentAttempt := attemptCount
 
 		if currentAttempt <= 3 {
-			// Attempts 1-3: return 503 with a body that tracks Close()
+			// Attempts 1-3: return 429 with a body that tracks Close()
 			body := io.NopCloser(bytes.NewReader([]byte(fmt.Sprintf("error attempt %d", currentAttempt))))
 			trackingBody := &trackingReadCloser{
 				ReadCloser: body,

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -1177,7 +1177,7 @@ func TestRetryMiddleware_IntermediateResponseBodyClosed(t *testing.T) {
 
 // TestRetryMiddleware_ContextCancellation_BodyClosed verifies that when the
 // context is canceled between retry attempts, the last intermediate response
-// body is still closed (via the post-loop cleanup).
+// body is still closed (eagerly inside op() before backoff observes the cancellation).
 func TestRetryMiddleware_ContextCancellation_BodyClosed(t *testing.T) {
 	logger := zerolog.Nop()
 
@@ -1232,6 +1232,60 @@ func TestRetryMiddleware_ContextCancellation_BodyClosed(t *testing.T) {
 	defer mu.Unlock()
 	assert.True(t, bodyClosed,
 		"Intermediate body must be closed even when context cancellation stops the retry loop")
+}
+
+// TestRetryMiddleware_503Permanent_OriginalBodyClosed verifies that when a 503
+// response causes a permanent stop (retries exhausted), the original transport
+// body is still closed even though getErrorList replaced response.Body with a
+// buffer.  Without this, the TCP connection leaks because the transport body
+// was consumed (ReadAll) but never Close()'d.
+func TestRetryMiddleware_503Permanent_OriginalBodyClosed(t *testing.T) {
+	logger := zerolog.Nop()
+
+	var mu sync.Mutex
+	bodyClosed := false
+
+	//nolint:unparam // error is always nil but signature must match http.RoundTripper
+	customRTFn := func(req *http.Request) (*http.Response, error) {
+		headers := http.Header{}
+
+		// Return a 503 (non-maintenance) with a tracking body.
+		// Since maxAttempts=1, shouldRetry will return Permanent on the first attempt.
+		body := io.NopCloser(bytes.NewReader([]byte("service unavailable")))
+		trackingBody := &trackingReadCloser{
+			ReadCloser: body,
+			onClose: func() {
+				mu.Lock()
+				bodyClosed = true
+				mu.Unlock()
+			},
+		}
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Header:     headers,
+			Body:       trackingBody,
+			Request:    req,
+		}, nil
+	}
+
+	rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+	config := configuration.NewWithOpts()
+	config.Set(ConfigurationKeyRequestAttempts, 1) // maxAttempts=1 → permanent stop on first 503
+	config.Set(configurationKeyRetryAfter, 1)
+
+	sut := NewRetryMiddleware(config, &logger, rt)
+	resp, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+	// The original transport body must be closed even on permanent 503, because
+	// getErrorList consumed it (ReadAll) and replaced response.Body with a buffer.
+	mu.Lock()
+	defer mu.Unlock()
+	assert.True(t, bodyClosed,
+		"Original response body must be closed on permanent 503 to avoid leaking connections")
 }
 
 // TestRetryMiddleware_MultipleIntermediateResponseBodiesClosed verifies that ALL

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -1029,6 +1029,88 @@ func TestRetryMiddleware_GetBodyNil_BuffersBody(t *testing.T) {
 	}
 }
 
+// seekableBody is a test helper that implements io.ReadSeeker + io.Closer,
+// allowing the retry middleware to detect it as seekable and avoid io.ReadAll.
+type seekableBody struct {
+	*bytes.Reader
+	closed bool
+}
+
+func newSeekableBody(data []byte) *seekableBody {
+	return &seekableBody{Reader: bytes.NewReader(data)}
+}
+
+func (s *seekableBody) Close() error {
+	s.closed = true
+	return nil
+}
+
+// TestRetryMiddleware_SeekableBody_NoBuffer verifies that when the request body
+// implements io.ReadSeeker (and GetBody is nil), the middleware rewinds via Seek
+// instead of copying into a memory buffer, and defers the real Close.
+func TestRetryMiddleware_SeekableBody_NoBuffer(t *testing.T) {
+	expectedBody := []byte(`{"seekable":"rewindable body, no buffer needed"}`)
+	logger := zerolog.Nop()
+
+	var bodiesReceived [][]byte
+	attemptCount := 0
+
+	//nolint:unparam // error is always nil but signature must match http.RoundTripper
+	customRTFn := func(req *http.Request) (*http.Response, error) {
+		attemptCount++
+
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		bodiesReceived = append(bodiesReceived, body)
+
+		// Close should be a no-op (suppressed by the wrapper)
+		require.NoError(t, req.Body.Close())
+
+		headers := http.Header{}
+		if attemptCount < 2 {
+			return &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Header:     headers,
+				Request:    req,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     headers,
+			Request:    req,
+		}, nil
+	}
+
+	rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+	config := configuration.NewWithOpts()
+	config.Set(ConfigurationKeyRequestAttempts, 3)
+	config.Set(configurationKeyRetryAfter, 1)
+
+	sut := NewRetryMiddleware(config, &logger, rt)
+
+	seekBody := newSeekableBody(expectedBody)
+	req, err := http.NewRequest(http.MethodPost, "http://example.com/api/v1/upload", seekBody)
+	require.NoError(t, err)
+	// seekableBody is not one of the types http.NewRequest recognises, so GetBody is nil
+	require.Nil(t, req.GetBody, "precondition: GetBody must be nil for custom ReadSeeker body")
+
+	response, err := sut.RoundTrip(req)
+
+	assert.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, 2, attemptCount, "Should retry once then succeed")
+
+	require.Len(t, bodiesReceived, 2)
+	for i, body := range bodiesReceived {
+		assert.Equal(t, expectedBody, body,
+			"Attempt %d: body must be correctly replayed via Seek", i+1)
+	}
+
+	// The deferred RealClose should have been called after RoundTrip returned
+	assert.True(t, seekBody.closed, "Real Close must be called after retry loop finishes")
+}
+
 // setupRetryMiddleware wires RetryMiddleware with a counting transport and the given config.
 func setupRetryMiddleware(
 	t *testing.T,

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -948,7 +948,9 @@ func TestRetryMiddleware_GetBodyPreset_SkipsBuffering(t *testing.T) {
 	sut := NewRetryMiddleware(config, &logger, rt)
 
 	// bytes.NewReader causes http.NewRequest to set GetBody automatically
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/upload", bytes.NewReader(expectedBody))
+	// (httptest.NewRequest does NOT set GetBody, so we use http.NewRequest here)
+	req, reqErr := http.NewRequest(http.MethodPost, "http://example.com/api/v1/upload", bytes.NewReader(expectedBody))
+	require.NoError(t, reqErr)
 	require.NotNil(t, req.GetBody, "precondition: GetBody must be set by http.NewRequest for *bytes.Reader")
 
 	response, err := sut.RoundTrip(req)

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -837,6 +837,66 @@ func TestRetryAttemptNotification(t *testing.T) {
 	})
 }
 
+// CLI-1591: Verify that POST body is preserved across retries when a 429 triggers
+// the per-status-code override (getMaxRetryAttempts) despite configured maxAttempts=1.
+func TestRetryMiddleware_429_POST_BodyPreservedAcrossRetries(t *testing.T) {
+	expectedBody := []byte(`{"depGraph":{"pkgManager":{"name":"npm"},"nodes":[]}}`)
+	logger := zerolog.Nop()
+
+	var bodiesReceived [][]byte
+	attemptCount := 0
+
+	//nolint:unparam // error is always nil but signature must match http.RoundTripper
+	customRTFn := func(req *http.Request) (*http.Response, error) {
+		attemptCount++
+
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		bodiesReceived = append(bodiesReceived, body)
+
+		headers := http.Header{}
+		if attemptCount < 3 {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     headers,
+				Request:    req,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     headers,
+			Request:    req,
+		}, nil
+	}
+
+	rt := &failRoundtripper{
+		t:           t,
+		roundTripFn: &customRTFn,
+	}
+
+	config := configuration.NewWithOpts()
+	config.Set(ConfigurationKeyRequestAttempts, 1)
+	config.Set(configurationKeyRetryAfter, 1)
+
+	sut := NewRetryMiddleware(config, &logger, rt)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/test", bytes.NewReader(expectedBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	response, err := sut.RoundTrip(req)
+
+	assert.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Equal(t, http.StatusOK, response.StatusCode, "Should succeed after retries")
+	assert.Equal(t, 3, attemptCount, "Should make 3 attempts per 429 override")
+
+	require.Len(t, bodiesReceived, 3, "Should have recorded body for each attempt")
+	for i, body := range bodiesReceived {
+		assert.Equal(t, expectedBody, body,
+			"Attempt %d: body must be preserved across retries", i+1)
+	}
+}
+
 // setupRetryMiddleware wires RetryMiddleware with a counting transport and the given config.
 func setupRetryMiddleware(
 	t *testing.T,

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -1128,7 +1128,7 @@ func TestRetryMiddleware_IntermediateResponseBodyClosed(t *testing.T) {
 
 		if attemptCount == 1 {
 			// First attempt: return 503 with a body that tracks Close()
-			body := io.NopCloser(bytes.NewReader([]byte("service unavailable")))
+			body := io.NopCloser(bytes.NewReader([]byte("too much")))
 			trackingBody := &trackingReadCloser{
 				ReadCloser: body,
 				onClose: func() {
@@ -1138,7 +1138,7 @@ func TestRetryMiddleware_IntermediateResponseBodyClosed(t *testing.T) {
 				},
 			}
 			return &http.Response{
-				StatusCode: http.StatusServiceUnavailable,
+				StatusCode: http.StatusTooManyRequests,
 				Header:     headers,
 				Body:       trackingBody,
 				Request:    req,
@@ -1207,7 +1207,7 @@ func TestRetryMiddleware_ContextCancellation_BodyClosed(t *testing.T) {
 		cancel()
 
 		return &http.Response{
-			StatusCode: http.StatusServiceUnavailable,
+			StatusCode: http.StatusTooManyRequests,
 			Header:     headers,
 			Body:       trackingBody,
 			Request:    req,
@@ -1261,7 +1261,7 @@ func TestRetryMiddleware_503Permanent_OriginalBodyClosed(t *testing.T) {
 			},
 		}
 		return &http.Response{
-			StatusCode: http.StatusServiceUnavailable,
+			StatusCode: http.StatusTooManyRequests,
 			Header:     headers,
 			Body:       trackingBody,
 			Request:    req,
@@ -1278,7 +1278,7 @@ func TestRetryMiddleware_503Permanent_OriginalBodyClosed(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 
 	// The original transport body must be closed even on permanent 503, because
 	// getErrorList consumed it (ReadAll) and replaced response.Body with a buffer.
@@ -1316,7 +1316,7 @@ func TestRetryMiddleware_MultipleIntermediateResponseBodiesClosed(t *testing.T) 
 				},
 			}
 			return &http.Response{
-				StatusCode: http.StatusServiceUnavailable,
+				StatusCode: http.StatusTooManyRequests,
 				Header:     headers,
 				Body:       trackingBody,
 				Request:    req,


### PR DESCRIPTION
### Description

Fixes empty request bodies when retrying POST requests. In addition it addresses several connection/resource management gaps in the retry middleware.

#### 1. Always buffer request body for retry overrides

POST request bodies were not preserved across retry attempts when a 429 triggered the per-status-code retry override (3 attempts despite `maxAttempts=1`).

**Root cause:** Body buffering was gated on `maxAttempts > 1`, but the per-status-code override in `getMaxRetryAttempts` is only evaluated after the first response — by which point the body was already consumed and never buffered.

**Fix:** `ensureGetBodyExists` now always prepares a replayable body using three strategies in order of preference:
1. `GetBody` already set (e.g. `http.NewRequest` with `*bytes.Reader`) → use as-is, no copy.
2. Body implements `io.ReadSeeker` (e.g. `*os.File`) → wrap to suppress Close, rewind with `Seek(0)`.
3. Fallback → `io.ReadAll` into memory buffer.

#### 2. Close intermediate response bodies between retries

The middleware returned `(response, retryErr)` on retriable status codes, but `backoff.Retry` discarded intermediate responses without closing their bodies — leaking one TCP connection per retry. This matches the drain+close behavior in stdlib's `Client.do`.

`drainAndClose` is called eagerly when the retry decision is made (non-permanent errors). On permanent 503 where `getErrorList` replaces `response.Body` with a buffer copy, the orphaned original transport body is also closed.

#### 3. Cleanup: remove dead code

Removed redundant `noCloseSeekBody.Read` method — the embedded `io.ReadSeeker` already promotes `Read`.

**Ticket:** [CLI-1591](https://snyksec.atlassian.net/browse/CLI-1591)

### Test coverage

| Scenario | Test |
|----------|------|
| POST body preserved across 429 retries | `TestRetryMiddleware_429_POST_BodyPreservedAcrossRetries` |
| GetBody preset skips buffering | `TestRetryMiddleware_GetBodyPreset_SkipsBuffering` |
| NopCloser body falls back to ReadAll | `TestRetryMiddleware_GetBodyNil_BuffersBody` |
| Seekable body rewinds without copy | `TestRetryMiddleware_SeekableBody_NoBuffer` |
| Intermediate response body closed (1 retry) | `TestRetryMiddleware_IntermediateResponseBodyClosed` |
| All intermediate bodies closed (3 retries) | `TestRetryMiddleware_MultipleIntermediateResponseBodiesClosed` |
| Context cancellation still closes body | `TestRetryMiddleware_ContextCancellation_BodyClosed` |
| Permanent 503 closes orphaned transport body | `TestRetryMiddleware_503Permanent_OriginalBodyClosed` |

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.


PR in CLI: https://github.com/snyk/cli/pull/6912

[CLI-1591]: https://snyksec.atlassian.net/browse/CLI-1591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ