### PR TITLE
fix: ignored-parent semantics

### DIFF
--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -148,7 +148,12 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 // buildGlobs iterates a list of ignore filesToFilter and returns a list of glob patterns that can be used to test for ignored filesToFilter
 func (fw *FileFilter) buildGlobs(ignoreFiles []string) ([]string, error) {
 	var globs = make([]string, 0)
+	globPatternMatcher := gitignore.CompileIgnoreLines()
 	for _, ignoreFile := range ignoreFiles {
+		if globPatternMatcher.MatchesPath(ignoreFile) {
+			continue
+		}
+
 		var content []byte
 		content, err := os.ReadFile(ignoreFile)
 		if err != nil {
@@ -162,6 +167,7 @@ func (fw *FileFilter) buildGlobs(ignoreFiles []string) ([]string, error) {
 			parsedRules := parseIgnoreFile(content, filepath.Dir(ignoreFile))
 			globs = append(globs, parsedRules...)
 		}
+		globPatternMatcher = gitignore.CompileIgnoreLines(globs...)
 	}
 
 	return globs, nil

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -606,6 +606,31 @@ func TestFileFilter_GetFilteredFiles_ignoreRuleScenarios(t *testing.T) {
 			excluded:  []string{"root.txt", "pkg/pkg.txt", "pkg/root.txt"},
 			kept:      []string{"pkg/keep.txt"},
 		},
+		{
+			name: "ignore file below ignored parent cannot reinclude files",
+			files: map[string]string{
+				".gitignore":                  "node_modules\n",
+				"node_modules/pkg/.gitignore": "!index.js\n",
+				"node_modules/pkg/index.js":   "x",
+				"node_modules/pkg/other.js":   "x",
+				"src/index.js":                "x",
+			},
+			ruleFiles: []string{".gitignore"},
+			excluded:  []string{"node_modules/pkg/index.js", "node_modules/pkg/other.js"},
+			kept:      []string{"src/index.js"},
+		},
+		{
+			name: "gitignore below snyk-excluded parent cannot reinclude files",
+			files: map[string]string{
+				".snyk":                       "version: v1.25.1\nexclude:\n  global:\n    - node_modules\n",
+				"node_modules/pkg/.gitignore": "!index.js\n",
+				"node_modules/pkg/index.js":   "x",
+				"src/index.js":                "x",
+			},
+			ruleFiles: []string{".gitignore", ".snyk"},
+			excluded:  []string{"node_modules/pkg/index.js"},
+			kept:      []string{"src/index.js"},
+		},
 
 		// --- C2. Special characters in the ignore rule pattern itself ---
 		// git treats parentheses/spaces in a gitignore pattern as literal (fnmatch), so a folder
@@ -992,7 +1017,7 @@ func testCases(t *testing.T) []fileFilterTestCase {
 				"a/.gitignore": "!*.txt",
 			},
 			filesToFilter: []string{"a/file2.js"},
-			expectedFiles: []string{"file1.js", "a/file1.txt", ".gitignore", "a/.gitignore"},
+			expectedFiles: []string{"file1.js", ".gitignore", "a/.gitignore"},
 		},
 		{
 			name:      "Supports .dcignore rule file",
@@ -1003,7 +1028,7 @@ func testCases(t *testing.T) []fileFilterTestCase {
 				"a/.dcignore": "!*.txt",
 			},
 			filesToFilter: []string{"a/file2.js"},
-			expectedFiles: []string{"file1.js", "a/file1.txt", ".dcignore", "a/.dcignore"},
+			expectedFiles: []string{"file1.js", ".dcignore", "a/.dcignore"},
 		},
 		{
 			name:      "Supports .snyk style exclude rules",


### PR DESCRIPTION
### Description

Prevents ignore files inside an already ignored directory from re-including descendant files.

GAF collected rules from every nested `.gitignore`, `.dcignore`, and `.snyk` file before filtering paths.

#### Example

```
.gitignore:                         node_modules
node_modules/pkg/.gitignore:        !index.js
node_modules/pkg/index.js
```

The nested negation incorrectly re-included `index.js`. Git does not process ignore files beneath an ignored parent directory.

#### Solution

While building ignore rules, ignore files whose path has been already ignored.

#### Testing

- Unit tests: new and modified existing.
- Verified `code-client-go` and `snyk-ls` consumers locally.
- `make format`, `make generate`, `make lint`, `make test`

#### Related task

[CLI-1526](https://snyksec.atlassian.net/browse/CLI-1526)

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.


[CLI-1526]: https://snyksec.atlassian.net/browse/CLI-1526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which files are scanned for Snyk/CLI uploads by altering ignore semantics; behavior shifts for repos that relied on nested negations under excluded trees, but matches Git and reduces incorrect inclusions.
> 
> **Overview**
> **Aligns ignore-rule collection with Git** by not reading `.gitignore`, `.dcignore`, or `.snyk` files whose path is already covered by rules gathered from earlier ignore files.
> 
> In `buildGlobs`, a matcher is built incrementally from accumulated globs. Each candidate ignore file is skipped when that matcher already matches its path; otherwise its rules are merged and the matcher is refreshed. That stops nested negations (e.g. `node_modules` at the root plus `!index.js` under `node_modules/pkg/`) from re-including files Git would still exclude.
> 
> Tests add `node_modules` / `.snyk` parent cases and tighten expectations for ignored folders with negation rules so descendants under an ignored parent stay excluded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe47ad77e2af48bc4a98a76da282051aba5f6d52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->