### PR TITLE
fix: Code scan exclusions ignored when paths or ignore rules contain special characters

### DIFF
--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -328,19 +328,30 @@ func parseIgnoreFile(content []byte, filePath string) []string {
 	return ignores
 }
 
-// escapeSpecialGlobChars escapes special characters that should be treated literally in glob patterns.
-// Special Characters to escape: $
+// ruleRegexMetaChars are regex metacharacters that gitignore treats as literal, so they must be
+// escaped before the rule reaches the regex-based go-gitignore matcher (e.g. a folder literally
+// named "build (old)"). Glob syntax the matcher relies on is deliberately excluded: "*", "?",
+// "[", "]" (wildcards / character classes) and "^" (character-class negation, e.g. "cache[^S]").
+var ruleRegexMetaChars = map[byte]bool{
+	'$': true,
+	'(': true,
+	')': true,
+	'+': true,
+	'|': true,
+	'{': true,
+	'}': true,
+}
+
+// escapeSpecialGlobChars escapes regex metacharacters in an ignore rule that gitignore treats as
+// literal, so they match literally instead of being interpreted by go-gitignore's regex engine.
 func escapeSpecialGlobChars(rule string) string {
 	var result strings.Builder
 	for i := 0; i < len(rule); i++ {
 		ch := rule[i]
-		switch ch {
-		case '$':
+		if ruleRegexMetaChars[ch] {
 			result.WriteByte('\\')
-			result.WriteByte(ch)
-		default:
-			result.WriteByte(ch)
 		}
+		result.WriteByte(ch)
 	}
 	return result.String()
 }

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -364,6 +365,7 @@ func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string)
 	const slash = "/"
 	const all = "**"
 	baseDir := filepath.ToSlash(filePath)
+	baseDir = regexp.QuoteMeta(baseDir)
 
 	if strings.HasPrefix(rule, negation) {
 		rule = rule[1:]
@@ -384,28 +386,28 @@ func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string)
 		// case `/foo/`, `/foo` => `{baseDir}/foo/**`
 		// case `**/foo/`, `**/foo` => `{baseDir}/**/foo/**`
 		if !endingGlobstar {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, rule, all))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, escapeSpecialGlobChars(rule), all))
+			globs = append(globs, glob)
 		}
 		// case `/foo` => `{baseDir}/foo`
 		// case `**/foo` => `{baseDir}/**/foo`
 		// case `/foo/**` => `{baseDir}/foo/**`
 		// case `**/foo/**` => `{baseDir}/**/foo/**`
 		if !endingSlash {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, rule))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, escapeSpecialGlobChars(rule)))
+			globs = append(globs, glob)
 		}
 	} else {
 		// case `foo/`, `foo` => `{baseDir}/**/foo/**`
 		if !endingGlobstar {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, all, rule, all))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, all, escapeSpecialGlobChars(rule), all))
+			globs = append(globs, glob)
 		}
 		// case `foo` => `{baseDir}/**/foo`
 		// case `foo/**` => `{baseDir}/**/foo/**`
 		if !endingSlash {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, all, rule))
-			globs = append(globs, escapeSpecialGlobChars(glob))
+			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, all, escapeSpecialGlobChars(rule)))
+			globs = append(globs, glob)
 		}
 	}
 	return globs

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -386,7 +387,7 @@ func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string)
 		// case `/foo/`, `/foo` => `{baseDir}/foo/**`
 		// case `**/foo/`, `**/foo` => `{baseDir}/**/foo/**`
 		if !endingGlobstar {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, escapeSpecialGlobChars(rule), all))
+			glob := prefix + path.Join(baseDir, escapeSpecialGlobChars(rule), all)
 			globs = append(globs, glob)
 		}
 		// case `/foo` => `{baseDir}/foo`
@@ -394,19 +395,19 @@ func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string)
 		// case `/foo/**` => `{baseDir}/foo/**`
 		// case `**/foo/**` => `{baseDir}/**/foo/**`
 		if !endingSlash {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, escapeSpecialGlobChars(rule)))
+			glob := prefix + path.Join(baseDir, escapeSpecialGlobChars(rule))
 			globs = append(globs, glob)
 		}
 	} else {
 		// case `foo/`, `foo` => `{baseDir}/**/foo/**`
 		if !endingGlobstar {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, all, escapeSpecialGlobChars(rule), all))
+			glob := prefix + path.Join(baseDir, all, escapeSpecialGlobChars(rule), all)
 			globs = append(globs, glob)
 		}
 		// case `foo` => `{baseDir}/**/foo`
 		// case `foo/**` => `{baseDir}/**/foo/**`
 		if !endingSlash {
-			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, all, escapeSpecialGlobChars(rule)))
+			glob := prefix + path.Join(baseDir, all, escapeSpecialGlobChars(rule))
 			globs = append(globs, glob)
 		}
 	}

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -377,6 +377,10 @@ func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string)
 	const all = "**"
 	baseDir := filepath.ToSlash(filePath)
 	baseDir = regexp.QuoteMeta(baseDir)
+	// Undo escaping for chars that go-gitignore already escapes internally,
+	// otherwise they get double-escaped and fail to match literal paths.
+	baseDir = strings.ReplaceAll(baseDir, `\.`, ".")
+	baseDir = strings.ReplaceAll(baseDir, `\?`, "?")
 
 	if strings.HasPrefix(rule, negation) {
 		rule = rule[1:]

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -345,6 +345,16 @@ func escapeSpecialGlobChars(rule string) string {
 	return result.String()
 }
 
+// joinGlob joins path parts like path.Join but preserves a leading "//" (UNC path prefix).
+// path.Clean (called by path.Join) collapses "//" to "/", which breaks UNC paths on Windows.
+func joinGlob(parts ...string) string {
+	result := path.Join(parts...)
+	if len(parts) > 0 && strings.HasPrefix(parts[0], "//") && !strings.HasPrefix(result, "//") {
+		result = "/" + result
+	}
+	return result
+}
+
 // parseIgnoreRuleToGlobs contains the business logic to build glob patterns from a given ignore file
 // we try to implement the same logic as gitignore pattern format - https://git-scm.com/docs/gitignore#_pattern_format
 func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string) (globs []string) {
@@ -387,7 +397,7 @@ func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string)
 		// case `/foo/`, `/foo` => `{baseDir}/foo/**`
 		// case `**/foo/`, `**/foo` => `{baseDir}/**/foo/**`
 		if !endingGlobstar {
-			glob := prefix + path.Join(baseDir, escapeSpecialGlobChars(rule), all)
+			glob := prefix + joinGlob(baseDir, escapeSpecialGlobChars(rule), all)
 			globs = append(globs, glob)
 		}
 		// case `/foo` => `{baseDir}/foo`
@@ -395,19 +405,19 @@ func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string)
 		// case `/foo/**` => `{baseDir}/foo/**`
 		// case `**/foo/**` => `{baseDir}/**/foo/**`
 		if !endingSlash {
-			glob := prefix + path.Join(baseDir, escapeSpecialGlobChars(rule))
+			glob := prefix + joinGlob(baseDir, escapeSpecialGlobChars(rule))
 			globs = append(globs, glob)
 		}
 	} else {
 		// case `foo/`, `foo` => `{baseDir}/**/foo/**`
 		if !endingGlobstar {
-			glob := prefix + path.Join(baseDir, all, escapeSpecialGlobChars(rule), all)
+			glob := prefix + joinGlob(baseDir, all, escapeSpecialGlobChars(rule), all)
 			globs = append(globs, glob)
 		}
 		// case `foo` => `{baseDir}/**/foo`
 		// case `foo/**` => `{baseDir}/**/foo/**`
 		if !endingSlash {
-			glob := prefix + path.Join(baseDir, all, escapeSpecialGlobChars(rule))
+			glob := prefix + joinGlob(baseDir, all, escapeSpecialGlobChars(rule))
 			globs = append(globs, glob)
 		}
 	}

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// windowsIllegalChars are characters Windows does not allow in file/directory names, so paths
+// containing them cannot exist there and the corresponding cases are skipped on Windows.
+const windowsIllegalChars = `<>:"/\|?*`
+
 type fileFilterTestCase struct {
 	// the name of the test case. Will be used as the test name in t.Run()
 	name string
@@ -266,10 +270,6 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 		"Users/first.last/OneDrive - Foobar (Team1)/docs", // combined: dot + parens + spaces
 	}
 
-	// Characters that Windows does not allow in file/directory names, so such paths cannot
-	// exist there and don't need to be exercised on that OS.
-	const windowsIllegalChars = `<>:"/\|?*`
-
 	for _, dirName := range metaCharDirs {
 		t.Run(dirName, func(t *testing.T) {
 			if runtime.GOOS == "windows" && strings.ContainsAny(dirName, windowsIllegalChars) {
@@ -298,18 +298,49 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 	}
 }
 
-// TestFileFilter_GetFilteredFiles_ignoreRuleScenarios covers ignore-rule behaviors that share
-// the same shape: build a filesystem (including ignore files), filter it, then assert which
-// files survive. "files" maps a slash-separated path (relative to the scan root) to its content;
-// "excluded"/"kept" list slash-separated paths that must / must not be filtered out.
+type ignoreRuleScenario struct {
+	name string
+	// scanRootName, when set, roots the FileFilter at t.TempDir()/scanRootName instead of
+	// t.TempDir(). This exercises metacharacters in the scan root itself, not just in
+	// intermediate directories. files/excluded/kept remain relative to that root.
+	scanRootName string
+	// files maps a slash-separated path (relative to the scan root) to its content.
+	files map[string]string
+	// ruleFiles lists the valid ignore filenames to extract rules from.
+	ruleFiles []string
+	// excluded/kept list slash-separated paths that must / must not be filtered out.
+	excluded []string
+	kept     []string
+	// windowsOnly skips the scenario on non-Windows platforms.
+	windowsOnly bool
+}
+
+// scenarioHasWindowsIllegalChars reports whether the scenario's scan root or any of its file
+// paths contain characters that are illegal in Windows paths, so it must be skipped there.
+func scenarioHasWindowsIllegalChars(tc ignoreRuleScenario) bool {
+	// "/" is the path separator in these test paths, so exclude it from the illegal set.
+	illegal := strings.ReplaceAll(windowsIllegalChars, "/", "")
+	if strings.ContainsAny(tc.scanRootName, illegal) {
+		return true
+	}
+	for p := range tc.files {
+		if strings.ContainsAny(p, illegal) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestFileFilter_GetFilteredFiles_ignoreRuleScenarios is the behavioral regression net for the
+// special-character-path fix (CLI-1648). Each scenario builds a filesystem (including ignore
+// files), filters it, then asserts which files survive.
+//
+// This is deliberately NOT a full gitignore conformance suite: go-gitignore has known gaps we
+// cannot fix here (the "?" single-char wildcard, escaped trailing spaces, full POSIX character
+// classes). We only cover behavior the library supports and that the fix must preserve.
 func TestFileFilter_GetFilteredFiles_ignoreRuleScenarios(t *testing.T) {
-	scenarios := []struct {
-		name      string
-		files     map[string]string
-		ruleFiles []string
-		excluded  []string
-		kept      []string
-	}{
+	scenarios := []ignoreRuleScenario{
+		// --- Existing behaviors (kept) ---
 		{
 			name: "negated character class rule keeps working",
 			files: map[string]string{
@@ -367,11 +398,298 @@ func TestFileFilter_GetFilteredFiles_ignoreRuleScenarios(t *testing.T) {
 			excluded:  []string{"build/out.js", "build/nested/deep.js"},
 			kept:      []string{"src/app.js"},
 		},
+
+		// --- A. Special-character scan roots (customer bug family) ---
+		{
+			name:         "scan root with parentheses and spaces",
+			scanRootName: "OneDrive - Foobar (Team1)",
+			files: map[string]string{
+				".gitignore":                "node_modules\n",
+				"node_modules/lib/index.js": "x",
+				"app.js":                    "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"node_modules/lib/index.js"},
+			kept:      []string{"app.js"},
+		},
+		{
+			name:         "scan root with dot",
+			scanRootName: "first.last",
+			files: map[string]string{
+				".gitignore":                "node_modules\n",
+				"node_modules/lib/index.js": "x",
+				"app.js":                    "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"node_modules/lib/index.js"},
+			kept:      []string{"app.js"},
+		},
+		{
+			name:         "scan root combined customer shape",
+			scanRootName: "first.last/OneDrive - Foobar (Team1)",
+			files: map[string]string{
+				".gitignore":                "node_modules\n",
+				"node_modules/lib/index.js": "x",
+				"app.js":                    "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"node_modules/lib/index.js"},
+			kept:      []string{"app.js"},
+		},
+		{
+			name:         "scan root with plus and braces",
+			scanRootName: "a+b/c{d}",
+			files: map[string]string{
+				".gitignore":                "node_modules\n",
+				"node_modules/lib/index.js": "x",
+				"app.js":                    "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"node_modules/lib/index.js"},
+			kept:      []string{"app.js"},
+		},
+		{
+			name:         "scan root with caret dollar and pipe",
+			scanRootName: "a^b/a$b/a|b",
+			files: map[string]string{
+				".gitignore":                "node_modules\n",
+				"node_modules/lib/index.js": "x",
+				"app.js":                    "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"node_modules/lib/index.js"},
+			kept:      []string{"app.js"},
+		},
+		{
+			name:         "scan root with backslash", // unix-legal, auto-skipped on Windows
+			scanRootName: "a\\b",
+			files: map[string]string{
+				".gitignore":                "node_modules\n",
+				"node_modules/lib/index.js": "x",
+				"app.js":                    "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"node_modules/lib/index.js"},
+			kept:      []string{"app.js"},
+		},
+
+		// --- B. gitignore rule variations (library-supported only) ---
+		{
+			name: "glob star matches extension",
+			files: map[string]string{
+				".gitignore": "*.log\n",
+				"a.log":      "x",
+				"a.txt":      "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"a.log"},
+			kept:      []string{"a.txt"},
+		},
+		{
+			name: "leading slash anchors to root",
+			files: map[string]string{
+				".gitignore":        "/root-only.txt\n",
+				"root-only.txt":     "x",
+				"sub/root-only.txt": "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"root-only.txt"},
+			kept:      []string{"sub/root-only.txt"},
+		},
+		{
+			name: "trailing slash excludes directory contents",
+			files: map[string]string{
+				".gitignore":   "logs/\n",
+				"logs/a.txt":   "x",
+				"logs/b/c.txt": "x",
+				"logsx.txt":    "x", // sibling whose name only shares the stem is kept
+				"src/app.js":   "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"logs/a.txt", "logs/b/c.txt"},
+			kept:      []string{"logsx.txt", "src/app.js"},
+		},
+		{
+			name: "nested path rule scoped to that path",
+			files: map[string]string{
+				".gitignore":     "src/gen/\n",
+				"src/gen/g.js":   "x",
+				"other/gen/g.js": "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"src/gen/g.js"},
+			kept:      []string{"other/gen/g.js"},
+		},
+		{
+			name: "double star matches at multiple depths",
+			files: map[string]string{
+				".gitignore":        "**/dist\n",
+				"dist/a.js":         "x",
+				"pkg/dist/b.js":     "x",
+				"pkg/sub/dist/c.js": "x",
+				"src/app.js":        "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"dist/a.js", "pkg/dist/b.js", "pkg/sub/dist/c.js"},
+			kept:      []string{"src/app.js"},
+		},
+		{
+			name: "negation re-includes a file",
+			files: map[string]string{
+				".gitignore": "*.log\n!keep.log\n",
+				"a.log":      "x",
+				"keep.log":   "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"a.log"},
+			kept:      []string{"keep.log"},
+		},
+		{
+			name: "comments and blank lines are ignored",
+			files: map[string]string{
+				".gitignore":                "# a comment\n\nnode_modules\n\n# trailing comment\n",
+				"node_modules/lib/index.js": "x",
+				"app.js":                    "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"node_modules/lib/index.js"},
+			kept:      []string{"app.js"},
+		},
+
+		// --- C. Ignore-file-format variations ---
+		{
+			name: "dcignore file is honored",
+			files: map[string]string{
+				".dcignore":                 "node_modules\n",
+				"node_modules/lib/index.js": "x",
+				"app.js":                    "x",
+			},
+			ruleFiles: []string{".dcignore"},
+			excluded:  []string{"node_modules/lib/index.js"},
+			kept:      []string{"app.js"},
+		},
+		{
+			name: "snyk global exclude (customer file)",
+			files: map[string]string{
+				".snyk":                     "# Snyk (https://snyk.io) policy file\nversion: v1.25.1\nexclude:\n  global:\n    - node_modules\n",
+				"node_modules/lib/index.js": "x",
+				"app.js":                    "x",
+			},
+			ruleFiles: []string{".snyk"},
+			excluded:  []string{"node_modules/lib/index.js"},
+			kept:      []string{"app.js"},
+		},
+		{
+			name: "snyk code exclude",
+			files: map[string]string{
+				".snyk":       "version: v1.25.1\nexclude:\n  code:\n    - dist\n",
+				"dist/out.js": "x",
+				"app.js":      "x",
+			},
+			ruleFiles: []string{".snyk"},
+			excluded:  []string{"dist/out.js"},
+			kept:      []string{"app.js"},
+		},
+		{
+			name: "gitignore and snyk applied together",
+			files: map[string]string{
+				".gitignore":                "node_modules\n",
+				".snyk":                     "version: v1.25.1\nexclude:\n  global:\n    - dist\n",
+				"node_modules/lib/index.js": "x",
+				"dist/out.js":               "x",
+				"app.js":                    "x",
+			},
+			ruleFiles: []string{".gitignore", ".snyk"},
+			excluded:  []string{"node_modules/lib/index.js", "dist/out.js"},
+			kept:      []string{"app.js"},
+		},
+		{
+			name: "nested gitignore files scope independently",
+			files: map[string]string{
+				".gitignore":     "root.txt\n",
+				"root.txt":       "x",
+				"pkg/.gitignore": "pkg.txt\n",
+				"pkg/pkg.txt":    "x",
+				"pkg/root.txt":   "x", // root rule also applies here (matches at any level)
+				"pkg/keep.txt":   "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"root.txt", "pkg/pkg.txt", "pkg/root.txt"},
+			kept:      []string{"pkg/keep.txt"},
+		},
+
+		// --- D. Path structure / real-world combinations ---
+		{
+			name: "deeply nested exclusion",
+			files: map[string]string{
+				".gitignore":          "build/\n",
+				"build/a/b/c/deep.js": "x",
+				"src/a/b/c/keep.js":   "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"build/a/b/c/deep.js"},
+			kept:      []string{"src/a/b/c/keep.js"},
+		},
+		{
+			name: "multiple siblings only matched one excluded",
+			files: map[string]string{
+				".gitignore": "temp\n",
+				"temp/a.js":  "x",
+				"tempx/a.js": "x",
+				"atemp/a.js": "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"temp/a.js"},
+			kept:      []string{"tempx/a.js", "atemp/a.js"},
+		},
+		{
+			name: "monorepo node_modules at multiple levels",
+			files: map[string]string{
+				".gitignore":                             "node_modules\n",
+				"node_modules/root/index.js":             "x",
+				"packages/app/.gitignore":                "dist\n",
+				"packages/app/node_modules/pkg/index.js": "x",
+				"packages/app/dist/out.js":               "x",
+				"packages/app/src/main.js":               "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded: []string{
+				"node_modules/root/index.js",
+				"packages/app/node_modules/pkg/index.js",
+				"packages/app/dist/out.js",
+			},
+			kept: []string{"packages/app/src/main.js"},
+		},
+
+		// --- E. OS-specific: drive-letter scan root (Windows-only) ---
+		{
+			name:         "windows drive-letter scan root",
+			windowsOnly:  true,
+			scanRootName: "project",
+			files: map[string]string{
+				".gitignore":                "node_modules\n",
+				"node_modules/lib/index.js": "x",
+				"app.js":                    "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"node_modules/lib/index.js"},
+			kept:      []string{"app.js"},
+		},
 	}
 
 	for _, tc := range scenarios {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.windowsOnly && runtime.GOOS != "windows" {
+				t.Skip("scenario only applies on Windows")
+			}
+			if runtime.GOOS == "windows" && scenarioHasWindowsIllegalChars(tc) {
+				t.Skip("path contains characters not allowed on Windows")
+			}
+
 			root := t.TempDir()
+			if tc.scanRootName != "" {
+				root = filepath.Join(root, filepath.FromSlash(tc.scanRootName))
+			}
 			for p, content := range tc.files {
 				createFileInPath(t, filepath.Join(root, filepath.FromSlash(p)), []byte(content))
 			}
@@ -395,6 +713,92 @@ func TestFileFilter_GetFilteredFiles_ignoreRuleScenarios(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestFileFilter_GetFilteredFiles_uncPaths covers UNC-style scan roots on Windows using real
+// filesystem walks. t.TempDir() is a local path, so these derive a UNC-style root that points
+// at the same files. They are Windows-only and skip gracefully when the derived root is not
+// reachable (e.g. admin shares disabled). Unit-level UNC glob building is covered separately in
+// TestParseIgnoreRuleToGlobs.
+func TestFileFilter_GetFilteredFiles_uncPaths(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("UNC paths only exist on Windows")
+	}
+
+	// buildTree creates the standard node_modules/app.js/.gitignore tree under base and returns
+	// the FileFilter rooted at scanRoot (which may be a UNC-style alias of base).
+	assertFiltered := func(t *testing.T, scanRoot string) {
+		t.Helper()
+		fileFilter := NewFileFilter(scanRoot, &log.Logger)
+		globs, err := fileFilter.GetRules([]string{".gitignore"})
+		assert.NoError(t, err)
+
+		kept := make(map[string]bool)
+		for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+			rel, relErr := filepath.Rel(scanRoot, f)
+			assert.NoError(t, relErr)
+			kept[filepath.ToSlash(rel)] = true
+		}
+		assert.False(t, kept["node_modules/lib/index.js"], "node_modules must be excluded")
+		assert.True(t, kept["app.js"], "app.js must be kept")
+	}
+
+	makeTree := func(t *testing.T, base string) {
+		t.Helper()
+		createFileInPath(t, filepath.Join(base, ".gitignore"), []byte("node_modules\n"))
+		createFileInPath(t, filepath.Join(base, "node_modules", "lib", "index.js"), []byte("x"))
+		createFileInPath(t, filepath.Join(base, "app.js"), []byte("x"))
+	}
+
+	// driveToAdminShare converts "C:\path" to "\\localhost\C$\path" (and 127.0.0.1 variant).
+	driveToAdminShare := func(host, p string) (string, bool) {
+		if len(p) < 2 || p[1] != ':' {
+			return "", false
+		}
+		drive := string(p[0])
+		rest := strings.TrimPrefix(p[2:], `\`)
+		return `\\` + host + `\` + drive + `$\` + rest, true
+	}
+
+	t.Run("genuine UNC via admin share", func(t *testing.T) {
+		base := t.TempDir()
+		makeTree(t, base)
+		for _, host := range []string{"localhost", "127.0.0.1"} {
+			unc, ok := driveToAdminShare(host, base)
+			if !ok {
+				t.Skipf("temp dir %q is not a drive-letter path", base)
+			}
+			if _, err := os.Stat(unc); err != nil {
+				continue // admin share not reachable on this host, try the next
+			}
+			assertFiltered(t, unc)
+			return
+		}
+		t.Skip("admin share (C$) not accessible; cannot exercise genuine UNC")
+	})
+
+	t.Run("extended-length prefix", func(t *testing.T) {
+		base := t.TempDir()
+		makeTree(t, base)
+		extended := `\\?\` + base
+		if _, err := os.Stat(extended); err != nil {
+			t.Skipf("extended-length path not accessible: %v", err)
+		}
+		assertFiltered(t, extended)
+	})
+
+	t.Run("UNC with metacharacters via admin share", func(t *testing.T) {
+		base := filepath.Join(t.TempDir(), "OneDrive - Foobar (Team1)")
+		makeTree(t, base)
+		unc, ok := driveToAdminShare("localhost", base)
+		if !ok {
+			t.Skipf("temp dir %q is not a drive-letter path", base)
+		}
+		if _, err := os.Stat(unc); err != nil {
+			t.Skip("admin share (C$) not accessible; cannot exercise genuine UNC")
+		}
+		assertFiltered(t, unc)
+	})
 }
 
 func BenchmarkFileFilter_GetFilteredFiles(b *testing.B) {

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -741,8 +741,8 @@ func TestParseIgnoreRuleToGlobs(t *testing.T) {
 			invalidRules:   []string{},
 			skipNonWindows: true,
 			expectedGlobs: []string{
-				path.Join("//server", "share", "OneDrive - Foobar \\(Team1\\)", "project", "**", "node_modules", "**"),
-				path.Join("//server", "share", "OneDrive - Foobar \\(Team1\\)", "project", "**", "node_modules"),
+				"//server" + path.Join("share", "OneDrive - Foobar \\(Team1\\)", "project", "**", "node_modules", "**"),
+				"//server" + path.Join("share", "OneDrive - Foobar \\(Team1\\)", "project", "**", "node_modules"),
 			},
 		},
 		{
@@ -784,7 +784,7 @@ func TestParseIgnoreRuleToGlobs(t *testing.T) {
 			}
 			globs := parseIgnoreRuleToGlobs(tc.rule, tc.baseDir, tc.invalidRules)
 			assert.ElementsMatch(t, tc.expectedGlobs, globs,
-				"Rule: %q, Expected: %v, Got: %v", tc.rule, tc.expectedGlobs, globs)
+				"Test Name: %s, Rule: %q, Expected: %v, Got: %v", tc.name, tc.rule, tc.expectedGlobs, globs)
 		})
 	}
 }

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -623,11 +623,12 @@ func createFileInPath(tb testing.TB, filePath string, content []byte) {
 
 func TestParseIgnoreRuleToGlobs(t *testing.T) {
 	testCases := []struct {
-		name          string
-		rule          string
-		baseDir       string
-		invalidRules  []string
-		expectedGlobs []string
+		name           string
+		rule           string
+		baseDir        string
+		invalidRules   []string
+		expectedGlobs  []string
+		skipNonWindows bool
 	}{
 		{
 			name:          "invalid rules are ignored",
@@ -731,20 +732,56 @@ func TestParseIgnoreRuleToGlobs(t *testing.T) {
 				path.Join(filepath.ToSlash(os.TempDir()), "OneDrive - Foobar \\(Team1\\)", "project") + "/**/node_modules",
 			},
 		},
-		// {
-		// 	name:         "UNC path with metacharacters",
-		// 	rule:         "node_modules",
-		// 	baseDir:      "//server/share/OneDrive - Foobar (Team1)/project",
-		// 	invalidRules: []string{},
-		// 	expectedGlobs: []string{
-		// 		"//server/share/OneDrive - Foobar \\(Team1\\)/project/**/node_modules/**",
-		// 		"//server/share/OneDrive - Foobar \\(Team1\\)/project/**/node_modules",
-		// 	},
-		// },
+		{
+			// UNC paths (\\server\share) are Windows-only. filepath.Join preserves the \\
+			// prefix on Windows but treats \ as literal filename characters on Unix.
+			name:           "UNC path with metacharacters",
+			rule:           "node_modules",
+			baseDir:        filepath.Join("\\\\server", "share", "OneDrive - Foobar (Team1)", "project"),
+			invalidRules:   []string{},
+			skipNonWindows: true,
+			expectedGlobs: []string{
+				path.Join("//server", "share", "OneDrive - Foobar \\(Team1\\)", "project", "**", "node_modules", "**"),
+				path.Join("//server", "share", "OneDrive - Foobar \\(Team1\\)", "project", "**", "node_modules"),
+			},
+		},
+		{
+			name:         "Windows drive letter path",
+			rule:         "node_modules",
+			baseDir:      filepath.Join("C:", string(filepath.Separator), "Users", "someone", "project"),
+			invalidRules: []string{},
+			expectedGlobs: []string{
+				path.Join(filepath.ToSlash(filepath.Join("C:", string(filepath.Separator), "Users", "someone", "project")), "**", "node_modules", "**"),
+				path.Join(filepath.ToSlash(filepath.Join("C:", string(filepath.Separator), "Users", "someone", "project")), "**", "node_modules"),
+			},
+		},
+		{
+			name:         "Windows drive letter path with metacharacters",
+			rule:         "node_modules",
+			baseDir:      filepath.Join("C:", string(filepath.Separator), "Users", "someone", "OneDrive - Foobar (Team1)", "project"),
+			invalidRules: []string{},
+			expectedGlobs: []string{
+				path.Join(filepath.ToSlash(filepath.Join("C:", string(filepath.Separator), "Users")), "someone", "OneDrive - Foobar \\(Team1\\)", "project", "**", "node_modules", "**"),
+				path.Join(filepath.ToSlash(filepath.Join("C:", string(filepath.Separator), "Users")), "someone", "OneDrive - Foobar \\(Team1\\)", "project", "**", "node_modules"),
+			},
+		},
+		{
+			name:         "base path with trailing slash",
+			rule:         "node_modules",
+			baseDir:      filepath.Join(os.TempDir(), "test") + string(filepath.Separator),
+			invalidRules: []string{},
+			expectedGlobs: []string{
+				path.Join(filepath.ToSlash(filepath.Join(os.TempDir(), "test")), "**", "node_modules", "**"),
+				path.Join(filepath.ToSlash(filepath.Join(os.TempDir(), "test")), "**", "node_modules"),
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.skipNonWindows && runtime.GOOS != "windows" {
+				t.Skip("UNC paths only exist on Windows")
+			}
 			globs := parseIgnoreRuleToGlobs(tc.rule, tc.baseDir, tc.invalidRules)
 			assert.ElementsMatch(t, tc.expectedGlobs, globs,
 				"Rule: %q, Expected: %v, Got: %v", tc.rule, tc.expectedGlobs, globs)

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -1235,6 +1235,21 @@ func TestParseIgnoreRuleToGlobs(t *testing.T) {
 				"/??/C:/Users/someone/project/**/node_modules",
 			},
 		},
+		{
+			// Extended-length path (\\?\C:\...). Windows-only because filepath.Join keeps the
+			// backslash prefix on Windows but treats \ as literal filename characters on Unix.
+			// On Windows filepath.ToSlash turns it into //?/C:/...; joinGlob preserves the
+			// leading "//" that path.Clean would otherwise collapse to "/".
+			name:           "extended-length path preserved",
+			rule:           "node_modules",
+			baseDir:        filepath.Join("\\\\?", "C:", string(filepath.Separator), "Users", "someone", "project"),
+			invalidRules:   []string{},
+			skipNonWindows: true,
+			expectedGlobs: []string{
+				"//?/C:/Users/someone/project/**/node_modules/**",
+				"//?/C:/Users/someone/project/**/node_modules",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -1176,6 +1176,20 @@ func TestParseIgnoreRuleToGlobs(t *testing.T) {
 				path.Join(filepath.ToSlash(filepath.Join(os.TempDir(), "test")), "**", "node_modules"),
 			},
 		},
+		{
+			// Root Local Device path (NT namespace, \??\C:\...). On Windows filepath.ToSlash turns it into
+			// /??/C:/... before parseIgnoreRuleToGlobs sees it; "??" is an ordinary path
+			// segment and the single leading slash is preserved, so the base survives intact.
+			name:           "root local device path preserved",
+			rule:           "node_modules",
+			baseDir:        filepath.Join("\\??", "C:", string(filepath.Separator), "Users", "someone", "project"),
+			invalidRules:   []string{},
+			skipNonWindows: true,
+			expectedGlobs: []string{
+				"/??/C:/Users/someone/project/**/node_modules/**",
+				"/??/C:/Users/someone/project/**/node_modules",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -713,6 +714,16 @@ func TestParseIgnoreRuleToGlobs(t *testing.T) {
 			expectedGlobs: []string{
 				"/foo/**",
 				"/foo",
+			},
+		},
+		{
+			name:         "base path with metacharacters uses native separator",
+			rule:         "node_modules",
+			baseDir:      filepath.Join(os.TempDir(), "OneDrive - Foobar (Team1)", "project"),
+			invalidRules: []string{},
+			expectedGlobs: []string{
+				path.Join(filepath.ToSlash(os.TempDir()), "OneDrive - Foobar \\(Team1\\)", "project") + "/**/node_modules/**",
+				path.Join(filepath.ToSlash(os.TempDir()), "OneDrive - Foobar \\(Team1\\)", "project") + "/**/node_modules",
 			},
 		},
 	}

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -245,6 +245,155 @@ func TestFileFilter_GetFilteredFiles(t *testing.T) {
 	}
 }
 
+// TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars checks that ignore rules still
+// apply when the project path contains regex metacharacters (CLI-1648).
+func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
+	metaCharDirs := []string{
+		"OneDrive - Foobar (Team1)", // parentheses + spaces (customer's path shape)
+		"Program Files (x86)",       // parentheses + spaces
+		"a+b",                       // plus
+		"c{d}",                      // braces (not a valid quantifier)
+		"backup{2}",                 // braces forming a valid regex quantifier
+		"a^b",                       // caret
+		"a|b",                       // pipe / alternation
+		"a$b",                       // dollar
+		"a*b",                       // glob wildcard in the path
+		"a[b]c",                     // glob character class in the path
+		// "a?b",                       // glob single-char wildcard in the path
+		"a\\b", // literal backslash (legal on unix, illegal on windows)
+	}
+
+	// Characters that Windows does not allow in file/directory names, so such paths cannot
+	// exist there and don't need to be exercised on that OS.
+	const windowsIllegalChars = `<>:"/\|?*`
+
+	for _, dirName := range metaCharDirs {
+		t.Run(dirName, func(t *testing.T) {
+			if runtime.GOOS == "windows" && strings.ContainsAny(dirName, windowsIllegalChars) {
+				t.Skipf("%q contains characters not allowed in Windows paths", dirName)
+			}
+			base := filepath.Join(t.TempDir(), dirName, "repo")
+			nodeModulesFile := filepath.Join(base, "node_modules", "lib", "index.js")
+			appFile := filepath.Join(base, "app.js")
+			gitignore := filepath.Join(base, ".gitignore")
+			createFileInPath(t, nodeModulesFile, []byte("x"))
+			createFileInPath(t, appFile, []byte("x"))
+			createFileInPath(t, gitignore, []byte("node_modules\n"))
+
+			fileFilter := NewFileFilter(base, &log.Logger)
+			globs, err := fileFilter.GetRules([]string{".gitignore"})
+			assert.NoError(t, err)
+
+			var filtered []string
+			for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+				filtered = append(filtered, f)
+			}
+
+			assert.Contains(t, filtered, appFile, "app.js should be scanned")
+			assert.NotContains(t, filtered, nodeModulesFile, "node_modules must be excluded")
+		})
+	}
+}
+
+// TestFileFilter_GetFilteredFiles_ignoreRuleScenarios covers ignore-rule behaviors that share
+// the same shape: build a filesystem (including ignore files), filter it, then assert which
+// files survive. "files" maps a slash-separated path (relative to the scan root) to its content;
+// "excluded"/"kept" list slash-separated paths that must / must not be filtered out.
+func TestFileFilter_GetFilteredFiles_ignoreRuleScenarios(t *testing.T) {
+	scenarios := []struct {
+		name      string
+		files     map[string]string
+		ruleFiles []string
+		excluded  []string
+		kept      []string
+	}{
+		{
+			name: "negated character class rule keeps working",
+			files: map[string]string{
+				".gitignore":      "cache[^S]\n",
+				"cache1/index.js": "x", // matches cache[^S]
+				"cacheS/index.js": "x", // excluded from the negated class
+				"app.js":          "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"cache1/index.js"},
+			kept:      []string{"cacheS/index.js", "app.js"},
+		},
+		{
+			name: "ignore file in dir with regex metacharacters",
+			files: map[string]string{
+				"my (dir)/.gitignore": "secret.txt\n",
+				"my (dir)/secret.txt": "x",
+				"my (dir)/keep.txt":   "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"my (dir)/secret.txt"},
+			kept:      []string{"my (dir)/keep.txt"},
+		},
+		{
+			name: "deeply nested ignore file with metacharacters at every level",
+			files: map[string]string{
+				"a (1)/b [2]/c +3/.gitignore": "secret.txt\n",
+				"a (1)/b [2]/c +3/secret.txt": "x",
+				"a (1)/b [2]/c +3/keep.txt":   "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"a (1)/b [2]/c +3/secret.txt"},
+			kept:      []string{"a (1)/b [2]/c +3/keep.txt"},
+		},
+		{
+			name: "nested rule is scoped to its own directory",
+			files: map[string]string{
+				"sub (x)/.gitignore": "only.txt\n",
+				"sub (x)/only.txt":   "x",
+				"other/only.txt":     "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"sub (x)/only.txt"},
+			kept:      []string{"other/only.txt"},
+		},
+		{
+			name: "directory rule excludes all contents at any depth",
+			files: map[string]string{
+				".gitignore":           "build/\n",
+				"build/out.js":         "x",
+				"build/nested/deep.js": "x",
+				"src/app.js":           "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"build/out.js", "build/nested/deep.js"},
+			kept:      []string{"src/app.js"},
+		},
+	}
+
+	for _, tc := range scenarios {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			for p, content := range tc.files {
+				createFileInPath(t, filepath.Join(root, filepath.FromSlash(p)), []byte(content))
+			}
+
+			fileFilter := NewFileFilter(root, &log.Logger)
+			globs, err := fileFilter.GetRules(tc.ruleFiles)
+			assert.NoError(t, err)
+
+			kept := make(map[string]bool)
+			for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+				rel, relErr := filepath.Rel(root, f)
+				assert.NoError(t, relErr)
+				kept[filepath.ToSlash(rel)] = true
+			}
+
+			for _, e := range tc.excluded {
+				assert.False(t, kept[e], "%q must be excluded", e)
+			}
+			for _, k := range tc.kept {
+				assert.True(t, kept[k], "%q must be kept", k)
+			}
+		})
+	}
+}
+
 func BenchmarkFileFilter_GetFilteredFiles(b *testing.B) {
 	b.Log("Creating filesystem...")
 	rootDir := b.TempDir()
@@ -551,6 +700,19 @@ func TestParseIgnoreRuleToGlobs(t *testing.T) {
 			invalidRules: []string{},
 			expectedGlobs: []string{
 				"/tmp/test/**/foo/**",
+			},
+		},
+		{
+			// A rule with enough "../" climbs above baseDir once filepath.Join cleans it, so the
+			// base is no longer a prefix and buildGlob takes the fallback path. The base content
+			// is gone at that point, so the remaining glob wildcards must be preserved.
+			name:         "rule climbing above base uses fallback",
+			rule:         "../../../../../../foo",
+			baseDir:      "/tmp/test",
+			invalidRules: []string{},
+			expectedGlobs: []string{
+				"/foo/**",
+				"/foo",
 			},
 		},
 	}

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -248,6 +248,11 @@ func TestFileFilter_GetFilteredFiles(t *testing.T) {
 
 // TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars checks that ignore rules still
 // apply when the project path contains regex metacharacters (CLI-1648).
+//
+// Note: "a?b" is not covered. regexp.QuoteMeta escapes ? to \?, then go-gitignore also
+// processes ? (replacing it with \?), so \? becomes \\? in the final regex — matching
+// literal \? instead of literal ?. This is a double-escaping issue caused by the library;
+// fixing it requires patching go-gitignore or switching to a different gitignore library.
 func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 	metaCharDirs := []string{
 		"OneDrive - Foobar (Team1)", // parentheses + spaces (customer's path shape)
@@ -261,7 +266,7 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 		"a*b",                       // glob wildcard in the path
 		"a[b]c",                     // glob character class in the path
 		// "a?b",                       // glob single-char wildcard in the path
-		"a\\b", // literal backslash (legal on unix, illegal on windows)
+		"a\\b",                      // literal backslash (legal on unix, illegal on windows)
 	}
 
 	// Characters that Windows does not allow in file/directory names, so such paths cannot
@@ -726,6 +731,16 @@ func TestParseIgnoreRuleToGlobs(t *testing.T) {
 				path.Join(filepath.ToSlash(os.TempDir()), "OneDrive - Foobar \\(Team1\\)", "project") + "/**/node_modules",
 			},
 		},
+		// {
+		// 	name:         "UNC path with metacharacters",
+		// 	rule:         "node_modules",
+		// 	baseDir:      "//server/share/OneDrive - Foobar (Team1)/project",
+		// 	invalidRules: []string{},
+		// 	expectedGlobs: []string{
+		// 		"//server/share/OneDrive - Foobar \\(Team1\\)/project/**/node_modules/**",
+		// 		"//server/share/OneDrive - Foobar \\(Team1\\)/project/**/node_modules",
+		// 	},
+		// },
 	}
 
 	for _, tc := range testCases {

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -612,28 +612,56 @@ func TestFileFilter_GetFilteredFiles_ignoreRuleScenarios(t *testing.T) {
 		// literally named "build (old)" should be excluded. These currently fail because the
 		// rule side only escapes "$"; regex metacharacters in the rule reach go-gitignore and are
 		// interpreted as regex. Documents the gap mirror of the base-path fix (CLI-1648).
-		// {
-		// 	name: "gitignore rule with parentheses and spaces",
-		// 	files: map[string]string{
-		// 		".gitignore":         "build (old)/\n",
-		// 		"build (old)/out.js": "x",
-		// 		"build/keep.js":      "x",
-		// 	},
-		// 	ruleFiles: []string{".gitignore"},
-		// 	excluded:  []string{"build (old)/out.js"},
-		// 	kept:      []string{"build/keep.js"},
-		// },
-		// {
-		// 	name: "snyk rule with parentheses and spaces",
-		// 	files: map[string]string{
-		// 		".snyk":              "version: v1.25.1\nexclude:\n  global:\n    - build (old)\n",
-		// 		"build (old)/out.js": "x",
-		// 		"build/keep.js":      "x",
-		// 	},
-		// 	ruleFiles: []string{".snyk"},
-		// 	excluded:  []string{"build (old)/out.js"},
-		// 	kept:      []string{"build/keep.js"},
-		// },
+		{
+			name: "gitignore rule with parentheses and spaces",
+			files: map[string]string{
+				".gitignore":         "build (old)/\n",
+				"build (old)/out.js": "x",
+				"build/keep.js":      "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"build (old)/out.js"},
+			kept:      []string{"build/keep.js"},
+		},
+		{
+			name: "snyk rule with parentheses and spaces",
+			files: map[string]string{
+				".snyk":              "version: v1.25.1\nexclude:\n  global:\n    - build (old)\n",
+				"build (old)/out.js": "x",
+				"build/keep.js":      "x",
+			},
+			ruleFiles: []string{".snyk"},
+			excluded:  []string{"build (old)/out.js"},
+			kept:      []string{"build/keep.js"},
+		},
+		{
+			// Guards every character in ruleRegexMetaChars except "|" (Windows-illegal, covered
+			// below). Each metachar sits where leaving it unescaped would change the regex, so
+			// dropping any one from the map makes go-gitignore mismatch the literal folder and
+			// this case fails: "$" (anchor), "(c)" (group), "d+" (quantifier), "e{2}" (repetition).
+			name: "gitignore rule with all windows-legal regex metacharacters",
+			files: map[string]string{
+				".gitignore":           "a$b(c)d+e{2}f/\n",
+				"a$b(c)d+e{2}f/out.js": "x",
+				"keep.js":              "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"a$b(c)d+e{2}f/out.js"},
+			kept:      []string{"keep.js"},
+		},
+		{
+			// "|" (alternation) is the only ruleRegexMetaChars entry illegal in Windows paths.
+			name:          "gitignore rule with pipe metacharacter",
+			skipOnWindows: true,
+			files: map[string]string{
+				".gitignore": "a|b/\n",
+				"a|b/out.js": "x",
+				"keep.js":    "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"a|b/out.js"},
+			kept:      []string{"keep.js"},
+		},
 
 		// --- D. Path structure / real-world combinations ---
 		{

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -262,7 +262,7 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 		"a[b]c",                     // glob character class in the path
 		"a?b",                       // glob single-char wildcard in the path
 		"a\\b",                      // literal backslash (legal on unix, illegal on windows)
-		"first.last",                                       // dot in path (e.g. C:\Users\first.last)
+		"first.last",                // dot in path (e.g. C:\Users\first.last)
 		"Users/first.last/OneDrive - Foobar (Team1)/docs", // combined: dot + parens + spaces
 	}
 

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -13,10 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// windowsIllegalChars are characters Windows does not allow in file/directory names, so paths
-// containing them cannot exist there and the corresponding cases are skipped on Windows.
-const windowsIllegalChars = `<>:"/\|?*`
-
 type fileFilterTestCase struct {
 	// the name of the test case. Will be used as the test name in t.Run()
 	name string
@@ -270,6 +266,10 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 		"Users/first.last/OneDrive - Foobar (Team1)/docs", // combined: dot + parens + spaces
 	}
 
+	// Characters Windows does not allow in file/directory names, so such paths cannot exist
+	// there and the corresponding cases are skipped on Windows.
+	const windowsIllegalChars = `<>:"/\|?*`
+
 	for _, dirName := range metaCharDirs {
 		t.Run(dirName, func(t *testing.T) {
 			if runtime.GOOS == "windows" && strings.ContainsAny(dirName, windowsIllegalChars) {
@@ -313,22 +313,9 @@ type ignoreRuleScenario struct {
 	kept     []string
 	// windowsOnly skips the scenario on non-Windows platforms.
 	windowsOnly bool
-}
-
-// scenarioHasWindowsIllegalChars reports whether the scenario's scan root or any of its file
-// paths contain characters that are illegal in Windows paths, so it must be skipped there.
-func scenarioHasWindowsIllegalChars(tc ignoreRuleScenario) bool {
-	// "/" is the path separator in these test paths, so exclude it from the illegal set.
-	illegal := strings.ReplaceAll(windowsIllegalChars, "/", "")
-	if strings.ContainsAny(tc.scanRootName, illegal) {
-		return true
-	}
-	for p := range tc.files {
-		if strings.ContainsAny(p, illegal) {
-			return true
-		}
-	}
-	return false
+	// skipOnWindows skips the scenario on Windows, for paths that contain characters Windows
+	// does not allow in file/directory names (e.g. "|", "\\").
+	skipOnWindows bool
 }
 
 // TestFileFilter_GetFilteredFiles_ignoreRuleScenarios is the behavioral regression net for the
@@ -449,8 +436,9 @@ func TestFileFilter_GetFilteredFiles_ignoreRuleScenarios(t *testing.T) {
 			kept:      []string{"app.js"},
 		},
 		{
-			name:         "scan root with caret dollar and pipe",
-			scanRootName: "a^b/a$b/a|b",
+			name:          "scan root with caret dollar and pipe",
+			scanRootName:  "a^b/a$b/a|b", // "|" is illegal on Windows
+			skipOnWindows: true,
 			files: map[string]string{
 				".gitignore":                "node_modules\n",
 				"node_modules/lib/index.js": "x",
@@ -461,8 +449,9 @@ func TestFileFilter_GetFilteredFiles_ignoreRuleScenarios(t *testing.T) {
 			kept:      []string{"app.js"},
 		},
 		{
-			name:         "scan root with backslash", // unix-legal, auto-skipped on Windows
-			scanRootName: "a\\b",
+			name:          "scan root with backslash", // "\" is illegal on Windows
+			scanRootName:  "a\\b",
+			skipOnWindows: true,
 			files: map[string]string{
 				".gitignore":                "node_modules\n",
 				"node_modules/lib/index.js": "x",
@@ -618,6 +607,34 @@ func TestFileFilter_GetFilteredFiles_ignoreRuleScenarios(t *testing.T) {
 			kept:      []string{"pkg/keep.txt"},
 		},
 
+		// --- C2. Special characters in the ignore rule pattern itself ---
+		// git treats parentheses/spaces in a gitignore pattern as literal (fnmatch), so a folder
+		// literally named "build (old)" should be excluded. These currently fail because the
+		// rule side only escapes "$"; regex metacharacters in the rule reach go-gitignore and are
+		// interpreted as regex. Documents the gap mirror of the base-path fix (CLI-1648).
+		// {
+		// 	name: "gitignore rule with parentheses and spaces",
+		// 	files: map[string]string{
+		// 		".gitignore":         "build (old)/\n",
+		// 		"build (old)/out.js": "x",
+		// 		"build/keep.js":      "x",
+		// 	},
+		// 	ruleFiles: []string{".gitignore"},
+		// 	excluded:  []string{"build (old)/out.js"},
+		// 	kept:      []string{"build/keep.js"},
+		// },
+		// {
+		// 	name: "snyk rule with parentheses and spaces",
+		// 	files: map[string]string{
+		// 		".snyk":              "version: v1.25.1\nexclude:\n  global:\n    - build (old)\n",
+		// 		"build (old)/out.js": "x",
+		// 		"build/keep.js":      "x",
+		// 	},
+		// 	ruleFiles: []string{".snyk"},
+		// 	excluded:  []string{"build (old)/out.js"},
+		// 	kept:      []string{"build/keep.js"},
+		// },
+
 		// --- D. Path structure / real-world combinations ---
 		{
 			name: "deeply nested exclusion",
@@ -682,7 +699,7 @@ func TestFileFilter_GetFilteredFiles_ignoreRuleScenarios(t *testing.T) {
 			if tc.windowsOnly && runtime.GOOS != "windows" {
 				t.Skip("scenario only applies on Windows")
 			}
-			if runtime.GOOS == "windows" && scenarioHasWindowsIllegalChars(tc) {
+			if tc.skipOnWindows && runtime.GOOS == "windows" {
 				t.Skip("path contains characters not allowed on Windows")
 			}
 

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -248,11 +248,6 @@ func TestFileFilter_GetFilteredFiles(t *testing.T) {
 
 // TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars checks that ignore rules still
 // apply when the project path contains regex metacharacters (CLI-1648).
-//
-// Note: "a?b" is not covered. regexp.QuoteMeta escapes ? to \?, then go-gitignore also
-// processes ? (replacing it with \?), so \? becomes \\? in the final regex — matching
-// literal \? instead of literal ?. This is a double-escaping issue caused by the library;
-// fixing it requires patching go-gitignore or switching to a different gitignore library.
 func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 	metaCharDirs := []string{
 		"OneDrive - Foobar (Team1)", // parentheses + spaces (customer's path shape)
@@ -265,8 +260,10 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 		"a$b",                       // dollar
 		"a*b",                       // glob wildcard in the path
 		"a[b]c",                     // glob character class in the path
-		// "a?b",                       // glob single-char wildcard in the path
+		"a?b",                       // glob single-char wildcard in the path
 		"a\\b",                      // literal backslash (legal on unix, illegal on windows)
+		"first.last",                                       // dot in path (e.g. C:\Users\first.last)
+		"Users/first.last/OneDrive - Foobar (Team1)/docs", // combined: dot + parens + spaces
 	}
 
 	// Characters that Windows does not allow in file/directory names, so such paths cannot
@@ -741,8 +738,8 @@ func TestParseIgnoreRuleToGlobs(t *testing.T) {
 			invalidRules:   []string{},
 			skipNonWindows: true,
 			expectedGlobs: []string{
-				"//server" + path.Join("share", "OneDrive - Foobar \\(Team1\\)", "project", "**", "node_modules", "**"),
-				"//server" + path.Join("share", "OneDrive - Foobar \\(Team1\\)", "project", "**", "node_modules"),
+				"//server/" + path.Join("share", "OneDrive - Foobar \\(Team1\\)", "project", "**", "node_modules", "**"),
+				"//server/" + path.Join("share", "OneDrive - Foobar \\(Team1\\)", "project", "**", "node_modules"),
 			},
 		},
 		{


### PR DESCRIPTION
### Description

Code SAST scanning (via CLI and IDE) silently stops honoring `.gitignore` and `.snyk` exclude
rules when the project lives under a path that contains regex metacharacters — parentheses,
plus signs, dollar signs, braces, etc.

The root cause: `parseIgnoreRuleToGlobs` builds absolute glob patterns by concatenating the
base directory path with the ignore rule. The `go-gitignore` library internally compiles these
patterns to regexes, so characters like `(`, `)`, `$`, `+` in the path are interpreted as regex
syntax instead of literals, causing all exclusion rules to silently fail.

The fix escapes the base path with `regexp.QuoteMeta` before embedding it in patterns, and
escapes only the regex-significant characters in the rule portion (preserving glob wildcards).

**Affected paths example:** `C:\Users\…\OneDrive - Foo (789EBar)\Documents\Projects\…`

**Risk: Low** — the change only affects how the base directory is embedded in ignore patterns;
glob/gitignore syntax in the rule portion is preserved. All existing tests pass, plus new tests
covering 11 metacharacter variants and 5 ignore-rule edge cases.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [X] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI: https://github.com/snyk/cli/pull/6980



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to ignore glob construction in file filtering; scope is narrow though incorrect escaping could still affect which files are scanned.
> 
> **Overview**
> Fixes **CLI-1648**, where `.gitignore`, `.dcignore`, and `.snyk` excludes could be ignored when the project or ignore-file directory path contains characters that `go-gitignore` treats as regex syntax (e.g. parentheses in OneDrive folder names).
> 
> `parseIgnoreRuleToGlobs` now **quotes the base directory** with `regexp.QuoteMeta` (with selective un-escaping so dots and `?` in paths still match literally), **escapes additional regex metacharacters in the rule text** while keeping glob wildcards like `*` and `[^S]`, and builds patterns with **`joinGlob`** so Windows **UNC** and extended-length `//` prefixes are not collapsed by `path.Join`.
> 
> Adds a large regression suite: metacharacter scan roots, ignore-rule scenarios (including `.snyk`), UNC integration tests on Windows, and expanded `TestParseIgnoreRuleToGlobs` cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 790cd588fe030b2bee7491ca6afd96140fb5d4b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->