### PR TITLE
feat: reapply support for HTML mime type for HTML rendering (#628)

### DIFF
--- a/internal/presenters/funcs.go
+++ b/internal/presenters/funcs.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	htmlTemplate "html/template"
 	"maps"
 	"os"
 	"reflect"
@@ -314,6 +315,15 @@ func getUnionValue(input interface{}) interface{} {
 	}
 
 	return result
+}
+
+func getHTMLTemplateFuncMap() htmlTemplate.FuncMap {
+	fnMap := htmlTemplate.FuncMap{}
+	// render simple HTML hello world in red
+	fnMap["helloworld"] = func() htmlTemplate.HTML {
+		return htmlTemplate.HTML("<h1 style='color: red;'>Hello World</h1>")
+	}
+	return fnMap
 }
 
 func getDefaultTemplateFuncMap(config configuration.Configuration, ri runtimeinfo.RuntimeInfo) template.FuncMap {

--- a/internal/presenters/presenter_local_finding.go
+++ b/internal/presenters/presenter_local_finding.go
@@ -19,6 +19,7 @@ const DefaultMimeType = "text/cli"
 const NoneMimeType = "unknown"
 const ApplicationJSONMimeType = "application/json"
 const ApplicationSarifMimeType = content_type.SARIF_JSON
+const ApplicationHTMLMimeType = content_type.HTML
 const CONFIG_JSON_STRIP_WHITESPACES = "internal_json_no_whitespaces"
 
 //go:embed templates/*

--- a/internal/presenters/presenter_ufm.go
+++ b/internal/presenters/presenter_ufm.go
@@ -2,7 +2,9 @@ package presenters
 
 import (
 	"fmt"
+	htmlTemplate "html/template"
 	"io"
+	"os"
 	"strings"
 	"text/template"
 
@@ -13,16 +15,24 @@ import (
 )
 
 type UfmPresenter struct {
-	TestPath     string
-	Input        []testapi.TestResult
-	config       configuration.Configuration
-	writer       io.Writer
-	runtimeinfo  runtimeinfo.RuntimeInfo
-	templateImpl map[string]TemplateImplFunction
+	TestPath         string
+	Input            []testapi.TestResult
+	config           configuration.Configuration
+	writer           io.Writer
+	runtimeinfo      runtimeinfo.RuntimeInfo
+	templateImpl     map[string]TemplateImplFunction
+	htmlTemplateImpl map[string]HTMLTemplateImplFunction
 }
+
+// HTMLTemplateImplFunction mirrors TemplateImplFunction but returns an *html/template.Template
+type HTMLTemplateImplFunction func() (*htmlTemplate.Template, htmlTemplate.FuncMap, error)
 
 var ApplicationSarifTemplatesUfm = []string{
 	"templates/ufm.sarif.tmpl",
+}
+
+var ApplicationHTMLTemplatesUfm = []string{
+	"templates/ufm.html.tmpl",
 }
 
 var DefaultTemplateFilesUfm = []string{
@@ -69,6 +79,17 @@ func NewUfmRenderer(results []testapi.TestResult, config configuration.Configura
 				return localFindingsTemplate, functionMapMimeType, nil
 			},
 		},
+		htmlTemplateImpl: map[string]HTMLTemplateImplFunction{
+			ApplicationHTMLMimeType: func() (*htmlTemplate.Template, htmlTemplate.FuncMap, error) {
+				ufmTemplate, err := htmlTemplate.New(ApplicationHTMLMimeType).Parse("")
+				if err != nil {
+					return nil, nil, err
+				}
+
+				functionMapMimeType := getHTMLTemplateFuncMap()
+				return ufmTemplate, functionMapMimeType, nil
+			},
+		},
 	}
 
 	for _, option := range options {
@@ -102,12 +123,20 @@ func (p *UfmPresenter) RegisterMimeType(mimeType string, implFactory TemplateImp
 	if _, ok := p.templateImpl[mimeType]; ok {
 		return fmt.Errorf("mimetype \"%s\" is already registered", mimeType)
 	}
+	if _, ok := p.htmlTemplateImpl[mimeType]; ok {
+		return fmt.Errorf("mimetype \"%s\" is already registered", mimeType)
+	}
 
 	p.templateImpl[mimeType] = implFactory
 	return nil
 }
 
 func (p *UfmPresenter) RenderTemplate(templateFiles []string, mimeType string) error {
+	// Call renderHTMLTemplate() for HTML mime type
+	if _, ok := p.htmlTemplateImpl[mimeType]; ok {
+		return p.renderHTMLTemplate(templateFiles, mimeType)
+	}
+
 	// mimetype specific
 	localFindingsTemplate, err := p.getImplementationFromMimeType(mimeType)
 	if err != nil {
@@ -137,6 +166,68 @@ func (p *UfmPresenter) RenderTemplate(templateFiles []string, mimeType string) e
 	})
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+// renderHTMLTemplate is the html/template counterpart of RenderTemplate
+func (p *UfmPresenter) renderHTMLTemplate(templateFiles []string, mimeType string) error {
+	ufmTemplate, err := p.getHTMLImplementationFromMimeType(mimeType)
+	if err != nil {
+		return err
+	}
+
+	err = loadHTMLTemplates(templateFiles, ufmTemplate)
+	if err != nil {
+		return err
+	}
+
+	mainTmpl := ufmTemplate.Lookup("main")
+	if mainTmpl == nil {
+		return fmt.Errorf("the template must contain a 'main'")
+	}
+
+	return mainTmpl.Execute(p.writer, struct {
+		TestResults []testapi.TestResult
+	}{
+		TestResults: p.Input,
+	})
+}
+
+func (p *UfmPresenter) getHTMLImplementationFromMimeType(mimeType string) (*htmlTemplate.Template, error) {
+	functionMapGeneral := getDefaultTemplateFuncMap(p.config, p.runtimeinfo)
+
+	ufmTemplate, functionMapMimeType, err := p.htmlTemplateImpl[mimeType]()
+	if err != nil {
+		return nil, err
+	}
+
+	if functionMapMimeType != nil {
+		functionMapGeneral = utils.MergeMaps(functionMapGeneral, functionMapMimeType)
+	}
+	_ = ufmTemplate.Funcs(functionMapGeneral)
+
+	return ufmTemplate, nil
+}
+
+// loadHTMLTemplates mirrors loadTemplates for the html/template tree
+func loadHTMLTemplates(files []string, tmpl *htmlTemplate.Template) error {
+	if len(files) == 0 {
+		return fmt.Errorf("a template file must be specified")
+	}
+
+	for _, filename := range files {
+		data, err := embeddedFiles.ReadFile(filename)
+		if err != nil {
+			data, err = os.ReadFile(filename)
+			if err != nil {
+				return fmt.Errorf("failed to read template file %s", filename)
+			}
+		}
+		tmpl, err = tmpl.Parse(string(data))
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/presenters/presenter_ufm_test.go
+++ b/internal/presenters/presenter_ufm_test.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"text/template"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
@@ -20,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/xeipuuv/gojsonschema"
+	"golang.org/x/net/html"
 
 	"github.com/snyk/go-application-framework/internal/presenters"
 	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
@@ -57,6 +59,50 @@ func validateSarifData(t *testing.T, data []byte) {
 		}
 		assert.True(t, validationResult.Valid(), "Sarif validation failed")
 	}
+}
+
+// validateHTMLOutput asserts the rendered output is a structurally valid HTML document
+func validateHTMLOutput(t *testing.T, data []byte) {
+	t.Helper()
+
+	doc, err := html.Parse(bytes.NewReader(data))
+	require.NoError(t, err, "rendered output must parse as HTML")
+
+	var doctypeCount, htmlCount, headCount, bodyCount int
+	var walk func(n *html.Node)
+	walk = func(n *html.Node) {
+		switch n.Type {
+		case html.DoctypeNode:
+			if strings.EqualFold(n.Data, "html") {
+				doctypeCount++
+			}
+		case html.ElementNode:
+			switch n.Data {
+			case "html":
+				htmlCount++
+			case "head":
+				headCount++
+			case "body":
+				bodyCount++
+			}
+		default:
+			// other node types (text, comments, etc.) are irrelevant to the structural checks
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+
+	// Note html.Parse is a WHATWG error-correcting parser that rarely
+	// errors and synthesizes missing html/head/body elements, so the meaningful
+	// assertions are the doctype and element-uniqueness counts. Extend with XSS
+	// canaries (javascript: hrefs, on* attributes) once the template renders
+	// finding content.
+	assert.Equal(t, 1, doctypeCount, "expected exactly one <!doctype html>")
+	assert.Equal(t, 1, htmlCount, "expected exactly one <html> element")
+	assert.Equal(t, 1, headCount, "expected exactly one <head> element")
+	assert.Equal(t, 1, bodyCount, "expected exactly one <body> element")
 }
 
 // normalizeAutomationID removes project name and timestamp from automation ID
@@ -1280,4 +1326,58 @@ func Test_UfmPresenter_HumanReadable(t *testing.T) {
 	}
 
 	lipgloss.SetColorProfile(termenv.Ascii)
+}
+
+func Test_UfmPresenter_HTML(t *testing.T) {
+	ri := runtimeinfo.New(runtimeinfo.WithName("snyk-cli"), runtimeinfo.WithVersion("1.1301.0"))
+
+	testCases := []struct {
+		name           string
+		testResultPath string
+	}{
+		{
+			name:           "cli",
+			testResultPath: "testdata/ufm/testresult_cli.json",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.FileExists(t, tc.testResultPath, "fixture missing — regenerate via `make generate-fixture` (see CONTRIBUTING.md)")
+
+			testResultBytes, err := os.ReadFile(tc.testResultPath)
+			assert.NoError(t, err)
+
+			testResult, err := ufm.NewSerializableTestResultFromBytes(testResultBytes)
+			assert.NoError(t, err)
+
+			config := configuration.NewWithOpts()
+			writer := &bytes.Buffer{}
+
+			presenter := presenters.NewUfmRenderer(testResult, config, writer, presenters.UfmWithRuntimeInfo(ri))
+			err = presenter.RenderTemplate(presenters.ApplicationHTMLTemplatesUfm, presenters.ApplicationHTMLMimeType)
+			assert.NoError(t, err)
+			validateHTMLOutput(t, writer.Bytes())
+		})
+	}
+}
+
+func Test_UfmPresenter_RegisterMimeType(t *testing.T) {
+	config := configuration.NewWithOpts()
+	writer := &bytes.Buffer{}
+	p := presenters.NewUfmRenderer(nil, config, writer)
+
+	t.Run("rejects double-registration of the HTML mime type", func(t *testing.T) {
+		err := p.RegisterMimeType(presenters.ApplicationHTMLMimeType, func() (*template.Template, template.FuncMap, error) {
+			return nil, nil, nil
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("registering a new mime type succeeds", func(t *testing.T) {
+		err := p.RegisterMimeType("mymime", func() (*template.Template, template.FuncMap, error) {
+			return nil, nil, nil
+		})
+		assert.NoError(t, err)
+	})
 }

--- a/internal/presenters/templates/ufm.html.tmpl
+++ b/internal/presenters/templates/ufm.html.tmpl
@@ -1,0 +1,3 @@
+{{define "main"}}<!doctype html>
+{{helloworld}}
+{{end}}

--- a/pkg/local_workflows/content_type/constants.go
+++ b/pkg/local_workflows/content_type/constants.go
@@ -5,5 +5,6 @@ const (
 	LOCAL_FINDING_MODEL = "application/json; schema=local-finding-summary"
 	LEGACY_CLI          = "application/json; schema=legacy-cli"
 	SARIF_JSON          = "application/sarif+json"
+	HTML                = "text/html"
 	UFM_RESULT          = "application/ufm.result"
 )

--- a/pkg/local_workflows/output_workflow/constants.go
+++ b/pkg/local_workflows/output_workflow/constants.go
@@ -7,6 +7,8 @@ const (
 	OUTPUT_CONFIG_KEY_JSON_FILE          = "json-file-output"
 	OUTPUT_CONFIG_KEY_SARIF              = "sarif"
 	OUTPUT_CONFIG_KEY_SARIF_FILE         = "sarif-file-output"
+	OUTPUT_CONFIG_KEY_HTML               = "html"
+	OUTPUT_CONFIG_KEY_HTML_FILE          = "html-file-output"
 	OUTPUT_CONFIG_TEMPLATE_FILE          = "internal_template_file"
 	OUTPUT_CONFIG_KEY_FILE_WRITERS       = "internal_output_file_writers"
 	OUTPUT_CONFIG_KEY_DEFAULT_WRITER_LUT = "internal_default_writer_mimetype_lut"
@@ -15,10 +17,12 @@ const (
 	DEFAULT_MIME_TYPE                    = presenters.DefaultMimeType
 	SARIF_MIME_TYPE                      = presenters.ApplicationSarifMimeType
 	JSON_MIME_TYPE                       = presenters.ApplicationJSONMimeType
+	HTML_MIME_TYPE                       = presenters.ApplicationHTMLMimeType
 )
 
 // DefaultTemplateFiles is an instance of TemplatePathsStruct with the template paths.
 var DefaultTemplateFiles = presenters.DefaultTemplateFiles
 var ApplicationSarifTemplates = presenters.ApplicationSarifTemplates
 var ApplicationSarifTemplatesUfm = presenters.ApplicationSarifTemplatesUfm
-var structuredContent = []string{SARIF_MIME_TYPE, JSON_MIME_TYPE}
+var ApplicationHTMLTemplatesUfm = presenters.ApplicationHTMLTemplatesUfm
+var structuredContent = []string{SARIF_MIME_TYPE, JSON_MIME_TYPE, HTML_MIME_TYPE}

--- a/pkg/local_workflows/output_workflow/other_tools.go
+++ b/pkg/local_workflows/output_workflow/other_tools.go
@@ -16,7 +16,7 @@ var ignoredMimetypes = []string{
 	content_type.TEST_SUMMARY,
 }
 
-var supportedMimeTypes = []string{"sarif", "json", DEFAULT_MIME_TYPE}
+var supportedMimeTypes = []string{"sarif", "json", "html", DEFAULT_MIME_TYPE}
 
 func HandleContentTypeOther(input []workflow.Data, invocation workflow.InvocationContext, writers WriterMap) ([]workflow.Data, error) {
 	var finalError error

--- a/pkg/local_workflows/output_workflow/other_tools_test.go
+++ b/pkg/local_workflows/output_workflow/other_tools_test.go
@@ -228,6 +228,42 @@ func Test_HandleContentTypeOther(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Contains(t, remaining, data)
 	})
+
+	t.Run("text/html data is routed to the text/html writer", func(t *testing.T) {
+		ctx := newMockContext(t)
+		buffer := &bytes.Buffer{}
+		writers := &testWriterMap{
+			writers: map[string][]*WriterEntry{
+				HTML_MIME_TYPE: {{
+					writer:   &nopCloser{writer: buffer},
+					mimeType: HTML_MIME_TYPE,
+					name:     "html-writer",
+				}},
+			},
+		}
+
+		data := workflow.NewData(workflowID, content_type.HTML, []byte(`<!doctype html><html></html>`))
+		remaining, err := HandleContentTypeOther([]workflow.Data{data}, ctx, writers)
+		assert.NoError(t, err)
+		assert.Equal(t, `<!doctype html><html></html>`, buffer.String())
+		assert.Empty(t, remaining)
+	})
+
+	t.Run("html config routes a text/html report to the default stdout writer", func(t *testing.T) {
+		ctx := newMockContext(t)
+
+		config := configuration.NewWithOpts()
+		config.Set(OUTPUT_CONFIG_KEY_HTML, true)
+
+		out := &stubOutputDestination{}
+		writers := GetWritersFromConfiguration(config, out)
+
+		data := workflow.NewData(workflowID, content_type.HTML, []byte(`<!doctype html><html>report</html>`))
+		remaining, err := HandleContentTypeOther([]workflow.Data{data}, ctx, writers)
+		assert.NoError(t, err)
+		assert.Contains(t, out.buffer.String(), `<!doctype html>`)
+		assert.Empty(t, remaining)
+	})
 }
 
 func Test_DefaultOutputIsStructured(t *testing.T) {
@@ -242,6 +278,14 @@ func Test_DefaultOutputIsStructured(t *testing.T) {
 	t.Run("returns true when json output is enabled", func(t *testing.T) {
 		config := configuration.NewWithOpts()
 		config.Set(OUTPUT_CONFIG_KEY_JSON, true)
+
+		result := DefaultOutputIsStructured(config)
+		assert.True(t, result)
+	})
+
+	t.Run("returns true when html output is enabled", func(t *testing.T) {
+		config := configuration.NewWithOpts()
+		config.Set(OUTPUT_CONFIG_KEY_HTML, true)
 
 		result := DefaultOutputIsStructured(config)
 		assert.True(t, result)

--- a/pkg/local_workflows/output_workflow/ufm_tools.go
+++ b/pkg/local_workflows/output_workflow/ufm_tools.go
@@ -106,6 +106,10 @@ func HandleContentTypeUnifiedModel(input []workflow.Data, invocation workflow.In
 			mimetype:  DEFAULT_MIME_TYPE,
 			templates: presenters.DefaultTemplateFilesUfm,
 		},
+		{
+			mimetype:  HTML_MIME_TYPE,
+			templates: presenters.ApplicationHTMLTemplatesUfm,
+		},
 	}
 	writerMap := applyTemplatesToWriters(supportedMimeTypes, writers)
 

--- a/pkg/local_workflows/output_workflow/ufm_tools_test.go
+++ b/pkg/local_workflows/output_workflow/ufm_tools_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -19,6 +21,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )
 
+//nolint:unparam // path should be kept configurable
 func loadTestResults(t *testing.T, path string) []testapi.TestResult {
 	t.Helper()
 	testResultBytes, err := os.ReadFile(path)
@@ -180,5 +183,70 @@ func Test_HandleContentTypeUnifiedModel(t *testing.T) {
 			unwrapped := joinedErrs.Unwrap()
 			assert.Equal(t, 2, len(unwrapped))
 		}
+	})
+
+	t.Run("html and sarif file outputs are produced in the same run", func(t *testing.T) {
+		mockCtl := gomock.NewController(t)
+		defer mockCtl.Finish()
+
+		fileConfig := configuration.NewWithOpts()
+		expectedHTMLFile := filepath.Join(t.TempDir(), "report.html")
+		expectedSarifFile := filepath.Join(t.TempDir(), "report.sarif")
+		fileConfig.Set(OUTPUT_CONFIG_KEY_HTML_FILE, expectedHTMLFile)
+		fileConfig.Set(OUTPUT_CONFIG_KEY_SARIF_FILE, expectedSarifFile)
+		fileConfig.Set(configuration.MAX_THREADS, 10)
+
+		ctx := pkgMocks.NewMockInvocationContext(mockCtl)
+		ctx.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
+		ctx.EXPECT().GetConfiguration().Return(fileConfig).AnyTimes()
+		ctx.EXPECT().GetRuntimeInfo().Return(runtimeinfo.New(runtimeinfo.WithName("snyk-cli"), runtimeinfo.WithVersion("1.1301.0"))).AnyTimes()
+		ctx.EXPECT().Context().Return(t.Context()).AnyTimes()
+
+		results := loadTestResults(t, "../../../internal/presenters/testdata/ufm/secrets.testresult.json")
+		workflowData := ufm.CreateWorkflowDataFromTestResults(workflow.NewWorkflowIdentifier("test"), results)
+		input := []workflow.Data{workflowData}
+
+		writers := GetWritersFromConfiguration(fileConfig, &stubOutputDestination{})
+
+		remaining, err := HandleContentTypeUnifiedModel(input, ctx, writers)
+		assert.NoError(t, err)
+		assert.NotNil(t, remaining)
+
+		htmlBytes, err := os.ReadFile(expectedHTMLFile)
+		assert.NoError(t, err, "HTML file should have been written")
+		assert.Contains(t, strings.ToLower(string(htmlBytes)), "<!doctype html>")
+
+		sarifBytes, err := os.ReadFile(expectedSarifFile)
+		assert.NoError(t, err, "SARIF file should have been written")
+		assert.Contains(t, string(sarifBytes), "\"version\": \"2.1.0\"")
+	})
+
+	t.Run("html flag renders HTML to the default stdout writer", func(t *testing.T) {
+		mockCtl := gomock.NewController(t)
+		defer mockCtl.Finish()
+
+		stdoutConfig := configuration.NewWithOpts()
+		stdoutConfig.Set(OUTPUT_CONFIG_KEY_HTML, true)
+		stdoutConfig.Set(configuration.MAX_THREADS, 10)
+
+		ctx := pkgMocks.NewMockInvocationContext(mockCtl)
+		ctx.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
+		ctx.EXPECT().GetConfiguration().Return(stdoutConfig).AnyTimes()
+		ctx.EXPECT().GetRuntimeInfo().Return(runtimeinfo.New(runtimeinfo.WithName("snyk-cli"), runtimeinfo.WithVersion("1.1301.0"))).AnyTimes()
+		ctx.EXPECT().Context().Return(t.Context()).AnyTimes()
+
+		results := loadTestResults(t, "../../../internal/presenters/testdata/ufm/secrets.testresult.json")
+		workflowData := ufm.CreateWorkflowDataFromTestResults(workflow.NewWorkflowIdentifier("test"), results)
+		input := []workflow.Data{workflowData}
+
+		outputDestination := &stubOutputDestination{}
+		writers := GetWritersFromConfiguration(stdoutConfig, outputDestination)
+
+		remaining, err := HandleContentTypeUnifiedModel(input, ctx, writers)
+		assert.NoError(t, err)
+		assert.NotNil(t, remaining)
+
+		stdout := outputDestination.buffer.String()
+		assert.Contains(t, strings.ToLower(stdout), "<!doctype html>", "default writer should have received HTML output")
 	})
 }

--- a/pkg/local_workflows/output_workflow/writer.go
+++ b/pkg/local_workflows/output_workflow/writer.go
@@ -132,6 +132,12 @@ func GetWritersFromConfiguration(config configuration.Configuration, outputDesti
 			[]string{},
 			true,
 		},
+		{
+			OUTPUT_CONFIG_KEY_HTML_FILE,
+			HTML_MIME_TYPE,
+			[]string{},
+			true,
+		},
 	}
 
 	// use configured file writers if available
@@ -187,6 +193,10 @@ func getDefaultWriterMimeType(config configuration.Configuration) string {
 
 	if config.GetBool(OUTPUT_CONFIG_KEY_JSON) {
 		return JSON_MIME_TYPE
+	}
+
+	if config.GetBool(OUTPUT_CONFIG_KEY_HTML) {
+		return HTML_MIME_TYPE
 	}
 
 	return DEFAULT_MIME_TYPE

--- a/pkg/local_workflows/output_workflow/writer_test.go
+++ b/pkg/local_workflows/output_workflow/writer_test.go
@@ -1,0 +1,110 @@
+package output_workflow
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+)
+
+// stubOutputDestination is a minimal iUtils.OutputDestination for tests in
+// this package; stdout-style output goes to an in-memory buffer while file
+// operations hit the real filesystem (callers should use t.TempDir() paths).
+type stubOutputDestination struct {
+	buffer bytes.Buffer
+}
+
+func (s *stubOutputDestination) Println(a ...any) (n int, err error) {
+	return fmt.Fprintln(&s.buffer, a...)
+}
+
+func (s *stubOutputDestination) Remove(name string) error {
+	return os.Remove(name)
+}
+
+func (s *stubOutputDestination) WriteFile(filename string, data []byte, perm fs.FileMode) error {
+	return os.WriteFile(filename, data, perm)
+}
+
+func (s *stubOutputDestination) GetWriter() io.Writer {
+	return &s.buffer
+}
+
+func Test_GetWritersFromConfiguration_HTMLFileWriter(t *testing.T) {
+	t.Run("html-file-output set creates an HTML file writer", func(t *testing.T) {
+		config := configuration.NewWithOpts()
+		config.Set(OUTPUT_CONFIG_KEY_HTML_FILE, "/tmp/x.html")
+
+		writerMap := GetWritersFromConfiguration(config, &stubOutputDestination{})
+
+		htmlWriters := writerMap.PopWritersByMimetype(HTML_MIME_TYPE)
+		assert.Len(t, htmlWriters, 1)
+		assert.Equal(t, HTML_MIME_TYPE, htmlWriters[0].mimeType)
+		assert.Equal(t, OUTPUT_CONFIG_KEY_HTML_FILE, htmlWriters[0].name)
+	})
+
+	t.Run("html-file-output unset creates no HTML writer", func(t *testing.T) {
+		config := configuration.NewWithOpts()
+
+		writerMap := GetWritersFromConfiguration(config, &stubOutputDestination{})
+
+		htmlWriters := writerMap.PopWritersByMimetype(HTML_MIME_TYPE)
+		assert.Empty(t, htmlWriters)
+	})
+}
+
+func Test_getDefaultWriterMimeType(t *testing.T) {
+	testCases := []struct {
+		name             string
+		configKeys       []string
+		expectedMimeType string
+	}{
+		{
+			name:             "no flags set returns default",
+			configKeys:       nil,
+			expectedMimeType: DEFAULT_MIME_TYPE,
+		},
+		{
+			name:             "sarif",
+			configKeys:       []string{OUTPUT_CONFIG_KEY_SARIF},
+			expectedMimeType: SARIF_MIME_TYPE,
+		},
+		{
+			name:             "json",
+			configKeys:       []string{OUTPUT_CONFIG_KEY_JSON},
+			expectedMimeType: JSON_MIME_TYPE,
+		},
+		{
+			name:             "html",
+			configKeys:       []string{OUTPUT_CONFIG_KEY_HTML},
+			expectedMimeType: HTML_MIME_TYPE,
+		},
+		{
+			name:             "sarif takes precedence over html",
+			configKeys:       []string{OUTPUT_CONFIG_KEY_SARIF, OUTPUT_CONFIG_KEY_HTML},
+			expectedMimeType: SARIF_MIME_TYPE,
+		},
+		{
+			name:             "json takes precedence over html",
+			configKeys:       []string{OUTPUT_CONFIG_KEY_JSON, OUTPUT_CONFIG_KEY_HTML},
+			expectedMimeType: JSON_MIME_TYPE,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := configuration.NewWithOpts()
+			for _, key := range tc.configKeys {
+				config.Set(key, true)
+			}
+
+			assert.Equal(t, tc.expectedMimeType, getDefaultWriterMimeType(config))
+		})
+	}
+}


### PR DESCRIPTION
### Description

This PR adds support for a new mime type, `text/html` in our presentation layer. This adds the initial changes necessary for HTML rendering and includes
- a new function map implementation that supports Go's `html/template` package
- an initial `ufm.html.tmpl` template that renders a simple HTML output using the new function map

#626 should be merged into this PR before this PR can be merged into main

### Checklist

- [ ] Tests added and all succeed (`make test`)
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.
