### PR TITLE
fix: respect Snyk Code exclusions on paths with special characters

### DIFF
--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -326,36 +327,30 @@ func parseIgnoreFile(content []byte, filePath string) []string {
 	return ignores
 }
 
-// regexMetaCharsToEscape are regex metacharacters that are not glob syntax; escaped in rules
-// so they match literally (e.g. "$" in a rule).
+// regexMetaCharsToEscape are regex metacharacters that are not glob syntax; escaped in ignore
+// rules so they match literally (e.g. "$" in a rule). "^", "[" and "]" are deliberately not
+// included: they are valid character-class syntax in gitignore rules (e.g. "foo[^x]").
 var regexMetaCharsToEscape = map[byte]bool{
 	'$': true,
 	'(': true,
 	')': true,
 	'+': true,
-	'^': true,
 	'|': true,
 	'{': true,
 	'}': true,
 }
 
-// pathMetaCharsToEscape extends regexMetaCharsToEscape with the glob wildcards "*", "[" and
-// "]" for escaping the literal base path (which is not a pattern), e.g. "Program Files (x86)"
-// or a folder named "a*b". "?" and "." are omitted: the ignore matcher already treats them
-// literally / escapes them itself.
-var pathMetaCharsToEscape = map[byte]bool{
-	'$': true,
-	'(': true,
-	')': true,
-	'+': true,
-	'^': true,
-	'|': true,
-	'{': true,
-	'}': true,
-	'*': true,
-	'[': true,
-	']': true,
-}
+// pathMetaCharsToEscape is used for the literal base path (which is not a pattern), so on top
+// of regexMetaCharsToEscape it also escapes the glob wildcards "*", "[", "]", the class anchor
+// "^", and "\". "?" and "." are omitted: the ignore matcher already treats them literally /
+// escapes them itself.
+var pathMetaCharsToEscape = func() map[byte]bool {
+	m := maps.Clone(regexMetaCharsToEscape)
+	for _, c := range []byte{'^', '*', '[', ']', '\\'} {
+		m[c] = true
+	}
+	return m
+}()
 
 func escapeChars(s string, charsToEscape map[byte]bool) string {
 	var result strings.Builder

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -326,21 +326,60 @@ func parseIgnoreFile(content []byte, filePath string) []string {
 	return ignores
 }
 
-// escapeSpecialGlobChars escapes special characters that should be treated literally in glob patterns.
-// Special Characters to escape: $
-func escapeSpecialGlobChars(rule string) string {
+// regexMetaCharsToEscape are regex metacharacters that are not glob syntax; escaped in rules
+// so they match literally (e.g. "$" in a rule).
+var regexMetaCharsToEscape = map[byte]bool{
+	'$': true,
+	'(': true,
+	')': true,
+	'+': true,
+	'^': true,
+	'|': true,
+	'{': true,
+	'}': true,
+}
+
+// pathMetaCharsToEscape extends regexMetaCharsToEscape with the glob wildcards "*", "[" and
+// "]" for escaping the literal base path (which is not a pattern), e.g. "Program Files (x86)"
+// or a folder named "a*b". "?" and "." are omitted: the ignore matcher already treats them
+// literally / escapes them itself.
+var pathMetaCharsToEscape = map[byte]bool{
+	'$': true,
+	'(': true,
+	')': true,
+	'+': true,
+	'^': true,
+	'|': true,
+	'{': true,
+	'}': true,
+	'*': true,
+	'[': true,
+	']': true,
+}
+
+func escapeChars(s string, charsToEscape map[byte]bool) string {
 	var result strings.Builder
-	for i := 0; i < len(rule); i++ {
-		ch := rule[i]
-		switch ch {
-		case '$':
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if charsToEscape[ch] {
 			result.WriteByte('\\')
-			result.WriteByte(ch)
-		default:
-			result.WriteByte(ch)
 		}
+		result.WriteByte(ch)
 	}
 	return result.String()
+}
+
+// buildGlob joins the base path with glob parts, escaping the base path literally (so path
+// characters are never interpreted as patterns) while the glob parts keep their wildcards.
+func buildGlob(prefix, baseDir string, parts ...string) string {
+	base := filepath.ToSlash(filepath.Clean(baseDir))
+	joined := filepath.ToSlash(filepath.Join(append([]string{baseDir}, parts...)...))
+	if rest, ok := strings.CutPrefix(joined, base); ok {
+		return prefix + escapeChars(base, pathMetaCharsToEscape) + escapeChars(rest, regexMetaCharsToEscape)
+	}
+	// Fallback: base is not a prefix of the joined path (e.g. a rule with "../" escaped above
+	// it). Escape conservatively as a glob so at least regex metacharacters are handled.
+	return escapeChars(prefix+joined, regexMetaCharsToEscape)
 }
 
 // parseIgnoreRuleToGlobs contains the business logic to build glob patterns from a given ignore file
@@ -384,28 +423,24 @@ func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string)
 		// case `/foo/`, `/foo` => `{baseDir}/foo/**`
 		// case `**/foo/`, `**/foo` => `{baseDir}/**/foo/**`
 		if !endingGlobstar {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, rule, all))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			globs = append(globs, buildGlob(prefix, baseDir, rule, all))
 		}
 		// case `/foo` => `{baseDir}/foo`
 		// case `**/foo` => `{baseDir}/**/foo`
 		// case `/foo/**` => `{baseDir}/foo/**`
 		// case `**/foo/**` => `{baseDir}/**/foo/**`
 		if !endingSlash {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, rule))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			globs = append(globs, buildGlob(prefix, baseDir, rule))
 		}
 	} else {
 		// case `foo/`, `foo` => `{baseDir}/**/foo/**`
 		if !endingGlobstar {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, all, rule, all))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			globs = append(globs, buildGlob(prefix, baseDir, all, rule, all))
 		}
 		// case `foo` => `{baseDir}/**/foo`
 		// case `foo/**` => `{baseDir}/**/foo/**`
 		if !endingSlash {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, all, rule))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			globs = append(globs, buildGlob(prefix, baseDir, all, rule))
 		}
 	}
 	return globs

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -246,7 +246,7 @@ func TestFileFilter_GetFilteredFiles(t *testing.T) {
 }
 
 // TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars checks that ignore rules still
-// apply when the project path contains regex metacharacters (CLI-1515).
+// apply when the project path contains regex metacharacters (CLI-1648).
 func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 	metaCharDirs := []string{
 		"OneDrive - Foobar (Team1)", // parentheses + spaces (customer's path shape)
@@ -262,8 +262,15 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 		"a?b",                       // glob single-char wildcard in the path
 	}
 
+	// Characters that Windows does not allow in file/directory names, so such paths cannot
+	// exist there and don't need to be exercised on that OS.
+	const windowsIllegalChars = `<>:"/\|?*`
+
 	for _, dirName := range metaCharDirs {
 		t.Run(dirName, func(t *testing.T) {
+			if runtime.GOOS == "windows" && strings.ContainsAny(dirName, windowsIllegalChars) {
+				t.Skipf("%q contains characters not allowed in Windows paths", dirName)
+			}
 			base := filepath.Join(t.TempDir(), dirName, "repo")
 			nodeModulesFile := filepath.Join(base, "node_modules", "lib", "index.js")
 			appFile := filepath.Join(base, "app.js")

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -294,6 +294,34 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 	}
 }
 
+// TestFileFilter_GetFilteredFiles_negatedCharacterClassRule ensures gitignore rules using a
+// negated character class (e.g. "cache[^S]") keep working, i.e. that "^" is not escaped in the
+// rule portion.
+func TestFileFilter_GetFilteredFiles_negatedCharacterClassRule(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "repo")
+	excluded := filepath.Join(base, "cache1", "index.js") // matches cache[^S]
+	kept := filepath.Join(base, "cacheS", "index.js")     // excluded from the negated class
+	appFile := filepath.Join(base, "app.js")
+	gitignore := filepath.Join(base, ".gitignore")
+	createFileInPath(t, excluded, []byte("x"))
+	createFileInPath(t, kept, []byte("x"))
+	createFileInPath(t, appFile, []byte("x"))
+	createFileInPath(t, gitignore, []byte("cache[^S]\n"))
+
+	fileFilter := NewFileFilter(base, &log.Logger)
+	globs, err := fileFilter.GetRules([]string{".gitignore"})
+	assert.NoError(t, err)
+
+	var filtered []string
+	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+		filtered = append(filtered, f)
+	}
+
+	assert.Contains(t, filtered, appFile, "app.js should be scanned")
+	assert.Contains(t, filtered, kept, "cacheS should be scanned (negated class excludes S)")
+	assert.NotContains(t, filtered, excluded, "cache1 must be excluded by cache[^S]")
+}
+
 func BenchmarkFileFilter_GetFilteredFiles(b *testing.B) {
 	b.Log("Creating filesystem...")
 	rootDir := b.TempDir()

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -323,6 +323,105 @@ func TestFileFilter_GetFilteredFiles_negatedCharacterClassRule(t *testing.T) {
 	assert.NotContains(t, filtered, excluded, "cache1 must be excluded by cache[^S]")
 }
 
+// TestFileFilter_GetFilteredFiles_ignoreFileInDirWithRegexMetaChars ensures an ignore file
+// located inside a directory whose name contains regex metacharacters (e.g. "my (dir)") is
+// still applied. The directory name becomes part of the compiled pattern, so it must be
+// escaped to be matched literally.
+func TestFileFilter_GetFilteredFiles_ignoreFileInDirWithRegexMetaChars(t *testing.T) {
+	root := t.TempDir()
+	nestedIgnore := filepath.Join(root, "my (dir)", ".gitignore")
+	excluded := filepath.Join(root, "my (dir)", "secret.txt")
+	kept := filepath.Join(root, "my (dir)", "keep.txt")
+	createFileInPath(t, nestedIgnore, []byte("secret.txt\n"))
+	createFileInPath(t, excluded, []byte("x"))
+	createFileInPath(t, kept, []byte("x"))
+
+	fileFilter := NewFileFilter(root, &log.Logger)
+	globs, err := fileFilter.GetRules([]string{".gitignore"})
+	assert.NoError(t, err)
+
+	var filtered []string
+	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+		filtered = append(filtered, f)
+	}
+
+	assert.Contains(t, filtered, kept, "keep.txt should be scanned")
+	assert.NotContains(t, filtered, excluded, "secret.txt must be excluded by the nested .gitignore")
+}
+
+// TestFileFilter_GetFilteredFiles_deeplyNestedIgnoreFileWithMetaChars covers an ignore file
+// several directories deep, where every level's name contains different regex metacharacters.
+func TestFileFilter_GetFilteredFiles_deeplyNestedIgnoreFileWithMetaChars(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "a (1)", "b [2]", "c +3")
+	excluded := filepath.Join(dir, "secret.txt")
+	kept := filepath.Join(dir, "keep.txt")
+	createFileInPath(t, filepath.Join(dir, ".gitignore"), []byte("secret.txt\n"))
+	createFileInPath(t, excluded, []byte("x"))
+	createFileInPath(t, kept, []byte("x"))
+
+	fileFilter := NewFileFilter(root, &log.Logger)
+	globs, err := fileFilter.GetRules([]string{".gitignore"})
+	assert.NoError(t, err)
+
+	var filtered []string
+	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+		filtered = append(filtered, f)
+	}
+
+	assert.Contains(t, filtered, kept, "keep.txt should be scanned")
+	assert.NotContains(t, filtered, excluded, "secret.txt must be excluded from a deeply nested dir")
+}
+
+// TestFileFilter_GetFilteredFiles_nestedRuleScoping ensures a rule from a nested ignore file
+// only applies within its own directory, not to a same-named file in a sibling directory.
+func TestFileFilter_GetFilteredFiles_nestedRuleScoping(t *testing.T) {
+	root := t.TempDir()
+	scopedExcluded := filepath.Join(root, "sub (x)", "only.txt")
+	siblingKept := filepath.Join(root, "other", "only.txt")
+	createFileInPath(t, filepath.Join(root, "sub (x)", ".gitignore"), []byte("only.txt\n"))
+	createFileInPath(t, scopedExcluded, []byte("x"))
+	createFileInPath(t, siblingKept, []byte("x"))
+
+	fileFilter := NewFileFilter(root, &log.Logger)
+	globs, err := fileFilter.GetRules([]string{".gitignore"})
+	assert.NoError(t, err)
+
+	var filtered []string
+	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+		filtered = append(filtered, f)
+	}
+
+	assert.NotContains(t, filtered, scopedExcluded, "only.txt under sub (x) must be excluded")
+	assert.Contains(t, filtered, siblingKept, "only.txt in a sibling dir must not be excluded")
+}
+
+// TestFileFilter_GetFilteredFiles_excludesDirectoryContents ensures a directory rule ("build/")
+// excludes all files under it, at any depth.
+func TestFileFilter_GetFilteredFiles_excludesDirectoryContents(t *testing.T) {
+	root := t.TempDir()
+	shallow := filepath.Join(root, "build", "out.js")
+	deep := filepath.Join(root, "build", "nested", "deep.js")
+	kept := filepath.Join(root, "src", "app.js")
+	createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("build/\n"))
+	createFileInPath(t, shallow, []byte("x"))
+	createFileInPath(t, deep, []byte("x"))
+	createFileInPath(t, kept, []byte("x"))
+
+	fileFilter := NewFileFilter(root, &log.Logger)
+	globs, err := fileFilter.GetRules([]string{".gitignore"})
+	assert.NoError(t, err)
+
+	var filtered []string
+	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+		filtered = append(filtered, f)
+	}
+
+	assert.Contains(t, filtered, kept, "src/app.js should be scanned")
+	assert.NotContains(t, filtered, shallow, "build/out.js must be excluded")
+	assert.NotContains(t, filtered, deep, "build/nested/deep.js must be excluded")
+}
+
 func BenchmarkFileFilter_GetFilteredFiles(b *testing.B) {
 	b.Log("Creating filesystem...")
 	rootDir := b.TempDir()

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -295,131 +295,103 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 	}
 }
 
-// TestFileFilter_GetFilteredFiles_negatedCharacterClassRule ensures gitignore rules using a
-// negated character class (e.g. "cache[^S]") keep working, i.e. that "^" is not escaped in the
-// rule portion.
-func TestFileFilter_GetFilteredFiles_negatedCharacterClassRule(t *testing.T) {
-	base := filepath.Join(t.TempDir(), "repo")
-	excluded := filepath.Join(base, "cache1", "index.js") // matches cache[^S]
-	kept := filepath.Join(base, "cacheS", "index.js")     // excluded from the negated class
-	appFile := filepath.Join(base, "app.js")
-	gitignore := filepath.Join(base, ".gitignore")
-	createFileInPath(t, excluded, []byte("x"))
-	createFileInPath(t, kept, []byte("x"))
-	createFileInPath(t, appFile, []byte("x"))
-	createFileInPath(t, gitignore, []byte("cache[^S]\n"))
-
-	fileFilter := NewFileFilter(base, &log.Logger)
-	globs, err := fileFilter.GetRules([]string{".gitignore"})
-	assert.NoError(t, err)
-
-	var filtered []string
-	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
-		filtered = append(filtered, f)
+// TestFileFilter_GetFilteredFiles_ignoreRuleScenarios covers ignore-rule behaviors that share
+// the same shape: build a filesystem (including ignore files), filter it, then assert which
+// files survive. "files" maps a slash-separated path (relative to the scan root) to its content;
+// "excluded"/"kept" list slash-separated paths that must / must not be filtered out.
+func TestFileFilter_GetFilteredFiles_ignoreRuleScenarios(t *testing.T) {
+	scenarios := []struct {
+		name      string
+		files     map[string]string
+		ruleFiles []string
+		excluded  []string
+		kept      []string
+	}{
+		{
+			name: "negated character class rule keeps working",
+			files: map[string]string{
+				".gitignore":      "cache[^S]\n",
+				"cache1/index.js": "x", // matches cache[^S]
+				"cacheS/index.js": "x", // excluded from the negated class
+				"app.js":          "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"cache1/index.js"},
+			kept:      []string{"cacheS/index.js", "app.js"},
+		},
+		{
+			name: "ignore file in dir with regex metacharacters",
+			files: map[string]string{
+				"my (dir)/.gitignore": "secret.txt\n",
+				"my (dir)/secret.txt": "x",
+				"my (dir)/keep.txt":   "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"my (dir)/secret.txt"},
+			kept:      []string{"my (dir)/keep.txt"},
+		},
+		{
+			name: "deeply nested ignore file with metacharacters at every level",
+			files: map[string]string{
+				"a (1)/b [2]/c +3/.gitignore": "secret.txt\n",
+				"a (1)/b [2]/c +3/secret.txt": "x",
+				"a (1)/b [2]/c +3/keep.txt":   "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"a (1)/b [2]/c +3/secret.txt"},
+			kept:      []string{"a (1)/b [2]/c +3/keep.txt"},
+		},
+		{
+			name: "nested rule is scoped to its own directory",
+			files: map[string]string{
+				"sub (x)/.gitignore": "only.txt\n",
+				"sub (x)/only.txt":   "x",
+				"other/only.txt":     "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"sub (x)/only.txt"},
+			kept:      []string{"other/only.txt"},
+		},
+		{
+			name: "directory rule excludes all contents at any depth",
+			files: map[string]string{
+				".gitignore":           "build/\n",
+				"build/out.js":         "x",
+				"build/nested/deep.js": "x",
+				"src/app.js":           "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"build/out.js", "build/nested/deep.js"},
+			kept:      []string{"src/app.js"},
+		},
 	}
 
-	assert.Contains(t, filtered, appFile, "app.js should be scanned")
-	assert.Contains(t, filtered, kept, "cacheS should be scanned (negated class excludes S)")
-	assert.NotContains(t, filtered, excluded, "cache1 must be excluded by cache[^S]")
-}
+	for _, tc := range scenarios {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			for p, content := range tc.files {
+				createFileInPath(t, filepath.Join(root, filepath.FromSlash(p)), []byte(content))
+			}
 
-// TestFileFilter_GetFilteredFiles_ignoreFileInDirWithRegexMetaChars ensures an ignore file
-// located inside a directory whose name contains regex metacharacters (e.g. "my (dir)") is
-// still applied. The directory name becomes part of the compiled pattern, so it must be
-// escaped to be matched literally.
-func TestFileFilter_GetFilteredFiles_ignoreFileInDirWithRegexMetaChars(t *testing.T) {
-	root := t.TempDir()
-	nestedIgnore := filepath.Join(root, "my (dir)", ".gitignore")
-	excluded := filepath.Join(root, "my (dir)", "secret.txt")
-	kept := filepath.Join(root, "my (dir)", "keep.txt")
-	createFileInPath(t, nestedIgnore, []byte("secret.txt\n"))
-	createFileInPath(t, excluded, []byte("x"))
-	createFileInPath(t, kept, []byte("x"))
+			fileFilter := NewFileFilter(root, &log.Logger)
+			globs, err := fileFilter.GetRules(tc.ruleFiles)
+			assert.NoError(t, err)
 
-	fileFilter := NewFileFilter(root, &log.Logger)
-	globs, err := fileFilter.GetRules([]string{".gitignore"})
-	assert.NoError(t, err)
+			kept := make(map[string]bool)
+			for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+				rel, relErr := filepath.Rel(root, f)
+				assert.NoError(t, relErr)
+				kept[filepath.ToSlash(rel)] = true
+			}
 
-	var filtered []string
-	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
-		filtered = append(filtered, f)
+			for _, e := range tc.excluded {
+				assert.False(t, kept[e], "%q must be excluded", e)
+			}
+			for _, k := range tc.kept {
+				assert.True(t, kept[k], "%q must be kept", k)
+			}
+		})
 	}
-
-	assert.Contains(t, filtered, kept, "keep.txt should be scanned")
-	assert.NotContains(t, filtered, excluded, "secret.txt must be excluded by the nested .gitignore")
-}
-
-// TestFileFilter_GetFilteredFiles_deeplyNestedIgnoreFileWithMetaChars covers an ignore file
-// several directories deep, where every level's name contains different regex metacharacters.
-func TestFileFilter_GetFilteredFiles_deeplyNestedIgnoreFileWithMetaChars(t *testing.T) {
-	root := t.TempDir()
-	dir := filepath.Join(root, "a (1)", "b [2]", "c +3")
-	excluded := filepath.Join(dir, "secret.txt")
-	kept := filepath.Join(dir, "keep.txt")
-	createFileInPath(t, filepath.Join(dir, ".gitignore"), []byte("secret.txt\n"))
-	createFileInPath(t, excluded, []byte("x"))
-	createFileInPath(t, kept, []byte("x"))
-
-	fileFilter := NewFileFilter(root, &log.Logger)
-	globs, err := fileFilter.GetRules([]string{".gitignore"})
-	assert.NoError(t, err)
-
-	var filtered []string
-	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
-		filtered = append(filtered, f)
-	}
-
-	assert.Contains(t, filtered, kept, "keep.txt should be scanned")
-	assert.NotContains(t, filtered, excluded, "secret.txt must be excluded from a deeply nested dir")
-}
-
-// TestFileFilter_GetFilteredFiles_nestedRuleScoping ensures a rule from a nested ignore file
-// only applies within its own directory, not to a same-named file in a sibling directory.
-func TestFileFilter_GetFilteredFiles_nestedRuleScoping(t *testing.T) {
-	root := t.TempDir()
-	scopedExcluded := filepath.Join(root, "sub (x)", "only.txt")
-	siblingKept := filepath.Join(root, "other", "only.txt")
-	createFileInPath(t, filepath.Join(root, "sub (x)", ".gitignore"), []byte("only.txt\n"))
-	createFileInPath(t, scopedExcluded, []byte("x"))
-	createFileInPath(t, siblingKept, []byte("x"))
-
-	fileFilter := NewFileFilter(root, &log.Logger)
-	globs, err := fileFilter.GetRules([]string{".gitignore"})
-	assert.NoError(t, err)
-
-	var filtered []string
-	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
-		filtered = append(filtered, f)
-	}
-
-	assert.NotContains(t, filtered, scopedExcluded, "only.txt under sub (x) must be excluded")
-	assert.Contains(t, filtered, siblingKept, "only.txt in a sibling dir must not be excluded")
-}
-
-// TestFileFilter_GetFilteredFiles_excludesDirectoryContents ensures a directory rule ("build/")
-// excludes all files under it, at any depth.
-func TestFileFilter_GetFilteredFiles_excludesDirectoryContents(t *testing.T) {
-	root := t.TempDir()
-	shallow := filepath.Join(root, "build", "out.js")
-	deep := filepath.Join(root, "build", "nested", "deep.js")
-	kept := filepath.Join(root, "src", "app.js")
-	createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("build/\n"))
-	createFileInPath(t, shallow, []byte("x"))
-	createFileInPath(t, deep, []byte("x"))
-	createFileInPath(t, kept, []byte("x"))
-
-	fileFilter := NewFileFilter(root, &log.Logger)
-	globs, err := fileFilter.GetRules([]string{".gitignore"})
-	assert.NoError(t, err)
-
-	var filtered []string
-	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
-		filtered = append(filtered, f)
-	}
-
-	assert.Contains(t, filtered, kept, "src/app.js should be scanned")
-	assert.NotContains(t, filtered, shallow, "build/out.js must be excluded")
-	assert.NotContains(t, filtered, deep, "build/nested/deep.js must be excluded")
 }
 
 func BenchmarkFileFilter_GetFilteredFiles(b *testing.B) {

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -245,6 +245,48 @@ func TestFileFilter_GetFilteredFiles(t *testing.T) {
 	}
 }
 
+// TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars checks that ignore rules still
+// apply when the project path contains regex metacharacters (CLI-1515).
+func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
+	metaCharDirs := []string{
+		"OneDrive - Foobar (Team1)", // parentheses + spaces (customer's path shape)
+		"Program Files (x86)",       // parentheses + spaces
+		"a+b",                       // plus
+		"c{d}",                      // braces (not a valid quantifier)
+		"backup{2}",                 // braces forming a valid regex quantifier
+		"a^b",                       // caret
+		"a|b",                       // pipe / alternation
+		"a$b",                       // dollar
+		"a*b",                       // glob wildcard in the path
+		"a[b]c",                     // glob character class in the path
+		"a?b",                       // glob single-char wildcard in the path
+	}
+
+	for _, dirName := range metaCharDirs {
+		t.Run(dirName, func(t *testing.T) {
+			base := filepath.Join(t.TempDir(), dirName, "repo")
+			nodeModulesFile := filepath.Join(base, "node_modules", "lib", "index.js")
+			appFile := filepath.Join(base, "app.js")
+			gitignore := filepath.Join(base, ".gitignore")
+			createFileInPath(t, nodeModulesFile, []byte("x"))
+			createFileInPath(t, appFile, []byte("x"))
+			createFileInPath(t, gitignore, []byte("node_modules\n"))
+
+			fileFilter := NewFileFilter(base, &log.Logger)
+			globs, err := fileFilter.GetRules([]string{".gitignore"})
+			assert.NoError(t, err)
+
+			var filtered []string
+			for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+				filtered = append(filtered, f)
+			}
+
+			assert.Contains(t, filtered, appFile, "app.js should be scanned")
+			assert.NotContains(t, filtered, nodeModulesFile, "node_modules must be excluded")
+		})
+	}
+}
+
 func BenchmarkFileFilter_GetFilteredFiles(b *testing.B) {
 	b.Log("Creating filesystem...")
 	rootDir := b.TempDir()

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -260,6 +260,7 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 		"a*b",                       // glob wildcard in the path
 		"a[b]c",                     // glob character class in the path
 		"a?b",                       // glob single-char wildcard in the path
+		"a\\b",                      // literal backslash (legal on unix, illegal on windows)
 	}
 
 	// Characters that Windows does not allow in file/directory names, so such paths cannot
@@ -628,6 +629,19 @@ func TestParseIgnoreRuleToGlobs(t *testing.T) {
 			invalidRules: []string{},
 			expectedGlobs: []string{
 				"/tmp/test/**/foo/**",
+			},
+		},
+		{
+			// A rule with enough "../" climbs above baseDir once filepath.Join cleans it, so the
+			// base is no longer a prefix and buildGlob takes the fallback path. The base content
+			// is gone at that point, so the remaining glob wildcards must be preserved.
+			name:         "rule climbing above base uses fallback",
+			rule:         "../../../../../../foo",
+			baseDir:      "/tmp/test",
+			invalidRules: []string{},
+			expectedGlobs: []string{
+				"/foo/**",
+				"/foo",
 			},
 		},
 	}


### PR DESCRIPTION
### Description

Snyk Code file exclusions from `.snyk`, `.gitignore`, and `.dcignore` were silently ignored when the project's absolute path contained regex/glob metacharacters — most commonly parentheses, e.g. `C:\Users\...\OneDrive - Company (Tenant)\...` or `C:\Program Files (x86)\...`.

`parseIgnoreRuleToGlobs` prepends the absolute base path to every rule, and the resulting glob is compiled into a regex by `sabhiram/go-gitignore`. The base path is not pattern data, but it was treated as such: `escapeSpecialGlobChars` only escaped `$`, so characters like `(`, `)`, `+`, `{`, `}`, `^`, `|`, and the glob wildcards `*`, `[`, `]` in the path were interpreted specially and matching silently failed — so nothing was excluded and directories like `node_modules` got scanned in full.

`buildGlob` now escapes the literal base path separately from the glob parts, so path characters always match literally while the rule/`**` parts keep their wildcard meaning. `?` and `.` are intentionally not escaped: `go-gitignore` already treats `?` as literal and escapes `.` itself.

Reproduced independently of OS: a project on a plain path excludes `node_modules` (~16 files bundled), while the same project under a `(...)` path did not (~28.9k files, matching a no-exclusion scan). After the fix, both exclude correctly.

Ticket: CLI-1648

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.

https://github.com/snyk/cli/pull/6980


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which files are included in Snyk Code scans; incorrect matching could over- or under-scan, though behavior is covered by new scenario tests.
> 
> **Overview**
> Fixes **silent failure of Snyk Code file exclusions** (`.gitignore`, `.snyk`, `.dcignore`) when the scan root’s absolute path contains characters that `go-gitignore` treats as regex/glob syntax—common on Windows paths like `Program Files (x86)` or OneDrive folder names with parentheses.
> 
> `parseIgnoreRuleToGlobs` no longer only escapes `$` on the full joined pattern. It uses **`buildGlob`** to escape the **literal base directory** aggressively (`*`, `[`, `]`, `^`, `\`, plus regex metacharacters) while still allowing **gitignore rule syntax** such as negated classes (`cache[^S]`) on the rule suffix. A conservative fallback applies when a rule’s `../` climbs above `baseDir`.
> 
> Adds broad tests for meta-character paths, nested ignore files, directory rules, and the `../` glob edge case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07a51b4f473f5c5bde3fe4bdb7bea48d2ade7167. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->