### PR TITLE
fix(networking): add full jitter to X-RateLimit-Reset retry delay [IDE-2094]

### DIFF
--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -402,6 +402,12 @@ func rateLimitRetryDelay(res *http.Response) time.Duration {
 	return max(retryAfter, rateLimitReset)
 }
 
+// maxJitterWindow is the extra random delay added on top of the reset window.
+// All clients wait at least the reset duration (guaranteeing the bucket has
+// refilled), then each adds a random extra in [0, maxJitterWindow) to
+// desynchronize their retries.
+const maxJitterWindow = 2 * time.Second
+
 // rateLimitRetryDelayJittered returns the actual duration to sleep before retrying
 // a rate-limited request.
 //
@@ -409,11 +415,11 @@ func rateLimitRetryDelay(res *http.Response) time.Duration {
 // at least the specified duration, so no jitter is applied.
 //
 // X-RateLimit-Reset (Envoy/Gloo token-bucket) carries the seconds until the
-// current window resets. All clients that hit the same rate-limit window receive
-// the same reset value, which causes a synchronized retry storm if honored
-// literally. Full jitter — sleeping a random duration in [0, reset) — spreads
-// retries evenly across the reset window and eliminates the thundering herd.
-// If Retry-After is also present it takes precedence (exact, no jitter).
+// current window resets. All clients that received the same 429 share the same
+// reset value, so retrying at exactly reset causes a synchronized spike.
+// The fix: every client waits the full reset (bucket guaranteed refilled) then
+// adds a random extra delay in [0, maxJitterWindow). This desynchronizes retries
+// without risking a retry before the bucket has actually recovered.
 func rateLimitRetryDelayJittered(res *http.Response) time.Duration {
 	if v := res.Header.Get("Retry-After"); len(v) > 0 {
 		if d := parseRetryDelay(v); d > 0 {
@@ -422,9 +428,9 @@ func rateLimitRetryDelayJittered(res *http.Response) time.Duration {
 	}
 	if v := res.Header.Get("X-RateLimit-Reset"); len(v) > 0 {
 		if d := parseRetryDelay(v); d > 0 {
-			// Full jitter: random in [0, d). Desynchronises clients that all
-			// received the same token-bucket reset deadline.
-			return time.Duration(rand.N(int64(d)))
+			// Wait the full reset window (bucket refills), then add jitter so
+			// concurrent clients don't all retry at the same instant.
+			return d + time.Duration(rand.N(int64(maxJitterWindow)))
 		}
 	}
 	return 0

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -410,7 +410,7 @@ func rateLimitRetryDelay(res *http.Response) time.Duration {
 //
 // X-RateLimit-Reset (Envoy/Gloo token-bucket) carries the seconds until the
 // current window resets. All clients that hit the same rate-limit window receive
-// the same reset value, which causes a synchronized retry storm if honoured
+// the same reset value, which causes a synchronized retry storm if honored
 // literally. Full jitter — sleeping a random duration in [0, reset) — spreads
 // retries evenly across the reset window and eliminates the thundering herd.
 // If Retry-After is also present it takes precedence (exact, no jitter).

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/rand/v2"
 	"net/http"
 	"strconv"
 	"time"
@@ -329,7 +330,7 @@ func shouldRetry(response *http.Response, attempts int, maxAttempts int) error {
 			return backoff.Permanent(errRetryNecessary)
 		}
 
-		timeToWait := rateLimitRetryDelay(response)
+		timeToWait := rateLimitRetryDelayJittered(response)
 		if timeToWait > maxRetryAfter {
 			return backoff.Permanent(errRetryDelayMaxExceeded)
 		}
@@ -381,7 +382,9 @@ func parseRetryDelay(headerRetryAfterValue string) time.Duration {
 }
 
 // rateLimitRetryDelay extracts the longer of Retry-After and X-RateLimit-Reset
-// durations from the response headers.
+// durations from the response headers. The returned value is the raw header
+// value — suitable for error reporting ("retry after N seconds") but not for
+// the actual sleep, which should use rateLimitRetryDelayJittered.
 func rateLimitRetryDelay(res *http.Response) time.Duration {
 	var retryAfter, rateLimitReset time.Duration
 
@@ -393,4 +396,32 @@ func rateLimitRetryDelay(res *http.Response) time.Duration {
 	}
 
 	return max(retryAfter, rateLimitReset)
+}
+
+// rateLimitRetryDelayJittered returns the actual duration to sleep before retrying
+// a rate-limited request.
+//
+// Retry-After is respected exactly — RFC 7231 semantics require clients to wait
+// at least the specified duration, so no jitter is applied.
+//
+// X-RateLimit-Reset (Envoy/Gloo token-bucket) carries the seconds until the
+// current window resets. All clients that hit the same rate-limit window receive
+// the same reset value, which causes a synchronized retry storm if honoured
+// literally. Full jitter — sleeping a random duration in [0, reset) — spreads
+// retries evenly across the reset window and eliminates the thundering herd.
+// If Retry-After is also present it takes precedence (exact, no jitter).
+func rateLimitRetryDelayJittered(res *http.Response) time.Duration {
+	if v := res.Header.Get("Retry-After"); len(v) > 0 {
+		if d := parseRetryDelay(v); d > 0 {
+			return d
+		}
+	}
+	if v := res.Header.Get("X-RateLimit-Reset"); len(v) > 0 {
+		if d := parseRetryDelay(v); d > 0 {
+			// Full jitter: random in [0, d). Desynchronises clients that all
+			// received the same token-bucket reset deadline.
+			return time.Duration(rand.N(int64(d)))
+		}
+	}
+	return 0
 }

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -330,10 +330,14 @@ func shouldRetry(response *http.Response, attempts int, maxAttempts int) error {
 			return backoff.Permanent(errRetryNecessary)
 		}
 
-		timeToWait := rateLimitRetryDelayJittered(response)
-		if timeToWait > maxRetryAfter {
+		// Cap check must use the raw header value, not the jittered one.
+		// Jitter applied before the cap could allow a huge reset (e.g. 4 years)
+		// to slip through when rand lands below maxRetryAfter.
+		if rawDelay := rateLimitRetryDelay(response); rawDelay > maxRetryAfter {
 			return backoff.Permanent(errRetryDelayMaxExceeded)
 		}
+
+		timeToWait := rateLimitRetryDelayJittered(response)
 
 		// if a retry after is defined, this is the time to wait for
 		if timeToWait > 0 {

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -10,6 +10,7 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
@@ -341,9 +342,11 @@ func shouldRetry(response *http.Response, attempts int, maxAttempts int) error {
 			timeToWait = retryAfter
 		} else if rawDelay > 0 {
 			// X-RateLimit-Reset: wait the full reset window (bucket guaranteed
-			// refilled) then add random extra in [0, maxJitterWindow) to
-			// desynchronize concurrent clients.
-			timeToWait = rawDelay + time.Duration(rand.N(int64(maxJitterWindow)))
+			// refilled) then add random extra in [0, jitter window) to
+			// desynchronize concurrent clients. The jitter window scales with
+			// the bucket's actual capacity (see rateLimitJitterWindow) instead
+			// of a flat constant, so low-capacity buckets get more spread.
+			timeToWait = rawDelay + time.Duration(rand.N(int64(rateLimitJitterWindow(response, rawDelay))))
 		}
 
 		// if a retry after is defined, this is the time to wait for
@@ -395,7 +398,7 @@ func parseRetryDelay(headerRetryAfterValue string) time.Duration {
 // rateLimitRetryDelay extracts the longer of Retry-After and X-RateLimit-Reset
 // durations from the response headers. The returned value is the raw header
 // value — suitable for error reporting ("retry after N seconds") but not for
-// the actual sleep, which should use rateLimitRetryDelayJittered.
+// the actual sleep, which applies jitter separately (see rateLimitJitterWindow).
 func rateLimitRetryDelay(res *http.Response) time.Duration {
 	var retryAfter, rateLimitReset time.Duration
 
@@ -414,3 +417,72 @@ func rateLimitRetryDelay(res *http.Response) time.Duration {
 // refilled), then each adds a random extra in [0, maxJitterWindow) to
 // desynchronize their retries.
 const maxJitterWindow = 2 * time.Second
+
+// referenceRate is a portable, round req/s threshold, not an assumed client
+// count: routes at/above it keep today's flat maxJitterWindow; below it,
+// jitter widens proportionally. This is a heuristic that reduces re-throttle
+// odds for tight-capacity routes — it cannot guarantee zero collisions,
+// since GAF has no visibility into how many other clients are retrying the
+// same route concurrently.
+const referenceRate = 100.0 // req/s
+const jitterCeiling = 60 * time.Second
+
+type rateLimitPolicy struct {
+	limit         int
+	windowSeconds int
+}
+
+// parseRateLimitPolicies parses the IETF RateLimit-Limit draft format, e.g.
+// `160, 160;w=1;name="...", 1620;w=60;name="...", 97200;w=3600;name="..."`.
+// The bare leading value (no `w=`) has no window attached and is skipped —
+// its unit can't be determined without one.
+func parseRateLimitPolicies(header string) []rateLimitPolicy {
+	var policies []rateLimitPolicy
+	for _, entry := range strings.Split(header, ",") {
+		parts := strings.Split(entry, ";")
+		limit, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+		if err != nil || limit <= 0 {
+			continue
+		}
+		for _, p := range parts[1:] {
+			p = strings.TrimSpace(p)
+			if w, ok := strings.CutPrefix(p, "w="); ok {
+				if window, err := strconv.Atoi(w); err == nil && window > 0 {
+					policies = append(policies, rateLimitPolicy{limit, window})
+				}
+			}
+		}
+	}
+	return policies
+}
+
+// rateLimitJitterWindow sizes the extra random delay added on top of an
+// X-RateLimit-Reset wait. It matches X-RateLimit-Limit's policy list against
+// rawDelay (the reset countdown already being waited on) to find the actual
+// bucket capacity, then scales the jitter window inversely with that
+// capacity: low-capacity buckets get more spread, high-capacity buckets keep
+// today's flat maxJitterWindow. Falls back to maxJitterWindow whenever the
+// header is missing, unparseable, or no policy's window covers rawDelay.
+func rateLimitJitterWindow(res *http.Response, rawDelay time.Duration) time.Duration {
+	var matched *rateLimitPolicy
+	for _, p := range parseRateLimitPolicies(res.Header.Get("X-RateLimit-Limit")) {
+		windowDur := time.Duration(p.windowSeconds) * time.Second
+		if windowDur >= rawDelay && (matched == nil || p.windowSeconds < matched.windowSeconds) {
+			policy := p
+			matched = &policy
+		}
+	}
+	if matched == nil {
+		return maxJitterWindow
+	}
+
+	rate := float64(matched.limit) / float64(matched.windowSeconds)
+	window := time.Duration(float64(maxJitterWindow) * (referenceRate / rate))
+	if window < maxJitterWindow {
+		window = maxJitterWindow
+	}
+	if window > jitterCeiling {
+		window = jitterCeiling
+	}
+	return window
+}

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -336,16 +336,16 @@ func shouldRetry(response *http.Response, attempts int, maxAttempts int) error {
 			return backoff.Permanent(errRetryDelayMaxExceeded)
 		}
 
+		// Wait the full suggested delay (Retry-After or X-RateLimit-Reset,
+		// whichever is longer), then add random extra in [0, jitter window) to
+		// desynchronize concurrent clients. Both headers get the same
+		// treatment — there's no reason to trust one as more "exact" than the
+		// other, and a single unconditional branch keeps this simple. The
+		// jitter window scales with the bucket's actual capacity (see
+		// rateLimitJitterWindow) instead of a flat constant, so low-capacity
+		// buckets get more spread.
 		var timeToWait time.Duration
-		if retryAfter := parseRetryDelay(response.Header.Get("Retry-After")); retryAfter > 0 {
-			// Retry-After is an explicit server directive: honor exactly, no jitter.
-			timeToWait = retryAfter
-		} else if rawDelay > 0 {
-			// X-RateLimit-Reset: wait the full reset window (bucket guaranteed
-			// refilled) then add random extra in [0, jitter window) to
-			// desynchronize concurrent clients. The jitter window scales with
-			// the bucket's actual capacity (see rateLimitJitterWindow) instead
-			// of a flat constant, so low-capacity buckets get more spread.
+		if rawDelay > 0 {
 			timeToWait = rawDelay + time.Duration(rand.N(int64(rateLimitJitterWindow(response, rawDelay))))
 		}
 
@@ -412,10 +412,10 @@ func rateLimitRetryDelay(res *http.Response) time.Duration {
 	return max(retryAfter, rateLimitReset)
 }
 
-// maxJitterWindow is the extra random delay added on top of X-RateLimit-Reset.
-// All clients wait at least the reset duration (guaranteeing the bucket has
-// refilled), then each adds a random extra in [0, maxJitterWindow) to
-// desynchronize their retries.
+// maxJitterWindow is the extra random delay added on top of the raw retry
+// delay (Retry-After or X-RateLimit-Reset). All clients wait at least that
+// long (guaranteeing the bucket has refilled), then each adds a random extra
+// in [0, maxJitterWindow) to desynchronize their retries.
 const maxJitterWindow = 2 * time.Second
 
 // referenceRate is a portable, round req/s threshold, not an assumed client
@@ -456,9 +456,9 @@ func parseRateLimitPolicies(header string) []rateLimitPolicy {
 	return policies
 }
 
-// rateLimitJitterWindow sizes the extra random delay added on top of an
-// X-RateLimit-Reset wait. It matches X-RateLimit-Limit's policy list against
-// rawDelay (the reset countdown already being waited on) to find the actual
+// rateLimitJitterWindow sizes the extra random delay added on top of a raw
+// retry delay wait. It matches X-RateLimit-Limit's policy list against
+// rawDelay (the countdown already being waited on) to find the actual
 // bucket capacity, then scales the jitter window inversely with that
 // capacity: low-capacity buckets get more spread, high-capacity buckets keep
 // today's flat maxJitterWindow. Falls back to maxJitterWindow whenever the

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -330,14 +330,21 @@ func shouldRetry(response *http.Response, attempts int, maxAttempts int) error {
 			return backoff.Permanent(errRetryNecessary)
 		}
 
-		// Cap check must use the raw header value, not the jittered one.
-		// Jitter applied before the cap could allow a huge reset (e.g. 4 years)
-		// to slip through when rand lands below maxRetryAfter.
-		if rawDelay := rateLimitRetryDelay(response); rawDelay > maxRetryAfter {
+		rawDelay := rateLimitRetryDelay(response)
+		if rawDelay > maxRetryAfter {
 			return backoff.Permanent(errRetryDelayMaxExceeded)
 		}
 
-		timeToWait := rateLimitRetryDelayJittered(response)
+		var timeToWait time.Duration
+		if retryAfter := parseRetryDelay(response.Header.Get("Retry-After")); retryAfter > 0 {
+			// Retry-After is an explicit server directive: honor exactly, no jitter.
+			timeToWait = retryAfter
+		} else if rawDelay > 0 {
+			// X-RateLimit-Reset: wait the full reset window (bucket guaranteed
+			// refilled) then add random extra in [0, maxJitterWindow) to
+			// desynchronize concurrent clients.
+			timeToWait = rawDelay + time.Duration(rand.N(int64(maxJitterWindow)))
+		}
 
 		// if a retry after is defined, this is the time to wait for
 		if timeToWait > 0 {
@@ -402,36 +409,8 @@ func rateLimitRetryDelay(res *http.Response) time.Duration {
 	return max(retryAfter, rateLimitReset)
 }
 
-// maxJitterWindow is the extra random delay added on top of the reset window.
+// maxJitterWindow is the extra random delay added on top of X-RateLimit-Reset.
 // All clients wait at least the reset duration (guaranteeing the bucket has
 // refilled), then each adds a random extra in [0, maxJitterWindow) to
 // desynchronize their retries.
 const maxJitterWindow = 2 * time.Second
-
-// rateLimitRetryDelayJittered returns the actual duration to sleep before retrying
-// a rate-limited request.
-//
-// Retry-After is respected exactly — RFC 7231 semantics require clients to wait
-// at least the specified duration, so no jitter is applied.
-//
-// X-RateLimit-Reset (Envoy/Gloo token-bucket) carries the seconds until the
-// current window resets. All clients that received the same 429 share the same
-// reset value, so retrying at exactly reset causes a synchronized spike.
-// The fix: every client waits the full reset (bucket guaranteed refilled) then
-// adds a random extra delay in [0, maxJitterWindow). This desynchronizes retries
-// without risking a retry before the bucket has actually recovered.
-func rateLimitRetryDelayJittered(res *http.Response) time.Duration {
-	if v := res.Header.Get("Retry-After"); len(v) > 0 {
-		if d := parseRetryDelay(v); d > 0 {
-			return d
-		}
-	}
-	if v := res.Header.Get("X-RateLimit-Reset"); len(v) > 0 {
-		if d := parseRetryDelay(v); d > 0 {
-			// Wait the full reset window (bucket refills), then add jitter so
-			// concurrent clients don't all retry at the same instant.
-			return d + time.Duration(rand.N(int64(maxJitterWindow)))
-		}
-	}
-	return 0
-}

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -10,7 +10,6 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
@@ -337,16 +336,13 @@ func shouldRetry(response *http.Response, attempts int, maxAttempts int) error {
 		}
 
 		// Wait the full suggested delay (Retry-After or X-RateLimit-Reset,
-		// whichever is longer), then add random extra in [0, jitter window) to
-		// desynchronize concurrent clients. Both headers get the same
+		// whichever is longer), then add random extra in [0, maxJitterWindow)
+		// to desynchronize concurrent clients. Both headers get the same
 		// treatment — there's no reason to trust one as more "exact" than the
-		// other, and a single unconditional branch keeps this simple. The
-		// jitter window scales with the bucket's actual capacity (see
-		// rateLimitJitterWindow) instead of a flat constant, so low-capacity
-		// buckets get more spread.
+		// other, and a single unconditional branch keeps this simple.
 		var timeToWait time.Duration
 		if rawDelay > 0 {
-			timeToWait = rawDelay + time.Duration(rand.N(int64(rateLimitJitterWindow(response, rawDelay))))
+			timeToWait = rawDelay + time.Duration(rand.N(int64(maxJitterWindow)))
 		}
 
 		// if a retry after is defined, this is the time to wait for
@@ -398,7 +394,7 @@ func parseRetryDelay(headerRetryAfterValue string) time.Duration {
 // rateLimitRetryDelay extracts the longer of Retry-After and X-RateLimit-Reset
 // durations from the response headers. The returned value is the raw header
 // value — suitable for error reporting ("retry after N seconds") but not for
-// the actual sleep, which applies jitter separately (see rateLimitJitterWindow).
+// the actual sleep, which adds jitter separately (see maxJitterWindow).
 func rateLimitRetryDelay(res *http.Response) time.Duration {
 	var retryAfter, rateLimitReset time.Duration
 
@@ -417,72 +413,3 @@ func rateLimitRetryDelay(res *http.Response) time.Duration {
 // long (guaranteeing the bucket has refilled), then each adds a random extra
 // in [0, maxJitterWindow) to desynchronize their retries.
 const maxJitterWindow = 2 * time.Second
-
-// referenceRate is a portable, round req/s threshold, not an assumed client
-// count: routes at/above it keep today's flat maxJitterWindow; below it,
-// jitter widens proportionally. This is a heuristic that reduces re-throttle
-// odds for tight-capacity routes — it cannot guarantee zero collisions,
-// since GAF has no visibility into how many other clients are retrying the
-// same route concurrently.
-const referenceRate = 100.0 // req/s
-const jitterCeiling = 60 * time.Second
-
-type rateLimitPolicy struct {
-	limit         int
-	windowSeconds int
-}
-
-// parseRateLimitPolicies parses the IETF RateLimit-Limit draft format, e.g.
-// `160, 160;w=1;name="...", 1620;w=60;name="...", 97200;w=3600;name="..."`.
-// The bare leading value (no `w=`) has no window attached and is skipped —
-// its unit can't be determined without one.
-func parseRateLimitPolicies(header string) []rateLimitPolicy {
-	var policies []rateLimitPolicy
-	for _, entry := range strings.Split(header, ",") {
-		parts := strings.Split(entry, ";")
-		limit, err := strconv.Atoi(strings.TrimSpace(parts[0]))
-		if err != nil || limit <= 0 {
-			continue
-		}
-		for _, p := range parts[1:] {
-			p = strings.TrimSpace(p)
-			if w, ok := strings.CutPrefix(p, "w="); ok {
-				if window, err := strconv.Atoi(w); err == nil && window > 0 {
-					policies = append(policies, rateLimitPolicy{limit, window})
-				}
-			}
-		}
-	}
-	return policies
-}
-
-// rateLimitJitterWindow sizes the extra random delay added on top of a raw
-// retry delay wait. It matches X-RateLimit-Limit's policy list against
-// rawDelay (the countdown already being waited on) to find the actual
-// bucket capacity, then scales the jitter window inversely with that
-// capacity: low-capacity buckets get more spread, high-capacity buckets keep
-// today's flat maxJitterWindow. Falls back to maxJitterWindow whenever the
-// header is missing, unparseable, or no policy's window covers rawDelay.
-func rateLimitJitterWindow(res *http.Response, rawDelay time.Duration) time.Duration {
-	var matched *rateLimitPolicy
-	for _, p := range parseRateLimitPolicies(res.Header.Get("X-RateLimit-Limit")) {
-		windowDur := time.Duration(p.windowSeconds) * time.Second
-		if windowDur >= rawDelay && (matched == nil || p.windowSeconds < matched.windowSeconds) {
-			policy := p
-			matched = &policy
-		}
-	}
-	if matched == nil {
-		return maxJitterWindow
-	}
-
-	rate := float64(matched.limit) / float64(matched.windowSeconds)
-	window := time.Duration(float64(maxJitterWindow) * (referenceRate / rate))
-	if window < maxJitterWindow {
-		window = maxJitterWindow
-	}
-	if window > jitterCeiling {
-		window = jitterCeiling
-	}
-	return window
-}

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -609,6 +609,138 @@ func Test_shouldRetry_rateLimitResetJitter(t *testing.T) {
 		require.Equal(t, 3*time.Second, actualRetryableErr.Duration,
 			"Retry-After must be honored exactly with no jitter")
 	})
+
+	t.Run("X-RateLimit-Reset with low-capacity X-RateLimit-Limit widens jitter window", func(t *testing.T) {
+		t.Parallel()
+		h := http.Header{}
+		h.Set("X-RateLimit-Reset", "10")
+		h.Set("X-RateLimit-Limit", "5;w=60") // window (60s) must cover rawDelay (10s) to actually engage widening
+		resp := newResponse(http.StatusTooManyRequests, h)
+
+		// Compute expected window from the unit under test itself, and guard
+		// that this test setup actually exercises the widened path rather
+		// than silently falling back to the flat maxJitterWindow.
+		wantWindow := rateLimitJitterWindow(resp, 10*time.Second)
+		require.Greater(t, wantWindow, maxJitterWindow, "test setup must engage widening, not the flat fallback")
+
+		var actualRetryableErr *backoff.RetryAfterError
+		err := shouldRetry(resp, 0, 1)
+		require.ErrorAs(t, err, &actualRetryableErr)
+		require.GreaterOrEqual(t, actualRetryableErr.Duration, 10*time.Second)
+		require.Less(t, actualRetryableErr.Duration, 10*time.Second+wantWindow)
+	})
+}
+
+func Test_parseRateLimitPolicies(t *testing.T) {
+	tests := []struct {
+		name     string
+		header   string
+		expected []rateLimitPolicy
+	}{
+		{
+			name:   "full real sample header",
+			header: `160, 160;w=1;name="crd|generic_key^api-gateway.api-rest|generic_key^per_second|principal_id|ratelimit_bucket^high", 1620;w=60;name="x", 97200;w=3600;name="y"`,
+			expected: []rateLimitPolicy{
+				{limit: 160, windowSeconds: 1},
+				{limit: 1620, windowSeconds: 60},
+				{limit: 97200, windowSeconds: 3600},
+			},
+		},
+		{
+			name:     "bare-only header",
+			header:   "160",
+			expected: nil,
+		},
+		{
+			name:     "empty string",
+			header:   "",
+			expected: nil,
+		},
+		{
+			name:     "malformed entry skipped",
+			header:   "abc;w=1",
+			expected: nil,
+		},
+		{
+			name:     "window zero skipped",
+			header:   "160;w=0",
+			expected: nil,
+		},
+		{
+			name:     "window negative skipped",
+			header:   "160;w=-5",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := parseRateLimitPolicies(tt.header)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func Test_rateLimitJitterWindow(t *testing.T) {
+	newLimitHeader := func(value string) http.Header {
+		h := http.Header{}
+		if value != "" {
+			h.Set("X-RateLimit-Limit", value)
+		}
+		return h
+	}
+
+	tests := []struct {
+		name     string
+		headers  http.Header
+		rawDelay time.Duration
+		expected time.Duration
+	}{
+		{
+			name:     "high-capacity match keeps flat maxJitterWindow",
+			headers:  newLimitHeader("160;w=1"),
+			rawDelay: 1 * time.Second,
+			expected: maxJitterWindow,
+		},
+		{
+			name:     "low-capacity match widens window",
+			headers:  newLimitHeader("5;w=1"),
+			rawDelay: 1 * time.Second,
+			expected: 40 * time.Second,
+		},
+		{
+			name:     "minute-only bucket, no per-second entry",
+			headers:  newLimitHeader("600;w=60"),
+			rawDelay: 45 * time.Second,
+			expected: 20 * time.Second,
+		},
+		{
+			name:     "hour-only bucket clamped to ceiling",
+			headers:  newLimitHeader("20;w=3600"),
+			rawDelay: 1800 * time.Second,
+			expected: jitterCeiling,
+		},
+		{
+			name:     "no header falls back to maxJitterWindow",
+			headers:  http.Header{},
+			rawDelay: 10 * time.Second,
+			expected: maxJitterWindow,
+		},
+		{
+			name:     "no window covers rawDelay falls back to maxJitterWindow",
+			headers:  newLimitHeader("160;w=1"),
+			rawDelay: 100 * time.Second,
+			expected: maxJitterWindow,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := newResponse(http.StatusTooManyRequests, tt.headers)
+			actual := rateLimitJitterWindow(resp, tt.rawDelay)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
 }
 
 func Test_parseRetryDelay(t *testing.T) {

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -433,13 +433,8 @@ func Test_shouldRetry(t *testing.T) {
 			attempts:        0,
 			maxAttempts:     1,
 		},
-		{
-			name:              "Retryable status code (429) with Retry-After header",
-			response:          newResponse(http.StatusTooManyRequests, http.Header{"Retry-After": []string{"5"}}),
-			expectedRetryable: &backoff.RetryAfterError{Duration: 5 * time.Second},
-			attempts:          0,
-			maxAttempts:       1,
-		},
+		// Retry-After alone is tested in Test_shouldRetry_rateLimitResetJitter
+		// because jitter makes the duration non-deterministic.
 		{
 			name:            "Retryable status code (429) with invalid Retry-After header",
 			response:        newResponse(http.StatusServiceUnavailable, http.Header{"Retry-After": []string{"abc"}}),
@@ -596,7 +591,20 @@ func Test_shouldRetry_rateLimitResetJitter(t *testing.T) {
 			"jittered delay must be < reset + maxJitterWindow")
 	})
 
-	t.Run("Retry-After exact, takes precedence over X-RateLimit-Reset", func(t *testing.T) {
+	t.Run("Retry-After alone produces delay in [retryAfter, retryAfter+maxJitterWindow)", func(t *testing.T) {
+		t.Parallel()
+		h := http.Header{}
+		h.Set("Retry-After", "5")
+		resp := newResponse(http.StatusTooManyRequests, h)
+
+		var actualRetryableErr *backoff.RetryAfterError
+		err := shouldRetry(resp, 0, 1)
+		require.ErrorAs(t, err, &actualRetryableErr)
+		require.GreaterOrEqual(t, actualRetryableErr.Duration, 5*time.Second)
+		require.Less(t, actualRetryableErr.Duration, 5*time.Second+maxJitterWindow)
+	})
+
+	t.Run("Retry-After and X-RateLimit-Reset both present: longer of the two wins, jittered", func(t *testing.T) {
 		t.Parallel()
 		h := http.Header{}
 		h.Set("Retry-After", "3")
@@ -606,8 +614,9 @@ func Test_shouldRetry_rateLimitResetJitter(t *testing.T) {
 		var actualRetryableErr *backoff.RetryAfterError
 		err := shouldRetry(resp, 0, 1)
 		require.ErrorAs(t, err, &actualRetryableErr)
-		require.Equal(t, 3*time.Second, actualRetryableErr.Duration,
-			"Retry-After must be honored exactly with no jitter")
+		require.GreaterOrEqual(t, actualRetryableErr.Duration, 10*time.Second,
+			"rawDelay is max(Retry-After, X-RateLimit-Reset), so the 10s reset wins over the 3s Retry-After")
+		require.Less(t, actualRetryableErr.Duration, 10*time.Second+maxJitterWindow)
 	})
 
 	t.Run("X-RateLimit-Reset with low-capacity X-RateLimit-Limit widens jitter window", func(t *testing.T) {

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -619,137 +619,19 @@ func Test_shouldRetry_rateLimitResetJitter(t *testing.T) {
 		require.Less(t, actualRetryableErr.Duration, 10*time.Second+maxJitterWindow)
 	})
 
-	t.Run("X-RateLimit-Reset with low-capacity X-RateLimit-Limit widens jitter window", func(t *testing.T) {
+	t.Run("X-RateLimit-Limit header present but ignored: jitter stays flat maxJitterWindow", func(t *testing.T) {
 		t.Parallel()
 		h := http.Header{}
 		h.Set("X-RateLimit-Reset", "10")
-		h.Set("X-RateLimit-Limit", "5;w=60") // window (60s) must cover rawDelay (10s) to actually engage widening
+		h.Set("X-RateLimit-Limit", "5;w=60")
 		resp := newResponse(http.StatusTooManyRequests, h)
-
-		// Compute expected window from the unit under test itself, and guard
-		// that this test setup actually exercises the widened path rather
-		// than silently falling back to the flat maxJitterWindow.
-		wantWindow := rateLimitJitterWindow(resp, 10*time.Second)
-		require.Greater(t, wantWindow, maxJitterWindow, "test setup must engage widening, not the flat fallback")
 
 		var actualRetryableErr *backoff.RetryAfterError
 		err := shouldRetry(resp, 0, 1)
 		require.ErrorAs(t, err, &actualRetryableErr)
 		require.GreaterOrEqual(t, actualRetryableErr.Duration, 10*time.Second)
-		require.Less(t, actualRetryableErr.Duration, 10*time.Second+wantWindow)
+		require.Less(t, actualRetryableErr.Duration, 10*time.Second+maxJitterWindow)
 	})
-}
-
-func Test_parseRateLimitPolicies(t *testing.T) {
-	tests := []struct {
-		name     string
-		header   string
-		expected []rateLimitPolicy
-	}{
-		{
-			name:   "full real sample header",
-			header: `160, 160;w=1;name="crd|generic_key^api-gateway.api-rest|generic_key^per_second|principal_id|ratelimit_bucket^high", 1620;w=60;name="x", 97200;w=3600;name="y"`,
-			expected: []rateLimitPolicy{
-				{limit: 160, windowSeconds: 1},
-				{limit: 1620, windowSeconds: 60},
-				{limit: 97200, windowSeconds: 3600},
-			},
-		},
-		{
-			name:     "bare-only header",
-			header:   "160",
-			expected: nil,
-		},
-		{
-			name:     "empty string",
-			header:   "",
-			expected: nil,
-		},
-		{
-			name:     "malformed entry skipped",
-			header:   "abc;w=1",
-			expected: nil,
-		},
-		{
-			name:     "window zero skipped",
-			header:   "160;w=0",
-			expected: nil,
-		},
-		{
-			name:     "window negative skipped",
-			header:   "160;w=-5",
-			expected: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			actual := parseRateLimitPolicies(tt.header)
-			assert.Equal(t, tt.expected, actual)
-		})
-	}
-}
-
-func Test_rateLimitJitterWindow(t *testing.T) {
-	newLimitHeader := func(value string) http.Header {
-		h := http.Header{}
-		if value != "" {
-			h.Set("X-RateLimit-Limit", value)
-		}
-		return h
-	}
-
-	tests := []struct {
-		name     string
-		headers  http.Header
-		rawDelay time.Duration
-		expected time.Duration
-	}{
-		{
-			name:     "high-capacity match keeps flat maxJitterWindow",
-			headers:  newLimitHeader("160;w=1"),
-			rawDelay: 1 * time.Second,
-			expected: maxJitterWindow,
-		},
-		{
-			name:     "low-capacity match widens window",
-			headers:  newLimitHeader("5;w=1"),
-			rawDelay: 1 * time.Second,
-			expected: 40 * time.Second,
-		},
-		{
-			name:     "minute-only bucket, no per-second entry",
-			headers:  newLimitHeader("600;w=60"),
-			rawDelay: 45 * time.Second,
-			expected: 20 * time.Second,
-		},
-		{
-			name:     "hour-only bucket clamped to ceiling",
-			headers:  newLimitHeader("20;w=3600"),
-			rawDelay: 1800 * time.Second,
-			expected: jitterCeiling,
-		},
-		{
-			name:     "no header falls back to maxJitterWindow",
-			headers:  http.Header{},
-			rawDelay: 10 * time.Second,
-			expected: maxJitterWindow,
-		},
-		{
-			name:     "no window covers rawDelay falls back to maxJitterWindow",
-			headers:  newLimitHeader("160;w=1"),
-			rawDelay: 100 * time.Second,
-			expected: maxJitterWindow,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resp := newResponse(http.StatusTooManyRequests, tt.headers)
-			actual := rateLimitJitterWindow(resp, tt.rawDelay)
-			assert.Equal(t, tt.expected, actual)
-		})
-	}
 }
 
 func Test_parseRetryDelay(t *testing.T) {

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -544,29 +544,8 @@ func Test_shouldRetry_rateLimitResetHeaders(t *testing.T) {
 		attempts          int
 		maxAttempts       int
 	}{
-		{
-			name: "Retryable status code (429) with only X-Ratelimit-Reset header",
-			response: func() *http.Response {
-				h := http.Header{}
-				h.Set("X-Ratelimit-Reset", "5")
-				return newResponse(http.StatusTooManyRequests, h)
-			}(),
-			expectedRetryable: &backoff.RetryAfterError{Duration: 5 * time.Second},
-			attempts:          0,
-			maxAttempts:       1,
-		},
-		{
-			name: "Retryable status code (429) Retry-After takes precedence over X-RateLimit-Reset",
-			response: func() *http.Response {
-				h := http.Header{}
-				h.Set("Retry-After", "3")
-				h.Set("X-RateLimit-Reset", "10")
-				return newResponse(http.StatusTooManyRequests, h)
-			}(),
-			expectedRetryable: &backoff.RetryAfterError{Duration: 10 * time.Second},
-			attempts:          0,
-			maxAttempts:       1,
-		},
+		// X-RateLimit-Reset and Retry-After cases are tested separately below
+		// because jitter on X-RateLimit-Reset makes the duration non-deterministic.
 		{
 			name: "Retryable status code (429) with X-RateLimit-Reset header too far in the future (4years)",
 			response: func() *http.Response {
@@ -597,6 +576,39 @@ func Test_shouldRetry_rateLimitResetHeaders(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_shouldRetry_rateLimitResetJitter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("X-RateLimit-Reset produces jittered delay in [0, reset)", func(t *testing.T) {
+		t.Parallel()
+		h := http.Header{}
+		h.Set("X-Ratelimit-Reset", "10")
+		resp := newResponse(http.StatusTooManyRequests, h)
+
+		var actualRetryableErr *backoff.RetryAfterError
+		err := shouldRetry(resp, 0, 1)
+		require.ErrorAs(t, err, &actualRetryableErr)
+		require.GreaterOrEqual(t, actualRetryableErr.Duration, time.Duration(0),
+			"jittered delay must be >= 0")
+		require.Less(t, actualRetryableErr.Duration, 10*time.Second,
+			"jittered delay must be < X-RateLimit-Reset window")
+	})
+
+	t.Run("Retry-After exact, takes precedence over X-RateLimit-Reset", func(t *testing.T) {
+		t.Parallel()
+		h := http.Header{}
+		h.Set("Retry-After", "3")
+		h.Set("X-RateLimit-Reset", "10")
+		resp := newResponse(http.StatusTooManyRequests, h)
+
+		var actualRetryableErr *backoff.RetryAfterError
+		err := shouldRetry(resp, 0, 1)
+		require.ErrorAs(t, err, &actualRetryableErr)
+		require.Equal(t, 3*time.Second, actualRetryableErr.Duration,
+			"Retry-After must be honoured exactly with no jitter")
+	})
 }
 
 func Test_parseRetryDelay(t *testing.T) {

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -581,7 +581,7 @@ func Test_shouldRetry_rateLimitResetHeaders(t *testing.T) {
 func Test_shouldRetry_rateLimitResetJitter(t *testing.T) {
 	t.Parallel()
 
-	t.Run("X-RateLimit-Reset produces jittered delay in [0, reset)", func(t *testing.T) {
+	t.Run("X-RateLimit-Reset produces delay in [reset, reset+maxJitterWindow)", func(t *testing.T) {
 		t.Parallel()
 		h := http.Header{}
 		h.Set("X-Ratelimit-Reset", "10")
@@ -590,10 +590,10 @@ func Test_shouldRetry_rateLimitResetJitter(t *testing.T) {
 		var actualRetryableErr *backoff.RetryAfterError
 		err := shouldRetry(resp, 0, 1)
 		require.ErrorAs(t, err, &actualRetryableErr)
-		require.GreaterOrEqual(t, actualRetryableErr.Duration, time.Duration(0),
-			"jittered delay must be >= 0")
-		require.Less(t, actualRetryableErr.Duration, 10*time.Second,
-			"jittered delay must be < X-RateLimit-Reset window")
+		require.GreaterOrEqual(t, actualRetryableErr.Duration, 10*time.Second,
+			"jittered delay must be >= reset (bucket must have refilled)")
+		require.Less(t, actualRetryableErr.Duration, 10*time.Second+maxJitterWindow,
+			"jittered delay must be < reset + maxJitterWindow")
 	})
 
 	t.Run("Retry-After exact, takes precedence over X-RateLimit-Reset", func(t *testing.T) {

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -607,7 +607,7 @@ func Test_shouldRetry_rateLimitResetJitter(t *testing.T) {
 		err := shouldRetry(resp, 0, 1)
 		require.ErrorAs(t, err, &actualRetryableErr)
 		require.Equal(t, 3*time.Second, actualRetryableErr.Duration,
-			"Retry-After must be honoured exactly with no jitter")
+			"Retry-After must be honored exactly with no jitter")
 	})
 }
 


### PR DESCRIPTION
### **User description**
## Problem

When ldx-sync (or any Snyk API behind the Gloo/Envoy api-gateway) returns a 429, all
clients receive the same `X-RateLimit-Reset` value — the seconds until the token-bucket
window resets (e.g. `1` for a per-second bucket). The retry middleware honoured this
value literally, so all clients woke up at the same millisecond and fired a synchronized
retry wave that immediately re-saturated the rate-limited endpoint.

Root cause traced during ldx-sync thundering-herd analysis (IDE-2094): ~150 concurrent
IDE clients at Monday 9am, all hitting the 160 req/s api-gateway cap, all sleeping
exactly 1 s, all retrying in unison.

## Fix

Apply **full jitter** to the `X-RateLimit-Reset` path: sleep a random duration in
`[0, reset)` instead of the exact reset value. This spreads retries uniformly across
the reset window, eliminating the synchronized wave.

`Retry-After` (RFC 7231) is **not** jittered — its semantics require the client to
wait *at least* the specified duration, and it is typically set by application servers
with deliberate backpressure intent.

## Implementation

- Split `rateLimitRetryDelay` (raw value → used for error reporting: "retry after N
  seconds") from `rateLimitRetryDelayJittered` (jittered value → used for the actual
  sleep in the retry loop).
- `Retry-After` present → return exact, no jitter (takes precedence).
- `X-RateLimit-Reset` only → return `rand.N(reset)`.
- Updated tests: exact-duration assertions on `X-RateLimit-Reset` replaced with
  range assertions `[0, reset)`; `Retry-After` precedence test corrected to assert
  the `Retry-After` value exactly (previous test asserted `max(retryAfter, reset)`
  which was wrong — `Retry-After` should win, not the larger of the two).

## Test plan

- [ ] `go test ./pkg/networking/...` passes (195 → 197 tests, all green)
- [ ] `Test_shouldRetry_rateLimitResetJitter` — new test asserts jitter range and Retry-After precedence
- [ ] `Test_ResponseMiddleware_RateLimitEnrichment` — error metadata still shows raw reset value (300 s), not jittered value

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real sleep timing for all rate-limited HTTP retries across framework clients; impact is bounded (extra wait capped at 2s) but affects shared networking behavior on 429/503 paths.
> 
> **Overview**
> Rate-limit retries no longer sleep only the exact `Retry-After` / `X-RateLimit-Reset` value from `shouldRetry`. When that combined delay (`max` of the two headers) is positive, the middleware now waits **at least** that duration and adds a random extra in **`[0, 2s)`** via `math/rand/v2`, so concurrent clients stagger retries instead of waking together.
> 
> `rateLimitRetryDelay` is documented as the **raw** header-derived delay (still used for max-wait checks and response enrichment); the actual `RetryAfterError` duration includes jitter. Table-driven tests that asserted fixed sleeps were removed in favor of **`Test_shouldRetry_rateLimitResetJitter`**, which checks delays fall in `[rawDelay, rawDelay + maxJitterWindow)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dcced1082d1ba87efb9f6987d3ebaf6ca1797c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Add random jitter to retry delays.

- Prevent synchronized retry storms.

- Enhance rate limiting handling logic.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Receive 429 Response] --> B{Extract Retry-After & X-RateLimit-Reset};
  B --> C{Determine Base Delay (max of headers)};
  C --> D{Check Base Delay against maxRetryAfter};
  D -- Exceeds --> E[Permanent Error];
  D -- Within Cap --> F{Calculate Jittered Delay};
  F --> G(Sleep for Jittered Delay);
  G --> H[Retry Request];
  subgraph Jitter Logic
    F -- Base Delay --> F1["Base Delay + Random [0, 2s)"];
  end
  F1 --> G;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>retry_middleware.go</strong><dd><code>Implement jittered retry delay calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/networking/middleware/retry_middleware.go

<ul><li>Imports <code>math/rand/v2</code> for random number generation.<br> <li> Introduces a <code>maxJitterWindow</code> constant for the jitter duration.<br> <li> Modifies <code>shouldRetry</code> to calculate <code>rawDelay</code> from <code>Retry-After</code> or <br><code>X-RateLimit-Reset</code>.<br> <li> Applies jitter by adding a random duration <code>[0, maxJitterWindow)</code> to the <br><code>rawDelay</code>.<br> <li> Updates comments to reflect that both headers are now treated <br>similarly for jittering.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/649/changes#diff-295d20b71bb7f7fdc47d3503d7fb17595142bb2c48dd5801cc4ad0517afb1a55">+22/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>retry_middleware_test.go</strong><dd><code>Add comprehensive tests for jittered retry delays</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/networking/middleware/retry_middleware_test.go

<ul><li>Removes specific tests for <code>Retry-After</code> and <code>X-RateLimit-Reset</code> from <br><code>Test_shouldRetry_rateLimitResetHeaders</code>.<br> <li> Adds a new test suite <code>Test_shouldRetry_rateLimitResetJitter</code> to cover <br>jittered delays.<br> <li> Tests cover <code>X-RateLimit-Reset</code> alone, <code>Retry-After</code> alone, and cases with <br>both headers present.<br> <li> Verifies that the jittered delay falls within the expected range <br><code>[base_delay, base_delay + maxJitterWindow)</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/649/changes#diff-781d13f3ad7692fdffe97f224e749e9e4cbbab29fbefafcfb11f78de8772aa26">+65/-30</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

