### PR TITLE
fix(auth): validate auth host via domain allowlist [IDE-1896]

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -5,4 +5,11 @@ const SNYK_DEFAULT_API_VERSION = "2024-04-22"
 const SNYK_DEFAULT_IN_MEMORY_THRESHOLD_MB = 512 * 1024 * 1024
 const SNYK_DOCS_URL = "https://docs.snyk.io"
 const SNYK_DOCS_ERROR_CATALOG_PATH = "/scan-with-snyk/error-catalog"
+
+// Superseded by SNYK_DEFAULT_ALLOWED_HOST_DOMAINS (used with
+// auth.CONFIG_KEY_ALLOWED_HOSTS). Retained for backwards compatibility.
 const SNYK_DEFAULT_ALLOWED_HOST_REGEXP = `^(https?://)?api(\.(.+))?\.(snyk|snykgov)\.io$`
+
+// SNYK_DEFAULT_ALLOWED_HOST_DOMAINS is the default allowlist of registrable
+// domains that an OAuth callback instance host is permitted to belong to.
+var SNYK_DEFAULT_ALLOWED_HOST_DOMAINS = []string{"snyk.io", "snykgov.io"}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -6,8 +6,14 @@ const SNYK_DEFAULT_IN_MEMORY_THRESHOLD_MB = 512 * 1024 * 1024
 const SNYK_DOCS_URL = "https://docs.snyk.io"
 const SNYK_DOCS_ERROR_CATALOG_PATH = "/scan-with-snyk/error-catalog"
 
-// Superseded by SNYK_DEFAULT_ALLOWED_HOST_DOMAINS (used with
-// auth.CONFIG_KEY_ALLOWED_HOSTS). Retained for backwards compatibility.
+// SNYK_DEFAULT_ALLOWED_HOST_REGEXP is superseded by
+// SNYK_DEFAULT_ALLOWED_HOST_DOMAINS (used with auth.CONFIG_KEY_ALLOWED_HOSTS)
+// via IsValidSnykHost — inert, no longer read anywhere in this module. It's
+// internal (unreachable outside this repo), so it's kept only so the
+// pkg/app default-registration wiring that still references it continues to
+// compile; will be removed alongside the exported symbols it backs
+// (CONFIG_KEY_ALLOWED_HOST_REGEXP, IsValidAuthHost) once those are confirmed
+// unused downstream.
 const SNYK_DEFAULT_ALLOWED_HOST_REGEXP = `^(https?://)?api(\.(.+))?\.(snyk|snykgov)\.io$`
 
 // SNYK_DEFAULT_ALLOWED_HOST_DOMAINS is the default allowlist of registrable

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -6,14 +6,15 @@ const SNYK_DEFAULT_IN_MEMORY_THRESHOLD_MB = 512 * 1024 * 1024
 const SNYK_DOCS_URL = "https://docs.snyk.io"
 const SNYK_DOCS_ERROR_CATALOG_PATH = "/scan-with-snyk/error-catalog"
 
-// SNYK_DEFAULT_ALLOWED_HOST_REGEXP is superseded by
-// SNYK_DEFAULT_ALLOWED_HOST_DOMAINS (used with auth.CONFIG_KEY_ALLOWED_HOSTS)
-// via IsValidSnykHost — inert, no longer read anywhere in this module. It's
-// internal (unreachable outside this repo), so it's kept only so the
-// pkg/app default-registration wiring that still references it continues to
-// compile; will be removed alongside the exported symbols it backs
-// (CONFIG_KEY_ALLOWED_HOST_REGEXP, IsValidAuthHost) once those are confirmed
-// unused downstream.
+// SNYK_DEFAULT_ALLOWED_HOST_REGEXP is inert, no longer read anywhere in this
+// module. It's internal (unreachable outside this repo), so it's kept only
+// so the pkg/app default-registration wiring that still references it
+// continues to compile; will be removed alongside the exported symbols it
+// backs (CONFIG_KEY_ALLOWED_HOST_REGEXP, IsValidAuthHost) once those are
+// confirmed unused downstream.
+//
+// Deprecated: use SNYK_DEFAULT_ALLOWED_HOST_DOMAINS (with
+// auth.CONFIG_KEY_ALLOWED_HOSTS) via auth.IsValidSnykHost instead.
 const SNYK_DEFAULT_ALLOWED_HOST_REGEXP = `^(https?://)?api(\.(.+))?\.(snyk|snykgov)\.io$`
 
 // SNYK_DEFAULT_ALLOWED_HOST_DOMAINS is the default allowlist of registrable

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -323,6 +323,7 @@ func initConfiguration(engine workflow.Engine, config configuration.Configuratio
 	config.AddDefaultValue(configuration.MAX_THREADS, configuration.StandardDefaultValueFunction(runtime.NumCPU()))
 	config.AddDefaultValue(presenters.CONFIG_JSON_STRIP_WHITESPACES, configuration.StandardDefaultValueFunction(true))
 	config.AddDefaultValue(auth.CONFIG_KEY_ALLOWED_HOST_REGEXP, configuration.StandardDefaultValueFunction(constants.SNYK_DEFAULT_ALLOWED_HOST_REGEXP))
+	config.AddDefaultValue(auth.CONFIG_KEY_ALLOWED_HOSTS, configuration.StandardDefaultValueFunction(constants.SNYK_DEFAULT_ALLOWED_HOST_DOMAINS))
 
 	// set default filesize threshold to 512MB
 	config.AddDefaultValue(configuration.IN_MEMORY_THRESHOLD_BYTES, configuration.StandardDefaultValueFunction(constants.SNYK_DEFAULT_IN_MEMORY_THRESHOLD_MB))

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -322,6 +322,10 @@ func initConfiguration(engine workflow.Engine, config configuration.Configuratio
 	config.AddDefaultValue(configuration.AUTHENTICATION_SUBDOMAINS, configuration.StandardDefaultValueFunction([]string{"deeproxy"}))
 	config.AddDefaultValue(configuration.MAX_THREADS, configuration.StandardDefaultValueFunction(runtime.NumCPU()))
 	config.AddDefaultValue(presenters.CONFIG_JSON_STRIP_WHITESPACES, configuration.StandardDefaultValueFunction(true))
+	// CONFIG_KEY_ALLOWED_HOST_REGEXP's default is kept registered only so
+	// any external caller still using IsValidAuthHost directly keeps
+	// working; GAF's own validation no longer reads this key (see
+	// IsValidSnykHost). Remove once that's confirmed unused downstream.
 	config.AddDefaultValue(auth.CONFIG_KEY_ALLOWED_HOST_REGEXP, configuration.StandardDefaultValueFunction(constants.SNYK_DEFAULT_ALLOWED_HOST_REGEXP))
 	config.AddDefaultValue(auth.CONFIG_KEY_ALLOWED_HOSTS, configuration.StandardDefaultValueFunction(constants.SNYK_DEFAULT_ALLOWED_HOST_DOMAINS))
 

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -617,6 +617,29 @@ func Test_initConfiguration_DEFAULT_TEMP_DIRECTORY(t *testing.T) {
 	})
 }
 
+func Test_initConfiguration_allowedHostDefaults(t *testing.T) {
+	config := configuration.NewInMemory()
+	engine := workflow.NewWorkFlowEngine(config)
+
+	ctrl := gomock.NewController(t)
+	mockApiClient := mocks.NewMockApiClient(ctrl)
+	apiClientFactory := func(url string, client *http.Client) api.ApiClient {
+		return mockApiClient
+	}
+
+	initConfiguration(engine, config, &zlog.Logger, apiClientFactory)
+
+	t.Run("deprecated regex default is still registered", func(t *testing.T) {
+		actual := config.GetString(auth.CONFIG_KEY_ALLOWED_HOST_REGEXP)
+		assert.Equal(t, constants.SNYK_DEFAULT_ALLOWED_HOST_REGEXP, actual)
+	})
+
+	t.Run("new allowed host domains default is registered", func(t *testing.T) {
+		actual := config.GetStringSlice(auth.CONFIG_KEY_ALLOWED_HOSTS)
+		assert.Equal(t, constants.SNYK_DEFAULT_ALLOWED_HOST_DOMAINS, actual)
+	})
+}
+
 func createMockPAT(t *testing.T, payload string) string {
 	t.Helper()
 

--- a/pkg/auth/authHost.go
+++ b/pkg/auth/authHost.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/snyk/go-application-framework/internal/api"
+	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/utils"
 )
 
@@ -27,10 +28,173 @@ func redirectAuthHost(instance string) (string, error) {
 	return canonicalizedInstanceUrl.Host, nil
 }
 
+// IsValidAuthHost is superseded by IsValidSnykHost, which is the preferred
+// entry point for new code. Retained for backwards compatibility.
 func IsValidAuthHost(instance string, redirectAuthHostRE string) (bool, error) {
 	isValidHost, err := utils.MatchesRegex(instance, redirectAuthHostRE)
 	if err != nil {
 		return false, err
 	}
 	return isValidHost, nil
+}
+
+// IsValidSnykHost reports whether input resolves to an "api." subdomain of one
+// of the domains configured under CONFIG_KEY_ALLOWED_HOSTS. It fails closed: if
+// no allowlist is configured, nothing is considered valid.
+//
+// Validation runs as small, single-purpose steps: parse the input as a URL,
+// confirm it carries nothing but a host, confirm the host's leading DNS label
+// is "api", and confirm an allowlisted domain matches on DNS-label boundaries.
+//
+// Each step is checked twice with two independent techniques — a url* helper
+// that inspects the parsed *url.URL, and a string* helper that inspects the raw
+// normalized string — and both must agree. If the parsed URL and the raw string
+// disagree (e.g. a parser quirk that hides a smuggled component), validation
+// fails closed rather than slipping through.
+func IsValidSnykHost(conf configuration.Configuration, input string) (bool, error) {
+	allowedDomains := conf.GetStringSlice(CONFIG_KEY_ALLOWED_HOSTS)
+	if len(allowedDomains) == 0 {
+		return false, nil
+	}
+
+	normalized, parsed, ok := parseHostURL(input)
+	if !ok {
+		return false, nil
+	}
+	// String checks are case-insensitive on host/domain; stringIsHostOnly keeps
+	// the original case because the scheme case matters to its reconstruction.
+	lowerNormalized := strings.ToLower(normalized)
+
+	if !urlIsHostOnly(parsed) || !stringIsHostOnly(normalized, parsed) {
+		return false, nil
+	}
+	if !urlHasApiSubdomain(parsed) || !stringHasApiSubdomain(lowerNormalized) {
+		return false, nil
+	}
+	if !urlHasAllowedDomain(parsed, allowedDomains) || !stringHasAllowedDomain(lowerNormalized, allowedDomains) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// parseHostURL normalizes input (trimmed, https:// prepended when schemeless)
+// and parses it. It returns the normalized string alongside the parsed URL so
+// callers can cross-check the two. Empty, whitespace-bearing, unparseable, or
+// non-http(s) input is rejected.
+func parseHostURL(input string) (string, *url.URL, bool) {
+	input = strings.TrimSpace(input)
+	// Any internal whitespace means this is not a single, well-formed host.
+	if input == "" || strings.ContainsAny(input, " \t\r\n") {
+		return "", nil, false
+	}
+
+	if !strings.Contains(input, "://") {
+		input = "https://" + input
+	}
+
+	parsed, err := url.Parse(input)
+	if err != nil {
+		return "", nil, false
+	}
+
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", nil, false
+	}
+
+	return input, parsed, true
+}
+
+// urlIsHostOnly confirms the parsed URL carries nothing but a host: no userinfo,
+// opaque, port, path, query, or fragment.
+func urlIsHostOnly(parsed *url.URL) bool {
+	if parsed.User != nil || parsed.Opaque != "" ||
+		parsed.Path != "" || parsed.RawQuery != "" || parsed.Fragment != "" ||
+		parsed.Port() != "" {
+		return false
+	}
+	return parsed.Hostname() != ""
+}
+
+// stringIsHostOnly cross-checks, against the raw string, that the normalized
+// input is exactly "scheme://host" — so any component urlIsHostOnly's field
+// checks might miss still causes a mismatch and rejection.
+func stringIsHostOnly(normalized string, parsed *url.URL) bool {
+	return normalized == parsed.Scheme+"://"+parsed.Host
+}
+
+// urlHasApiSubdomain confirms the parsed host's leading DNS label is "api" and
+// that a further domain follows it.
+func urlHasApiSubdomain(parsed *url.URL) bool {
+	host := strings.ToLower(parsed.Hostname())
+	labels := strings.Split(host, ".")
+	return len(labels) > 1 && labels[0] == api.API_PREFIX
+}
+
+// stringHasApiSubdomain confirms, from the raw normalized string alone, that the
+// host begins with an "api." label under an http(s) scheme.
+func stringHasApiSubdomain(lowerNormalized string) bool {
+	apiLabel := api.API_PREFIX + "."
+	return strings.HasPrefix(lowerNormalized, "http://"+apiLabel) ||
+		strings.HasPrefix(lowerNormalized, "https://"+apiLabel)
+}
+
+// urlHasAllowedDomain confirms the parsed host ends with one of the allowed
+// registrable domains on a DNS-label boundary, with at least the "api" label
+// ahead of it.
+func urlHasAllowedDomain(parsed *url.URL, allowedDomains []string) bool {
+	labels := strings.Split(strings.ToLower(parsed.Hostname()), ".")
+	for _, domain := range allowedDomains {
+		domainLabels, ok := domainToLabels(domain)
+		if !ok {
+			continue
+		}
+		// Require at least one label (the "api" label) ahead of the domain, and
+		// match on label boundaries rather than as a raw suffix.
+		if len(labels) > len(domainLabels) && hasLabelSuffix(labels, domainLabels) {
+			return true
+		}
+	}
+	return false
+}
+
+// domainToLabels normalizes an allowlist entry and splits it into DNS labels,
+// reporting ok=false for empty/whitespace-only entries so callers skip them.
+func domainToLabels(domain string) ([]string, bool) {
+	domain = strings.ToLower(strings.TrimSpace(domain))
+	if domain == "" {
+		return nil, false
+	}
+	return strings.Split(domain, "."), true
+}
+
+// hasLabelSuffix reports whether labels ends with suffix, comparing whole DNS
+// labels (not characters), so "snykXsnyk.io" is not a suffix of "snyk.io".
+func hasLabelSuffix(labels, suffix []string) bool {
+	if len(suffix) > len(labels) {
+		return false
+	}
+	offset := len(labels) - len(suffix)
+	for i, s := range suffix {
+		if labels[offset+i] != s {
+			return false
+		}
+	}
+	return true
+}
+
+// stringHasAllowedDomain cross-checks, from the raw normalized string, that it
+// ends with "." plus one of the allowed domains. This is anchored at the host
+// because stringIsHostOnly has already established the string is "scheme://host".
+func stringHasAllowedDomain(lowerNormalized string, allowedDomains []string) bool {
+	for _, domain := range allowedDomains {
+		domain = strings.ToLower(strings.TrimSpace(domain))
+		if domain == "" {
+			continue
+		}
+		if strings.HasSuffix(lowerNormalized, "."+domain) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/auth/authHost.go
+++ b/pkg/auth/authHost.go
@@ -11,7 +11,7 @@ import (
 
 func redirectAuthHost(instance string) (string, error) {
 	// handle both cases if instance is a URL or just a host
-	if !strings.HasPrefix(instance, "http") {
+	if !strings.Contains(instance, "://") {
 		instance = "https://" + instance
 	}
 
@@ -52,9 +52,10 @@ func IsValidAuthHost(instance string, redirectAuthHostRE string) (bool, error) {
 //
 // Each step is checked twice with two independent techniques — a url* helper
 // that inspects the parsed *url.URL, and a string* helper that inspects the raw
-// normalized string — and both must agree. If the parsed URL and the raw string
-// disagree (e.g. a parser quirk that hides a smuggled component), validation
-// fails closed rather than slipping through.
+// normalized string — and both must agree; this is intentional
+// parser-differential defense, so a discrepancy between the two
+// interpretations (e.g. a parser quirk that hides a smuggled component) fails
+// closed rather than trusting either one alone.
 func IsValidSnykHost(conf configuration.Configuration, input string) (bool, error) {
 	// GetStringSlice does not split a plain string value on commas: an env
 	// var override of CONFIG_KEY_ALLOWED_HOSTS yields a single-element slice

--- a/pkg/auth/authHost.go
+++ b/pkg/auth/authHost.go
@@ -56,6 +56,10 @@ func IsValidAuthHost(instance string, redirectAuthHostRE string) (bool, error) {
 // disagree (e.g. a parser quirk that hides a smuggled component), validation
 // fails closed rather than slipping through.
 func IsValidSnykHost(conf configuration.Configuration, input string) (bool, error) {
+	// GetStringSlice does not split a plain string value on commas: an env
+	// var override of CONFIG_KEY_ALLOWED_HOSTS yields a single-element slice
+	// containing the whole value. See the CONFIG_KEY_ALLOWED_HOSTS doc
+	// comment for the single-domain-only env var caveat.
 	allowedDomains := conf.GetStringSlice(CONFIG_KEY_ALLOWED_HOSTS)
 	if len(allowedDomains) == 0 {
 		return false, nil

--- a/pkg/auth/authHost.go
+++ b/pkg/auth/authHost.go
@@ -28,8 +28,12 @@ func redirectAuthHost(instance string) (string, error) {
 	return canonicalizedInstanceUrl.Host, nil
 }
 
-// IsValidAuthHost is superseded by IsValidSnykHost, which is the preferred
-// entry point for new code. Retained for backwards compatibility.
+// IsValidAuthHost is superseded by IsValidSnykHost — no code within this
+// module calls it anymore; OAuth callback host validation goes exclusively
+// through IsValidSnykHost. It's exported public API, though, so other repos
+// may still call it directly; it's kept for now so any such callers keep
+// compiling while we confirm they've migrated off it, and will be removed in
+// a follow-up once that's verified.
 func IsValidAuthHost(instance string, redirectAuthHostRE string) (bool, error) {
 	isValidHost, err := utils.MatchesRegex(instance, redirectAuthHostRE)
 	if err != nil {

--- a/pkg/auth/authHost.go
+++ b/pkg/auth/authHost.go
@@ -28,12 +28,14 @@ func redirectAuthHost(instance string) (string, error) {
 	return canonicalizedInstanceUrl.Host, nil
 }
 
-// IsValidAuthHost is superseded by IsValidSnykHost — no code within this
-// module calls it anymore; OAuth callback host validation goes exclusively
-// through IsValidSnykHost. It's exported public API, though, so other repos
-// may still call it directly; it's kept for now so any such callers keep
-// compiling while we confirm they've migrated off it, and will be removed in
-// a follow-up once that's verified.
+// IsValidAuthHost — no code within this module calls it anymore; OAuth
+// callback host validation goes exclusively through IsValidSnykHost. It's
+// exported public API, though, so other repos may still call it directly;
+// it's kept for now so any such callers keep compiling while we confirm
+// they've migrated off it, and will be removed in a follow-up once that's
+// verified.
+//
+// Deprecated: use IsValidSnykHost instead.
 func IsValidAuthHost(instance string, redirectAuthHostRE string) (bool, error) {
 	isValidHost, err := utils.MatchesRegex(instance, redirectAuthHostRE)
 	if err != nil {

--- a/pkg/auth/authHost_test.go
+++ b/pkg/auth/authHost_test.go
@@ -9,6 +9,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test_redirectAuthHost(t *testing.T) {
+	testCases := []struct {
+		name     string
+		instance string
+		expected string
+	}{
+		{"bare host gets https and api prefix", "snyk.io", "api.snyk.io"},
+		{"explicit https scheme kept", "https://api.snyk.io", "api.snyk.io"},
+		{"explicit http scheme kept", "http://api.snyk.io", "api.snyk.io"},
+		// A schemeless host that happens to start with the substring "http"
+		// must not be misclassified as already carrying a scheme (which
+		// would skip the https:// prepend and produce a malformed parse).
+		{"schemeless host starting with http", "httpfoo.example.com", "api.httpfoo.example.com"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := redirectAuthHost(tc.instance)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
 func Test_isValidAuthHost(t *testing.T) {
 	testCases := []struct {
 		authHost string
@@ -52,6 +76,12 @@ func Test_IsValidSnykHost(t *testing.T) {
 		{"http scheme prefixed host", "http://api.snyk.io", true},
 		{"non-http scheme rejected", "ftp://api.snyk.io", false},
 		{"custom scheme rejected", "gopher://api.snyk.io", false},
+		// url.Parse lowercases the parsed scheme, but the raw normalized
+		// string retains its original case, so stringIsHostOnly's
+		// reconstruction ("scheme://host" using the lowercased parsed
+		// scheme) no longer matches the original-case string. This pins
+		// the fail-closed rejection of an uppercase scheme.
+		{"uppercase scheme rejected", "HTTPS://api.snyk.io", false},
 		{"bare domain no api prefix", "snyk.io", false},
 		{"domain not in allowlist", "api.example.com", false},
 		{"suffix trick - domain as sub-suffix of evil host", "api.snyk.evil.com", false},

--- a/pkg/auth/authHost_test.go
+++ b/pkg/auth/authHost_test.go
@@ -1,9 +1,11 @@
 package auth
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/snyk/go-application-framework/internal/constants"
+	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -30,5 +32,326 @@ func Test_isValidAuthHost(t *testing.T) {
 		if actual != tc.expected {
 			t.Errorf("isValidAuthHost(%q) = %v, want %v", tc.authHost, actual, tc.expected)
 		}
+	}
+}
+
+func Test_IsValidSnykHost(t *testing.T) {
+	testCases := []struct {
+		name     string
+		host     string
+		expected bool
+	}{
+		{"api.snyk.io", "api.snyk.io", true},
+		{"api.au.snyk.io", "api.au.snyk.io", true},
+		{"api.example.snyk.io", "api.example.snyk.io", true},
+		{"api.snykgov.io", "api.snykgov.io", true},
+		{"api.pre-release.snykgov.io", "api.pre-release.snykgov.io", true},
+		{"case-insensitive", "API.SNYK.IO", true},
+		{"multi-level subdomain", "api.a.b.c.snyk.io", true},
+		{"https scheme prefixed host", "https://api.snyk.io", true},
+		{"http scheme prefixed host", "http://api.snyk.io", true},
+		{"non-http scheme rejected", "ftp://api.snyk.io", false},
+		{"custom scheme rejected", "gopher://api.snyk.io", false},
+		{"bare domain no api prefix", "snyk.io", false},
+		{"domain not in allowlist", "api.example.com", false},
+		{"suffix trick - domain as sub-suffix of evil host", "api.snyk.evil.com", false},
+		{"missing label boundary prefix", "evilsnykgov.io", false},
+		{"ticket attack host", "api.attacker-site.com", false},
+		{"label boundary trick", "api.snykXsnyk.io", false},
+		{"embedded domain as non-final label", "api.snyk.io.evil.com", false},
+		{"embedded gov domain as non-final label", "api.snykgov.io.attacker.com", false},
+		{"embedded domain then evil tld", "api.example.snyk.io.evil.com", false},
+		{"embedded domain then attacker", "api.snyk.io.attacker.com", false},
+		{"trailing dot", "api.snyk.io.", false},
+		{"host with port", "api.snyk.io:8443", false},
+		// Path/userinfo/whitespace smuggling: the allowlisted domain appears in
+		// the input but not as the parsed host.
+		{"path smuggle - trailing path", "api.snyk.io/haha", false},
+		{"path smuggle - domain in path", "api.attacker.io/haha.snyk.io", false},
+		{"userinfo smuggle", "token@api.snyk.io", false},
+		{"whitespace smuggle", "api.something api.snyk.io", false},
+		{"empty host", "", false},
+	}
+
+	allowedDomains := []string{"snyk.io", "snykgov.io"}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conf := configuration.NewWithOpts()
+			conf.Set(CONFIG_KEY_ALLOWED_HOSTS, allowedDomains)
+
+			actual, err := IsValidSnykHost(conf, tc.host)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, actual, "IsValidSnykHost(%q)", tc.host)
+		})
+	}
+}
+
+func Test_IsValidSnykHost_EmptyAllowlistFailsClosed(t *testing.T) {
+	conf := configuration.NewWithOpts()
+
+	actual, err := IsValidSnykHost(conf, "api.snyk.io")
+	assert.NoError(t, err)
+	assert.False(t, actual, "empty allowlist should fail closed")
+}
+
+func Test_IsValidSnykHost_WhitespaceOnlyAllowlistFailsClosed(t *testing.T) {
+	conf := configuration.NewWithOpts()
+	conf.Set(CONFIG_KEY_ALLOWED_HOSTS, []string{"  "})
+
+	actual, err := IsValidSnykHost(conf, "api.snyk.io")
+	assert.NoError(t, err)
+	assert.False(t, actual, "whitespace-only allowlist entries must be skipped and fail closed")
+}
+
+func Test_IsValidSnykHost_MixedEmptyAllowlistStillValidates(t *testing.T) {
+	conf := configuration.NewWithOpts()
+	conf.Set(CONFIG_KEY_ALLOWED_HOSTS, []string{"", "snyk.io"})
+
+	actual, err := IsValidSnykHost(conf, "api.snyk.io")
+	assert.NoError(t, err)
+	assert.True(t, actual, "empty entries skipped, valid domain still matches")
+}
+
+func Test_parseHostURL(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          string
+		wantOK         bool
+		wantNormalized string
+		wantScheme     string
+	}{
+		{"bare host gets https", "api.snyk.io", true, "https://api.snyk.io", "https"},
+		{"surrounding whitespace trimmed", "  api.snyk.io  ", true, "https://api.snyk.io", "https"},
+		{"explicit https kept", "https://api.snyk.io", true, "https://api.snyk.io", "https"},
+		{"explicit http kept", "http://api.snyk.io", true, "http://api.snyk.io", "http"},
+		{"non-http scheme rejected", "ftp://api.snyk.io", false, "", ""},
+		{"empty rejected", "", false, "", ""},
+		{"internal whitespace rejected", "api snyk.io", false, "", ""},
+		{"unparseable rejected", "http://[::1", false, "", ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			normalized, parsed, ok := parseHostURL(tc.input)
+			assert.Equal(t, tc.wantOK, ok)
+			if !tc.wantOK {
+				return
+			}
+			assert.Equal(t, tc.wantNormalized, normalized)
+			assert.Equal(t, tc.wantScheme, parsed.Scheme)
+		})
+	}
+}
+
+// hostURL builds a *url.URL carrying only the given host, for exercising the
+// url* helpers directly with hosts that parseHostURL would not accept.
+func hostURL(host string) *url.URL {
+	return &url.URL{Scheme: "https", Host: host}
+}
+
+func Test_urlIsHostOnly(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"plain host", "api.snyk.io", true},
+		{"trailing path", "api.snyk.io/haha", false},
+		{"query", "api.snyk.io?x=1", false},
+		{"fragment", "api.snyk.io#frag", false},
+		{"userinfo", "token@api.snyk.io", false},
+		{"port", "api.snyk.io:8443", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, parsed, ok := parseHostURL(tc.input)
+			if !ok {
+				assert.False(t, tc.expected, "parseHostURL rejected %q before urlIsHostOnly", tc.input)
+				return
+			}
+			assert.Equal(t, tc.expected, urlIsHostOnly(parsed))
+		})
+	}
+}
+
+func Test_stringIsHostOnly(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"plain host", "api.snyk.io", true},
+		{"trailing path", "api.snyk.io/haha", false},
+		{"query", "api.snyk.io?x=1", false},
+		{"fragment", "api.snyk.io#frag", false},
+		{"userinfo", "token@api.snyk.io", false},
+		// A port survives the reconstruction because parsed.Host includes it;
+		// it is urlIsHostOnly's job to reject the port. This documents the split.
+		{"port matches reconstruction", "api.snyk.io:8443", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			normalized, parsed, ok := parseHostURL(tc.input)
+			if !ok {
+				assert.False(t, tc.expected, "parseHostURL rejected %q before stringIsHostOnly", tc.input)
+				return
+			}
+			assert.Equal(t, tc.expected, stringIsHostOnly(normalized, parsed))
+		})
+	}
+}
+
+func Test_stringIsHostOnly_rejectsReconstructionMismatch(t *testing.T) {
+	// A parsed URL whose fields look clean but whose reconstruction does not
+	// match the normalized string must be rejected by the string cross-check.
+	parsed := &url.URL{Scheme: "https", Host: "api.snyk.io"}
+	assert.False(t, stringIsHostOnly("https://api.snyk.io/smuggled", parsed),
+		"normalized string carrying more than scheme://host must be rejected")
+	assert.True(t, stringIsHostOnly("https://api.snyk.io", parsed))
+}
+
+func Test_urlHasApiSubdomain(t *testing.T) {
+	testCases := []struct {
+		host     string
+		expected bool
+	}{
+		{"api.snyk.io", true},
+		{"api.au.snyk.io", true},
+		{"API.SNYK.IO", true},
+		{"api", false},
+		{"snyk.io", false},
+		{"xapi.snyk.io", false},
+		{"apix.snyk.io", false},
+		{"", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.host, func(t *testing.T) {
+			assert.Equal(t, tc.expected, urlHasApiSubdomain(hostURL(tc.host)))
+		})
+	}
+}
+
+func Test_stringHasApiSubdomain(t *testing.T) {
+	// Input is the lower-cased normalized string, as passed by IsValidSnykHost.
+	testCases := []struct {
+		lowerNormalized string
+		expected        bool
+	}{
+		{"https://api.snyk.io", true},
+		{"http://api.snyk.io", true},
+		{"https://api.au.snyk.io", true},
+		{"https://xapi.snyk.io", false},
+		{"https://apix.snyk.io", false},
+		{"https://snyk.io", false},
+		{"https://api", false},
+		{"ftp://api.snyk.io", false},
+		{"api.snyk.io", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.lowerNormalized, func(t *testing.T) {
+			assert.Equal(t, tc.expected, stringHasApiSubdomain(tc.lowerNormalized))
+		})
+	}
+}
+
+func Test_urlHasAllowedDomain(t *testing.T) {
+	allowed := []string{"snyk.io", "snykgov.io"}
+	testCases := []struct {
+		name     string
+		host     string
+		domains  []string
+		expected bool
+	}{
+		{"exact api.snyk.io", "api.snyk.io", allowed, true},
+		{"regional subdomain", "api.au.snyk.io", allowed, true},
+		{"gov domain", "api.snykgov.io", allowed, true},
+		{"uppercase host", "API.SNYK.IO", allowed, true},
+		{"domain not allowed", "api.example.com", allowed, false},
+		{"embedded domain non-final", "api.snyk.io.evil.com", allowed, false},
+		{"label boundary trick", "api.snykXsnyk.io", allowed, false},
+		{"bare domain equals allowlist entry", "snyk.io", allowed, false},
+		{"whitespace-only domains skipped", "api.snyk.io", []string{" "}, false},
+		{"empty entry skipped, valid still matches", "api.snyk.io", []string{"", "snyk.io"}, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, urlHasAllowedDomain(hostURL(tc.host), tc.domains))
+		})
+	}
+}
+
+func Test_stringHasAllowedDomain(t *testing.T) {
+	allowed := []string{"snyk.io", "snykgov.io"}
+	testCases := []struct {
+		name            string
+		lowerNormalized string
+		domains         []string
+		expected        bool
+	}{
+		{"exact api.snyk.io", "https://api.snyk.io", allowed, true},
+		{"regional subdomain", "https://api.au.snyk.io", allowed, true},
+		{"gov domain", "https://api.snykgov.io", allowed, true},
+		{"domain not allowed", "https://api.example.com", allowed, false},
+		{"embedded domain non-final", "https://api.snyk.io.evil.com", allowed, false},
+		{"label boundary trick", "https://api.snykxsnyk.io", allowed, false},
+		{"whitespace-only domains skipped", "https://api.snyk.io", []string{" "}, false},
+		{"empty entry skipped, valid still matches", "https://api.snyk.io", []string{"", "snyk.io"}, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, stringHasAllowedDomain(tc.lowerNormalized, tc.domains))
+		})
+	}
+}
+
+func Test_domainToLabels(t *testing.T) {
+	testCases := []struct {
+		name       string
+		domain     string
+		wantOK     bool
+		wantLabels []string
+	}{
+		{"simple domain", "snyk.io", true, []string{"snyk", "io"}},
+		{"trims and lowercases", "  SNYK.IO  ", true, []string{"snyk", "io"}},
+		{"empty rejected", "", false, nil},
+		{"whitespace-only rejected", "  ", false, nil},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			labels, ok := domainToLabels(tc.domain)
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				assert.Equal(t, tc.wantLabels, labels)
+			}
+		})
+	}
+}
+
+func Test_hasLabelSuffix(t *testing.T) {
+	testCases := []struct {
+		name     string
+		labels   []string
+		suffix   []string
+		expected bool
+	}{
+		{"multi-label suffix", []string{"api", "snyk", "io"}, []string{"snyk", "io"}, true},
+		{"single-label suffix", []string{"api", "snyk", "io"}, []string{"io"}, true},
+		{"mismatch in middle", []string{"api", "snyk", "io"}, []string{"x", "io"}, false},
+		{"suffix longer than labels", []string{"io"}, []string{"snyk", "io"}, false},
+		{"exact equality", []string{"snyk", "io"}, []string{"snyk", "io"}, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, hasLabelSuffix(tc.labels, tc.suffix))
+		})
 	}
 }

--- a/pkg/auth/oauth2authenticator.go
+++ b/pkg/auth/oauth2authenticator.go
@@ -27,8 +27,13 @@ import (
 )
 
 const (
-	// Superseded by CONFIG_KEY_ALLOWED_HOSTS. Retained for backwards
-	// compatibility.
+	// CONFIG_KEY_ALLOWED_HOST_REGEXP is superseded by CONFIG_KEY_ALLOWED_HOSTS
+	// / IsValidSnykHost — no code within this module reads it anymore, so
+	// setting this env var no longer has any effect here. It's exported
+	// public API, though, so other repos may still reference it directly;
+	// it's kept for now so any such references keep compiling while we
+	// confirm they've migrated off it, and will be removed in a follow-up
+	// once that's verified.
 	//nolint:gosec // not a token value, but a configuration key
 	CONFIG_KEY_ALLOWED_HOST_REGEXP = "INTERNAL_OAUTH_ALLOWED_HOSTS"
 	//nolint:gosec // not a token value, but a configuration key

--- a/pkg/auth/oauth2authenticator.go
+++ b/pkg/auth/oauth2authenticator.go
@@ -36,6 +36,14 @@ const (
 	// once that's verified.
 	//nolint:gosec // not a token value, but a configuration key
 	CONFIG_KEY_ALLOWED_HOST_REGEXP = "INTERNAL_OAUTH_ALLOWED_HOSTS"
+	// CONFIG_KEY_ALLOWED_HOSTS holds the allowlist of registrable domains
+	// consulted by IsValidSnykHost. When set programmatically (e.g. via
+	// Configuration.Set) it accepts a []string of multiple domains. When set
+	// via the environment variable below, it supports a single domain only:
+	// conf.GetStringSlice returns the raw env var value as a one-element
+	// slice, it does not split on commas. For multiple allowed domains,
+	// configure this key programmatically as a []string rather than via the
+	// environment variable.
 	//nolint:gosec // not a token value, but a configuration key
 	CONFIG_KEY_ALLOWED_HOSTS        = "INTERNAL_OAUTH_ALLOWED_HOST_DOMAINS"
 	CONFIG_KEY_OAUTH_TOKEN   string = "INTERNAL_OAUTH_TOKEN_STORAGE"

--- a/pkg/auth/oauth2authenticator.go
+++ b/pkg/auth/oauth2authenticator.go
@@ -27,17 +27,21 @@ import (
 )
 
 const (
+	// Superseded by CONFIG_KEY_ALLOWED_HOSTS. Retained for backwards
+	// compatibility.
 	//nolint:gosec // not a token value, but a configuration key
-	CONFIG_KEY_ALLOWED_HOST_REGEXP        = "INTERNAL_OAUTH_ALLOWED_HOSTS"
-	CONFIG_KEY_OAUTH_TOKEN         string = "INTERNAL_OAUTH_TOKEN_STORAGE"
-	OAUTH_CLIENT_ID                string = "b56d4c2e-b9e1-4d27-8773-ad47eafb0956"
-	CALLBACK_HOSTNAME              string = "127.0.0.1"
-	CALLBACK_PATH                  string = "/authorization-code/callback"
-	TIMEOUT_SECONDS                       = 120 * time.Second
-	AUTHENTICATED_MESSAGE                 = "Your account has been authenticated."
-	PARAMETER_CLIENT_ID            string = "client-id"
-	PARAMETER_CLIENT_SECRET        string = "client-secret"
-	AUTH_TYPE_OAUTH                       = "oauth"
+	CONFIG_KEY_ALLOWED_HOST_REGEXP = "INTERNAL_OAUTH_ALLOWED_HOSTS"
+	//nolint:gosec // not a token value, but a configuration key
+	CONFIG_KEY_ALLOWED_HOSTS        = "INTERNAL_OAUTH_ALLOWED_HOST_DOMAINS"
+	CONFIG_KEY_OAUTH_TOKEN   string = "INTERNAL_OAUTH_TOKEN_STORAGE"
+	OAUTH_CLIENT_ID          string = "b56d4c2e-b9e1-4d27-8773-ad47eafb0956"
+	CALLBACK_HOSTNAME        string = "127.0.0.1"
+	CALLBACK_PATH            string = "/authorization-code/callback"
+	TIMEOUT_SECONDS                 = 120 * time.Second
+	AUTHENTICATED_MESSAGE           = "Your account has been authenticated."
+	PARAMETER_CLIENT_ID      string = "client-id"
+	PARAMETER_CLIENT_SECRET  string = "client-secret"
+	AUTH_TYPE_OAUTH                 = "oauth"
 )
 
 type GrantType int
@@ -473,9 +477,8 @@ func (o *oAuth2Authenticator) modifyTokenUrl(responseInstance string) error {
 		return err
 	}
 
-	redirectAuthHostRE := o.config.GetString(CONFIG_KEY_ALLOWED_HOST_REGEXP)
-	o.logger.Info().Msgf("Validating with regexp: \"%s\"", redirectAuthHostRE)
-	isValidHost, err := IsValidAuthHost(authHost, redirectAuthHostRE)
+	o.logger.Info().Msgf("Validating host: \"%s\"", authHost)
+	isValidHost, err := IsValidSnykHost(o.config, authHost)
 	if err != nil {
 		return err
 	}

--- a/pkg/auth/oauth2authenticator.go
+++ b/pkg/auth/oauth2authenticator.go
@@ -27,13 +27,14 @@ import (
 )
 
 const (
-	// CONFIG_KEY_ALLOWED_HOST_REGEXP is superseded by CONFIG_KEY_ALLOWED_HOSTS
-	// / IsValidSnykHost — no code within this module reads it anymore, so
-	// setting this env var no longer has any effect here. It's exported
-	// public API, though, so other repos may still reference it directly;
-	// it's kept for now so any such references keep compiling while we
-	// confirm they've migrated off it, and will be removed in a follow-up
-	// once that's verified.
+	// CONFIG_KEY_ALLOWED_HOST_REGEXP — no code within this module reads it
+	// anymore, so setting this env var no longer has any effect here. It's
+	// exported public API, though, so other repos may still reference it
+	// directly; it's kept for now so any such references keep compiling
+	// while we confirm they've migrated off it, and will be removed in a
+	// follow-up once that's verified.
+	//
+	// Deprecated: use CONFIG_KEY_ALLOWED_HOSTS with IsValidSnykHost instead.
 	//nolint:gosec // not a token value, but a configuration key
 	CONFIG_KEY_ALLOWED_HOST_REGEXP = "INTERNAL_OAUTH_ALLOWED_HOSTS"
 	// CONFIG_KEY_ALLOWED_HOSTS holds the allowlist of registrable domains

--- a/pkg/auth/oauth2authenticator_test.go
+++ b/pkg/auth/oauth2authenticator_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
@@ -389,18 +392,33 @@ func Test_Authenticate_AuthorizationCode(t *testing.T) {
 
 		// Create mock server for successful oauth2 flow
 		mux := http.NewServeMux()
-		mux.HandleFunc("/oauth2/authorize", mockAuthorizeHandler("", tokenServer.URL))
+		// Redirect to a host that is valid per the CONFIG_KEY_ALLOWED_HOSTS
+		// allowlist below. The actual network call is routed to tokenServer's
+		// real address via the custom httpClient's DialContext, since
+		// "api.example.snyk.io" doesn't actually resolve.
+		mux.HandleFunc("/oauth2/authorize", mockAuthorizeHandler("", "api.example.snyk.io"))
 		initialAuthServer := httptest.NewServer(mux)
 		defer initialAuthServer.Close()
 
 		config := configuration.NewWithOpts()
-		config.Set(CONFIG_KEY_ALLOWED_HOST_REGEXP, ".*")
+		config.Set(CONFIG_KEY_ALLOWED_HOSTS, []string{"snyk.io", "snykgov.io"})
 		config.Set(configuration.API_URL, initialAuthServer.URL)
 		config.Set(configuration.WEB_APP_URL, initialAuthServer.URL)
+
+		tokenServerAddr := tokenServer.Listener.Addr().String()
+		httpClient := &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+					var dialer net.Dialer
+					return dialer.DialContext(ctx, network, tokenServerAddr)
+				},
+			},
+		}
 
 		authenticator := NewOAuth2AuthenticatorWithOpts(
 			config,
 			WithOpenBrowserFunc(headlessOpenBrowserFunc(t)),
+			WithHttpClient(httpClient),
 		)
 
 		err := authenticator.Authenticate()
@@ -410,11 +428,34 @@ func Test_Authenticate_AuthorizationCode(t *testing.T) {
 
 	t.Run("does not redirect to invalid instance", func(t *testing.T) {
 		config := configuration.NewWithOpts()
-		config.Set(CONFIG_KEY_ALLOWED_HOST_REGEXP, constants.SNYK_DEFAULT_ALLOWED_HOST_REGEXP)
+		config.Set(CONFIG_KEY_ALLOWED_HOSTS, constants.SNYK_DEFAULT_ALLOWED_HOST_DOMAINS)
 
 		// Create mock server for successful oauth2 flow
 		mux := http.NewServeMux()
 		mux.HandleFunc("/oauth2/authorize", mockAuthorizeHandler("", "api.malicioussnyk.io"))
+		mux.HandleFunc("/oauth2/token", mockOAuth2TokenHandler(t))
+
+		ts := httptest.NewServer(mux)
+		defer ts.Close()
+
+		config.Set(configuration.WEB_APP_URL, ts.URL)
+		config.Set(configuration.API_URL, ts.URL)
+		authenticator := NewOAuth2AuthenticatorWithOpts(
+			config,
+			WithOpenBrowserFunc(headlessOpenBrowserFunc(t)),
+		)
+
+		err := authenticator.Authenticate()
+		assert.ErrorContains(t, err, "invalid host")
+	})
+
+	t.Run("does not redirect to attacker-controlled instance", func(t *testing.T) {
+		config := configuration.NewWithOpts()
+		config.Set(CONFIG_KEY_ALLOWED_HOSTS, constants.SNYK_DEFAULT_ALLOWED_HOST_DOMAINS)
+
+		// Create mock server for successful oauth2 flow
+		mux := http.NewServeMux()
+		mux.HandleFunc("/oauth2/authorize", mockAuthorizeHandler("", "api.attacker-site.com"))
 		mux.HandleFunc("/oauth2/token", mockOAuth2TokenHandler(t))
 
 		ts := httptest.NewServer(mux)
@@ -565,4 +606,49 @@ func Test_Authenticate_UTMSource_EmptyIntegrationName(t *testing.T) {
 
 	assert.NotContains(t, capturedURL, "utm_source",
 		"Expected utm_source to not be present when INTEGRATION_NAME is empty")
+}
+
+func Test_modifyTokenUrl(t *testing.T) {
+	newAuthenticator := func() *oAuth2Authenticator {
+		conf := configuration.NewWithOpts()
+		conf.Set(CONFIG_KEY_ALLOWED_HOSTS, constants.SNYK_DEFAULT_ALLOWED_HOST_DOMAINS)
+		logger := zerolog.Nop()
+		return &oAuth2Authenticator{
+			config: conf,
+			logger: &logger,
+			oauthConfig: &oauth2.Config{
+				Endpoint: oauth2.Endpoint{TokenURL: "https://api.snyk.io/oauth2/token"},
+			},
+		}
+	}
+
+	t.Run("rewrites token url host for a valid instance", func(t *testing.T) {
+		o := newAuthenticator()
+
+		err := o.modifyTokenUrl("api.example.snyk.io")
+		require.NoError(t, err)
+
+		got, perr := url.Parse(o.oauthConfig.Endpoint.TokenURL)
+		require.NoError(t, perr)
+		assert.Equal(t, "api.example.snyk.io", got.Host, "token url host should be rewritten to the valid instance")
+		assert.Equal(t, "/oauth2/token", got.Path, "token url path must be preserved")
+	})
+
+	t.Run("rejects an attacker-controlled instance and leaves the token url unchanged", func(t *testing.T) {
+		o := newAuthenticator()
+		original := o.oauthConfig.Endpoint.TokenURL
+
+		err := o.modifyTokenUrl("api.attacker-site.com")
+		require.ErrorContains(t, err, "invalid host")
+		assert.Equal(t, original, o.oauthConfig.Endpoint.TokenURL, "token url must not change for a rejected instance")
+	})
+
+	t.Run("empty instance is a no-op", func(t *testing.T) {
+		o := newAuthenticator()
+		original := o.oauthConfig.Endpoint.TokenURL
+
+		err := o.modifyTokenUrl("")
+		require.NoError(t, err)
+		assert.Equal(t, original, o.oauthConfig.Endpoint.TokenURL)
+	})
 }


### PR DESCRIPTION
### Description

Replaces the brittle allowed-host regex (`SNYK_DEFAULT_ALLOWED_HOST_REGEXP` = `^(https?://)?api(\.(.+))?\.(snyk|snykgov)\.io$`) used to validate the OAuth instance-redirect host, with parsed-URL validation.

New public API in `pkg/auth/authHost.go`:

- `IsValidSnykHost(conf configuration.Configuration, input string) (bool, error)` — orchestrates four single-purpose checks, each performed twice with independent techniques (parsed `*url.URL` **and** raw normalized string) that must agree, else fail closed:
  - `parseHostURL` — trim, prepend `https://` if schemeless, `url.Parse`, reject empty/whitespace/unparseable/non-http(s).
  - `urlIsHostOnly` / `stringIsHostOnly` — no userinfo/opaque/port/path/query/fragment.
  - `urlHasApiSubdomain` / `stringHasApiSubdomain` — leading label is `api`.
  - `urlHasAllowedDomain` / `stringHasAllowedDomain` — DNS-label-boundary match against new config key `CONFIG_KEY_ALLOWED_HOSTS` (default `{snyk.io, snykgov.io}`, configurable for private cloud), fail-closed on empty allowlist.
- New config key `auth.CONFIG_KEY_ALLOWED_HOSTS = "INTERNAL_OAUTH_ALLOWED_HOST_DOMAINS"` (`[]string`).
- `oauth2authenticator.go` `modifyTokenUrl` switched to `IsValidSnykHost`.

**Additive / non-breaking** (see [RFC: Breaking changes in GAF](https://snyksec.atlassian.net/wiki/spaces/IDE/pages/4835934272/RFC+Breaking+changes+in+GAF)): the old `CONFIG_KEY_ALLOWED_HOST_REGEXP`, `IsValidAuthHost`, and `SNYK_DEFAULT_ALLOWED_HOST_REGEXP` are retained, with plain "superseded / retained for backwards compatibility" comments — deliberately not the Go `// Deprecated:` marker, since that trips staticcheck SA1019 and could block a consumer's routine GAF bump. Real deprecation/removal is a follow-up ticket once consumers have migrated.

### Stack

Part of the IDE-1896 PR stack (base of stack):

1. **This PR** — go-application-framework
2. snyk-ls — "Depends on GAF #<this PR>" (points at this branch's pseudo-version; will be repointed to a GAF release tag before merge, per RFC merge order)
3. [cli](https://github.com/snyk/cli/pull/) — independent tidy-up, mergeable any time

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [ ] Test your changes work for the CLI (n/a — additive, no CLI-facing change required for this PR)

Jira: [IDE-1896](https://snyksec.atlassian.net/browse/IDE-1896)

[IDE-1896]: https://snyksec.atlassian.net/browse/IDE-1896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes OAuth callback instance validation and token URL host rewriting—security-critical auth redirect logic—with new fail-closed rules that could block legitimate private-cloud hosts if allowlists are misconfigured.
> 
> **Overview**
> OAuth **instance redirect** validation no longer uses the regex config key **`INTERNAL_OAUTH_ALLOWED_HOSTS`** inside GAF. **`modifyTokenUrl`** now calls **`IsValidSnykHost`**, which only accepts hosts that are **`api.*`** subdomains of domains in **`CONFIG_KEY_ALLOWED_HOSTS`** (`INTERNAL_OAUTH_ALLOWED_HOST_DOMAINS`, default **`snyk.io`** / **`snykgov.io`**).
> 
> The new validator parses http(s) URLs, rejects ports/paths/userinfo/smuggling, matches allowlisted domains on **DNS label boundaries**, and **fails closed** on an empty allowlist. Each check is duplicated on parsed `*url.URL` and the normalized string so parser quirks cannot bypass rules.
> 
> **`redirectAuthHost`** now treats schemeless hosts via **`://`** instead of a **`http`** prefix, so names like **`httpfoo.example.com`** are not mis-parsed. App init registers defaults for both the legacy regex key (for external **`IsValidAuthHost`** callers) and the new domain list. Regex-based **`IsValidAuthHost`** remains exported but deprecated; broad tests cover OAuth flows and **`modifyTokenUrl`** rejection of attacker hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a23b7612120268c299ab98ad62f628fa23e784a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->