### PR TITLE
fix: Close response body after reading in getErrorList

### DIFF
--- a/pkg/networking/middleware/response.go
+++ b/pkg/networking/middleware/response.go
@@ -74,11 +74,12 @@ func getErrorList(res *http.Response) []snyk_errors.Error {
 	if res.Body == nil {
 		return []snyk_errors.Error{}
 	}
+	originalBody := res.Body
+	defer originalBody.Close()
 	// get JSONApiErrors from body
 	bodyBytes, err := io.ReadAll(res.Body)
-	closeErr := res.Body.Close()
 	res.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-	if err != nil || closeErr != nil {
+	if err != nil {
 		return []snyk_errors.Error{}
 	}
 

--- a/pkg/networking/middleware/response.go
+++ b/pkg/networking/middleware/response.go
@@ -76,11 +76,11 @@ func getErrorList(res *http.Response) []snyk_errors.Error {
 	}
 	// get JSONApiErrors from body
 	bodyBytes, err := io.ReadAll(res.Body)
-	if err != nil {
+	closeErr := res.Body.Close()
+	res.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+	if err != nil || closeErr != nil {
 		return []snyk_errors.Error{}
 	}
-
-	res.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
 	errorList, err := snyk_errors.FromJSONAPIErrorBytes(bodyBytes)
 	if err != nil {

--- a/pkg/networking/middleware/response.go
+++ b/pkg/networking/middleware/response.go
@@ -74,14 +74,14 @@ func getErrorList(res *http.Response) []snyk_errors.Error {
 	if res.Body == nil {
 		return []snyk_errors.Error{}
 	}
-	originalBody := res.Body
-	defer originalBody.Close()
 	// get JSONApiErrors from body
 	bodyBytes, err := io.ReadAll(res.Body)
-	res.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	if err != nil {
 		return []snyk_errors.Error{}
 	}
+
+	_ = res.Body.Close()
+	res.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
 	errorList, err := snyk_errors.FromJSONAPIErrorBytes(bodyBytes)
 	if err != nil {

--- a/pkg/networking/middleware/response_internal_test.go
+++ b/pkg/networking/middleware/response_internal_test.go
@@ -38,8 +38,9 @@ func Test_getErrorList_closesBody(t *testing.T) {
 		tb := &trackingBody{ReadCloser: io.NopCloser(strings.NewReader("not json"))}
 		res := &http.Response{Body: tb}
 
-		getErrorList(res)
+		errors := getErrorList(res)
 
+		assert.Len(t, errors, 0)
 		assert.True(t, tb.closed, "original body must be closed even when JSON parsing fails")
 	})
 }

--- a/pkg/networking/middleware/response_internal_test.go
+++ b/pkg/networking/middleware/response_internal_test.go
@@ -22,7 +22,7 @@ func (tb *trackingBody) Close() error {
 func Test_getErrorList_closesBody(t *testing.T) {
 	validJSON := `{"jsonapi":{"version":"1.0"},"errors":[{"status":"400","detail":"bad request","title":"Bad Request"}]}`
 
-	t.Run("parses errors and closes body", func(t *testing.T) {
+	t.Run("parses errors and closes body after successful read", func(t *testing.T) {
 		tb := &trackingBody{ReadCloser: io.NopCloser(strings.NewReader(validJSON))}
 		res := &http.Response{Body: tb}
 
@@ -31,15 +31,6 @@ func Test_getErrorList_closesBody(t *testing.T) {
 		assert.Len(t, errors, 1)
 		assert.Equal(t, "Bad Request", errors[0].Title)
 		assert.Equal(t, "bad request", errors[0].Detail)
-		assert.True(t, tb.closed, "original body must be closed after reading")
-	})
-
-	t.Run("closes body after successful read", func(t *testing.T) {
-		tb := &trackingBody{ReadCloser: io.NopCloser(strings.NewReader(validJSON))}
-		res := &http.Response{Body: tb}
-
-		getErrorList(res)
-
 		assert.True(t, tb.closed, "original body must be closed after reading")
 	})
 

--- a/pkg/networking/middleware/response_internal_test.go
+++ b/pkg/networking/middleware/response_internal_test.go
@@ -1,0 +1,42 @@
+package middleware
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type trackingBody struct {
+	io.ReadCloser
+	closed bool
+}
+
+func (tb *trackingBody) Close() error {
+	tb.closed = true
+	return tb.ReadCloser.Close()
+}
+
+func Test_getErrorList_closesBody(t *testing.T) {
+	validJSON := `{"jsonapi":{"version":"1.0"},"errors":[{"status":"400","detail":"bad request","title":"Bad Request"}]}`
+
+	t.Run("closes body after successful read", func(t *testing.T) {
+		tb := &trackingBody{ReadCloser: io.NopCloser(strings.NewReader(validJSON))}
+		res := &http.Response{Body: tb}
+
+		getErrorList(res)
+
+		assert.True(t, tb.closed, "original body must be closed after reading")
+	})
+
+	t.Run("closes body when JSON parsing fails", func(t *testing.T) {
+		tb := &trackingBody{ReadCloser: io.NopCloser(strings.NewReader("not json"))}
+		res := &http.Response{Body: tb}
+
+		getErrorList(res)
+
+		assert.True(t, tb.closed, "original body must be closed even when JSON parsing fails")
+	})
+}

--- a/pkg/networking/middleware/response_internal_test.go
+++ b/pkg/networking/middleware/response_internal_test.go
@@ -22,6 +22,18 @@ func (tb *trackingBody) Close() error {
 func Test_getErrorList_closesBody(t *testing.T) {
 	validJSON := `{"jsonapi":{"version":"1.0"},"errors":[{"status":"400","detail":"bad request","title":"Bad Request"}]}`
 
+	t.Run("parses errors and closes body", func(t *testing.T) {
+		tb := &trackingBody{ReadCloser: io.NopCloser(strings.NewReader(validJSON))}
+		res := &http.Response{Body: tb}
+
+		errors := getErrorList(res)
+
+		assert.Len(t, errors, 1)
+		assert.Equal(t, "Bad Request", errors[0].Title)
+		assert.Equal(t, "bad request", errors[0].Detail)
+		assert.True(t, tb.closed, "original body must be closed after reading")
+	})
+
 	t.Run("closes body after successful read", func(t *testing.T) {
 		tb := &trackingBody{ReadCloser: io.NopCloser(strings.NewReader(validJSON))}
 		res := &http.Response{Body: tb}

--- a/pkg/networking/middleware/response_test.go
+++ b/pkg/networking/middleware/response_test.go
@@ -344,18 +344,18 @@ func Test_getErrorList_ClosesOriginalBody(t *testing.T) {
 		config := getBaseConfig()
 		config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, []string{"https://api.snyk.io"})
 
-		_ = middleware.HandleResponse(res, config)
-
+		err := middleware.HandleResponse(res, config)
+		assert.Error(t, err)
 		assert.True(t, tb.closed, "original body must be closed after reading")
 	})
 
 	t.Run("closes body on invalid JSON", func(t *testing.T) {
-		res, tb := newTrackingResponse(http.StatusBadRequest, "not json")
+		res, tb := newTrackingResponse(http.StatusInternalServerError, "not json")
 		config := getBaseConfig()
 		config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, []string{"https://api.snyk.io"})
 
-		_ = middleware.HandleResponse(res, config)
-
+		err := middleware.HandleResponse(res, config)
+		assert.Error(t, err)
 		assert.True(t, tb.closed, "original body must be closed even when JSON parsing fails")
 	})
 
@@ -364,8 +364,8 @@ func Test_getErrorList_ClosesOriginalBody(t *testing.T) {
 		config := getBaseConfig()
 		config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, []string{"https://api.snyk.io"})
 
-		_ = middleware.HandleResponse(res, config)
-
+		err := middleware.HandleResponse(res, config)
+		assert.Error(t, err)
 		assert.True(t, tb.closed, "original body must be closed")
 
 		bodyBytes, err := io.ReadAll(res.Body)
@@ -393,8 +393,8 @@ func Test_getErrorList_ClosesOriginalBody(t *testing.T) {
 		config := getBaseConfig()
 		config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, []string{"https://api.snyk.io"})
 
-		_ = middleware.HandleResponse(res, config)
-
+		err := middleware.HandleResponse(res, config)
+		assert.Error(t, err)
 		assert.True(t, tb.closed, "original body must be closed even when empty")
 	})
 }

--- a/pkg/networking/middleware/response_test.go
+++ b/pkg/networking/middleware/response_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/snyk/error-catalog-golang-public/cli"
@@ -334,94 +333,6 @@ func Test_ResponseMiddleware_RateLimitEnrichment(t *testing.T) {
 		assert.Contains(t, snykErr.Description, "shared across all usage of this token")
 		assert.Nil(t, snykErr.Meta["retry-after-seconds"])
 	})
-}
-
-func Test_getErrorList_ClosesOriginalBody(t *testing.T) {
-	validErrorBody := `{"jsonapi":{"version":"1.0"},"errors":[{"status":"400","detail":"bad request","title":"Bad Request"}]}`
-
-	t.Run("closes body on valid JSON API error", func(t *testing.T) {
-		res, tb := newTrackingResponse(http.StatusBadRequest, validErrorBody)
-		config := getBaseConfig()
-		config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, []string{"https://api.snyk.io"})
-
-		err := middleware.HandleResponse(res, config)
-		assert.Error(t, err)
-		assert.True(t, tb.closed, "original body must be closed after reading")
-	})
-
-	t.Run("closes body on invalid JSON", func(t *testing.T) {
-		res, tb := newTrackingResponse(http.StatusInternalServerError, "not json")
-		config := getBaseConfig()
-		config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, []string{"https://api.snyk.io"})
-
-		err := middleware.HandleResponse(res, config)
-		assert.Error(t, err)
-		assert.True(t, tb.closed, "original body must be closed even when JSON parsing fails")
-	})
-
-	t.Run("body is readable after HandleResponse", func(t *testing.T) {
-		res, tb := newTrackingResponse(http.StatusBadRequest, validErrorBody)
-		config := getBaseConfig()
-		config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, []string{"https://api.snyk.io"})
-
-		err := middleware.HandleResponse(res, config)
-		assert.Error(t, err)
-		assert.True(t, tb.closed, "original body must be closed")
-
-		bodyBytes, err := io.ReadAll(res.Body)
-		assert.NoError(t, err, "replacement body should be readable")
-		assert.Equal(t, validErrorBody, string(bodyBytes))
-	})
-
-	t.Run("nil body returns empty error list without panic", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "https://api.snyk.io/test", nil)
-		res := &http.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       nil,
-			Header:     http.Header{},
-			Request:    req,
-		}
-		config := getBaseConfig()
-		config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, []string{"https://api.snyk.io"})
-
-		err := middleware.HandleResponse(res, config)
-		assert.Error(t, err)
-	})
-
-	t.Run("empty body returns empty error list", func(t *testing.T) {
-		res, tb := newTrackingResponse(http.StatusBadRequest, "")
-		config := getBaseConfig()
-		config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, []string{"https://api.snyk.io"})
-
-		err := middleware.HandleResponse(res, config)
-		assert.Error(t, err)
-		assert.True(t, tb.closed, "original body must be closed even when empty")
-	})
-}
-
-// --- test helpers ---
-
-type trackingBody struct {
-	io.ReadCloser
-	closed bool
-}
-
-func (tb *trackingBody) Close() error {
-	tb.closed = true
-	return tb.ReadCloser.Close()
-}
-
-func newTrackingResponse(statusCode int, body string) (*http.Response, *trackingBody) {
-	tb := &trackingBody{
-		ReadCloser: io.NopCloser(strings.NewReader(body)),
-	}
-	req := httptest.NewRequest(http.MethodGet, "https://api.snyk.io/test", nil)
-	return &http.Response{
-		StatusCode: statusCode,
-		Body:       tb,
-		Header:     http.Header{},
-		Request:    req,
-	}, tb
 }
 
 func buildRequest(url string) *http.Request {

--- a/pkg/networking/middleware/response_test.go
+++ b/pkg/networking/middleware/response_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/snyk/error-catalog-golang-public/cli"
@@ -333,6 +334,94 @@ func Test_ResponseMiddleware_RateLimitEnrichment(t *testing.T) {
 		assert.Contains(t, snykErr.Description, "shared across all usage of this token")
 		assert.Nil(t, snykErr.Meta["retry-after-seconds"])
 	})
+}
+
+func Test_getErrorList_ClosesOriginalBody(t *testing.T) {
+	validErrorBody := `{"jsonapi":{"version":"1.0"},"errors":[{"status":"400","detail":"bad request","title":"Bad Request"}]}`
+
+	t.Run("closes body on valid JSON API error", func(t *testing.T) {
+		res, tb := newTrackingResponse(http.StatusBadRequest, validErrorBody)
+		config := getBaseConfig()
+		config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, []string{"https://api.snyk.io"})
+
+		_ = middleware.HandleResponse(res, config)
+
+		assert.True(t, tb.closed, "original body must be closed after reading")
+	})
+
+	t.Run("closes body on invalid JSON", func(t *testing.T) {
+		res, tb := newTrackingResponse(http.StatusBadRequest, "not json")
+		config := getBaseConfig()
+		config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, []string{"https://api.snyk.io"})
+
+		_ = middleware.HandleResponse(res, config)
+
+		assert.True(t, tb.closed, "original body must be closed even when JSON parsing fails")
+	})
+
+	t.Run("body is readable after HandleResponse", func(t *testing.T) {
+		res, tb := newTrackingResponse(http.StatusBadRequest, validErrorBody)
+		config := getBaseConfig()
+		config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, []string{"https://api.snyk.io"})
+
+		_ = middleware.HandleResponse(res, config)
+
+		assert.True(t, tb.closed, "original body must be closed")
+
+		bodyBytes, err := io.ReadAll(res.Body)
+		assert.NoError(t, err, "replacement body should be readable")
+		assert.Equal(t, validErrorBody, string(bodyBytes))
+	})
+
+	t.Run("nil body returns empty error list without panic", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "https://api.snyk.io/test", nil)
+		res := &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       nil,
+			Header:     http.Header{},
+			Request:    req,
+		}
+		config := getBaseConfig()
+		config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, []string{"https://api.snyk.io"})
+
+		err := middleware.HandleResponse(res, config)
+		assert.Error(t, err)
+	})
+
+	t.Run("empty body returns empty error list", func(t *testing.T) {
+		res, tb := newTrackingResponse(http.StatusBadRequest, "")
+		config := getBaseConfig()
+		config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, []string{"https://api.snyk.io"})
+
+		_ = middleware.HandleResponse(res, config)
+
+		assert.True(t, tb.closed, "original body must be closed even when empty")
+	})
+}
+
+// --- test helpers ---
+
+type trackingBody struct {
+	io.ReadCloser
+	closed bool
+}
+
+func (tb *trackingBody) Close() error {
+	tb.closed = true
+	return tb.ReadCloser.Close()
+}
+
+func newTrackingResponse(statusCode int, body string) (*http.Response, *trackingBody) {
+	tb := &trackingBody{
+		ReadCloser: io.NopCloser(strings.NewReader(body)),
+	}
+	req := httptest.NewRequest(http.MethodGet, "https://api.snyk.io/test", nil)
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       tb,
+		Header:     http.Header{},
+		Request:    req,
+	}, tb
 }
 
 func buildRequest(url string) *http.Request {


### PR DESCRIPTION
### Description

Fixes an unclosed response body leak in `getErrorList()`. After `io.ReadAll(res.Body)` consumed the original transport body, it was replaced with a buffer but never closed, leaving the TCP connection open.

The fix closes the original body after a successful read, then replaces `res.Body` with the buffered copy.

Adds direct unit tests for `getErrorList` that verify the original body is closed after reading (valid JSON and invalid JSON).

Fixes [CLI-1626](https://snyksec.atlassian.net/browse/CLI-1626)

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [X] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.

CLI PR: https://github.com/snyk/cli/pull/6959

[CLI-1626]: https://snyksec.atlassian.net/browse/CLI-1626