### PR TITLE
fix: render Snyk Doctor tip when presenting errors

### DIFF
--- a/internal/presenters/__snapshots__/components_test.snap
+++ b/internal/presenters/__snapshots__/components_test.snap
@@ -140,3 +140,17 @@ Status:  400 Bad Request
 Docs:    https://docs.snyk.io/scan-with-snyk/error-catalog#snyk-0003 
                                                                      
 ---
+
+[Test_RenderError/with_error_tip - 1]
+
+[41m [0m[97;41mERROR[0m[41m [0m  [1mUnable to process request (SNYK-9999)[0m
+         The server cannot process the request due to an unexpected error. Check Snyk   
+         status, then try again.                                                        
+                                                                                        
+           An error                                                                     
+
+Status:  500 Internal Server Error 
+Docs:    https://docs.snyk.io/scan-with-snyk/error-catalog#snyk-9999 
+Tip:     Run `snyk doctor` to diagnose this. 
+                                             
+---

--- a/internal/presenters/components.go
+++ b/internal/presenters/components.go
@@ -22,6 +22,7 @@ import (
 	"github.com/snyk/go-application-framework/internal/constants"
 	errorutils "github.com/snyk/go-application-framework/pkg/local_workflows/error_utils"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
+	"github.com/snyk/go-application-framework/pkg/ui/uitypes"
 )
 
 type Finding struct {
@@ -69,6 +70,7 @@ func errorLevelToStyle(errLevel string) lipgloss.Style {
 	return style
 }
 
+//nolint:gocyclo // presentation logic builds the error output as a flat sequence of optional sections
 func RenderError(err snyk_errors.Error, ctx context.Context) string {
 	var body []string
 
@@ -133,11 +135,28 @@ func RenderError(err snyk_errors.Error, ctx context.Context) string {
 		))
 	}
 
+	tip, hasTip := "", false
+	if v := ctx.Value(uitypes.ErrorTipKey); v != nil {
+		if t, ok := v.(string); ok && len(t) > 0 {
+			tip, hasTip = t, true
+		}
+	}
+
 	if len(err.Links) > 0 {
-		link := err.Links[0] + "\n"
+		link := err.Links[0]
+		if !hasTip {
+			link += "\n"
+		}
 		body = append(body, lipgloss.JoinHorizontal(lipgloss.Top,
 			label.Render("Docs:"),
 			value.Render(link),
+		))
+	}
+
+	if hasTip {
+		body = append(body, lipgloss.JoinHorizontal(lipgloss.Top,
+			label.Render("Tip:"),
+			value.Render(tip+"\n"),
 		))
 	}
 

--- a/internal/presenters/components_test.go
+++ b/internal/presenters/components_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/muesli/termenv"
 	"github.com/snyk/error-catalog-golang-public/snyk"
+	"github.com/snyk/go-application-framework/pkg/ui/uitypes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -78,6 +79,37 @@ func Test_RenderError(t *testing.T) {
 		assert.Contains(t, output, "Docs:")
 		assert.Contains(t, output, "ID:")
 		snaps.MatchSnapshot(t, output)
+	})
+
+	t.Run("with error tip", func(t *testing.T) {
+		lipgloss.SetColorProfile(termenv.TrueColor)
+		lipgloss.SetHasDarkBackground(false)
+		err := snyk.NewServerError("An error")
+		ctx := context.WithValue(defaultContext, uitypes.ErrorTipKey, "Run `snyk doctor` to diagnose this.")
+		output := RenderError(err, ctx)
+
+		assert.Contains(t, output, "Tip:")
+		assert.Contains(t, output, "Run `snyk doctor` to diagnose this.")
+		snaps.MatchSnapshot(t, output)
+	})
+
+	t.Run("without error tip", func(t *testing.T) {
+		lipgloss.SetColorProfile(termenv.TrueColor)
+		lipgloss.SetHasDarkBackground(false)
+		err := snyk.NewServerError("An error")
+		output := RenderError(err, defaultContext)
+
+		assert.NotContains(t, output, "Tip:")
+	})
+
+	t.Run("empty error tip is not rendered", func(t *testing.T) {
+		lipgloss.SetColorProfile(termenv.TrueColor)
+		lipgloss.SetHasDarkBackground(false)
+		err := snyk.NewServerError("An error")
+		ctx := context.WithValue(defaultContext, uitypes.ErrorTipKey, "")
+		output := RenderError(err, ctx)
+
+		assert.NotContains(t, output, "Tip:")
 	})
 
 	t.Run("detail with URL should not break URL", func(t *testing.T) {

--- a/pkg/ui/uitypes/types.go
+++ b/pkg/ui/uitypes/types.go
@@ -2,6 +2,13 @@ package uitypes
 
 import "context"
 
+type keyTypeString string
+
+// ErrorTipKey is the name to be used for an error tip context key.
+// It should be used if setting an additional helpful tip into a
+// context.Context that is then rendered as part of an error's presentation.
+const ErrorTipKey = keyTypeString("errorTip")
+
 //go:generate go tool github.com/golang/mock/mockgen -source=types.go -destination ../../mocks/userinterface.go -package mocks -self_package github.com/snyk/go-application-framework/pkg/ui/uitypes/
 
 // UserInterface defines the interface for user interaction.


### PR DESCRIPTION
### Description

Updates the error presentation logic to include a "Tip:" label with the value provided thought he context. This is populated by the CLI to include a helper message that advertises the Snyk Doctor command.

[Ticket](https://snyksec.atlassian.net/browse/CLI-1583)

### Checklist

- [x] Tests added and all succeed (`make test`)
- [ ] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI - [CLI PR](https://github.com/snyk/cli/pull/6913)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional terminal presentation change only; behavior is unchanged when no tip is set on the context.
> 
> **Overview**
> Terminal error output can now show an optional **Tip:** line when callers put a non-empty string on `context.Context` via `uitypes.ErrorTipKey` (intended for CLI messaging such as `snyk doctor`).
> 
> `RenderError` reads that value and renders it after **Docs:**; empty or missing tips are omitted. **Docs:** trailing newline handling is adjusted so spacing stays correct when a tip is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 416bf0f83e124e22cb26473f2d59b4ceecf5a5b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->