### PR TITLE
fix: load snyk.json only from configstore path

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -276,7 +276,6 @@ func readConfigFilesIntoViper(files []string, config *extendedViper) {
 	}
 
 	config.viper.AddConfigPath(configPath)
-	config.viper.AddConfigPath(".")
 
 	// read config files
 	//nolint:errcheck // breaking api change needed to fix this

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -1178,6 +1178,65 @@ func Test_ReloadConfig(t *testing.T) {
 	cleanupConfigstore(t)
 }
 
+func Test_Configuration_doesNotLoadSnykJsonFromWorkingDirectory(t *testing.T) {
+	fakeHome := t.TempDir()
+	projectDir := t.TempDir()
+
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("USERPROFILE", fakeHome)
+
+	cwdConfig := filepath.Join(projectDir, "snyk.json")
+	err := os.WriteFile(cwdConfig, []byte(`{
+		"api": "local-dir-token",
+		"org": "dir-org",
+		"endpoint": "https://api.invalid/api"
+	}`), 0o600)
+	assert.NoError(t, err)
+
+	oldWd, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.NoError(t, os.Chdir(projectDir))
+	t.Cleanup(func() {
+		assert.NoError(t, os.Chdir(oldWd))
+	})
+
+	config := New()
+
+	assert.Empty(t, config.GetString("api"))
+	assert.Empty(t, config.GetString("org"))
+	assert.Empty(t, config.GetString("endpoint"))
+}
+
+func Test_Configuration_loadsSnykJsonFromConfigstoreNotWorkingDirectory(t *testing.T) {
+	fakeHome := t.TempDir()
+	projectDir := t.TempDir()
+
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("USERPROFILE", fakeHome)
+
+	configstoreDir := filepath.Join(fakeHome, ".config", "configstore")
+	assert.NoError(t, os.MkdirAll(configstoreDir, 0o700))
+	assert.NoError(t, os.WriteFile(filepath.Join(configstoreDir, "snyk.json"), []byte(`{
+		"api": "home-token",
+		"org": "my-org",
+		"endpoint": "https://api.example/api"
+	}`), 0o600))
+	assert.NoError(t, os.WriteFile(filepath.Join(projectDir, "snyk.json"), []byte(`{"api":"bad-token"}`), 0o600))
+
+	oldWd, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.NoError(t, os.Chdir(projectDir))
+	t.Cleanup(func() {
+		assert.NoError(t, os.Chdir(oldWd))
+	})
+
+	config := New()
+
+	assert.Equal(t, "home-token", config.GetString("api"))
+	assert.Equal(t, "my-org", config.GetString("org"))
+	assert.Equal(t, "https://api.example/api", config.GetString("endpoint"))
+}
+
 func Test_EmptyStorage(t *testing.T) {
 	s := &EmptyStorage{}
 	assert.NoError(t, s.Set("k", "v"))


### PR DESCRIPTION
### Description

Noted that if a `snyk.json` file is present in the working directory and absent from the user’s `~/.config/configstore/` , snyk will use the file from the working directory to authenticate requests.

This PR ensures we have a single source of truth for the `snyk.json`.

Relevant ticket: [CLI-1124](https://snyksec.atlassian.net/browse/CLI-1124)
CLI PR: https://github.com/snyk/cli/pull/7008

### Checklist

- [x] Tests added and all succeed (`make test`)
- [ ] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where authentication and endpoint settings are sourced from disk; correct for security but may surprise users who relied on a project-local snyk.json.
> 
> **Overview**
> Stops the CLI from treating a **`snyk.json` in the current working directory** as configuration when loading defaults. **`readConfigFilesIntoViper`** no longer adds `"."` as a Viper config path, so file-based settings (including **`api`**, **`org`**, **`endpoint`**) come only from **`~/.config/configstore`** via **`determineBasePath()`**.
> 
> This closes the case where a repo-local **`snyk.json`** could supply credentials when nothing was in the user configstore. New tests cover **cwd-only** (values stay empty) and **configstore + cwd** (home configstore wins).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d9e0f2df7ee9172339ee1c210842886264bd56a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



[CLI-1124]: https://snyksec.atlassian.net/browse/CLI-1124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ