### PR TITLE
perf: add single-walk file filter that prunes ignored directories

### DIFF
--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -147,22 +147,226 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 func (fw *FileFilter) buildGlobs(ignoreFiles []string) ([]string, error) {
 	var globs = make([]string, 0)
 	for _, ignoreFile := range ignoreFiles {
-		var content []byte
-		content, err := os.ReadFile(ignoreFile)
+		parsedRules, err := fw.globsForIgnoreFile(ignoreFile)
 		if err != nil {
 			return nil, err
 		}
-
-		if filepath.Base(ignoreFile) == ".snyk" { // .snyk files are yaml files and should be parsed differently
-			parsedRules := fw.parseDotSnykFile(content, filepath.Dir(ignoreFile))
-			globs = append(globs, parsedRules...)
-		} else { // .gitignore, .dcignore, etc. are just a list of ignore rules
-			parsedRules := parseIgnoreFile(content, filepath.Dir(ignoreFile))
-			globs = append(globs, parsedRules...)
-		}
+		globs = append(globs, parsedRules...)
 	}
 
 	return globs, nil
+}
+
+// globsForIgnoreFile reads a single ignore file and returns the glob patterns it
+// contributes. .snyk files are YAML and parsed differently from .gitignore-style
+// files.
+func (fw *FileFilter) globsForIgnoreFile(ignoreFile string) ([]string, error) {
+	content, err := os.ReadFile(ignoreFile)
+	if err != nil {
+		return nil, err
+	}
+
+	if filepath.Base(ignoreFile) == ".snyk" {
+		return fw.parseDotSnykFile(content, filepath.Dir(ignoreFile)), nil
+	}
+	return parseIgnoreFile(content, filepath.Dir(ignoreFile)), nil
+}
+
+// GetFilteredFilesSingleWalk traverses the directory tree exactly once, reading
+// ignore files (ruleFiles, e.g. .gitignore/.dcignore/.snyk) as it descends and
+// pruning any directory that the rules exclude in its entirety.
+//
+// This replaces the GetAllFiles + GetRules + GetFilteredFiles pipeline, which
+// walked the whole tree twice and glob-matched every file — including everything
+// under ignored directories such as node_modules and .git. By pruning excluded
+// directories we never descend into them, which is where almost all of the time
+// on real projects was being spent.
+//
+// Correctness: a directory is only pruned when a rule excludes the *directory
+// itself* (e.g. `node_modules`, `/node_modules/`, `**/dist`) — never when a rule
+// only excludes its contents (e.g. `src/*`, `obj/**`), because those are exactly
+// the cases where a `!` negation may re-include files within. A directory that
+// contains its own ignore file is also never pruned, since that file may negate.
+// Per-file emission still uses the full rule set, so the output is identical to
+// the original pipeline. Rules are applied hierarchically; within a directory,
+// dotfiles such as .gitignore are visited before normal entries, so ignore rules
+// take effect before sibling directories are evaluated for pruning.
+func (fw *FileFilter) GetFilteredFilesSingleWalk(ruleFiles []string) chan string {
+	filteredFilesCh := make(chan string)
+
+	ruleFileSet := make(map[string]struct{}, len(ruleFiles))
+	for _, rf := range ruleFiles {
+		ruleFileSet[rf] = struct{}{}
+	}
+
+	go func() {
+		defer close(filteredFilesCh)
+
+		// dirGlobs/dirMatcher decide which directories are safe to prune (only
+		// whole-directory exclusions). The matcher is rebuilt only when a new
+		// directory rule is discovered, not on every file. fileGlobs accumulates
+		// every rule so the final per-file decision is compiled once, matching the
+		// original pipeline exactly.
+		dirGlobs := append([]string{}, fw.defaultRules...)
+		dirMatcher := gitignore.CompileIgnoreLines(dirGlobs...)
+		fileGlobs := append([]string{}, fw.defaultRules...)
+		var candidates []string
+
+		err := filepath.WalkDir(fw.path, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+
+			if d.IsDir() {
+				if path != fw.path &&
+					dirMatcher.MatchesPath(path) &&
+					!fw.dirContainsRuleFile(path, ruleFileSet) {
+					return fs.SkipDir
+				}
+				return nil
+			}
+
+			// Fold ignore-file rules. Directory-exclusion rules update dirMatcher
+			// immediately so sibling directories (visited after the dotfile) can be
+			// pruned; full rules are accumulated for the single final compile.
+			if _, ok := ruleFileSet[d.Name()]; ok {
+				fw.foldIgnoreFile(path, &fileGlobs, &dirGlobs, &dirMatcher)
+				// Ignore files are themselves scannable.
+			}
+
+			candidates = append(candidates, path)
+			return nil
+		})
+		if err != nil {
+			fw.logger.Error().Msgf("walk dir failed: %v", err)
+		}
+
+		fw.emitCandidates(candidates, fileGlobs, filteredFilesCh)
+	}()
+
+	return filteredFilesCh
+}
+
+// foldIgnoreFile incorporates the rules from a discovered ignore file: every rule
+// is appended to fileGlobs for the final per-file compile, while whole-directory
+// exclusions additionally update dirGlobs/dirMatcher so sibling directories
+// (visited after the dotfile) can be pruned immediately.
+func (fw *FileFilter) foldIgnoreFile(path string, fileGlobs, dirGlobs *[]string, dirMatcher **gitignore.GitIgnore) {
+	if newGlobs, gErr := fw.globsForIgnoreFile(path); gErr == nil {
+		*fileGlobs = append(*fileGlobs, newGlobs...)
+	} else {
+		fw.logger.Error().Msgf("failed to read ignore file %s: %v", path, gErr)
+	}
+	// .snyk is intentionally excluded from dir pruning (its excludes are honored
+	// per-file below); only .gitignore-style files contribute whole-directory
+	// exclusions.
+	if filepath.Base(path) == ".snyk" {
+		return
+	}
+	if dirOnly := fw.dirExclusionGlobs(path); len(dirOnly) > 0 {
+		*dirGlobs = append(*dirGlobs, dirOnly...)
+		*dirMatcher = gitignore.CompileIgnoreLines(*dirGlobs...)
+	}
+}
+
+// emitCandidates compiles the full rule set once and emits the surviving files on
+// ch. Pruning has already removed everything under wholly-excluded directories, so
+// only a small candidate set remains. Matching against the (potentially large)
+// rule set is the dominant cost, so it is parallelised across max_threads like the
+// original GetFilteredFiles. MatchesPath is read-only and safe for concurrent use.
+func (fw *FileFilter) emitCandidates(candidates, fileGlobs []string, ch chan string) {
+	fileMatcher := gitignore.CompileIgnoreLines(fileGlobs...)
+	ctx := context.Background()
+	availableThreads := semaphore.NewWeighted(fw.max_threads)
+	for _, f := range candidates {
+		if acqErr := availableThreads.Acquire(ctx, 1); acqErr != nil {
+			fw.logger.Err(acqErr).Msg("failed to limit threads")
+		}
+		go func(f string) {
+			defer availableThreads.Release(1)
+			if !fileMatcher.MatchesPath(f) {
+				ch <- f
+			}
+		}(f)
+	}
+	// Wait for all in-flight matches to finish before returning.
+	if acqErr := availableThreads.Acquire(ctx, fw.max_threads); acqErr != nil {
+		fw.logger.Err(acqErr).Msg("failed to wait for all threads")
+	}
+}
+
+// dirExclusionGlobs reads a .gitignore-style file and returns globs that match a
+// directory *as a whole* (so it is safe to prune). Content-only rules (`dir/*`,
+// `dir/**`) are deliberately excluded, because a later `!` negation can re-include
+// files beneath such a directory. Negation rules are preserved so that `!dir`
+// correctly un-prunes a directory.
+func (fw *FileFilter) dirExclusionGlobs(ignoreFile string) []string {
+	content, err := os.ReadFile(ignoreFile)
+	if err != nil {
+		return nil
+	}
+	baseDir := filepath.Dir(ignoreFile)
+	var globs []string
+	for _, line := range strings.Split(string(content), "\n") {
+		if g, ok := dirExclusionGlob(line, baseDir); ok {
+			globs = append(globs, g)
+		}
+	}
+	return globs
+}
+
+// dirExclusionGlob converts a single .gitignore rule into a glob that matches the
+// directory it excludes, or returns ok=false if the rule does not exclude a whole
+// directory (blank/comment, or a content-only rule ending in `/*` or `/**`).
+func dirExclusionGlob(rule, baseDir string) (string, bool) {
+	r := strings.TrimSpace(rule)
+	if r == "" || strings.HasPrefix(r, "#") {
+		return "", false
+	}
+
+	negation := strings.HasPrefix(r, "!")
+	if negation {
+		r = r[1:]
+	}
+
+	// Normalise trailing slashes first so directory rules like `obj/**/` are
+	// recognized as the content-only rule `obj/**` below.
+	r = strings.TrimRight(r, "/")
+	if r == "" {
+		return "", false
+	}
+	// Content-only rules exclude what's *inside* the directory, not the directory
+	// itself, so they must not trigger pruning (a `!` may re-include within).
+	if strings.HasSuffix(r, "/*") || strings.HasSuffix(r, "/**") {
+		return "", false
+	}
+
+	base := filepath.ToSlash(baseDir)
+	var glob string
+	if strings.HasPrefix(r, "/") || strings.HasPrefix(r, "**") {
+		// anchored to the ignore file's directory
+		glob = filepath.ToSlash(filepath.Join(base, r))
+	} else {
+		// applies in this directory and any subdirectory
+		glob = filepath.ToSlash(filepath.Join(base, "**", r))
+	}
+	glob = escapeSpecialGlobChars(glob)
+	if negation {
+		glob = "!" + glob
+	}
+	return glob, true
+}
+
+// dirContainsRuleFile reports whether dir directly contains any of the given
+// ignore files. Used to decide whether an ignored directory is safe to prune:
+// a directory with its own ignore file may re-include (negate) files inside it.
+func (fw *FileFilter) dirContainsRuleFile(dir string, ruleFileSet map[string]struct{}) bool {
+	for ruleFile := range ruleFileSet {
+		if _, err := os.Stat(filepath.Join(dir, ruleFile)); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // parseDotSnykFile builds a list of glob patterns from a given .snyk style file

--- a/pkg/utils/file_filter_singlewalk_test.go
+++ b/pkg/utils/file_filter_singlewalk_test.go
@@ -1,0 +1,229 @@
+package utils
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"testing"
+
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func drainChannelToSortedSlice(ch chan string) []string {
+	var out []string
+	for v := range ch {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestFileFilter_GetFilteredFilesSingleWalk_EquivalentToPipeline asserts the new
+// single-walk implementation returns exactly the same set of files as the
+// original GetAllFiles + GetRules + GetFilteredFiles pipeline across every
+// existing test case (including nested ignore files and negation-in-ignored-dir).
+func TestFileFilter_GetFilteredFilesSingleWalk_EquivalentToPipeline(t *testing.T) {
+	for _, testCase := range testCases(t) {
+		t.Run(testCase.name, func(t *testing.T) {
+			setupTestFileSystem(t, testCase)
+
+			oldFilter := NewFileFilter(testCase.repoPath, &log.Logger)
+			globs, err := oldFilter.GetRules(testCase.ruleFiles)
+			assert.NoError(t, err)
+			oldResult := drainChannelToSortedSlice(
+				oldFilter.GetFilteredFiles(oldFilter.GetAllFiles(), globs),
+			)
+
+			newFilter := NewFileFilter(testCase.repoPath, &log.Logger)
+			newResult := drainChannelToSortedSlice(
+				newFilter.GetFilteredFilesSingleWalk(testCase.ruleFiles),
+			)
+
+			// The shared test fixture only writes ignore files to disk (regular
+			// files like file1.java are never created), so the canonical
+			// correctness check is exact equivalence with the original pipeline
+			// over whatever actually exists on disk.
+			assert.Equal(t, oldResult, newResult,
+				"single-walk result differs from the original pipeline")
+		})
+	}
+}
+
+// setupNodeModulesTree builds a small "source" tree plus a large ignored
+// directory (simulating node_modules) that the root .gitignore excludes. Returns
+// the root and the number of non-ignored files.
+func setupNodeModulesTree(tb testing.TB, ignoredFiles int) (root string, wantFiles int) {
+	tb.Helper()
+	root = tb.TempDir()
+
+	// root .gitignore excluding node_modules
+	createFileInPath(tb, filepath.Join(root, ".gitignore"), []byte("node_modules\n"))
+
+	// a handful of real source files
+	src := []string{"src/index.js", "src/app.js", "lib/util.js"}
+	for _, f := range src {
+		createFileInPath(tb, filepath.Join(root, f), []byte("console.log(1)"))
+	}
+
+	// a large node_modules that should be pruned entirely
+	for i := 0; i < ignoredFiles; i++ {
+		p := filepath.Join(root, "node_modules", fmt.Sprintf("pkg_%d", i%50), fmt.Sprintf("file_%d.js", i))
+		createFileInPath(tb, p, []byte("module.exports={}"))
+	}
+
+	// expected: the source files + the .gitignore itself
+	return root, len(src) + 1
+}
+
+func TestFileFilter_GetFilteredFilesSingleWalk_PrunesNodeModules(t *testing.T) {
+	root, want := setupNodeModulesTree(t, 500)
+	ff := NewFileFilter(root, &log.Logger)
+	got := drainChannelToSortedSlice(ff.GetFilteredFilesSingleWalk([]string{".gitignore", ".dcignore", ".snyk"}))
+	assert.Len(t, got, want)
+	for _, f := range got {
+		assert.NotContains(t, f, "node_modules", "node_modules files must be filtered out")
+	}
+}
+
+// buildRealTree writes every file in files (relative path -> content) under a
+// fresh temp dir and returns the root. Unlike the shared setupTestFileSystem
+// fixture, this creates *all* files on disk so behavior can be asserted exactly.
+func buildRealTree(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for rel, content := range files {
+		createFileInPath(t, filepath.Join(root, rel), []byte(content))
+	}
+	return root
+}
+
+// TestFileFilter_GetFilteredFilesSingleWalk_NegationScenarios pins down the exact
+// behavior for the directory-pruning edge cases discovered against real repos:
+// negations that re-include content inside an otherwise-ignored directory must
+// still be honored (the directory must not be pruned), while wholly-excluded
+// directories must be pruned. Each case is asserted both against an explicit
+// expected set and for exact equivalence with the original pipeline.
+func TestFileFilter_GetFilteredFilesSingleWalk_NegationScenarios(t *testing.T) {
+	ruleFiles := []string{".gitignore", ".dcignore", ".snyk"}
+
+	cases := []struct {
+		name     string
+		files    map[string]string
+		expected []string // relative paths expected in the output
+	}{
+		{
+			// `src/*` ignores src's children; `!src/keep` re-includes a subdir.
+			// The bug: pruning `src` dropped everything under src/keep.
+			name: "negation re-includes subdir of contents-ignored dir",
+			files: map[string]string{
+				".gitignore":      "src/*\n!src/keep\n",
+				"main.js":         "x",
+				"src/c.js":        "x",
+				"src/drop/b.js":   "x",
+				"src/keep/a.js":   "x",
+				"src/keep/n/d.js": "x",
+			},
+			expected: []string{".gitignore", "main.js", "src/keep/a.js", "src/keep/n/d.js"},
+		},
+		{
+			// `obj/**` (+ trailing-slash variant) ignores obj's contents;
+			// `!*.assets.json` re-includes one file. The bug: `obj/**/` was
+			// mis-read as a whole-dir exclusion and pruned obj.
+			name: "negation re-includes file under content-ignored dir",
+			files: map[string]string{
+				".gitignore":              "obj/**\nobj/**/\n!*.assets.json\n",
+				"app.cs":                  "x",
+				"obj/project.assets.json": "x",
+				"obj/foo.dll":             "x",
+				"obj/sub/bar.dll":         "x",
+			},
+			expected: []string{".gitignore", "app.cs", "obj/project.assets.json"},
+		},
+		{
+			// Leading+trailing slash form: a true whole-directory exclusion that
+			// MUST be pruned.
+			name: "whole-directory exclusion is pruned",
+			files: map[string]string{
+				".gitignore":            "/node_modules/\n",
+				"src/app.js":            "x",
+				"node_modules/pkg/i.js": "x",
+				"node_modules/pkg/j.js": "x",
+			},
+			expected: []string{".gitignore", "src/app.js"},
+		},
+		{
+			// `**/dist` excludes dist directories at any depth -> pruned.
+			name: "globstar directory exclusion pruned at any depth",
+			files: map[string]string{
+				".gitignore":  "**/dist\n",
+				"a/keep.js":   "x",
+				"dist/y.js":   "x",
+				"a/dist/x.js": "x",
+			},
+			expected: []string{".gitignore", "a/keep.js"},
+		},
+		{
+			// `/a/` excludes dir a, but a/.gitignore re-includes *.txt. Behavior
+			// is preserved (not git-strict): the dir owning an ignore file is not
+			// pruned, so the negation is honored.
+			name: "ignored dir with its own negating ignore file is not pruned",
+			files: map[string]string{
+				".gitignore":   "/a/\n",
+				"a/.gitignore": "!*.txt\n",
+				"a/keep.txt":   "x",
+				"a/drop.js":    "x",
+				"b.js":         "x",
+			},
+			expected: []string{".gitignore", "a/keep.txt", "b.js"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := buildRealTree(t, tc.files)
+
+			want := make([]string, 0, len(tc.expected))
+			for _, rel := range tc.expected {
+				want = append(want, filepath.Join(root, rel))
+			}
+			sort.Strings(want)
+
+			got := drainChannelToSortedSlice(
+				NewFileFilter(root, &log.Logger).GetFilteredFilesSingleWalk(ruleFiles),
+			)
+			assert.Equal(t, want, got, "single-walk output does not match expected set")
+
+			// Cross-check: identical to the original pipeline on real files.
+			old := NewFileFilter(root, &log.Logger)
+			globs, err := old.GetRules(ruleFiles)
+			assert.NoError(t, err)
+			oldResult := drainChannelToSortedSlice(old.GetFilteredFiles(old.GetAllFiles(), globs))
+			assert.Equal(t, oldResult, got, "single-walk diverges from original pipeline")
+		})
+	}
+}
+
+func BenchmarkFileFilter_Pipeline_vs_SingleWalk(b *testing.B) {
+	root, _ := setupNodeModulesTree(b, 20000)
+	ruleFiles := []string{".gitignore", ".dcignore", ".snyk"}
+
+	b.Run("OldPipeline", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			ff := NewFileFilter(root, &log.Logger, WithThreadNumber(runtime.NumCPU()))
+			globs, err := ff.GetRules(ruleFiles)
+			assert.NoError(b, err)
+			for range ff.GetFilteredFiles(ff.GetAllFiles(), globs) {
+			}
+		}
+	})
+
+	b.Run("SingleWalkPruning", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			ff := NewFileFilter(root, &log.Logger, WithThreadNumber(runtime.NumCPU()))
+			for range ff.GetFilteredFilesSingleWalk(ruleFiles) {
+			}
+		}
+	})
+}


### PR DESCRIPTION
This PR is in relation to this [ticket](https://snyksec.atlassian.net/browse/COIN-2536). My testing shows that the changes here reduce bundle creation time from between %50 to %90. Feel free to take whatever you want from this PR and remix it with whatever design might suite engineering better.

Add GetFilteredFilesSingleWalk, which traverses the directory tree once instead of twice (GetAllFiles + GetFilteredFiles) and prunes wholly- excluded directories such as node_modules and .git rather than globbing every file beneath them — where almost all the time on real projects was spent.

A directory is pruned only when a rule excludes the directory itself (node_modules, /node_modules/, **/dist), never when a rule excludes only its contents (src/*, obj/**) or when the directory contains its own ignore file, since those may be re-included by a ! negation. Per-file emission still uses the full rule set, so output is identical to the original pipeline.

Includes equivalence, negation-edge-case, and pruning tests plus a benchmark against the old pipeline.

### Description

_Provide description of this PR and changes._

### Checklist

- [X] Tests added and all succeed (`make test`)
- [N/A] Regenerated mocks, etc. (`make generate`)
- [X] Linted (`make lint`)
- [X] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.
