### PR TITLE
feat: add live authentication check

### DIFF
--- a/pkg/local_workflows/doctor_workflow/init.go
+++ b/pkg/local_workflows/doctor_workflow/init.go
@@ -9,9 +9,9 @@ import (
 const (
 	doctorWorkflowName = "doctor"
 
-	inputFlag       = "input"
-	noLiveCheckFlag = "no-live-check"
-	jsonFlag        = "json"
+	inputFlag = "input"
+	liveFlag  = "live"
+	jsonFlag  = "json"
 )
 
 var WORKFLOWID_DOCTOR workflow.Identifier = workflow.NewWorkflowIdentifier(doctorWorkflowName)
@@ -19,7 +19,7 @@ var WORKFLOWID_DOCTOR workflow.Identifier = workflow.NewWorkflowIdentifier(docto
 func InitDoctorWorkflow(engine workflow.Engine) error {
 	flags := pflag.NewFlagSet(doctorWorkflowName, pflag.ExitOnError)
 	flags.String(inputFlag, "", "Path to a Snyk CLI debug log file.")
-	flags.Bool(noLiveCheckFlag, false, "Skip live authentication and connectivity checks.")
+	flags.Bool(liveFlag, false, "Run live checks (authentication, connectivity) against the current environment. Off by default.")
 	flags.Bool(jsonFlag, false, "Output the diagnostic report as JSON.")
 
 	_, err := engine.Register(

--- a/pkg/local_workflows/doctor_workflow/livecheck/auth.go
+++ b/pkg/local_workflows/doctor_workflow/livecheck/auth.go
@@ -1,0 +1,54 @@
+package livecheck
+
+import (
+	"github.com/snyk/go-application-framework/pkg/local_workflows/doctor_workflow/diagnosis"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+)
+
+var workflowIDWhoAmI = workflow.NewWorkflowIdentifier("whoami")
+
+// AuthStatus is the outcome of the live authentication check.
+type AuthStatus struct {
+	OK           bool
+	Identity     string
+	ErrorMessage string
+}
+
+// checkAuth verifies authentication by invoking the whoami workflow: a string
+// result is the identity; any error or empty result is a failure.
+func checkAuth(invocationCtx workflow.InvocationContext) AuthStatus {
+	config := invocationCtx.GetConfiguration().Clone()
+
+	data, err := invocationCtx.GetEngine().InvokeWithConfig(workflowIDWhoAmI, config)
+	if err != nil {
+		return AuthStatus{ErrorMessage: err.Error()}
+	}
+	if len(data) == 0 {
+		return AuthStatus{ErrorMessage: "whoami returned no usable result"}
+	}
+	identity, ok := data[0].GetPayload().(string)
+	if !ok {
+		return AuthStatus{ErrorMessage: "whoami returned no usable result"}
+	}
+	return AuthStatus{OK: true, Identity: identity}
+}
+
+// finding maps the auth status into the generic contract (Source = auth).
+func (a AuthStatus) finding() diagnosis.Finding {
+	if a.OK {
+		return diagnosis.Finding{
+			Source:   diagnosis.SourceAuth,
+			Kind:     "auth",
+			Severity: diagnosis.SeverityInfo,
+			Message:  "Authenticated as " + a.Identity,
+			Fields:   map[string]string{"identity": a.Identity},
+		}
+	}
+	return diagnosis.Finding{
+		Source:   diagnosis.SourceAuth,
+		Kind:     "auth",
+		Severity: diagnosis.SeverityError,
+		Message:  "Failed to verify authentication",
+		Details:  []string{a.ErrorMessage},
+	}
+}

--- a/pkg/local_workflows/doctor_workflow/livecheck/auth.go
+++ b/pkg/local_workflows/doctor_workflow/livecheck/auth.go
@@ -1,11 +1,27 @@
 package livecheck
 
 import (
+	"time"
+
 	"github.com/snyk/go-application-framework/pkg/local_workflows/doctor_workflow/diagnosis"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )
 
-var workflowIDWhoAmI = workflow.NewWorkflowIdentifier("whoami")
+// WhoAmIWorkflowID is the whoami workflow this check invokes. It's re-derived
+// from the name (not imported from localworkflows) to avoid an import cycle;
+// whoami_id_test.go pins it to the canonical constant to prevent drift.
+var WhoAmIWorkflowID = workflow.NewWorkflowIdentifier("whoami")
+
+const (
+	// whoamiJSONFlag is the whoami config flag that switches its payload from a
+	// plain-string identity to a JSON []byte. We force it off so the string
+	// contract below holds even when the doctor run itself used --json.
+	whoamiJSONFlag = "json"
+
+	// authCheckTimeout bounds the live whoami call so a hung request degrades to
+	// a finding instead of blocking the already-computed report.
+	authCheckTimeout = 15 * time.Second
+)
 
 // AuthStatus is the outcome of the live authentication check.
 type AuthStatus struct {
@@ -14,23 +30,40 @@ type AuthStatus struct {
 	ErrorMessage string
 }
 
-// checkAuth verifies authentication by invoking the whoami workflow: a string
-// result is the identity; any error or empty result is a failure.
+// checkAuth verifies authentication via the whoami workflow: a string result is
+// the identity; error/empty is a failure. Bounded by authCheckTimeout so a hung
+// call can't block doctor (InvokeWithConfig takes no context).
 func checkAuth(invocationCtx workflow.InvocationContext) AuthStatus {
 	config := invocationCtx.GetConfiguration().Clone()
+	// Force whoami's string-payload path regardless of the doctor run's --json.
+	config.Set(whoamiJSONFlag, false)
 
-	data, err := invocationCtx.GetEngine().InvokeWithConfig(workflowIDWhoAmI, config)
-	if err != nil {
-		return AuthStatus{ErrorMessage: err.Error()}
+	type invokeResult struct {
+		data []workflow.Data
+		err  error
 	}
-	if len(data) == 0 {
-		return AuthStatus{ErrorMessage: "whoami returned no usable result"}
+	resultCh := make(chan invokeResult, 1)
+	go func() {
+		data, err := invocationCtx.GetEngine().InvokeWithConfig(WhoAmIWorkflowID, config)
+		resultCh <- invokeResult{data: data, err: err}
+	}()
+
+	select {
+	case <-time.After(authCheckTimeout):
+		return AuthStatus{ErrorMessage: "authentication check timed out"}
+	case result := <-resultCh:
+		if result.err != nil {
+			return AuthStatus{ErrorMessage: result.err.Error()}
+		}
+		if len(result.data) == 0 {
+			return AuthStatus{ErrorMessage: "whoami returned no usable result"}
+		}
+		identity, ok := result.data[0].GetPayload().(string)
+		if !ok {
+			return AuthStatus{ErrorMessage: "whoami returned an unexpected payload type"}
+		}
+		return AuthStatus{OK: true, Identity: identity}
 	}
-	identity, ok := data[0].GetPayload().(string)
-	if !ok {
-		return AuthStatus{ErrorMessage: "whoami returned no usable result"}
-	}
-	return AuthStatus{OK: true, Identity: identity}
 }
 
 // finding maps the auth status into the generic contract (Source = auth).

--- a/pkg/local_workflows/doctor_workflow/livecheck/auth.go
+++ b/pkg/local_workflows/doctor_workflow/livecheck/auth.go
@@ -1,8 +1,10 @@
 package livecheck
 
 import (
+	"context"
 	"time"
 
+	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/doctor_workflow/diagnosis"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )
@@ -18,8 +20,8 @@ const (
 	// contract below holds even when the doctor run itself used --json.
 	whoamiJSONFlag = "json"
 
-	// authCheckTimeout bounds the live whoami call so a hung request degrades to
-	// a finding instead of blocking the already-computed report.
+	// authCheckTimeout bounds the live whoami call (via WithContext) so a hung
+	// request degrades to a finding instead of blocking the already-computed report.
 	authCheckTimeout = 15 * time.Second
 )
 
@@ -31,39 +33,36 @@ type AuthStatus struct {
 }
 
 // checkAuth verifies authentication via the whoami workflow: a string result is
-// the identity; error/empty is a failure. Bounded by authCheckTimeout so a hung
-// call can't block doctor (InvokeWithConfig takes no context).
+// the identity; error/empty is a failure. The call is bounded by authCheckTimeout
+// via WithContext so a hung request cancels rather than blocking doctor.
 func checkAuth(invocationCtx workflow.InvocationContext) AuthStatus {
-	config := invocationCtx.GetConfiguration().Clone()
-	// Force whoami's string-payload path regardless of the doctor run's --json.
+	ctx, cancel := context.WithTimeout(invocationCtx.Context(), authCheckTimeout)
+	defer cancel()
+
+	data, err := invocationCtx.GetEngine().Invoke(
+		WhoAmIWorkflowID,
+		workflow.WithConfig(whoamiConfig(invocationCtx.GetConfiguration())),
+		workflow.WithContext(ctx),
+	)
+	if err != nil {
+		return AuthStatus{ErrorMessage: err.Error()}
+	}
+	if len(data) == 0 {
+		return AuthStatus{ErrorMessage: "whoami returned no usable result"}
+	}
+	identity, ok := data[0].GetPayload().(string)
+	if !ok {
+		return AuthStatus{ErrorMessage: "whoami returned an unexpected payload type"}
+	}
+	return AuthStatus{OK: true, Identity: identity}
+}
+
+// whoamiConfig clones the doctor config and forces json off so whoami returns
+// its plain-string identity payload regardless of the doctor run's --json.
+func whoamiConfig(base configuration.Configuration) configuration.Configuration {
+	config := base.Clone()
 	config.Set(whoamiJSONFlag, false)
-
-	type invokeResult struct {
-		data []workflow.Data
-		err  error
-	}
-	resultCh := make(chan invokeResult, 1)
-	go func() {
-		data, err := invocationCtx.GetEngine().InvokeWithConfig(WhoAmIWorkflowID, config)
-		resultCh <- invokeResult{data: data, err: err}
-	}()
-
-	select {
-	case <-time.After(authCheckTimeout):
-		return AuthStatus{ErrorMessage: "authentication check timed out"}
-	case result := <-resultCh:
-		if result.err != nil {
-			return AuthStatus{ErrorMessage: result.err.Error()}
-		}
-		if len(result.data) == 0 {
-			return AuthStatus{ErrorMessage: "whoami returned no usable result"}
-		}
-		identity, ok := result.data[0].GetPayload().(string)
-		if !ok {
-			return AuthStatus{ErrorMessage: "whoami returned an unexpected payload type"}
-		}
-		return AuthStatus{OK: true, Identity: identity}
-	}
+	return config
 }
 
 // finding maps the auth status into the generic contract (Source = auth).

--- a/pkg/local_workflows/doctor_workflow/livecheck/auth_test.go
+++ b/pkg/local_workflows/doctor_workflow/livecheck/auth_test.go
@@ -1,0 +1,80 @@
+package livecheck
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/doctor_workflow/diagnosis"
+	"github.com/snyk/go-application-framework/pkg/mocks"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+)
+
+func TestCheckAuth(t *testing.T) {
+	tests := []struct {
+		name      string
+		invokeOut []workflow.Data
+		invokeErr error
+		want      AuthStatus
+	}{
+		{
+			name:      "authenticated",
+			invokeOut: []workflow.Data{whoAmIData("user@snyk.io")},
+			want:      AuthStatus{OK: true, Identity: "user@snyk.io"},
+		},
+		{
+			name:      "whoami fails",
+			invokeErr: errors.New("authentication error (status: 401)"),
+			want:      AuthStatus{ErrorMessage: "authentication error (status: 401)"},
+		},
+		{
+			name:      "empty result",
+			invokeOut: []workflow.Data{},
+			want:      AuthStatus{ErrorMessage: "whoami returned no usable result"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			config := configuration.NewWithOpts()
+
+			engine := mocks.NewMockEngine(ctrl)
+			engine.EXPECT().
+				InvokeWithConfig(workflowIDWhoAmI, gomock.Any()).
+				Return(tt.invokeOut, tt.invokeErr)
+
+			ctx := mocks.NewMockInvocationContext(ctrl)
+			ctx.EXPECT().GetConfiguration().Return(config).AnyTimes()
+			ctx.EXPECT().GetEngine().Return(engine).AnyTimes()
+
+			assert.Equal(t, tt.want, checkAuth(ctx))
+		})
+	}
+}
+
+func TestAuthStatus_finding(t *testing.T) {
+	ok := AuthStatus{OK: true, Identity: "user@snyk.io"}.finding()
+	assert.Equal(t, diagnosis.SourceAuth, ok.Source)
+	assert.Equal(t, diagnosis.SeverityInfo, ok.Severity)
+	assert.Contains(t, ok.Message, "user@snyk.io")
+	assert.Equal(t, "user@snyk.io", ok.Fields["identity"])
+
+	failed := AuthStatus{ErrorMessage: "Authentication error"}.finding()
+	assert.Equal(t, diagnosis.SourceAuth, failed.Source)
+	assert.Equal(t, diagnosis.SeverityError, failed.Severity)
+	assert.Contains(t, failed.Message, "Failed to verify authentication")
+	assert.Contains(t, failed.Details, "Authentication error")
+}
+
+func whoAmIData(payload string) workflow.Data {
+	// whoami (without --json) returns the username as a plain string payload.
+	return workflow.NewData(
+		workflow.NewTypeIdentifier(workflowIDWhoAmI, "whoami"),
+		"text/plain",
+		payload,
+	)
+}

--- a/pkg/local_workflows/doctor_workflow/livecheck/auth_test.go
+++ b/pkg/local_workflows/doctor_workflow/livecheck/auth_test.go
@@ -35,6 +35,11 @@ func TestCheckAuth(t *testing.T) {
 			invokeOut: []workflow.Data{},
 			want:      AuthStatus{ErrorMessage: "whoami returned no usable result"},
 		},
+		{
+			name:      "unexpected payload type",
+			invokeOut: []workflow.Data{jsonWhoAmIData(`{"userName":"user@snyk.io"}`)},
+			want:      AuthStatus{ErrorMessage: "whoami returned an unexpected payload type"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -44,7 +49,7 @@ func TestCheckAuth(t *testing.T) {
 
 			engine := mocks.NewMockEngine(ctrl)
 			engine.EXPECT().
-				InvokeWithConfig(workflowIDWhoAmI, gomock.Any()).
+				InvokeWithConfig(WhoAmIWorkflowID, gomock.Any()).
 				Return(tt.invokeOut, tt.invokeErr)
 
 			ctx := mocks.NewMockInvocationContext(ctrl)
@@ -54,6 +59,31 @@ func TestCheckAuth(t *testing.T) {
 			assert.Equal(t, tt.want, checkAuth(ctx))
 		})
 	}
+}
+
+func TestCheckAuth_forcesJSONOff(t *testing.T) {
+	// The doctor run itself may be invoked with --json; the whoami sub-invocation
+	// must still take its string-payload path or the identity assertion breaks.
+	ctrl := gomock.NewController(t)
+	config := configuration.NewWithOpts()
+	config.Set("json", true)
+
+	var invokedWithJSON bool
+	engine := mocks.NewMockEngine(ctrl)
+	engine.EXPECT().
+		InvokeWithConfig(WhoAmIWorkflowID, gomock.Any()).
+		DoAndReturn(func(_ workflow.Identifier, c configuration.Configuration) ([]workflow.Data, error) {
+			invokedWithJSON = c.GetBool("json")
+			return []workflow.Data{whoAmIData("user@snyk.io")}, nil
+		})
+
+	ctx := mocks.NewMockInvocationContext(ctrl)
+	ctx.EXPECT().GetConfiguration().Return(config).AnyTimes()
+	ctx.EXPECT().GetEngine().Return(engine).AnyTimes()
+
+	got := checkAuth(ctx)
+	assert.True(t, got.OK)
+	assert.False(t, invokedWithJSON, "whoami must be invoked with json disabled")
 }
 
 func TestAuthStatus_finding(t *testing.T) {
@@ -73,8 +103,17 @@ func TestAuthStatus_finding(t *testing.T) {
 func whoAmIData(payload string) workflow.Data {
 	// whoami (without --json) returns the username as a plain string payload.
 	return workflow.NewData(
-		workflow.NewTypeIdentifier(workflowIDWhoAmI, "whoami"),
+		workflow.NewTypeIdentifier(WhoAmIWorkflowID, "whoami"),
 		"text/plain",
 		payload,
+	)
+}
+
+func jsonWhoAmIData(payload string) workflow.Data {
+	// whoami with --json returns a []byte JSON payload, not a string.
+	return workflow.NewData(
+		workflow.NewTypeIdentifier(WhoAmIWorkflowID, "whoami"),
+		"application/json",
+		[]byte(payload),
 	)
 }

--- a/pkg/local_workflows/doctor_workflow/livecheck/auth_test.go
+++ b/pkg/local_workflows/doctor_workflow/livecheck/auth_test.go
@@ -1,6 +1,7 @@
 package livecheck
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -49,10 +50,11 @@ func TestCheckAuth(t *testing.T) {
 
 			engine := mocks.NewMockEngine(ctrl)
 			engine.EXPECT().
-				InvokeWithConfig(WhoAmIWorkflowID, gomock.Any()).
+				Invoke(WhoAmIWorkflowID, gomock.Any(), gomock.Any()).
 				Return(tt.invokeOut, tt.invokeErr)
 
 			ctx := mocks.NewMockInvocationContext(ctrl)
+			ctx.EXPECT().Context().Return(context.Background()).AnyTimes()
 			ctx.EXPECT().GetConfiguration().Return(config).AnyTimes()
 			ctx.EXPECT().GetEngine().Return(engine).AnyTimes()
 
@@ -61,29 +63,16 @@ func TestCheckAuth(t *testing.T) {
 	}
 }
 
-func TestCheckAuth_forcesJSONOff(t *testing.T) {
+func TestWhoamiConfig_forcesJSONOff(t *testing.T) {
 	// The doctor run itself may be invoked with --json; the whoami sub-invocation
 	// must still take its string-payload path or the identity assertion breaks.
-	ctrl := gomock.NewController(t)
-	config := configuration.NewWithOpts()
-	config.Set("json", true)
+	base := configuration.NewWithOpts()
+	base.Set("json", true)
 
-	var invokedWithJSON bool
-	engine := mocks.NewMockEngine(ctrl)
-	engine.EXPECT().
-		InvokeWithConfig(WhoAmIWorkflowID, gomock.Any()).
-		DoAndReturn(func(_ workflow.Identifier, c configuration.Configuration) ([]workflow.Data, error) {
-			invokedWithJSON = c.GetBool("json")
-			return []workflow.Data{whoAmIData("user@snyk.io")}, nil
-		})
+	got := whoamiConfig(base)
 
-	ctx := mocks.NewMockInvocationContext(ctrl)
-	ctx.EXPECT().GetConfiguration().Return(config).AnyTimes()
-	ctx.EXPECT().GetEngine().Return(engine).AnyTimes()
-
-	got := checkAuth(ctx)
-	assert.True(t, got.OK)
-	assert.False(t, invokedWithJSON, "whoami must be invoked with json disabled")
+	assert.False(t, got.GetBool("json"), "whoami config must disable json")
+	assert.True(t, base.GetBool("json"), "the doctor config must not be mutated")
 }
 
 func TestAuthStatus_finding(t *testing.T) {

--- a/pkg/local_workflows/doctor_workflow/livecheck/livecheck.go
+++ b/pkg/local_workflows/doctor_workflow/livecheck/livecheck.go
@@ -1,0 +1,17 @@
+// Package livecheck runs live, environment-touching diagnostics (auth now,
+// connectivity later) and maps each into the shared diagnosis.Finding contract,
+// so live results join the same findings stream as log analysis.
+package livecheck
+
+import (
+	"github.com/snyk/go-application-framework/pkg/local_workflows/doctor_workflow/diagnosis"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+)
+
+// Run executes the live checks and returns their findings for inclusion in the
+// doctor report. New checks append their findings here.
+func Run(invocationCtx workflow.InvocationContext) []diagnosis.Finding {
+	return []diagnosis.Finding{
+		checkAuth(invocationCtx).finding(),
+	}
+}

--- a/pkg/local_workflows/doctor_workflow/livecheck/whoami_id_test.go
+++ b/pkg/local_workflows/doctor_workflow/livecheck/whoami_id_test.go
@@ -1,0 +1,22 @@
+package livecheck_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/doctor_workflow/livecheck"
+)
+
+// TestWhoAmIWorkflowID_matchesCanonical guards the locally derived whoami
+// identifier against drifting from the canonical localworkflows.WORKFLOWID_WHOAMI.
+//
+// livecheck cannot import localworkflows in non-test code (localworkflows ->
+// doctor_workflow -> livecheck would cycle), so the identifier is derived from
+// its name in auth.go and pinned here instead. This external test package can
+// import localworkflows because nothing imports it back.
+func TestWhoAmIWorkflowID_matchesCanonical(t *testing.T) {
+	assert.Equal(t, localworkflows.WORKFLOWID_WHOAMI, livecheck.WhoAmIWorkflowID,
+		"whoami identifier drifted from localworkflows.WORKFLOWID_WHOAMI")
+}

--- a/pkg/local_workflows/doctor_workflow/workflow.go
+++ b/pkg/local_workflows/doctor_workflow/workflow.go
@@ -21,44 +21,50 @@ func runDoctor(invocationCtx workflow.InvocationContext, stdin io.Reader, stdinI
 	config := invocationCtx.GetConfiguration()
 	logger := invocationCtx.GetEnhancedLogger()
 
-	// 1. Open input
-	reader, err := diagnosis.OpenInput(config.GetString(inputFlag), stdin, stdinIsTerminal)
-	if err != nil {
-		return nil, err
+	inputPath := config.GetString(inputFlag)
+	// A log is available from --input or from a pipe (stdin is not a terminal).
+	// A bare `snyk doctor` with neither has nothing to analyze, so it defaults to
+	// live checks rather than erroring.
+	hasLogInput := inputPath != "" || !stdinIsTerminal
+
+	// 1. Analyze the log when there is one; otherwise start from an empty report.
+	report := &diagnosis.DoctorReport{SchemaVersion: diagnosis.SchemaVersion}
+	if hasLogInput {
+		reader, err := diagnosis.OpenInput(inputPath, stdin, stdinIsTerminal)
+		if err != nil {
+			return nil, err
+		}
+		defer reader.Close()
+
+		report, err = diagnosis.Analyze(ctx, reader, diagnosis.DefaultLogChecks())
+		if err != nil {
+			return nil, err
+		}
+		logger.Debug().Msgf("doctor: analyzed debug log (%d findings)", len(report.Findings))
 	}
-	defer reader.Close()
 
-	// 2. Analyze
-	report, err := diagnosis.Analyze(ctx, reader, diagnosis.DefaultLogChecks())
-	if err != nil {
-		return nil, err
-	}
-
-	logger.Debug().Msgf("doctor: analyzed debug log (%d findings)", len(report.Findings))
-
-	// 3. Live checks (auth now, connectivity later) are opt-in via --live: they
-	// touch the current environment, so they stay off for offline log analysis.
-	// They append to the same findings stream, so no format changes are needed.
-	if config.GetBool(liveFlag) {
+	// 2. Live checks (auth now, connectivity later) touch the current environment.
+	// They run when requested via --live, or by default for a bare invocation
+	// (no log to analyze). They append to the same findings stream.
+	if config.GetBool(liveFlag) || !hasLogInput {
 		live := livecheck.Run(invocationCtx)
 		report.Findings = append(report.Findings, live...)
 		logger.Debug().Msgf("doctor: gathered %d live-check finding(s)", len(live))
 	}
 
-	// 4. Format — select by --json flag
+	// 3. Format — select by --json flag
 	var buf bytes.Buffer
 	contentType := "text/plain"
+	render := diagnosis.FormatText
 	if config.GetBool(jsonFlag) {
 		contentType = "application/json"
-		err = diagnosis.FormatJSON(&buf, report)
-	} else {
-		err = diagnosis.FormatText(&buf, report)
+		render = diagnosis.FormatJSON
 	}
-	if err != nil {
+	if err := render(&buf, report); err != nil {
 		return nil, err
 	}
 
-	// 5. Package
+	// 4. Package
 	data := workflow.NewData(
 		workflow.NewTypeIdentifier(WORKFLOWID_DOCTOR, doctorWorkflowName),
 		contentType,

--- a/pkg/local_workflows/doctor_workflow/workflow.go
+++ b/pkg/local_workflows/doctor_workflow/workflow.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/snyk/go-application-framework/pkg/local_workflows/doctor_workflow/diagnosis"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/doctor_workflow/livecheck"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )
 
@@ -35,7 +36,17 @@ func runDoctor(invocationCtx workflow.InvocationContext, stdin io.Reader, stdinI
 
 	logger.Debug().Msgf("doctor: analyzed debug log (%d findings)", len(report.Findings))
 
-	// 3. Format — select by --json flag
+	// 3. Live checks (auth now, connectivity later), unless disabled — they
+	// append to the same findings stream.
+	if config.GetBool(noLiveCheckFlag) {
+		logger.Debug().Msg("doctor: --no-live-check set, skipping live checks")
+	} else {
+		live := livecheck.Run(invocationCtx)
+		report.Findings = append(report.Findings, live...)
+		logger.Debug().Msgf("doctor: gathered %d live-check finding(s)", len(live))
+	}
+
+	// 4. Format — select by --json flag
 	var buf bytes.Buffer
 	contentType := "text/plain"
 	if config.GetBool(jsonFlag) {
@@ -48,7 +59,7 @@ func runDoctor(invocationCtx workflow.InvocationContext, stdin io.Reader, stdinI
 		return nil, err
 	}
 
-	// 4. Package
+	// 5. Package
 	data := workflow.NewData(
 		workflow.NewTypeIdentifier(WORKFLOWID_DOCTOR, doctorWorkflowName),
 		contentType,

--- a/pkg/local_workflows/doctor_workflow/workflow.go
+++ b/pkg/local_workflows/doctor_workflow/workflow.go
@@ -36,11 +36,10 @@ func runDoctor(invocationCtx workflow.InvocationContext, stdin io.Reader, stdinI
 
 	logger.Debug().Msgf("doctor: analyzed debug log (%d findings)", len(report.Findings))
 
-	// 3. Live checks (auth now, connectivity later), unless disabled — they
-	// append to the same findings stream.
-	if config.GetBool(noLiveCheckFlag) {
-		logger.Debug().Msg("doctor: --no-live-check set, skipping live checks")
-	} else {
+	// 3. Live checks (auth now, connectivity later) are opt-in via --live: they
+	// touch the current environment, so they stay off for offline log analysis.
+	// They append to the same findings stream, so no format changes are needed.
+	if config.GetBool(liveFlag) {
 		live := livecheck.Run(invocationCtx)
 		report.Findings = append(report.Findings, live...)
 		logger.Debug().Msgf("doctor: gathered %d live-check finding(s)", len(live))

--- a/pkg/local_workflows/doctor_workflow/workflow_test.go
+++ b/pkg/local_workflows/doctor_workflow/workflow_test.go
@@ -58,6 +58,7 @@ func Test_runDoctor_summarizesInputFile(t *testing.T) {
 
 	config := configuration.NewWithOpts()
 	config.Set(inputFlag, path)
+	config.Set(noLiveCheckFlag, true)
 
 	output, err := runDoctor(setupMockContext(t, config), strings.NewReader(""), false)
 	require.NoError(t, err)
@@ -74,6 +75,7 @@ func Test_runDoctor_summarizesInputFile(t *testing.T) {
 
 func Test_runDoctor_readsPipedStdin(t *testing.T) {
 	config := configuration.NewWithOpts()
+	config.Set(noLiveCheckFlag, true)
 
 	output, err := runDoctor(setupMockContext(t, config), strings.NewReader(sampleLog), false)
 	require.NoError(t, err)
@@ -82,6 +84,36 @@ func Test_runDoctor_readsPipedStdin(t *testing.T) {
 	assert.True(t, ok)
 	rendered := string(payload)
 	assert.Contains(t, rendered, "Notable Events")
+}
+
+func Test_runDoctor_gathersAuthContext(t *testing.T) {
+	config := configuration.NewWithOpts()
+
+	ctx := setupMockContext(t, config)
+	engine := mocks.NewMockEngine(gomock.NewController(t))
+	engine.EXPECT().
+		InvokeWithConfig(gomock.Any(), gomock.Any()).
+		Return([]workflow.Data{whoAmIData("user@snyk.io")}, nil)
+	ctx.EXPECT().GetEngine().Return(engine).AnyTimes()
+
+	output, err := runDoctor(ctx, strings.NewReader(sampleLog), false)
+	require.NoError(t, err)
+	require.Len(t, output, 1)
+
+	payload, ok := output[0].GetPayload().([]byte)
+	require.True(t, ok)
+	rendered := string(payload)
+	assert.Contains(t, rendered, "Authentication")
+	assert.Contains(t, rendered, "Authenticated as user@snyk.io")
+}
+
+func whoAmIData(payload string) workflow.Data {
+	// whoami (without --json) returns the username as a plain string payload.
+	return workflow.NewData(
+		workflow.NewTypeIdentifier(workflow.NewWorkflowIdentifier("whoami"), "whoami"),
+		"text/plain",
+		payload,
+	)
 }
 
 func Test_runDoctor_noInputOnTerminalErrors(t *testing.T) {
@@ -107,6 +139,7 @@ func Test_runDoctor_missingInputFile(t *testing.T) {
 func Test_runDoctor_jsonOutput(t *testing.T) {
 	config := configuration.NewWithOpts()
 	config.Set(jsonFlag, true)
+	config.Set(noLiveCheckFlag, true)
 
 	output, err := runDoctor(setupMockContext(t, config), strings.NewReader(sampleLog), false)
 	require.NoError(t, err)

--- a/pkg/local_workflows/doctor_workflow/workflow_test.go
+++ b/pkg/local_workflows/doctor_workflow/workflow_test.go
@@ -91,7 +91,7 @@ func Test_runDoctor_gathersAuthContext(t *testing.T) {
 	ctx := setupMockContext(t, config)
 	engine := mocks.NewMockEngine(gomock.NewController(t))
 	engine.EXPECT().
-		InvokeWithConfig(gomock.Any(), gomock.Any()).
+		Invoke(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return([]workflow.Data{whoAmIData("user@snyk.io")}, nil)
 	ctx.EXPECT().GetEngine().Return(engine).AnyTimes()
 
@@ -115,13 +115,25 @@ func whoAmIData(payload string) workflow.Data {
 	)
 }
 
-func Test_runDoctor_noInputOnTerminalErrors(t *testing.T) {
+func Test_runDoctor_bareInvocationDefaultsToLive(t *testing.T) {
+	// No --input and stdin is a terminal (no pipe): nothing to analyze, so the
+	// live checks run by default instead of erroring.
 	config := configuration.NewWithOpts()
 
-	_, err := runDoctor(setupMockContext(t, config), strings.NewReader(""), true)
+	ctx := setupMockContext(t, config)
+	engine := mocks.NewMockEngine(gomock.NewController(t))
+	engine.EXPECT().
+		Invoke(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]workflow.Data{whoAmIData("user@snyk.io")}, nil)
+	ctx.EXPECT().GetEngine().Return(engine).AnyTimes()
 
-	var snykErr snyk_errors.Error
-	require.ErrorAs(t, err, &snykErr)
+	output, err := runDoctor(ctx, strings.NewReader(""), true)
+	require.NoError(t, err)
+	require.Len(t, output, 1)
+
+	payload, ok := output[0].GetPayload().([]byte)
+	require.True(t, ok)
+	assert.Contains(t, string(payload), "Authenticated as user@snyk.io")
 }
 
 func Test_runDoctor_missingInputFile(t *testing.T) {

--- a/pkg/local_workflows/doctor_workflow/workflow_test.go
+++ b/pkg/local_workflows/doctor_workflow/workflow_test.go
@@ -37,7 +37,7 @@ func Test_DoctorWorkflow_registration(t *testing.T) {
 	flagSet := workflow.FlagsetFromConfigurationOptions(entry.GetConfigurationOptions())
 	require.NotNil(t, flagSet)
 	assert.NotNil(t, flagSet.Lookup(inputFlag))
-	assert.NotNil(t, flagSet.Lookup(noLiveCheckFlag))
+	assert.NotNil(t, flagSet.Lookup(liveFlag))
 	assert.NotNil(t, flagSet.Lookup(jsonFlag))
 }
 
@@ -58,7 +58,6 @@ func Test_runDoctor_summarizesInputFile(t *testing.T) {
 
 	config := configuration.NewWithOpts()
 	config.Set(inputFlag, path)
-	config.Set(noLiveCheckFlag, true)
 
 	output, err := runDoctor(setupMockContext(t, config), strings.NewReader(""), false)
 	require.NoError(t, err)
@@ -75,7 +74,6 @@ func Test_runDoctor_summarizesInputFile(t *testing.T) {
 
 func Test_runDoctor_readsPipedStdin(t *testing.T) {
 	config := configuration.NewWithOpts()
-	config.Set(noLiveCheckFlag, true)
 
 	output, err := runDoctor(setupMockContext(t, config), strings.NewReader(sampleLog), false)
 	require.NoError(t, err)
@@ -88,6 +86,7 @@ func Test_runDoctor_readsPipedStdin(t *testing.T) {
 
 func Test_runDoctor_gathersAuthContext(t *testing.T) {
 	config := configuration.NewWithOpts()
+	config.Set(liveFlag, true)
 
 	ctx := setupMockContext(t, config)
 	engine := mocks.NewMockEngine(gomock.NewController(t))
@@ -139,7 +138,6 @@ func Test_runDoctor_missingInputFile(t *testing.T) {
 func Test_runDoctor_jsonOutput(t *testing.T) {
 	config := configuration.NewWithOpts()
 	config.Set(jsonFlag, true)
-	config.Set(noLiveCheckFlag, true)
 
 	output, err := runDoctor(setupMockContext(t, config), strings.NewReader(sampleLog), false)
 	require.NoError(t, err)


### PR DESCRIPTION
Adds a live authentication check to snyk doctor, ported to the current diagnosis architecture (targets feat/snyk-doctor). A new livecheck package invokes the whoami workflow and maps the result into the shared diagnosis.Finding contract (source: "auth"): success yields an info finding with the identity, failure an error finding with the underlying message. Findings are appended to the report's findings stream, so the existing generic formatter renders them under an "Authentication" section and they appear in --json with no downstream changes. Gated by the existing --no-live-check flag.

This is the same behavior as the original feat/CLI-1574_auth_context (d3619aa), re-expressed against the generic findings contract instead of the old scaffold's string-concatenated report.