### PR TITLE
Fix/cli 1648 to relative file path

### DIFF
--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -83,7 +82,14 @@ func (fw *FileFilter) GetAllFiles() chan string {
 	return filesCh
 }
 
-// GetRules builds a list of glob patterns that can be used to filter filesToFilter
+// GetRules builds absolute glob patterns from ignore files under the scan root (fw.path).
+// The returned strings are intended to be passed to GetFilteredFiles together with
+// absolute file paths from GetAllFiles — not compiled directly into a matcher.
+//
+// GetFilteredFiles strips fw.path from each glob and matches repo-relative paths
+// (via ToRelativeUnixPath). Feeding these globs to go-gitignore against absolute
+// paths can fail when the scan root or in-repo directory names contain regex/glob
+// metacharacters (e.g. parentheses in "OneDrive - Company (Tenant)").
 func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
 	files := fw.GetAllFiles()
 
@@ -107,12 +113,41 @@ func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
 	return append(fw.defaultRules, globs...), nil
 }
 
-// GetFilteredFiles returns a filtered channel of filepaths from a given channel of filespaths and glob patterns to filter on
+// toMatchGlob strips the scan root from an absolute ignore glob so matching can use
+// repo-relative paths (via ToRelativeUnixPath) instead of embedding parent-dir metacharacters.
+func (fw *FileFilter) toMatchGlob(glob string) string {
+	negated := ""
+	if strings.HasPrefix(glob, "!") {
+		negated = "!"
+		glob = glob[1:]
+	}
+
+	base := filepath.ToSlash(filepath.Clean(fw.path))
+	slashGlob := filepath.ToSlash(glob)
+	if rel, ok := strings.CutPrefix(slashGlob, base+"/"); ok {
+		return negated + escapeRelativeGlobForMatch(rel)
+	}
+	if slashGlob == base {
+		return negated + "."
+	}
+	return negated + escapeRelativeGlobForMatch(slashGlob)
+}
+
+// GetFilteredFiles returns files from filesCh that are not excluded by globs.
+// globs should come from GetRules on the same FileFilter instance: each glob is
+// rewritten for matching (scan-root prefix removed, path segments escaped) and
+// each file is compared using its path relative to fw.path. Output paths remain
+// absolute.
 func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan string {
 	var filteredFilesCh = make(chan string)
 
+	matchGlobs := make([]string, len(globs))
+	for i, g := range globs {
+		matchGlobs[i] = fw.toMatchGlob(g)
+	}
+
 	// create pattern matcher used to match filesToFilter to glob patterns
-	globPatternMatcher := gitignore.CompileIgnoreLines(globs...)
+	globPatternMatcher := gitignore.CompileIgnoreLines(matchGlobs...)
 	go func() {
 		ctx := context.Background()
 		availableThreads := semaphore.NewWeighted(fw.max_threads)
@@ -127,8 +162,13 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 			}
 			go func(f string) {
 				defer availableThreads.Release(1)
+				rel, err := ToRelativeUnixPath(fw.path, f)
+				if err != nil {
+					fw.logger.Err(err).Str("file", f).Msg("failed to relativize path for filter matching")
+					return
+				}
 				// filesToFilter that do not match the glob pattern are filtered
-				if !globPatternMatcher.MatchesPath(f) {
+				if !globPatternMatcher.MatchesPath(rel) {
 					filteredFilesCh <- f
 				}
 			}(file)
@@ -327,36 +367,12 @@ func parseIgnoreFile(content []byte, filePath string) []string {
 	return ignores
 }
 
-// regexMetaCharsToEscape are regex metacharacters that are not glob syntax; escaped in ignore
-// rules so they match literally (e.g. "$" in a rule). "^", "[" and "]" are deliberately not
-// included: they are valid character-class syntax in gitignore rules (e.g. "foo[^x]").
-var regexMetaCharsToEscape = map[byte]bool{
-	'$': true,
-	'(': true,
-	')': true,
-	'+': true,
-	'|': true,
-	'{': true,
-	'}': true,
-}
-
-// pathMetaCharsToEscape is used for the literal base path (which is not a pattern), so on top
-// of regexMetaCharsToEscape it also escapes the glob wildcards "*", "[", "]", the class anchor
-// "^", and "\". "?" and "." are omitted: the ignore matcher already treats them literally /
-// escapes them itself.
-var pathMetaCharsToEscape = func() map[byte]bool {
-	m := maps.Clone(regexMetaCharsToEscape)
-	for _, c := range []byte{'^', '*', '[', ']', '\\'} {
-		m[c] = true
-	}
-	return m
-}()
-
-func escapeChars(s string, charsToEscape map[byte]bool) string {
+// escapeSpecialGlobChars escapes $ in the rule portion of a glob (not literal path segments).
+func escapeSpecialGlobChars(rule string) string {
 	var result strings.Builder
-	for i := 0; i < len(s); i++ {
-		ch := s[i]
-		if charsToEscape[ch] {
+	for i := 0; i < len(rule); i++ {
+		ch := rule[i]
+		if ch == '$' {
 			result.WriteByte('\\')
 		}
 		result.WriteByte(ch)
@@ -364,17 +380,46 @@ func escapeChars(s string, charsToEscape map[byte]bool) string {
 	return result.String()
 }
 
-// buildGlob joins the base path with glob parts, escaping the base path literally (so path
-// characters are never interpreted as patterns) while the glob parts keep their wildcards.
+// pathMetaCharsToEscape are regex/glob metacharacters in literal directory names.
+var pathMetaCharsToEscape = map[byte]bool{
+	'$': true, '(': true, ')': true, '+': true, '|': true, '{': true, '}': true,
+	'^': true, '*': true, '[': true, ']': true, '\\': true,
+}
+
+func escapePathMetaChars(s string) string {
+	var result strings.Builder
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if pathMetaCharsToEscape[ch] {
+			result.WriteByte('\\')
+		}
+		result.WriteByte(ch)
+	}
+	return result.String()
+}
+
+func escapeRelativeGlobForMatch(rel string) string {
+	if rel == "" {
+		return rel
+	}
+	parts := strings.Split(rel, "/")
+	out := make([]string, 0, len(parts))
+	for i, p := range parts {
+		if p == "**" || strings.ContainsAny(p, "*?") {
+			return strings.Join(append(out, parts[i:]...), "/")
+		}
+		out = append(out, escapePathMetaChars(p))
+	}
+	return strings.Join(out, "/")
+}
+
 func buildGlob(prefix, baseDir string, parts ...string) string {
 	base := filepath.ToSlash(filepath.Clean(baseDir))
 	joined := filepath.ToSlash(filepath.Join(append([]string{baseDir}, parts...)...))
 	if rest, ok := strings.CutPrefix(joined, base); ok {
-		return prefix + escapeChars(base, pathMetaCharsToEscape) + escapeChars(rest, regexMetaCharsToEscape)
+		return prefix + base + escapeSpecialGlobChars(rest)
 	}
-	// Fallback: base is not a prefix of the joined path (e.g. a rule with "../" escaped above
-	// it). Escape conservatively as a glob so at least regex metacharacters are handled.
-	return escapeChars(prefix+joined, regexMetaCharsToEscape)
+	return escapeSpecialGlobChars(prefix + joined)
 }
 
 // parseIgnoreRuleToGlobs contains the business logic to build glob patterns from a given ignore file

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -326,36 +327,30 @@ func parseIgnoreFile(content []byte, filePath string) []string {
 	return ignores
 }
 
-// regexMetaCharsToEscape are regex metacharacters that are not glob syntax; escaped in rules
-// so they match literally (e.g. "$" in a rule).
+// regexMetaCharsToEscape are regex metacharacters that are not glob syntax; escaped in ignore
+// rules so they match literally (e.g. "$" in a rule). "^", "[" and "]" are deliberately not
+// included: they are valid character-class syntax in gitignore rules (e.g. "foo[^x]").
 var regexMetaCharsToEscape = map[byte]bool{
 	'$': true,
 	'(': true,
 	')': true,
 	'+': true,
-	'^': true,
 	'|': true,
 	'{': true,
 	'}': true,
 }
 
-// pathMetaCharsToEscape extends regexMetaCharsToEscape with the glob wildcards "*", "[" and
-// "]" for escaping the literal base path (which is not a pattern), e.g. "Program Files (x86)"
-// or a folder named "a*b". "?" and "." are omitted: the ignore matcher already treats them
-// literally / escapes them itself.
-var pathMetaCharsToEscape = map[byte]bool{
-	'$': true,
-	'(': true,
-	')': true,
-	'+': true,
-	'^': true,
-	'|': true,
-	'{': true,
-	'}': true,
-	'*': true,
-	'[': true,
-	']': true,
-}
+// pathMetaCharsToEscape is used for the literal base path (which is not a pattern), so on top
+// of regexMetaCharsToEscape it also escapes the glob wildcards "*", "[", "]", the class anchor
+// "^", and "\". "?" and "." are omitted: the ignore matcher already treats them literally /
+// escapes them itself.
+var pathMetaCharsToEscape = func() map[byte]bool {
+	m := maps.Clone(regexMetaCharsToEscape)
+	for _, c := range []byte{'^', '*', '[', ']', '\\'} {
+		m[c] = true
+	}
+	return m
+}()
 
 func escapeChars(s string, charsToEscape map[byte]bool) string {
 	var result strings.Builder

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -326,21 +326,60 @@ func parseIgnoreFile(content []byte, filePath string) []string {
 	return ignores
 }
 
-// escapeSpecialGlobChars escapes special characters that should be treated literally in glob patterns.
-// Special Characters to escape: $
-func escapeSpecialGlobChars(rule string) string {
+// regexMetaCharsToEscape are regex metacharacters that are not glob syntax; escaped in rules
+// so they match literally (e.g. "$" in a rule).
+var regexMetaCharsToEscape = map[byte]bool{
+	'$': true,
+	'(': true,
+	')': true,
+	'+': true,
+	'^': true,
+	'|': true,
+	'{': true,
+	'}': true,
+}
+
+// pathMetaCharsToEscape extends regexMetaCharsToEscape with the glob wildcards "*", "[" and
+// "]" for escaping the literal base path (which is not a pattern), e.g. "Program Files (x86)"
+// or a folder named "a*b". "?" and "." are omitted: the ignore matcher already treats them
+// literally / escapes them itself.
+var pathMetaCharsToEscape = map[byte]bool{
+	'$': true,
+	'(': true,
+	')': true,
+	'+': true,
+	'^': true,
+	'|': true,
+	'{': true,
+	'}': true,
+	'*': true,
+	'[': true,
+	']': true,
+}
+
+func escapeChars(s string, charsToEscape map[byte]bool) string {
 	var result strings.Builder
-	for i := 0; i < len(rule); i++ {
-		ch := rule[i]
-		switch ch {
-		case '$':
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if charsToEscape[ch] {
 			result.WriteByte('\\')
-			result.WriteByte(ch)
-		default:
-			result.WriteByte(ch)
 		}
+		result.WriteByte(ch)
 	}
 	return result.String()
+}
+
+// buildGlob joins the base path with glob parts, escaping the base path literally (so path
+// characters are never interpreted as patterns) while the glob parts keep their wildcards.
+func buildGlob(prefix, baseDir string, parts ...string) string {
+	base := filepath.ToSlash(filepath.Clean(baseDir))
+	joined := filepath.ToSlash(filepath.Join(append([]string{baseDir}, parts...)...))
+	if rest, ok := strings.CutPrefix(joined, base); ok {
+		return prefix + escapeChars(base, pathMetaCharsToEscape) + escapeChars(rest, regexMetaCharsToEscape)
+	}
+	// Fallback: base is not a prefix of the joined path (e.g. a rule with "../" escaped above
+	// it). Escape conservatively as a glob so at least regex metacharacters are handled.
+	return escapeChars(prefix+joined, regexMetaCharsToEscape)
 }
 
 // parseIgnoreRuleToGlobs contains the business logic to build glob patterns from a given ignore file
@@ -384,28 +423,24 @@ func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string)
 		// case `/foo/`, `/foo` => `{baseDir}/foo/**`
 		// case `**/foo/`, `**/foo` => `{baseDir}/**/foo/**`
 		if !endingGlobstar {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, rule, all))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			globs = append(globs, buildGlob(prefix, baseDir, rule, all))
 		}
 		// case `/foo` => `{baseDir}/foo`
 		// case `**/foo` => `{baseDir}/**/foo`
 		// case `/foo/**` => `{baseDir}/foo/**`
 		// case `**/foo/**` => `{baseDir}/**/foo/**`
 		if !endingSlash {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, rule))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			globs = append(globs, buildGlob(prefix, baseDir, rule))
 		}
 	} else {
 		// case `foo/`, `foo` => `{baseDir}/**/foo/**`
 		if !endingGlobstar {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, all, rule, all))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			globs = append(globs, buildGlob(prefix, baseDir, all, rule, all))
 		}
 		// case `foo` => `{baseDir}/**/foo`
 		// case `foo/**` => `{baseDir}/**/foo/**`
 		if !endingSlash {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, all, rule))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			globs = append(globs, buildGlob(prefix, baseDir, all, rule))
 		}
 	}
 	return globs

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -123,7 +123,9 @@ func (fw *FileFilter) toMatchGlob(glob string) string {
 	}
 
 	base := filepath.ToSlash(filepath.Clean(fw.path))
-	slashGlob := filepath.ToSlash(glob)
+	// buildGlob already normalizes path separators to '/'; backslashes only appear as
+	// rule escapes (e.g. \$). filepath.ToSlash would turn \$ into /$ on Windows.
+	slashGlob := glob
 	if rel, ok := strings.CutPrefix(slashGlob, base+"/"); ok {
 		return negated + escapeRelativeGlobForMatch(rel)
 	}

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -260,6 +260,7 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 		"a*b",                       // glob wildcard in the path
 		"a[b]c",                     // glob character class in the path
 		"a?b",                       // glob single-char wildcard in the path
+		"a.b",                       // dot in path (go-gitignore self-escapes; must not double-break)
 		"a\\b",                      // literal backslash (legal on unix, illegal on windows)
 	}
 
@@ -364,6 +365,78 @@ func TestFileFilter_GetFilteredFiles_ignoreRuleScenarios(t *testing.T) {
 			excluded:  []string{"build/out.js", "build/nested/deep.js"},
 			kept:      []string{"src/app.js"},
 		},
+		{
+			name: "parentheses in ignore rule pattern",
+			files: map[string]string{
+				".gitignore":         "foo(bar)\n",
+				"foo(bar)/index.js":  "x",
+				"foo(bar)x/index.js": "x",
+				"app.js":             "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			// go-gitignore compiles (bar) as a regex group, not a literal directory name.
+			excluded: []string{},
+			kept:     []string{"foo(bar)/index.js", "foo(bar)x/index.js", "app.js"},
+		},
+		{
+			name: "dollar sign in rule text matches directory name",
+			files: map[string]string{
+				".gitignore":          "price$tag\n",
+				"price$tag/inside.js": "x",
+				"price.js":            "x",
+				"app.js":              "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"price$tag/inside.js"},
+			kept:      []string{"price.js", "app.js"},
+		},
+		{
+			name: "pipe in rule text is regex alternation not a literal character",
+			files: map[string]string{
+				".gitignore": "foo|bar\n",
+				"foo.js":     "x",
+				"bar.js":     "x",
+				"baz.js":     "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"foo.js"},
+			kept:      []string{"bar.js", "baz.js"},
+		},
+		{
+			name: "dot in directory name still respects exclusion",
+			files: map[string]string{
+				".gitignore":          "node_modules\n",
+				"v1.0/app.js":         "x",
+				"node_modules/lib.js": "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"node_modules/lib.js"},
+			kept:      []string{"v1.0/app.js"},
+		},
+		{
+			name: "snyk code exclude in repo directory with metacharacters",
+			files: map[string]string{
+				".snyk": `exclude:
+  code:
+    - node_modules
+`,
+				"pkg (core)/node_modules/lib.js": "x",
+				"pkg (core)/src/app.js":          "x",
+			},
+			ruleFiles: []string{".snyk"},
+			excluded:  []string{"pkg (core)/node_modules/lib.js"},
+			kept:      []string{"pkg (core)/src/app.js"},
+		},
+		{
+			name: "default git rule excludes dot-git contents",
+			files: map[string]string{
+				".git/config": "x",
+				"src/app.js":  "x",
+			},
+			ruleFiles: []string{},
+			excluded:  []string{".git/config"},
+			kept:      []string{"src/app.js"},
+		},
 	}
 
 	for _, tc := range scenarios {
@@ -392,6 +465,61 @@ func TestFileFilter_GetFilteredFiles_ignoreRuleScenarios(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestFileFilter_GetFilteredFiles_dotSnykUnderMetacharParentPath ensures .snyk Code exclusions
+// work when the scan root sits under a parent path with regex metacharacters (CLI-1648).
+func TestFileFilter_GetFilteredFiles_dotSnykUnderMetacharParentPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("parent path shape uses characters awkward on Windows temp paths")
+	}
+	base := filepath.Join(t.TempDir(), "OneDrive - Foobar (Team1)", "repo")
+	excluded := filepath.Join(base, "node_modules", "lib", "index.js")
+	kept := filepath.Join(base, "src", "app.js")
+	snykFile := filepath.Join(base, ".snyk")
+	createFileInPath(t, excluded, []byte("x"))
+	createFileInPath(t, kept, []byte("x"))
+	createFileInPath(t, snykFile, []byte(`exclude:
+  code:
+    - node_modules
+`))
+
+	fileFilter := NewFileFilter(base, &log.Logger)
+	globs, err := fileFilter.GetRules([]string{".snyk"})
+	assert.NoError(t, err)
+
+	var filtered []string
+	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+		filtered = append(filtered, f)
+	}
+
+	assert.Contains(t, filtered, kept)
+	assert.NotContains(t, filtered, excluded)
+}
+
+// TestFileFilter_GetFilteredFiles_dotGitExcludedUnderMetacharParentPath ensures the default
+// **/.git/** rule still applies when the scan root is under a path with regex metacharacters.
+func TestFileFilter_GetFilteredFiles_dotGitExcludedUnderMetacharParentPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("parent path shape uses characters awkward on Windows temp paths")
+	}
+	base := filepath.Join(t.TempDir(), "Program Files (x86)", "repo")
+	gitConfig := filepath.Join(base, ".git", "config")
+	appFile := filepath.Join(base, "src", "app.js")
+	createFileInPath(t, gitConfig, []byte("x"))
+	createFileInPath(t, appFile, []byte("x"))
+
+	fileFilter := NewFileFilter(base, &log.Logger)
+	globs, err := fileFilter.GetRules([]string{})
+	assert.NoError(t, err)
+
+	var filtered []string
+	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+		filtered = append(filtered, f)
+	}
+
+	assert.Contains(t, filtered, appFile)
+	assert.NotContains(t, filtered, gitConfig)
 }
 
 func BenchmarkFileFilter_GetFilteredFiles(b *testing.B) {
@@ -700,6 +828,16 @@ func TestParseIgnoreRuleToGlobs(t *testing.T) {
 			invalidRules: []string{},
 			expectedGlobs: []string{
 				"/tmp/test/**/foo/**",
+			},
+		},
+		{
+			name:         "parentheses in rule text",
+			rule:         "foo(bar)",
+			baseDir:      "/tmp/test",
+			invalidRules: []string{},
+			expectedGlobs: []string{
+				"/tmp/test/**/foo(bar)/**",
+				"/tmp/test/**/foo(bar)",
 			},
 		},
 		{

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -246,7 +246,7 @@ func TestFileFilter_GetFilteredFiles(t *testing.T) {
 }
 
 // TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars checks that ignore rules still
-// apply when the project path contains regex metacharacters (CLI-1515).
+// apply when the project path contains regex metacharacters (CLI-1648).
 func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 	metaCharDirs := []string{
 		"OneDrive - Foobar (Team1)", // parentheses + spaces (customer's path shape)
@@ -262,8 +262,15 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 		"a?b",                       // glob single-char wildcard in the path
 	}
 
+	// Characters that Windows does not allow in file/directory names, so such paths cannot
+	// exist there and don't need to be exercised on that OS.
+	const windowsIllegalChars = `<>:"/\|?*`
+
 	for _, dirName := range metaCharDirs {
 		t.Run(dirName, func(t *testing.T) {
+			if runtime.GOOS == "windows" && strings.ContainsAny(dirName, windowsIllegalChars) {
+				t.Skipf("%q contains characters not allowed in Windows paths", dirName)
+			}
 			base := filepath.Join(t.TempDir(), dirName, "repo")
 			nodeModulesFile := filepath.Join(base, "node_modules", "lib", "index.js")
 			appFile := filepath.Join(base, "app.js")

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -296,6 +296,18 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 	}
 }
 
+func TestFileFilter_toMatchGlob_preservesBackslashDollarEscape(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.ToSlash(filepath.Clean(root))
+	glob := base + `/**/price\$tag/**`
+
+	fw := NewFileFilter(root, &log.Logger)
+	got := fw.toMatchGlob(glob)
+
+	assert.Equal(t, `**/price\$tag/**`, got)
+	assert.NotContains(t, got, `price/$tag`)
+}
+
 // TestFileFilter_GetFilteredFiles_ignoreRuleScenarios covers ignore-rule behaviors that share
 // the same shape: build a filesystem (including ignore files), filter it, then assert which
 // files survive. "files" maps a slash-separated path (relative to the scan root) to its content;

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -294,6 +294,34 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 	}
 }
 
+// TestFileFilter_GetFilteredFiles_negatedCharacterClassRule ensures gitignore rules using a
+// negated character class (e.g. "cache[^S]") keep working, i.e. that "^" is not escaped in the
+// rule portion.
+func TestFileFilter_GetFilteredFiles_negatedCharacterClassRule(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "repo")
+	excluded := filepath.Join(base, "cache1", "index.js") // matches cache[^S]
+	kept := filepath.Join(base, "cacheS", "index.js")     // excluded from the negated class
+	appFile := filepath.Join(base, "app.js")
+	gitignore := filepath.Join(base, ".gitignore")
+	createFileInPath(t, excluded, []byte("x"))
+	createFileInPath(t, kept, []byte("x"))
+	createFileInPath(t, appFile, []byte("x"))
+	createFileInPath(t, gitignore, []byte("cache[^S]\n"))
+
+	fileFilter := NewFileFilter(base, &log.Logger)
+	globs, err := fileFilter.GetRules([]string{".gitignore"})
+	assert.NoError(t, err)
+
+	var filtered []string
+	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+		filtered = append(filtered, f)
+	}
+
+	assert.Contains(t, filtered, appFile, "app.js should be scanned")
+	assert.Contains(t, filtered, kept, "cacheS should be scanned (negated class excludes S)")
+	assert.NotContains(t, filtered, excluded, "cache1 must be excluded by cache[^S]")
+}
+
 func BenchmarkFileFilter_GetFilteredFiles(b *testing.B) {
 	b.Log("Creating filesystem...")
 	rootDir := b.TempDir()

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -323,6 +323,105 @@ func TestFileFilter_GetFilteredFiles_negatedCharacterClassRule(t *testing.T) {
 	assert.NotContains(t, filtered, excluded, "cache1 must be excluded by cache[^S]")
 }
 
+// TestFileFilter_GetFilteredFiles_ignoreFileInDirWithRegexMetaChars ensures an ignore file
+// located inside a directory whose name contains regex metacharacters (e.g. "my (dir)") is
+// still applied. The directory name becomes part of the compiled pattern, so it must be
+// escaped to be matched literally.
+func TestFileFilter_GetFilteredFiles_ignoreFileInDirWithRegexMetaChars(t *testing.T) {
+	root := t.TempDir()
+	nestedIgnore := filepath.Join(root, "my (dir)", ".gitignore")
+	excluded := filepath.Join(root, "my (dir)", "secret.txt")
+	kept := filepath.Join(root, "my (dir)", "keep.txt")
+	createFileInPath(t, nestedIgnore, []byte("secret.txt\n"))
+	createFileInPath(t, excluded, []byte("x"))
+	createFileInPath(t, kept, []byte("x"))
+
+	fileFilter := NewFileFilter(root, &log.Logger)
+	globs, err := fileFilter.GetRules([]string{".gitignore"})
+	assert.NoError(t, err)
+
+	var filtered []string
+	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+		filtered = append(filtered, f)
+	}
+
+	assert.Contains(t, filtered, kept, "keep.txt should be scanned")
+	assert.NotContains(t, filtered, excluded, "secret.txt must be excluded by the nested .gitignore")
+}
+
+// TestFileFilter_GetFilteredFiles_deeplyNestedIgnoreFileWithMetaChars covers an ignore file
+// several directories deep, where every level's name contains different regex metacharacters.
+func TestFileFilter_GetFilteredFiles_deeplyNestedIgnoreFileWithMetaChars(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "a (1)", "b [2]", "c +3")
+	excluded := filepath.Join(dir, "secret.txt")
+	kept := filepath.Join(dir, "keep.txt")
+	createFileInPath(t, filepath.Join(dir, ".gitignore"), []byte("secret.txt\n"))
+	createFileInPath(t, excluded, []byte("x"))
+	createFileInPath(t, kept, []byte("x"))
+
+	fileFilter := NewFileFilter(root, &log.Logger)
+	globs, err := fileFilter.GetRules([]string{".gitignore"})
+	assert.NoError(t, err)
+
+	var filtered []string
+	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+		filtered = append(filtered, f)
+	}
+
+	assert.Contains(t, filtered, kept, "keep.txt should be scanned")
+	assert.NotContains(t, filtered, excluded, "secret.txt must be excluded from a deeply nested dir")
+}
+
+// TestFileFilter_GetFilteredFiles_nestedRuleScoping ensures a rule from a nested ignore file
+// only applies within its own directory, not to a same-named file in a sibling directory.
+func TestFileFilter_GetFilteredFiles_nestedRuleScoping(t *testing.T) {
+	root := t.TempDir()
+	scopedExcluded := filepath.Join(root, "sub (x)", "only.txt")
+	siblingKept := filepath.Join(root, "other", "only.txt")
+	createFileInPath(t, filepath.Join(root, "sub (x)", ".gitignore"), []byte("only.txt\n"))
+	createFileInPath(t, scopedExcluded, []byte("x"))
+	createFileInPath(t, siblingKept, []byte("x"))
+
+	fileFilter := NewFileFilter(root, &log.Logger)
+	globs, err := fileFilter.GetRules([]string{".gitignore"})
+	assert.NoError(t, err)
+
+	var filtered []string
+	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+		filtered = append(filtered, f)
+	}
+
+	assert.NotContains(t, filtered, scopedExcluded, "only.txt under sub (x) must be excluded")
+	assert.Contains(t, filtered, siblingKept, "only.txt in a sibling dir must not be excluded")
+}
+
+// TestFileFilter_GetFilteredFiles_excludesDirectoryContents ensures a directory rule ("build/")
+// excludes all files under it, at any depth.
+func TestFileFilter_GetFilteredFiles_excludesDirectoryContents(t *testing.T) {
+	root := t.TempDir()
+	shallow := filepath.Join(root, "build", "out.js")
+	deep := filepath.Join(root, "build", "nested", "deep.js")
+	kept := filepath.Join(root, "src", "app.js")
+	createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("build/\n"))
+	createFileInPath(t, shallow, []byte("x"))
+	createFileInPath(t, deep, []byte("x"))
+	createFileInPath(t, kept, []byte("x"))
+
+	fileFilter := NewFileFilter(root, &log.Logger)
+	globs, err := fileFilter.GetRules([]string{".gitignore"})
+	assert.NoError(t, err)
+
+	var filtered []string
+	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+		filtered = append(filtered, f)
+	}
+
+	assert.Contains(t, filtered, kept, "src/app.js should be scanned")
+	assert.NotContains(t, filtered, shallow, "build/out.js must be excluded")
+	assert.NotContains(t, filtered, deep, "build/nested/deep.js must be excluded")
+}
+
 func BenchmarkFileFilter_GetFilteredFiles(b *testing.B) {
 	b.Log("Creating filesystem...")
 	rootDir := b.TempDir()

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -295,131 +295,103 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 	}
 }
 
-// TestFileFilter_GetFilteredFiles_negatedCharacterClassRule ensures gitignore rules using a
-// negated character class (e.g. "cache[^S]") keep working, i.e. that "^" is not escaped in the
-// rule portion.
-func TestFileFilter_GetFilteredFiles_negatedCharacterClassRule(t *testing.T) {
-	base := filepath.Join(t.TempDir(), "repo")
-	excluded := filepath.Join(base, "cache1", "index.js") // matches cache[^S]
-	kept := filepath.Join(base, "cacheS", "index.js")     // excluded from the negated class
-	appFile := filepath.Join(base, "app.js")
-	gitignore := filepath.Join(base, ".gitignore")
-	createFileInPath(t, excluded, []byte("x"))
-	createFileInPath(t, kept, []byte("x"))
-	createFileInPath(t, appFile, []byte("x"))
-	createFileInPath(t, gitignore, []byte("cache[^S]\n"))
-
-	fileFilter := NewFileFilter(base, &log.Logger)
-	globs, err := fileFilter.GetRules([]string{".gitignore"})
-	assert.NoError(t, err)
-
-	var filtered []string
-	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
-		filtered = append(filtered, f)
+// TestFileFilter_GetFilteredFiles_ignoreRuleScenarios covers ignore-rule behaviors that share
+// the same shape: build a filesystem (including ignore files), filter it, then assert which
+// files survive. "files" maps a slash-separated path (relative to the scan root) to its content;
+// "excluded"/"kept" list slash-separated paths that must / must not be filtered out.
+func TestFileFilter_GetFilteredFiles_ignoreRuleScenarios(t *testing.T) {
+	scenarios := []struct {
+		name      string
+		files     map[string]string
+		ruleFiles []string
+		excluded  []string
+		kept      []string
+	}{
+		{
+			name: "negated character class rule keeps working",
+			files: map[string]string{
+				".gitignore":      "cache[^S]\n",
+				"cache1/index.js": "x", // matches cache[^S]
+				"cacheS/index.js": "x", // excluded from the negated class
+				"app.js":          "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"cache1/index.js"},
+			kept:      []string{"cacheS/index.js", "app.js"},
+		},
+		{
+			name: "ignore file in dir with regex metacharacters",
+			files: map[string]string{
+				"my (dir)/.gitignore": "secret.txt\n",
+				"my (dir)/secret.txt": "x",
+				"my (dir)/keep.txt":   "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"my (dir)/secret.txt"},
+			kept:      []string{"my (dir)/keep.txt"},
+		},
+		{
+			name: "deeply nested ignore file with metacharacters at every level",
+			files: map[string]string{
+				"a (1)/b [2]/c +3/.gitignore": "secret.txt\n",
+				"a (1)/b [2]/c +3/secret.txt": "x",
+				"a (1)/b [2]/c +3/keep.txt":   "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"a (1)/b [2]/c +3/secret.txt"},
+			kept:      []string{"a (1)/b [2]/c +3/keep.txt"},
+		},
+		{
+			name: "nested rule is scoped to its own directory",
+			files: map[string]string{
+				"sub (x)/.gitignore": "only.txt\n",
+				"sub (x)/only.txt":   "x",
+				"other/only.txt":     "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"sub (x)/only.txt"},
+			kept:      []string{"other/only.txt"},
+		},
+		{
+			name: "directory rule excludes all contents at any depth",
+			files: map[string]string{
+				".gitignore":           "build/\n",
+				"build/out.js":         "x",
+				"build/nested/deep.js": "x",
+				"src/app.js":           "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"build/out.js", "build/nested/deep.js"},
+			kept:      []string{"src/app.js"},
+		},
 	}
 
-	assert.Contains(t, filtered, appFile, "app.js should be scanned")
-	assert.Contains(t, filtered, kept, "cacheS should be scanned (negated class excludes S)")
-	assert.NotContains(t, filtered, excluded, "cache1 must be excluded by cache[^S]")
-}
+	for _, tc := range scenarios {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			for p, content := range tc.files {
+				createFileInPath(t, filepath.Join(root, filepath.FromSlash(p)), []byte(content))
+			}
 
-// TestFileFilter_GetFilteredFiles_ignoreFileInDirWithRegexMetaChars ensures an ignore file
-// located inside a directory whose name contains regex metacharacters (e.g. "my (dir)") is
-// still applied. The directory name becomes part of the compiled pattern, so it must be
-// escaped to be matched literally.
-func TestFileFilter_GetFilteredFiles_ignoreFileInDirWithRegexMetaChars(t *testing.T) {
-	root := t.TempDir()
-	nestedIgnore := filepath.Join(root, "my (dir)", ".gitignore")
-	excluded := filepath.Join(root, "my (dir)", "secret.txt")
-	kept := filepath.Join(root, "my (dir)", "keep.txt")
-	createFileInPath(t, nestedIgnore, []byte("secret.txt\n"))
-	createFileInPath(t, excluded, []byte("x"))
-	createFileInPath(t, kept, []byte("x"))
+			fileFilter := NewFileFilter(root, &log.Logger)
+			globs, err := fileFilter.GetRules(tc.ruleFiles)
+			assert.NoError(t, err)
 
-	fileFilter := NewFileFilter(root, &log.Logger)
-	globs, err := fileFilter.GetRules([]string{".gitignore"})
-	assert.NoError(t, err)
+			kept := make(map[string]bool)
+			for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+				rel, relErr := filepath.Rel(root, f)
+				assert.NoError(t, relErr)
+				kept[filepath.ToSlash(rel)] = true
+			}
 
-	var filtered []string
-	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
-		filtered = append(filtered, f)
+			for _, e := range tc.excluded {
+				assert.False(t, kept[e], "%q must be excluded", e)
+			}
+			for _, k := range tc.kept {
+				assert.True(t, kept[k], "%q must be kept", k)
+			}
+		})
 	}
-
-	assert.Contains(t, filtered, kept, "keep.txt should be scanned")
-	assert.NotContains(t, filtered, excluded, "secret.txt must be excluded by the nested .gitignore")
-}
-
-// TestFileFilter_GetFilteredFiles_deeplyNestedIgnoreFileWithMetaChars covers an ignore file
-// several directories deep, where every level's name contains different regex metacharacters.
-func TestFileFilter_GetFilteredFiles_deeplyNestedIgnoreFileWithMetaChars(t *testing.T) {
-	root := t.TempDir()
-	dir := filepath.Join(root, "a (1)", "b [2]", "c +3")
-	excluded := filepath.Join(dir, "secret.txt")
-	kept := filepath.Join(dir, "keep.txt")
-	createFileInPath(t, filepath.Join(dir, ".gitignore"), []byte("secret.txt\n"))
-	createFileInPath(t, excluded, []byte("x"))
-	createFileInPath(t, kept, []byte("x"))
-
-	fileFilter := NewFileFilter(root, &log.Logger)
-	globs, err := fileFilter.GetRules([]string{".gitignore"})
-	assert.NoError(t, err)
-
-	var filtered []string
-	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
-		filtered = append(filtered, f)
-	}
-
-	assert.Contains(t, filtered, kept, "keep.txt should be scanned")
-	assert.NotContains(t, filtered, excluded, "secret.txt must be excluded from a deeply nested dir")
-}
-
-// TestFileFilter_GetFilteredFiles_nestedRuleScoping ensures a rule from a nested ignore file
-// only applies within its own directory, not to a same-named file in a sibling directory.
-func TestFileFilter_GetFilteredFiles_nestedRuleScoping(t *testing.T) {
-	root := t.TempDir()
-	scopedExcluded := filepath.Join(root, "sub (x)", "only.txt")
-	siblingKept := filepath.Join(root, "other", "only.txt")
-	createFileInPath(t, filepath.Join(root, "sub (x)", ".gitignore"), []byte("only.txt\n"))
-	createFileInPath(t, scopedExcluded, []byte("x"))
-	createFileInPath(t, siblingKept, []byte("x"))
-
-	fileFilter := NewFileFilter(root, &log.Logger)
-	globs, err := fileFilter.GetRules([]string{".gitignore"})
-	assert.NoError(t, err)
-
-	var filtered []string
-	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
-		filtered = append(filtered, f)
-	}
-
-	assert.NotContains(t, filtered, scopedExcluded, "only.txt under sub (x) must be excluded")
-	assert.Contains(t, filtered, siblingKept, "only.txt in a sibling dir must not be excluded")
-}
-
-// TestFileFilter_GetFilteredFiles_excludesDirectoryContents ensures a directory rule ("build/")
-// excludes all files under it, at any depth.
-func TestFileFilter_GetFilteredFiles_excludesDirectoryContents(t *testing.T) {
-	root := t.TempDir()
-	shallow := filepath.Join(root, "build", "out.js")
-	deep := filepath.Join(root, "build", "nested", "deep.js")
-	kept := filepath.Join(root, "src", "app.js")
-	createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("build/\n"))
-	createFileInPath(t, shallow, []byte("x"))
-	createFileInPath(t, deep, []byte("x"))
-	createFileInPath(t, kept, []byte("x"))
-
-	fileFilter := NewFileFilter(root, &log.Logger)
-	globs, err := fileFilter.GetRules([]string{".gitignore"})
-	assert.NoError(t, err)
-
-	var filtered []string
-	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
-		filtered = append(filtered, f)
-	}
-
-	assert.Contains(t, filtered, kept, "src/app.js should be scanned")
-	assert.NotContains(t, filtered, shallow, "build/out.js must be excluded")
-	assert.NotContains(t, filtered, deep, "build/nested/deep.js must be excluded")
 }
 
 func BenchmarkFileFilter_GetFilteredFiles(b *testing.B) {

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -245,6 +245,48 @@ func TestFileFilter_GetFilteredFiles(t *testing.T) {
 	}
 }
 
+// TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars checks that ignore rules still
+// apply when the project path contains regex metacharacters (CLI-1515).
+func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
+	metaCharDirs := []string{
+		"OneDrive - Foobar (Team1)", // parentheses + spaces (customer's path shape)
+		"Program Files (x86)",       // parentheses + spaces
+		"a+b",                       // plus
+		"c{d}",                      // braces (not a valid quantifier)
+		"backup{2}",                 // braces forming a valid regex quantifier
+		"a^b",                       // caret
+		"a|b",                       // pipe / alternation
+		"a$b",                       // dollar
+		"a*b",                       // glob wildcard in the path
+		"a[b]c",                     // glob character class in the path
+		"a?b",                       // glob single-char wildcard in the path
+	}
+
+	for _, dirName := range metaCharDirs {
+		t.Run(dirName, func(t *testing.T) {
+			base := filepath.Join(t.TempDir(), dirName, "repo")
+			nodeModulesFile := filepath.Join(base, "node_modules", "lib", "index.js")
+			appFile := filepath.Join(base, "app.js")
+			gitignore := filepath.Join(base, ".gitignore")
+			createFileInPath(t, nodeModulesFile, []byte("x"))
+			createFileInPath(t, appFile, []byte("x"))
+			createFileInPath(t, gitignore, []byte("node_modules\n"))
+
+			fileFilter := NewFileFilter(base, &log.Logger)
+			globs, err := fileFilter.GetRules([]string{".gitignore"})
+			assert.NoError(t, err)
+
+			var filtered []string
+			for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+				filtered = append(filtered, f)
+			}
+
+			assert.Contains(t, filtered, appFile, "app.js should be scanned")
+			assert.NotContains(t, filtered, nodeModulesFile, "node_modules must be excluded")
+		})
+	}
+}
+
 func BenchmarkFileFilter_GetFilteredFiles(b *testing.B) {
 	b.Log("Creating filesystem...")
 	rootDir := b.TempDir()

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -260,6 +260,7 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 		"a*b",                       // glob wildcard in the path
 		"a[b]c",                     // glob character class in the path
 		"a?b",                       // glob single-char wildcard in the path
+		"a\\b",                      // literal backslash (legal on unix, illegal on windows)
 	}
 
 	// Characters that Windows does not allow in file/directory names, so such paths cannot
@@ -628,6 +629,19 @@ func TestParseIgnoreRuleToGlobs(t *testing.T) {
 			invalidRules: []string{},
 			expectedGlobs: []string{
 				"/tmp/test/**/foo/**",
+			},
+		},
+		{
+			// A rule with enough "../" climbs above baseDir once filepath.Join cleans it, so the
+			// base is no longer a prefix and buildGlob takes the fallback path. The base content
+			// is gone at that point, so the remaining glob wildcards must be preserved.
+			name:         "rule climbing above base uses fallback",
+			rule:         "../../../../../../foo",
+			baseDir:      "/tmp/test",
+			invalidRules: []string{},
+			expectedGlobs: []string{
+				"/foo/**",
+				"/foo",
 			},
 		},
 	}


### PR DESCRIPTION
### Description

Alternative approach to https://github.com/snyk/go-application-framework/pull/653

`pkg/utils/file_filter.go` (lines 165->173): we transform absolute paths (with or without special characters) to relative for `globPatternMatcher.MatchesPath()`. This avoids the `go-gitignore` problem with special characters.



### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.
