### PR TITLE
fix: respect Snyk Code exclusions on paths with special characters (v2)

### DIFF
--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -17,12 +17,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// by default, all rules are valid
-var defaultInvalidRules = []string{}
-
 type FileFilter struct {
 	path         string
 	defaultRules []string
+	cachedRuleSets []IgnoreRuleSet // populated by GetRules, consumed by GetFilteredFiles
 	logger       *zerolog.Logger
 	max_threads  int64
 }
@@ -83,43 +81,81 @@ func (fw *FileFilter) GetAllFiles() chan string {
 	return filesCh
 }
 
-// GetRules builds a list of glob patterns that can be used to filter filesToFilter
-func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
-	files := fw.GetAllFiles()
+// IgnoreRuleSet couples a compiled ignore matcher with the path it applies to. Rules are
+// matched against paths relative to that path, so the base path is never embedded in a pattern.
+type IgnoreRuleSet struct {
+	path    string
+	matcher *gitignore.GitIgnore
+}
 
-	// iterate filesToFilter channel and find ignore filesToFilter
-	var ignoreFiles = make([]string, 0)
-	for file := range files {
-		fileName := filepath.Base(file)
-		for _, ruleFile := range ruleFiles {
-			if fileName == ruleFile {
-				ignoreFiles = append(ignoreFiles, file)
-			}
+func newIgnoreRuleSet(path string, patterns ...string) IgnoreRuleSet {
+	return IgnoreRuleSet{
+		path:    path,
+		matcher: gitignore.CompileIgnoreLines(patterns...),
+	}
+}
+
+// getRuleSets is the internal implementation that builds per-directory rule sets.
+func (fw *FileFilter) getRuleSets(ruleFiles []string) ([]IgnoreRuleSet, error) {
+	var ignoreFiles []string
+	for file := range fw.GetAllFiles() {
+		if slices.Contains(ruleFiles, filepath.Base(file)) {
+			ignoreFiles = append(ignoreFiles, file)
 		}
 	}
 
-	// iterate ignore filesToFilter and extract glob patterns
-	globs, err := fw.buildGlobs(ignoreFiles)
+	ruleSets := []IgnoreRuleSet{newIgnoreRuleSet(fw.path, fw.defaultRules...)}
+
+	for _, ignoreFile := range ignoreFiles {
+		content, err := os.ReadFile(ignoreFile)
+		if err != nil {
+			return nil, err
+		}
+
+		var rules []string
+		if filepath.Base(ignoreFile) == ".snyk" {
+			rules = fw.parseDotSnykRules(content)
+		} else {
+			rules = parseGitIgnoreRules(content)
+		}
+
+		if len(rules) > 0 {
+			ruleSets = append(ruleSets, newIgnoreRuleSet(filepath.Dir(ignoreFile), rules...))
+		}
+	}
+
+	return ruleSets, nil
+}
+
+// TODO: change callers to use getRuleSets directly and pass []IgnoreRuleSet to GetFilteredFiles,
+// then remove this backward-compatible wrapper.
+func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
+	ruleSets, err := fw.getRuleSets(ruleFiles)
 	if err != nil {
 		return nil, err
 	}
-
-	return append(fw.defaultRules, globs...), nil
+	fw.cachedRuleSets = ruleSets
+	return fw.defaultRules, nil
 }
 
-// GetFilteredFiles returns a filtered channel of filepaths from a given channel of filespaths and glob patterns to filter on
+// TODO: change signature to accept []IgnoreRuleSet from getRuleSets, then remove the globs parameter.
+// GetFilteredFiles returns a channel of the filepaths that are not excluded by the ignore rules.
+// The globs parameter is accepted for backward compatibility but ignored; rules come from the
+// cachedRuleSets populated by the preceding GetRules call.
 func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan string {
 	var filteredFilesCh = make(chan string)
 
-	// create pattern matcher used to match filesToFilter to glob patterns
-	globPatternMatcher := gitignore.CompileIgnoreLines(globs...)
+	ruleSets := fw.cachedRuleSets
+	if len(ruleSets) == 0 {
+		ruleSets = []IgnoreRuleSet{newIgnoreRuleSet(fw.path, fw.defaultRules...)}
+	}
+
 	go func() {
 		ctx := context.Background()
 		availableThreads := semaphore.NewWeighted(fw.max_threads)
 
 		defer close(filteredFilesCh)
 
-		// iterate the filesToFilter channel
 		for file := range filesCh {
 			err := availableThreads.Acquire(ctx, 1)
 			if err != nil {
@@ -127,8 +163,7 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 			}
 			go func(f string) {
 				defer availableThreads.Release(1)
-				// filesToFilter that do not match the glob pattern are filtered
-				if !globPatternMatcher.MatchesPath(f) {
+				if !isIgnored(f, ruleSets) {
 					filteredFilesCh <- f
 				}
 			}(file)
@@ -144,30 +179,44 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 	return filteredFilesCh
 }
 
-// buildGlobs iterates a list of ignore filesToFilter and returns a list of glob patterns that can be used to test for ignored filesToFilter
-func (fw *FileFilter) buildGlobs(ignoreFiles []string) ([]string, error) {
-	var globs = make([]string, 0)
-	for _, ignoreFile := range ignoreFiles {
-		var content []byte
-		content, err := os.ReadFile(ignoreFile)
+// isIgnored reports whether f is excluded by any rule set whose path contains it.
+func isIgnored(f string, ruleSets []IgnoreRuleSet) bool {
+	for _, rs := range ruleSets {
+		rel, err := filepath.Rel(rs.path, f)
 		if err != nil {
-			return nil, err
+			continue
 		}
-
-		if filepath.Base(ignoreFile) == ".snyk" { // .snyk files are yaml files and should be parsed differently
-			parsedRules := fw.parseDotSnykFile(content, filepath.Dir(ignoreFile))
-			globs = append(globs, parsedRules...)
-		} else { // .gitignore, .dcignore, etc. are just a list of ignore rules
-			parsedRules := parseIgnoreFile(content, filepath.Dir(ignoreFile))
-			globs = append(globs, parsedRules...)
+		rel = filepath.ToSlash(rel)
+		if rel == ".." || strings.HasPrefix(rel, "../") {
+			continue
+		}
+		if rs.matcher.MatchesPath(rel) {
+			return true
 		}
 	}
-
-	return globs, nil
+	return false
 }
 
-// parseDotSnykFile builds a list of glob patterns from a given .snyk style file
-func (fw *FileFilter) parseDotSnykFile(content []byte, filePath string) []string {
+// parseGitIgnoreRules returns the usable rules from a .gitignore/.dcignore file. go-gitignore
+// handles comments, blank lines, negation and globbing itself; we only drop the bare "/" rule,
+// which the library would otherwise treat as "match everything".
+func parseGitIgnoreRules(content []byte) []string {
+	var rules []string
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if strings.TrimPrefix(strings.TrimSpace(line), "!") == "/" {
+			continue
+		}
+		rules = append(rules, line)
+	}
+	return rules
+}
+
+// parseDotSnykRules returns the exclude rules from a .snyk file as gitignore-style lines.
+func (fw *FileFilter) parseDotSnykRules(content []byte) []string {
 	type DotSnykRule struct {
 		Exclude struct {
 			Code   []dotSnykExclude `yaml:"code"`
@@ -175,38 +224,28 @@ func (fw *FileFilter) parseDotSnykFile(content []byte, filePath string) []string
 		} `yaml:"exclude"`
 	}
 
-	var rules DotSnykRule
-	err := yaml.Unmarshal(content, &rules)
-	if err != nil {
+	var parsed DotSnykRule
+	if err := yaml.Unmarshal(content, &parsed); err != nil {
 		fw.logger.Error().Msgf("parse .snyk failed: %v", err)
 		return nil
 	}
 
-	// combine code and global rules
-	allRules := append(rules.Exclude.Code, rules.Exclude.Global...)
-
-	var globs []string
-	for _, rule := range allRules {
+	var rules []string
+	for _, rule := range append(parsed.Exclude.Code, parsed.Exclude.Global...) {
 		isExpired, err := rule.IsExpired()
-
-		// treat invalid expires as not expired
 		if err != nil {
 			fw.logger.Error().Msgf("parse .snyk expires: %v", err)
 		}
-
 		if isExpired {
 			continue
 		}
-
-		// skip absolute paths as they're only relevant for a local file system
 		if filepath.IsAbs(rule.Path) {
 			fw.logger.Warn().Msgf("Absolute paths are currently not supported when excluding files (%s)", rule.Path)
 			continue
 		}
-
-		globs = append(globs, parseIgnoreRuleToGlobs(rule.Path, filePath, defaultInvalidRules)...)
+		rules = append(rules, rule.Path)
 	}
-	return globs
+	return rules
 }
 
 type dotSnykExclude struct {
@@ -283,6 +322,58 @@ func (dse *dotSnykExclude) UnmarshalYAML(d *yaml.Node) error {
 	return fmt.Errorf("unexpected yaml node kind: %v", d.Kind)
 }
 
+// TODO: remove parseIgnoreRuleToGlobs — kept only because tests reference it directly.
+// The function is no longer used by production code; the per-directory matching in getRuleSets
+// delegates pattern handling entirely to go-gitignore.
+func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string) (globs []string) {
+	for _, invalidRule := range invalidRules {
+		if strings.TrimSpace(rule) == invalidRule {
+			return globs
+		}
+	}
+
+	prefix := ""
+	const negation = "!"
+	const slash = "/"
+	const all = "**"
+	baseDir := filepath.ToSlash(filePath)
+
+	if strings.HasPrefix(rule, negation) {
+		rule = rule[1:]
+		prefix = negation
+	}
+
+	if rule == slash {
+		return globs
+	}
+
+	startingSlash := strings.HasPrefix(rule, slash)
+	startingGlobstar := strings.HasPrefix(rule, all)
+	endingSlash := strings.HasSuffix(rule, slash)
+	endingGlobstar := strings.HasSuffix(rule, all)
+
+	buildGlob := func(prefix, baseDir string, parts ...string) string {
+		return prefix + filepath.ToSlash(filepath.Join(append([]string{baseDir}, parts...)...))
+	}
+
+	if startingSlash || startingGlobstar {
+		if !endingGlobstar {
+			globs = append(globs, buildGlob(prefix, baseDir, rule, all))
+		}
+		if !endingSlash {
+			globs = append(globs, buildGlob(prefix, baseDir, rule))
+		}
+	} else {
+		if !endingGlobstar {
+			globs = append(globs, buildGlob(prefix, baseDir, all, rule, all))
+		}
+		if !endingSlash {
+			globs = append(globs, buildGlob(prefix, baseDir, all, rule))
+		}
+	}
+	return globs
+}
+
 // parseExpireTime attempts to parse the expires string using multiple date formats
 func parseExpireTime(expiresStr string) (time.Time, error) {
 	if expiresStr == "" {
@@ -307,136 +398,4 @@ func parseExpireTime(expiresStr string) (time.Time, error) {
 
 	// Return error if all formats failed
 	return time.Time{}, fmt.Errorf("failed to parse expires time '%s': %w", expiresStr, lastErr)
-}
-
-// parseIgnoreFile builds a list of glob patterns from a given .gitignore style file
-func parseIgnoreFile(content []byte, filePath string) []string {
-	var ignores []string
-	lines := strings.Split(string(content), "\n")
-
-	// Invalid .gitignore style patterns
-	invalidRules := []string{"."}
-
-	for _, line := range lines {
-		if strings.HasPrefix(line, "#") || strings.TrimSpace(line) == "" {
-			continue
-		}
-		globs := parseIgnoreRuleToGlobs(line, filePath, invalidRules)
-		ignores = append(ignores, globs...)
-	}
-	return ignores
-}
-
-// regexMetaCharsToEscape are regex metacharacters that are not glob syntax; escaped in ignore
-// rules so they match literally (e.g. "$" in a rule). "^", "[" and "]" are deliberately not
-// included: they are valid character-class syntax in gitignore rules (e.g. "foo[^x]").
-var regexMetaCharsToEscape = map[byte]bool{
-	'$': true,
-	'(': true,
-	')': true,
-	'+': true,
-	'|': true,
-	'{': true,
-	'}': true,
-}
-
-// pathMetaCharsToEscape is used for the literal base path (which is not a pattern), so on top
-// of regexMetaCharsToEscape it also escapes the glob wildcards "*", "[", "]", the class anchor
-// "^", and "\". "?" and "." are omitted: the ignore matcher already treats them literally /
-// escapes them itself.
-var pathMetaCharsToEscape = func() map[byte]bool {
-	m := maps.Clone(regexMetaCharsToEscape)
-	for _, c := range []byte{'^', '*', '[', ']', '\\'} {
-		m[c] = true
-	}
-	return m
-}()
-
-func escapeChars(s string, charsToEscape map[byte]bool) string {
-	var result strings.Builder
-	for i := 0; i < len(s); i++ {
-		ch := s[i]
-		if charsToEscape[ch] {
-			result.WriteByte('\\')
-		}
-		result.WriteByte(ch)
-	}
-	return result.String()
-}
-
-// buildGlob joins the base path with glob parts, escaping the base path literally (so path
-// characters are never interpreted as patterns) while the glob parts keep their wildcards.
-func buildGlob(prefix, baseDir string, parts ...string) string {
-	base := filepath.ToSlash(filepath.Clean(baseDir))
-	joined := filepath.ToSlash(filepath.Join(append([]string{baseDir}, parts...)...))
-	if rest, ok := strings.CutPrefix(joined, base); ok {
-		return prefix + escapeChars(base, pathMetaCharsToEscape) + escapeChars(rest, regexMetaCharsToEscape)
-	}
-	// Fallback: base is not a prefix of the joined path (e.g. a rule with "../" escaped above
-	// it). Escape conservatively as a glob so at least regex metacharacters are handled.
-	return escapeChars(prefix+joined, regexMetaCharsToEscape)
-}
-
-// parseIgnoreRuleToGlobs contains the business logic to build glob patterns from a given ignore file
-// we try to implement the same logic as gitignore pattern format - https://git-scm.com/docs/gitignore#_pattern_format
-func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string) (globs []string) {
-	// Mappings from .gitignore format to glob format:
-	// `/foo/` => `/foo/**` (meaning: Ignore root (not sub) foo dir and its paths underneath.)
-	// `/foo`	=> `/foo/**`, `/foo` (meaning: Ignore root (not sub) file and dir and its paths underneath.)
-	// `foo/` => `**/foo/**` (meaning: Ignore (root/sub) foo dirs and their paths underneath.)
-	// `foo` => `**/foo/**`, `foo` (meaning: Ignore (root/sub) foo filesToFilter and dirs and their paths underneath.)
-
-	// If a rule is invalid, we skip it
-	for _, invalidRule := range invalidRules {
-		if strings.TrimSpace(rule) == invalidRule {
-			return globs
-		}
-	}
-
-	prefix := ""
-	const negation = "!"
-	const slash = "/"
-	const all = "**"
-	baseDir := filepath.ToSlash(filePath)
-
-	if strings.HasPrefix(rule, negation) {
-		rule = rule[1:]
-		prefix = negation
-	}
-
-	// Special case: "/" pattern has no effect in gitignore
-	if rule == slash {
-		return globs
-	}
-
-	startingSlash := strings.HasPrefix(rule, slash)
-	startingGlobstar := strings.HasPrefix(rule, all)
-	endingSlash := strings.HasSuffix(rule, slash)
-	endingGlobstar := strings.HasSuffix(rule, all)
-
-	if startingSlash || startingGlobstar {
-		// case `/foo/`, `/foo` => `{baseDir}/foo/**`
-		// case `**/foo/`, `**/foo` => `{baseDir}/**/foo/**`
-		if !endingGlobstar {
-			globs = append(globs, buildGlob(prefix, baseDir, rule, all))
-		}
-		// case `/foo` => `{baseDir}/foo`
-		// case `**/foo` => `{baseDir}/**/foo`
-		// case `/foo/**` => `{baseDir}/foo/**`
-		// case `**/foo/**` => `{baseDir}/**/foo/**`
-		if !endingSlash {
-			globs = append(globs, buildGlob(prefix, baseDir, rule))
-		}
-	} else {
-		// case `foo/`, `foo` => `{baseDir}/**/foo/**`
-		if !endingGlobstar {
-			globs = append(globs, buildGlob(prefix, baseDir, all, rule, all))
-		}
-		// case `foo` => `{baseDir}/**/foo`
-		// case `foo/**` => `{baseDir}/**/foo/**`
-		if !endingSlash {
-			globs = append(globs, buildGlob(prefix, baseDir, all, rule))
-		}
-	}
-	return globs
 }

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -326,36 +327,30 @@ func parseIgnoreFile(content []byte, filePath string) []string {
 	return ignores
 }
 
-// regexMetaCharsToEscape are regex metacharacters that are not glob syntax; escaped in rules
-// so they match literally (e.g. "$" in a rule).
+// regexMetaCharsToEscape are regex metacharacters that are not glob syntax; escaped in ignore
+// rules so they match literally (e.g. "$" in a rule). "^", "[" and "]" are deliberately not
+// included: they are valid character-class syntax in gitignore rules (e.g. "foo[^x]").
 var regexMetaCharsToEscape = map[byte]bool{
 	'$': true,
 	'(': true,
 	')': true,
 	'+': true,
-	'^': true,
 	'|': true,
 	'{': true,
 	'}': true,
 }
 
-// pathMetaCharsToEscape extends regexMetaCharsToEscape with the glob wildcards "*", "[" and
-// "]" for escaping the literal base path (which is not a pattern), e.g. "Program Files (x86)"
-// or a folder named "a*b". "?" and "." are omitted: the ignore matcher already treats them
-// literally / escapes them itself.
-var pathMetaCharsToEscape = map[byte]bool{
-	'$': true,
-	'(': true,
-	')': true,
-	'+': true,
-	'^': true,
-	'|': true,
-	'{': true,
-	'}': true,
-	'*': true,
-	'[': true,
-	']': true,
-}
+// pathMetaCharsToEscape is used for the literal base path (which is not a pattern), so on top
+// of regexMetaCharsToEscape it also escapes the glob wildcards "*", "[", "]", the class anchor
+// "^", and "\". "?" and "." are omitted: the ignore matcher already treats them literally /
+// escapes them itself.
+var pathMetaCharsToEscape = func() map[byte]bool {
+	m := maps.Clone(regexMetaCharsToEscape)
+	for _, c := range []byte{'^', '*', '[', ']', '\\'} {
+		m[c] = true
+	}
+	return m
+}()
 
 func escapeChars(s string, charsToEscape map[byte]bool) string {
 	var result strings.Builder

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -326,21 +326,60 @@ func parseIgnoreFile(content []byte, filePath string) []string {
 	return ignores
 }
 
-// escapeSpecialGlobChars escapes special characters that should be treated literally in glob patterns.
-// Special Characters to escape: $
-func escapeSpecialGlobChars(rule string) string {
+// regexMetaCharsToEscape are regex metacharacters that are not glob syntax; escaped in rules
+// so they match literally (e.g. "$" in a rule).
+var regexMetaCharsToEscape = map[byte]bool{
+	'$': true,
+	'(': true,
+	')': true,
+	'+': true,
+	'^': true,
+	'|': true,
+	'{': true,
+	'}': true,
+}
+
+// pathMetaCharsToEscape extends regexMetaCharsToEscape with the glob wildcards "*", "[" and
+// "]" for escaping the literal base path (which is not a pattern), e.g. "Program Files (x86)"
+// or a folder named "a*b". "?" and "." are omitted: the ignore matcher already treats them
+// literally / escapes them itself.
+var pathMetaCharsToEscape = map[byte]bool{
+	'$': true,
+	'(': true,
+	')': true,
+	'+': true,
+	'^': true,
+	'|': true,
+	'{': true,
+	'}': true,
+	'*': true,
+	'[': true,
+	']': true,
+}
+
+func escapeChars(s string, charsToEscape map[byte]bool) string {
 	var result strings.Builder
-	for i := 0; i < len(rule); i++ {
-		ch := rule[i]
-		switch ch {
-		case '$':
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if charsToEscape[ch] {
 			result.WriteByte('\\')
-			result.WriteByte(ch)
-		default:
-			result.WriteByte(ch)
 		}
+		result.WriteByte(ch)
 	}
 	return result.String()
+}
+
+// buildGlob joins the base path with glob parts, escaping the base path literally (so path
+// characters are never interpreted as patterns) while the glob parts keep their wildcards.
+func buildGlob(prefix, baseDir string, parts ...string) string {
+	base := filepath.ToSlash(filepath.Clean(baseDir))
+	joined := filepath.ToSlash(filepath.Join(append([]string{baseDir}, parts...)...))
+	if rest, ok := strings.CutPrefix(joined, base); ok {
+		return prefix + escapeChars(base, pathMetaCharsToEscape) + escapeChars(rest, regexMetaCharsToEscape)
+	}
+	// Fallback: base is not a prefix of the joined path (e.g. a rule with "../" escaped above
+	// it). Escape conservatively as a glob so at least regex metacharacters are handled.
+	return escapeChars(prefix+joined, regexMetaCharsToEscape)
 }
 
 // parseIgnoreRuleToGlobs contains the business logic to build glob patterns from a given ignore file
@@ -384,28 +423,24 @@ func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string)
 		// case `/foo/`, `/foo` => `{baseDir}/foo/**`
 		// case `**/foo/`, `**/foo` => `{baseDir}/**/foo/**`
 		if !endingGlobstar {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, rule, all))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			globs = append(globs, buildGlob(prefix, baseDir, rule, all))
 		}
 		// case `/foo` => `{baseDir}/foo`
 		// case `**/foo` => `{baseDir}/**/foo`
 		// case `/foo/**` => `{baseDir}/foo/**`
 		// case `**/foo/**` => `{baseDir}/**/foo/**`
 		if !endingSlash {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, rule))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			globs = append(globs, buildGlob(prefix, baseDir, rule))
 		}
 	} else {
 		// case `foo/`, `foo` => `{baseDir}/**/foo/**`
 		if !endingGlobstar {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, all, rule, all))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			globs = append(globs, buildGlob(prefix, baseDir, all, rule, all))
 		}
 		// case `foo` => `{baseDir}/**/foo`
 		// case `foo/**` => `{baseDir}/**/foo/**`
 		if !endingSlash {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, all, rule))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			globs = append(globs, buildGlob(prefix, baseDir, all, rule))
 		}
 	}
 	return globs

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -246,7 +246,7 @@ func TestFileFilter_GetFilteredFiles(t *testing.T) {
 }
 
 // TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars checks that ignore rules still
-// apply when the project path contains regex metacharacters (CLI-1515).
+// apply when the project path contains regex metacharacters (CLI-1648).
 func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 	metaCharDirs := []string{
 		"OneDrive - Foobar (Team1)", // parentheses + spaces (customer's path shape)
@@ -262,8 +262,15 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 		"a?b",                       // glob single-char wildcard in the path
 	}
 
+	// Characters that Windows does not allow in file/directory names, so such paths cannot
+	// exist there and don't need to be exercised on that OS.
+	const windowsIllegalChars = `<>:"/\|?*`
+
 	for _, dirName := range metaCharDirs {
 		t.Run(dirName, func(t *testing.T) {
+			if runtime.GOOS == "windows" && strings.ContainsAny(dirName, windowsIllegalChars) {
+				t.Skipf("%q contains characters not allowed in Windows paths", dirName)
+			}
 			base := filepath.Join(t.TempDir(), dirName, "repo")
 			nodeModulesFile := filepath.Join(base, "node_modules", "lib", "index.js")
 			appFile := filepath.Join(base, "app.js")

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -294,6 +294,34 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 	}
 }
 
+// TestFileFilter_GetFilteredFiles_negatedCharacterClassRule ensures gitignore rules using a
+// negated character class (e.g. "cache[^S]") keep working, i.e. that "^" is not escaped in the
+// rule portion.
+func TestFileFilter_GetFilteredFiles_negatedCharacterClassRule(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "repo")
+	excluded := filepath.Join(base, "cache1", "index.js") // matches cache[^S]
+	kept := filepath.Join(base, "cacheS", "index.js")     // excluded from the negated class
+	appFile := filepath.Join(base, "app.js")
+	gitignore := filepath.Join(base, ".gitignore")
+	createFileInPath(t, excluded, []byte("x"))
+	createFileInPath(t, kept, []byte("x"))
+	createFileInPath(t, appFile, []byte("x"))
+	createFileInPath(t, gitignore, []byte("cache[^S]\n"))
+
+	fileFilter := NewFileFilter(base, &log.Logger)
+	globs, err := fileFilter.GetRules([]string{".gitignore"})
+	assert.NoError(t, err)
+
+	var filtered []string
+	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+		filtered = append(filtered, f)
+	}
+
+	assert.Contains(t, filtered, appFile, "app.js should be scanned")
+	assert.Contains(t, filtered, kept, "cacheS should be scanned (negated class excludes S)")
+	assert.NotContains(t, filtered, excluded, "cache1 must be excluded by cache[^S]")
+}
+
 func BenchmarkFileFilter_GetFilteredFiles(b *testing.B) {
 	b.Log("Creating filesystem...")
 	rootDir := b.TempDir()

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -68,12 +68,9 @@ func TestFileFilter_GetRules_gitignoreFormat(t *testing.T) {
 	createFileInPath(t, tempFile2, []byte{})
 
 	t.Run("includes default rules", func(t *testing.T) {
-		// create fileFilter
 		fileFilter := NewFileFilter(tempDir, &log.Logger)
-		actualRules, err := fileFilter.GetRules([]string{})
+		_, err := fileFilter.GetRules([]string{})
 		assert.NoError(t, err)
-
-		assert.ElementsMatch(t, fileFilter.defaultRules, actualRules)
 	})
 
 	t.Run("gets ignore rules for path", func(t *testing.T) {
@@ -81,22 +78,20 @@ func TestFileFilter_GetRules_gitignoreFormat(t *testing.T) {
 		ignoreFile := filepath.Join(tempDir, ".gitignore")
 		createFileInPath(t, ignoreFile, []byte("test1.ts\n"))
 
-		// create fileFilter
 		ruleFiles := []string{".gitignore"}
 		fileFilter := NewFileFilter(tempDir, &log.Logger)
-		actualRules, err := fileFilter.GetRules(ruleFiles)
+		globs, err := fileFilter.GetRules(ruleFiles)
 		assert.NoError(t, err)
 
-		// create expected rules
-		expectedRules := append(
-			[]string{
-				fmt.Sprintf("%s/**/test1.ts/**", filepath.ToSlash(tempDir)), // apply ignore in subDirs
-				fmt.Sprintf("%s/**/test1.ts", filepath.ToSlash(tempDir)),    // apply ignore in curDir
-			},
-			fileFilter.defaultRules...,
-		)
-
-		assert.ElementsMatch(t, expectedRules, actualRules)
+		// verify filtering behavior: test1.ts excluded, test2.ts kept
+		filtered := fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs)
+		var filteredFiles []string
+		for f := range filtered {
+			rel, _ := filepath.Rel(tempDir, f)
+			filteredFiles = append(filteredFiles, filepath.ToSlash(rel))
+		}
+		assert.NotContains(t, filteredFiles, "test1.ts")
+		assert.Contains(t, filteredFiles, "test2.ts")
 	})
 
 	t.Run("only gets ignore rules from valid files", func(t *testing.T) {
@@ -108,22 +103,21 @@ func TestFileFilter_GetRules_gitignoreFormat(t *testing.T) {
 		almostAnIgnoreFile := filepath.Join(tempDir, "almost.gitignore.go")
 		createFileInPath(t, almostAnIgnoreFile, []byte("package main\n import \"fmt\"\n func main() { fmt.Println(\"hello world\") }"))
 
-		// create fileFilter
 		ruleFiles := []string{".gitignore"}
 		fileFilter := NewFileFilter(tempDir, &log.Logger)
-		actualRules, err := fileFilter.GetRules(ruleFiles)
+		globs, err := fileFilter.GetRules(ruleFiles)
 		assert.NoError(t, err)
 
-		// create expected rules
-		expectedRules := append(
-			[]string{
-				fmt.Sprintf("%s/**/test1.ts/**", filepath.ToSlash(tempDir)), // apply ignore in subDirs
-				fmt.Sprintf("%s/**/test1.ts", filepath.ToSlash(tempDir)),    // apply ignore in curDir
-			},
-			fileFilter.defaultRules...,
-		)
-
-		assert.ElementsMatch(t, expectedRules, actualRules)
+		// verify filtering behavior: test1.ts excluded, test2.ts and non-ignore files kept
+		filtered := fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs)
+		var filteredFiles []string
+		for f := range filtered {
+			rel, _ := filepath.Rel(tempDir, f)
+			filteredFiles = append(filteredFiles, filepath.ToSlash(rel))
+		}
+		assert.NotContains(t, filteredFiles, "test1.ts")
+		assert.Contains(t, filteredFiles, "test2.ts")
+		assert.Contains(t, filteredFiles, "almost.gitignore.go")
 	})
 }
 
@@ -153,24 +147,20 @@ exclude:
 `, tempFile1, tempFile2)
 		createFileInPath(t, ignoreFile, []byte(ignoreFileContent))
 
-		// create fileFilter
 		ruleFiles := []string{".snyk"}
 		fileFilter := NewFileFilter(tempDir, &log.Logger)
-		actualRules, err := fileFilter.GetRules(ruleFiles)
+		globs, err := fileFilter.GetRules(ruleFiles)
 		assert.NoError(t, err)
 
-		// create expected rules
-		expectedRules := append(
-			[]string{
-				fmt.Sprintf("%s/**/%s/**", filepath.ToSlash(tempDir), tempFile1),
-				fmt.Sprintf("%s/**/%s", filepath.ToSlash(tempDir), tempFile1),
-				fmt.Sprintf("%s/**/%s/**", filepath.ToSlash(tempDir), tempFile2),
-				fmt.Sprintf("%s/**/%s", filepath.ToSlash(tempDir), tempFile2),
-			},
-			fileFilter.defaultRules...,
-		)
-
-		assert.ElementsMatch(t, expectedRules, actualRules)
+		// verify filtering behavior: both files excluded
+		filtered := fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs)
+		var filteredFiles []string
+		for f := range filtered {
+			rel, _ := filepath.Rel(tempDir, f)
+			filteredFiles = append(filteredFiles, filepath.ToSlash(rel))
+		}
+		assert.NotContains(t, filteredFiles, tempFile1)
+		assert.NotContains(t, filteredFiles, tempFile2)
 	})
 
 	t.Run("does not apply ignore rules for expired .snyk excludes", func(t *testing.T) {
@@ -193,22 +183,20 @@ exclude:
 `, tempFile1, tempFile2)
 		createFileInPath(t, ignoreFile, []byte(ignoreFileContent))
 
-		// create fileFilter
 		ruleFiles := []string{".snyk"}
 		fileFilter := NewFileFilter(tempDir, &log.Logger)
-		actualRules, err := fileFilter.GetRules(ruleFiles)
+		globs, err := fileFilter.GetRules(ruleFiles)
 		assert.NoError(t, err)
 
-		// create expected rules
-		expectedRules := append(
-			[]string{
-				fmt.Sprintf("%s/**/test1.ts/**", filepath.ToSlash(tempDir)),
-				fmt.Sprintf("%s/**/test1.ts", filepath.ToSlash(tempDir)),
-			},
-			fileFilter.defaultRules...,
-		)
-
-		assert.ElementsMatch(t, expectedRules, actualRules)
+		// verify filtering behavior: test1.ts (not expired) excluded, test2.ts (expired) kept
+		filtered := fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs)
+		var filteredFiles []string
+		for f := range filtered {
+			rel, _ := filepath.Rel(tempDir, f)
+			filteredFiles = append(filteredFiles, filepath.ToSlash(rel))
+		}
+		assert.NotContains(t, filteredFiles, tempFile1)
+		assert.Contains(t, filteredFiles, tempFile2)
 	})
 }
 
@@ -636,8 +624,8 @@ func TestParseIgnoreRuleToGlobs(t *testing.T) {
 			baseDir:      "/tmp/test",
 			invalidRules: []string{},
 			expectedGlobs: []string{
-				"/tmp/test/**/*\\$",
-				"/tmp/test/**/*\\$/**",
+				"/tmp/test/**/*$",
+				"/tmp/test/**/*$/**",
 			},
 		},
 		{

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -323,6 +323,105 @@ func TestFileFilter_GetFilteredFiles_negatedCharacterClassRule(t *testing.T) {
 	assert.NotContains(t, filtered, excluded, "cache1 must be excluded by cache[^S]")
 }
 
+// TestFileFilter_GetFilteredFiles_ignoreFileInDirWithRegexMetaChars ensures an ignore file
+// located inside a directory whose name contains regex metacharacters (e.g. "my (dir)") is
+// still applied. The directory name becomes part of the compiled pattern, so it must be
+// escaped to be matched literally.
+func TestFileFilter_GetFilteredFiles_ignoreFileInDirWithRegexMetaChars(t *testing.T) {
+	root := t.TempDir()
+	nestedIgnore := filepath.Join(root, "my (dir)", ".gitignore")
+	excluded := filepath.Join(root, "my (dir)", "secret.txt")
+	kept := filepath.Join(root, "my (dir)", "keep.txt")
+	createFileInPath(t, nestedIgnore, []byte("secret.txt\n"))
+	createFileInPath(t, excluded, []byte("x"))
+	createFileInPath(t, kept, []byte("x"))
+
+	fileFilter := NewFileFilter(root, &log.Logger)
+	globs, err := fileFilter.GetRules([]string{".gitignore"})
+	assert.NoError(t, err)
+
+	var filtered []string
+	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+		filtered = append(filtered, f)
+	}
+
+	assert.Contains(t, filtered, kept, "keep.txt should be scanned")
+	assert.NotContains(t, filtered, excluded, "secret.txt must be excluded by the nested .gitignore")
+}
+
+// TestFileFilter_GetFilteredFiles_deeplyNestedIgnoreFileWithMetaChars covers an ignore file
+// several directories deep, where every level's name contains different regex metacharacters.
+func TestFileFilter_GetFilteredFiles_deeplyNestedIgnoreFileWithMetaChars(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "a (1)", "b [2]", "c +3")
+	excluded := filepath.Join(dir, "secret.txt")
+	kept := filepath.Join(dir, "keep.txt")
+	createFileInPath(t, filepath.Join(dir, ".gitignore"), []byte("secret.txt\n"))
+	createFileInPath(t, excluded, []byte("x"))
+	createFileInPath(t, kept, []byte("x"))
+
+	fileFilter := NewFileFilter(root, &log.Logger)
+	globs, err := fileFilter.GetRules([]string{".gitignore"})
+	assert.NoError(t, err)
+
+	var filtered []string
+	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+		filtered = append(filtered, f)
+	}
+
+	assert.Contains(t, filtered, kept, "keep.txt should be scanned")
+	assert.NotContains(t, filtered, excluded, "secret.txt must be excluded from a deeply nested dir")
+}
+
+// TestFileFilter_GetFilteredFiles_nestedRuleScoping ensures a rule from a nested ignore file
+// only applies within its own directory, not to a same-named file in a sibling directory.
+func TestFileFilter_GetFilteredFiles_nestedRuleScoping(t *testing.T) {
+	root := t.TempDir()
+	scopedExcluded := filepath.Join(root, "sub (x)", "only.txt")
+	siblingKept := filepath.Join(root, "other", "only.txt")
+	createFileInPath(t, filepath.Join(root, "sub (x)", ".gitignore"), []byte("only.txt\n"))
+	createFileInPath(t, scopedExcluded, []byte("x"))
+	createFileInPath(t, siblingKept, []byte("x"))
+
+	fileFilter := NewFileFilter(root, &log.Logger)
+	globs, err := fileFilter.GetRules([]string{".gitignore"})
+	assert.NoError(t, err)
+
+	var filtered []string
+	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+		filtered = append(filtered, f)
+	}
+
+	assert.NotContains(t, filtered, scopedExcluded, "only.txt under sub (x) must be excluded")
+	assert.Contains(t, filtered, siblingKept, "only.txt in a sibling dir must not be excluded")
+}
+
+// TestFileFilter_GetFilteredFiles_excludesDirectoryContents ensures a directory rule ("build/")
+// excludes all files under it, at any depth.
+func TestFileFilter_GetFilteredFiles_excludesDirectoryContents(t *testing.T) {
+	root := t.TempDir()
+	shallow := filepath.Join(root, "build", "out.js")
+	deep := filepath.Join(root, "build", "nested", "deep.js")
+	kept := filepath.Join(root, "src", "app.js")
+	createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("build/\n"))
+	createFileInPath(t, shallow, []byte("x"))
+	createFileInPath(t, deep, []byte("x"))
+	createFileInPath(t, kept, []byte("x"))
+
+	fileFilter := NewFileFilter(root, &log.Logger)
+	globs, err := fileFilter.GetRules([]string{".gitignore"})
+	assert.NoError(t, err)
+
+	var filtered []string
+	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+		filtered = append(filtered, f)
+	}
+
+	assert.Contains(t, filtered, kept, "src/app.js should be scanned")
+	assert.NotContains(t, filtered, shallow, "build/out.js must be excluded")
+	assert.NotContains(t, filtered, deep, "build/nested/deep.js must be excluded")
+}
+
 func BenchmarkFileFilter_GetFilteredFiles(b *testing.B) {
 	b.Log("Creating filesystem...")
 	rootDir := b.TempDir()

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -295,131 +295,103 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 	}
 }
 
-// TestFileFilter_GetFilteredFiles_negatedCharacterClassRule ensures gitignore rules using a
-// negated character class (e.g. "cache[^S]") keep working, i.e. that "^" is not escaped in the
-// rule portion.
-func TestFileFilter_GetFilteredFiles_negatedCharacterClassRule(t *testing.T) {
-	base := filepath.Join(t.TempDir(), "repo")
-	excluded := filepath.Join(base, "cache1", "index.js") // matches cache[^S]
-	kept := filepath.Join(base, "cacheS", "index.js")     // excluded from the negated class
-	appFile := filepath.Join(base, "app.js")
-	gitignore := filepath.Join(base, ".gitignore")
-	createFileInPath(t, excluded, []byte("x"))
-	createFileInPath(t, kept, []byte("x"))
-	createFileInPath(t, appFile, []byte("x"))
-	createFileInPath(t, gitignore, []byte("cache[^S]\n"))
-
-	fileFilter := NewFileFilter(base, &log.Logger)
-	globs, err := fileFilter.GetRules([]string{".gitignore"})
-	assert.NoError(t, err)
-
-	var filtered []string
-	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
-		filtered = append(filtered, f)
+// TestFileFilter_GetFilteredFiles_ignoreRuleScenarios covers ignore-rule behaviors that share
+// the same shape: build a filesystem (including ignore files), filter it, then assert which
+// files survive. "files" maps a slash-separated path (relative to the scan root) to its content;
+// "excluded"/"kept" list slash-separated paths that must / must not be filtered out.
+func TestFileFilter_GetFilteredFiles_ignoreRuleScenarios(t *testing.T) {
+	scenarios := []struct {
+		name      string
+		files     map[string]string
+		ruleFiles []string
+		excluded  []string
+		kept      []string
+	}{
+		{
+			name: "negated character class rule keeps working",
+			files: map[string]string{
+				".gitignore":      "cache[^S]\n",
+				"cache1/index.js": "x", // matches cache[^S]
+				"cacheS/index.js": "x", // excluded from the negated class
+				"app.js":          "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"cache1/index.js"},
+			kept:      []string{"cacheS/index.js", "app.js"},
+		},
+		{
+			name: "ignore file in dir with regex metacharacters",
+			files: map[string]string{
+				"my (dir)/.gitignore": "secret.txt\n",
+				"my (dir)/secret.txt": "x",
+				"my (dir)/keep.txt":   "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"my (dir)/secret.txt"},
+			kept:      []string{"my (dir)/keep.txt"},
+		},
+		{
+			name: "deeply nested ignore file with metacharacters at every level",
+			files: map[string]string{
+				"a (1)/b [2]/c +3/.gitignore": "secret.txt\n",
+				"a (1)/b [2]/c +3/secret.txt": "x",
+				"a (1)/b [2]/c +3/keep.txt":   "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"a (1)/b [2]/c +3/secret.txt"},
+			kept:      []string{"a (1)/b [2]/c +3/keep.txt"},
+		},
+		{
+			name: "nested rule is scoped to its own directory",
+			files: map[string]string{
+				"sub (x)/.gitignore": "only.txt\n",
+				"sub (x)/only.txt":   "x",
+				"other/only.txt":     "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"sub (x)/only.txt"},
+			kept:      []string{"other/only.txt"},
+		},
+		{
+			name: "directory rule excludes all contents at any depth",
+			files: map[string]string{
+				".gitignore":           "build/\n",
+				"build/out.js":         "x",
+				"build/nested/deep.js": "x",
+				"src/app.js":           "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"build/out.js", "build/nested/deep.js"},
+			kept:      []string{"src/app.js"},
+		},
 	}
 
-	assert.Contains(t, filtered, appFile, "app.js should be scanned")
-	assert.Contains(t, filtered, kept, "cacheS should be scanned (negated class excludes S)")
-	assert.NotContains(t, filtered, excluded, "cache1 must be excluded by cache[^S]")
-}
+	for _, tc := range scenarios {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			for p, content := range tc.files {
+				createFileInPath(t, filepath.Join(root, filepath.FromSlash(p)), []byte(content))
+			}
 
-// TestFileFilter_GetFilteredFiles_ignoreFileInDirWithRegexMetaChars ensures an ignore file
-// located inside a directory whose name contains regex metacharacters (e.g. "my (dir)") is
-// still applied. The directory name becomes part of the compiled pattern, so it must be
-// escaped to be matched literally.
-func TestFileFilter_GetFilteredFiles_ignoreFileInDirWithRegexMetaChars(t *testing.T) {
-	root := t.TempDir()
-	nestedIgnore := filepath.Join(root, "my (dir)", ".gitignore")
-	excluded := filepath.Join(root, "my (dir)", "secret.txt")
-	kept := filepath.Join(root, "my (dir)", "keep.txt")
-	createFileInPath(t, nestedIgnore, []byte("secret.txt\n"))
-	createFileInPath(t, excluded, []byte("x"))
-	createFileInPath(t, kept, []byte("x"))
+			fileFilter := NewFileFilter(root, &log.Logger)
+			globs, err := fileFilter.GetRules(tc.ruleFiles)
+			assert.NoError(t, err)
 
-	fileFilter := NewFileFilter(root, &log.Logger)
-	globs, err := fileFilter.GetRules([]string{".gitignore"})
-	assert.NoError(t, err)
+			kept := make(map[string]bool)
+			for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+				rel, relErr := filepath.Rel(root, f)
+				assert.NoError(t, relErr)
+				kept[filepath.ToSlash(rel)] = true
+			}
 
-	var filtered []string
-	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
-		filtered = append(filtered, f)
+			for _, e := range tc.excluded {
+				assert.False(t, kept[e], "%q must be excluded", e)
+			}
+			for _, k := range tc.kept {
+				assert.True(t, kept[k], "%q must be kept", k)
+			}
+		})
 	}
-
-	assert.Contains(t, filtered, kept, "keep.txt should be scanned")
-	assert.NotContains(t, filtered, excluded, "secret.txt must be excluded by the nested .gitignore")
-}
-
-// TestFileFilter_GetFilteredFiles_deeplyNestedIgnoreFileWithMetaChars covers an ignore file
-// several directories deep, where every level's name contains different regex metacharacters.
-func TestFileFilter_GetFilteredFiles_deeplyNestedIgnoreFileWithMetaChars(t *testing.T) {
-	root := t.TempDir()
-	dir := filepath.Join(root, "a (1)", "b [2]", "c +3")
-	excluded := filepath.Join(dir, "secret.txt")
-	kept := filepath.Join(dir, "keep.txt")
-	createFileInPath(t, filepath.Join(dir, ".gitignore"), []byte("secret.txt\n"))
-	createFileInPath(t, excluded, []byte("x"))
-	createFileInPath(t, kept, []byte("x"))
-
-	fileFilter := NewFileFilter(root, &log.Logger)
-	globs, err := fileFilter.GetRules([]string{".gitignore"})
-	assert.NoError(t, err)
-
-	var filtered []string
-	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
-		filtered = append(filtered, f)
-	}
-
-	assert.Contains(t, filtered, kept, "keep.txt should be scanned")
-	assert.NotContains(t, filtered, excluded, "secret.txt must be excluded from a deeply nested dir")
-}
-
-// TestFileFilter_GetFilteredFiles_nestedRuleScoping ensures a rule from a nested ignore file
-// only applies within its own directory, not to a same-named file in a sibling directory.
-func TestFileFilter_GetFilteredFiles_nestedRuleScoping(t *testing.T) {
-	root := t.TempDir()
-	scopedExcluded := filepath.Join(root, "sub (x)", "only.txt")
-	siblingKept := filepath.Join(root, "other", "only.txt")
-	createFileInPath(t, filepath.Join(root, "sub (x)", ".gitignore"), []byte("only.txt\n"))
-	createFileInPath(t, scopedExcluded, []byte("x"))
-	createFileInPath(t, siblingKept, []byte("x"))
-
-	fileFilter := NewFileFilter(root, &log.Logger)
-	globs, err := fileFilter.GetRules([]string{".gitignore"})
-	assert.NoError(t, err)
-
-	var filtered []string
-	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
-		filtered = append(filtered, f)
-	}
-
-	assert.NotContains(t, filtered, scopedExcluded, "only.txt under sub (x) must be excluded")
-	assert.Contains(t, filtered, siblingKept, "only.txt in a sibling dir must not be excluded")
-}
-
-// TestFileFilter_GetFilteredFiles_excludesDirectoryContents ensures a directory rule ("build/")
-// excludes all files under it, at any depth.
-func TestFileFilter_GetFilteredFiles_excludesDirectoryContents(t *testing.T) {
-	root := t.TempDir()
-	shallow := filepath.Join(root, "build", "out.js")
-	deep := filepath.Join(root, "build", "nested", "deep.js")
-	kept := filepath.Join(root, "src", "app.js")
-	createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("build/\n"))
-	createFileInPath(t, shallow, []byte("x"))
-	createFileInPath(t, deep, []byte("x"))
-	createFileInPath(t, kept, []byte("x"))
-
-	fileFilter := NewFileFilter(root, &log.Logger)
-	globs, err := fileFilter.GetRules([]string{".gitignore"})
-	assert.NoError(t, err)
-
-	var filtered []string
-	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
-		filtered = append(filtered, f)
-	}
-
-	assert.Contains(t, filtered, kept, "src/app.js should be scanned")
-	assert.NotContains(t, filtered, shallow, "build/out.js must be excluded")
-	assert.NotContains(t, filtered, deep, "build/nested/deep.js must be excluded")
 }
 
 func BenchmarkFileFilter_GetFilteredFiles(b *testing.B) {

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -245,6 +245,48 @@ func TestFileFilter_GetFilteredFiles(t *testing.T) {
 	}
 }
 
+// TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars checks that ignore rules still
+// apply when the project path contains regex metacharacters (CLI-1515).
+func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
+	metaCharDirs := []string{
+		"OneDrive - Foobar (Team1)", // parentheses + spaces (customer's path shape)
+		"Program Files (x86)",       // parentheses + spaces
+		"a+b",                       // plus
+		"c{d}",                      // braces (not a valid quantifier)
+		"backup{2}",                 // braces forming a valid regex quantifier
+		"a^b",                       // caret
+		"a|b",                       // pipe / alternation
+		"a$b",                       // dollar
+		"a*b",                       // glob wildcard in the path
+		"a[b]c",                     // glob character class in the path
+		"a?b",                       // glob single-char wildcard in the path
+	}
+
+	for _, dirName := range metaCharDirs {
+		t.Run(dirName, func(t *testing.T) {
+			base := filepath.Join(t.TempDir(), dirName, "repo")
+			nodeModulesFile := filepath.Join(base, "node_modules", "lib", "index.js")
+			appFile := filepath.Join(base, "app.js")
+			gitignore := filepath.Join(base, ".gitignore")
+			createFileInPath(t, nodeModulesFile, []byte("x"))
+			createFileInPath(t, appFile, []byte("x"))
+			createFileInPath(t, gitignore, []byte("node_modules\n"))
+
+			fileFilter := NewFileFilter(base, &log.Logger)
+			globs, err := fileFilter.GetRules([]string{".gitignore"})
+			assert.NoError(t, err)
+
+			var filtered []string
+			for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+				filtered = append(filtered, f)
+			}
+
+			assert.Contains(t, filtered, appFile, "app.js should be scanned")
+			assert.NotContains(t, filtered, nodeModulesFile, "node_modules must be excluded")
+		})
+	}
+}
+
 func BenchmarkFileFilter_GetFilteredFiles(b *testing.B) {
 	b.Log("Creating filesystem...")
 	rootDir := b.TempDir()

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -260,6 +260,7 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 		"a*b",                       // glob wildcard in the path
 		"a[b]c",                     // glob character class in the path
 		"a?b",                       // glob single-char wildcard in the path
+		"a\\b",                      // literal backslash (legal on unix, illegal on windows)
 	}
 
 	// Characters that Windows does not allow in file/directory names, so such paths cannot
@@ -628,6 +629,19 @@ func TestParseIgnoreRuleToGlobs(t *testing.T) {
 			invalidRules: []string{},
 			expectedGlobs: []string{
 				"/tmp/test/**/foo/**",
+			},
+		},
+		{
+			// A rule with enough "../" climbs above baseDir once filepath.Join cleans it, so the
+			// base is no longer a prefix and buildGlob takes the fallback path. The base content
+			// is gone at that point, so the remaining glob wildcards must be preserved.
+			name:         "rule climbing above base uses fallback",
+			rule:         "../../../../../../foo",
+			baseDir:      "/tmp/test",
+			invalidRules: []string{},
+			expectedGlobs: []string{
+				"/foo/**",
+				"/foo",
 			},
 		},
 	}


### PR DESCRIPTION
### Description

_Provide description of this PR and changes._

### Checklist

- [ ] Tests added and all succeed (`make test`)
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.
