### PR TITLE
fix: escape regex and glob metacharacters in ignore path globs

### DIFF
--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -326,21 +326,60 @@ func parseIgnoreFile(content []byte, filePath string) []string {
 	return ignores
 }
 
-// escapeSpecialGlobChars escapes special characters that should be treated literally in glob patterns.
-// Special Characters to escape: $
-func escapeSpecialGlobChars(rule string) string {
+// regexMetaCharsToEscape are regex metacharacters that are not glob syntax; escaped in rules
+// so they match literally (e.g. "$" in a rule).
+var regexMetaCharsToEscape = map[byte]bool{
+	'$': true,
+	'(': true,
+	')': true,
+	'+': true,
+	'^': true,
+	'|': true,
+	'{': true,
+	'}': true,
+}
+
+// pathMetaCharsToEscape extends regexMetaCharsToEscape with the glob wildcards "*", "[" and
+// "]" for escaping the literal base path (which is not a pattern), e.g. "Program Files (x86)"
+// or a folder named "a*b". "?" and "." are omitted: the ignore matcher already treats them
+// literally / escapes them itself.
+var pathMetaCharsToEscape = map[byte]bool{
+	'$': true,
+	'(': true,
+	')': true,
+	'+': true,
+	'^': true,
+	'|': true,
+	'{': true,
+	'}': true,
+	'*': true,
+	'[': true,
+	']': true,
+}
+
+func escapeChars(s string, charsToEscape map[byte]bool) string {
 	var result strings.Builder
-	for i := 0; i < len(rule); i++ {
-		ch := rule[i]
-		switch ch {
-		case '$':
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if charsToEscape[ch] {
 			result.WriteByte('\\')
-			result.WriteByte(ch)
-		default:
-			result.WriteByte(ch)
 		}
+		result.WriteByte(ch)
 	}
 	return result.String()
+}
+
+// buildGlob joins the base path with glob parts, escaping the base path literally (so path
+// characters are never interpreted as patterns) while the glob parts keep their wildcards.
+func buildGlob(prefix, baseDir string, parts ...string) string {
+	base := filepath.ToSlash(filepath.Clean(baseDir))
+	joined := filepath.ToSlash(filepath.Join(append([]string{baseDir}, parts...)...))
+	if rest, ok := strings.CutPrefix(joined, base); ok {
+		return prefix + escapeChars(base, pathMetaCharsToEscape) + escapeChars(rest, regexMetaCharsToEscape)
+	}
+	// Fallback: base is not a prefix of the joined path (e.g. a rule with "../" escaped above
+	// it). Escape conservatively as a glob so at least regex metacharacters are handled.
+	return escapeChars(prefix+joined, regexMetaCharsToEscape)
 }
 
 // parseIgnoreRuleToGlobs contains the business logic to build glob patterns from a given ignore file
@@ -384,28 +423,24 @@ func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string)
 		// case `/foo/`, `/foo` => `{baseDir}/foo/**`
 		// case `**/foo/`, `**/foo` => `{baseDir}/**/foo/**`
 		if !endingGlobstar {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, rule, all))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			globs = append(globs, buildGlob(prefix, baseDir, rule, all))
 		}
 		// case `/foo` => `{baseDir}/foo`
 		// case `**/foo` => `{baseDir}/**/foo`
 		// case `/foo/**` => `{baseDir}/foo/**`
 		// case `**/foo/**` => `{baseDir}/**/foo/**`
 		if !endingSlash {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, rule))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			globs = append(globs, buildGlob(prefix, baseDir, rule))
 		}
 	} else {
 		// case `foo/`, `foo` => `{baseDir}/**/foo/**`
 		if !endingGlobstar {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, all, rule, all))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			globs = append(globs, buildGlob(prefix, baseDir, all, rule, all))
 		}
 		// case `foo` => `{baseDir}/**/foo`
 		// case `foo/**` => `{baseDir}/**/foo/**`
 		if !endingSlash {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, all, rule))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			globs = append(globs, buildGlob(prefix, baseDir, all, rule))
 		}
 	}
 	return globs

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -245,6 +245,48 @@ func TestFileFilter_GetFilteredFiles(t *testing.T) {
 	}
 }
 
+// TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars checks that ignore rules still
+// apply when the project path contains regex metacharacters (CLI-1515).
+func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
+	metaCharDirs := []string{
+		"OneDrive - Foobar (Team1)", // parentheses + spaces (customer's path shape)
+		"Program Files (x86)",       // parentheses + spaces
+		"a+b",                       // plus
+		"c{d}",                      // braces (not a valid quantifier)
+		"backup{2}",                 // braces forming a valid regex quantifier
+		"a^b",                       // caret
+		"a|b",                       // pipe / alternation
+		"a$b",                       // dollar
+		"a*b",                       // glob wildcard in the path
+		"a[b]c",                     // glob character class in the path
+		"a?b",                       // glob single-char wildcard in the path
+	}
+
+	for _, dirName := range metaCharDirs {
+		t.Run(dirName, func(t *testing.T) {
+			base := filepath.Join(t.TempDir(), dirName, "repo")
+			nodeModulesFile := filepath.Join(base, "node_modules", "lib", "index.js")
+			appFile := filepath.Join(base, "app.js")
+			gitignore := filepath.Join(base, ".gitignore")
+			createFileInPath(t, nodeModulesFile, []byte("x"))
+			createFileInPath(t, appFile, []byte("x"))
+			createFileInPath(t, gitignore, []byte("node_modules\n"))
+
+			fileFilter := NewFileFilter(base, &log.Logger)
+			globs, err := fileFilter.GetRules([]string{".gitignore"})
+			assert.NoError(t, err)
+
+			var filtered []string
+			for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+				filtered = append(filtered, f)
+			}
+
+			assert.Contains(t, filtered, appFile, "app.js should be scanned")
+			assert.NotContains(t, filtered, nodeModulesFile, "node_modules must be excluded")
+		})
+	}
+}
+
 func BenchmarkFileFilter_GetFilteredFiles(b *testing.B) {
 	b.Log("Creating filesystem...")
 	rootDir := b.TempDir()

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -262,8 +262,15 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 		"a?b",                       // glob single-char wildcard in the path
 	}
 
+	// Characters that Windows does not allow in file/directory names, so such paths cannot
+	// exist there and don't need to be exercised on that OS.
+	const windowsIllegalChars = `<>:"/\|?*`
+
 	for _, dirName := range metaCharDirs {
 		t.Run(dirName, func(t *testing.T) {
+			if runtime.GOOS == "windows" && strings.ContainsAny(dirName, windowsIllegalChars) {
+				t.Skipf("%q contains characters not allowed in Windows paths", dirName)
+			}
 			base := filepath.Join(t.TempDir(), dirName, "repo")
 			nodeModulesFile := filepath.Join(base, "node_modules", "lib", "index.js")
 			appFile := filepath.Join(base, "app.js")


### PR DESCRIPTION
### Description

Snyk Code file exclusions from `.snyk`, `.gitignore`, and `.dcignore` were silently ignored when the project's absolute path contained regex/glob metacharacters — most commonly parentheses, e.g. `C:\Users\...\OneDrive - Foobar (Team1)\...` or `C:\Program Files (x86)\...`.

`parseIgnoreRuleToGlobs` prepends the absolute base path to every rule, and the resulting glob is compiled into a regex by `sabhiram/go-gitignore`. The base path is not pattern data, but it was treated as such: `escapeSpecialGlobChars` only escaped `$`, so characters like `(`, `)`, `+`, `{`, `}`, `^`, `|`, and the glob wildcards `*`, `[`, `]` in the path were interpreted specially and matching silently failed — so nothing was excluded and directories like `node_modules` got scanned in full.

This change escapes the literal base path separately from the glob parts:

- `buildGlob` splits the joined path into the literal base and the glob remainder, escaping the base with the full set (including `*`, `[`, `]`) so it always matches literally, while the rule/`**` parts keep their wildcard meaning.
- `?` and `.` are intentionally not escaped: `go-gitignore` already treats `?` as literal and escapes `.` itself, so escaping them here would double-escape and break matching.

Reproduced independently of OS: a project on a plain path excludes `node_modules` (16 files bundled), while the same project under a `(...)` path did not (~28.9k files, matching a no-exclusion scan). After the fix, both exclude correctly.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core ignore-glob construction used by Snyk Code file filtering; incorrect escaping could over- or under-exclude files, though behavior is covered by new path metacharacter tests.
> 
> **Overview**
> Fixes **silent failure of `.gitignore` / `.snyk` / `.dcignore` exclusions** when the scan root’s absolute path contains characters that `go-gitignore` treats as regex or glob syntax (e.g. `Program Files (x86)`, `OneDrive - Foobar (Team1)`).
> 
> `parseIgnoreRuleToGlobs` now builds patterns via **`buildGlob`**, which escapes the **literal base directory** (including `*`, `[`, `]` in path segments) separately from the **rule / `**` suffix**, using generalized **`escapeChars`** instead of only escaping `$`. Wildcards in ignore rules are unchanged; `?` and `.` are still not escaped on the path to avoid double-escaping in the matcher.
> 
> Adds **`TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars`** to assert `node_modules` stays excluded across many metacharacter-heavy parent folder names (CLI-1515).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfe1280270cb92f846b1f626d27e22dede635c2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->