### PR TITLE
feat: add gitignore filtering that respects git-tracked files

### DIFF
--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -94,4 +94,7 @@ const (
 	FF_CODE_CONSISTENT_IGNORES string = "internal_snyk_code_ignores_enabled"
 	// Feature flag to enable native implementation for code, used in code-client-go's code workflow
 	FF_CODE_NATIVE_IMPLEMENTATION string = "internal_snyk_code_native_implementation"
+	// Feature flag to enable tracked-file-aware .gitignore filtering (CLI-1411). Consumers gate
+	// utils.FileFilter.GetRulesBySource/GetFilteredFilesBySource behind this flag.
+	FF_GITIGNORE_RESPECT_TRACKED_FILES string = "internal_snyk_gitignore_respect_tracked_files_enabled"
 )

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -12,11 +13,23 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-git/go-git/v5"
 	"github.com/rs/zerolog"
 	gitignore "github.com/sabhiram/go-gitignore"
 	"golang.org/x/sync/semaphore"
 	"gopkg.in/yaml.v3"
 )
+
+type SourcedRules struct {
+	Gitignore []string // globs derived only from .gitignore files
+	Other     []string // globs from .snyk, .dcignore, and FileFilter's default rules
+}
+
+// matchersBySource is SourcedRules compiled into matchers, one per source.
+type matchersBySource struct {
+	Other     *gitignore.GitIgnore
+	Gitignore *gitignore.GitIgnore
+}
 
 // by default, all rules are valid
 var defaultInvalidRules = []string{}
@@ -86,9 +99,27 @@ func (fw *FileFilter) GetAllFiles() chan string {
 
 // GetRules builds a list of glob patterns that can be used to filter filesToFilter
 func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
+	ignoreFiles := fw.findIgnoreFiles(ruleFiles)
+	globs, err := fw.buildGlobs(ignoreFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(fw.defaultRules, globs...), nil
+}
+
+// GetRulesBySource is like GetRules, but keeps .gitignore-sourced globs separate from every
+// other source instead of merging everything into one flat list.
+func (fw *FileFilter) GetRulesBySource(ruleFiles []string) (SourcedRules, error) {
+	ignoreFiles := fw.findIgnoreFiles(ruleFiles)
+	rules, err := fw.buildSourcedRules(ignoreFiles)
+	return rules, err
+}
+
+// findIgnoreFiles walks fw.path and returns every file whose name matches one of ruleFiles.
+func (fw *FileFilter) findIgnoreFiles(ruleFiles []string) []string {
 	files := fw.GetAllFiles()
 
-	// iterate filesToFilter channel and find ignore filesToFilter
 	var ignoreFiles = make([]string, 0)
 	for file := range files {
 		fileName := filepath.Base(file)
@@ -99,21 +130,91 @@ func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
 		}
 	}
 
-	// iterate ignore filesToFilter and extract glob patterns
-	globs, err := fw.buildGlobs(ignoreFiles)
-	if err != nil {
-		return nil, err
+	return ignoreFiles
+}
+
+// buildSourcedRules is like buildGlobs, but keeps .gitignore-sourced globs separate from every
+// other source (see SourcedRules).
+func (fw *FileFilter) buildSourcedRules(ignoreFiles []string) (SourcedRules, error) {
+	rules := SourcedRules{Other: append([]string{}, fw.defaultRules...)}
+	for _, ignoreFile := range ignoreFiles {
+		content, err := os.ReadFile(ignoreFile)
+		if err != nil {
+			return SourcedRules{}, err
+		}
+
+		dir := filepath.Dir(ignoreFile)
+		switch filepath.Base(ignoreFile) {
+		case ".snyk":
+			rules.Other = append(rules.Other, fw.parseDotSnykFile(content, dir)...)
+		case ".gitignore":
+			rules.Gitignore = append(rules.Gitignore, parseIgnoreFile(content, dir)...)
+		default:
+			rules.Other = append(rules.Other, parseIgnoreFile(content, dir)...)
+		}
 	}
 
-	return append(fw.defaultRules, globs...), nil
+	return rules, nil
 }
 
 // GetFilteredFiles returns a filtered channel of filepaths from a given channel of filespaths and glob patterns to filter on
 func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan string {
+	matcher := gitignore.CompileIgnoreLines(globs...)
+	shouldKeepFn := func(filePath string) bool {
+		return !matcher.MatchesPath(filePath)
+	}
+	return fw.filterFiles(filesCh, shouldKeepFn)
+}
+
+// GetFilteredFilesBySource is like GetFilteredFiles, but rules.Other always excludes while
+// rules.Gitignore excludes only untracked files (CLI-1411: git only ignores untracked files).
+func (fw *FileFilter) GetFilteredFilesBySource(filesCh chan string, rules SourcedRules) chan string {
+	matchers := matchersBySource{
+		Other:     gitignore.CompileIgnoreLines(rules.Other...),
+		Gitignore: gitignore.CompileIgnoreLines(rules.Gitignore...),
+	}
+	trackedGitignoreMatches := fw.trackedFilesMatching(matchers.Gitignore)
+
+	shouldKeepFn := func(filePath string) bool {
+		return shouldKeepBySource(filePath, fw.path, matchers, trackedGitignoreMatches)
+	}
+	return fw.filterFiles(filesCh, shouldKeepFn)
+}
+
+// shouldKeepBySource: matchers.Other always excludes; matchers.Gitignore excludes unless
+// filePath is a tracked match (nil trackedGitignoreMatches means fail-open: exclude as usual).
+// filePath is a path as produced by GetAllFiles (rooted at scanRoot; not necessarily absolute).
+func shouldKeepBySource(filePath string, scanRoot string, matchers matchersBySource, trackedGitignoreMatches map[string]bool) bool {
+	if matchers.Other.MatchesPath(filePath) {
+		return false
+	}
+
+	matchesGitignore := matchers.Gitignore.MatchesPath(filePath)
+	if !matchesGitignore {
+		return true
+	}
+
+	return isTrackedMatch(filePath, scanRoot, trackedGitignoreMatches)
+}
+
+// isTrackedMatch reports whether filePath (relative to scanRoot) is a key in
+// trackedGitignoreMatches; false if trackedGitignoreMatches is nil (no git repo) or filePath
+// can't be made relative to scanRoot.
+func isTrackedMatch(filePath string, scanRoot string, trackedGitignoreMatches map[string]bool) bool {
+	if trackedGitignoreMatches == nil {
+		return false
+	}
+	rel, err := filepath.Rel(scanRoot, filePath)
+	if err != nil {
+		return false
+	}
+	return trackedGitignoreMatches[filepath.ToSlash(rel)]
+}
+
+// filterFiles reads filesCh, keeping only files for which shouldKeepFn returns true.
+func (fw *FileFilter) filterFiles(filesCh chan string, shouldKeepFn func(string) bool) chan string {
 	var filteredFilesCh = make(chan string)
 
-	// create pattern matcher used to match filesToFilter to glob patterns
-	globPatternMatcher := gitignore.CompileIgnoreLines(globs...)
 	go func() {
 		ctx := context.Background()
 		availableThreads := semaphore.NewWeighted(fw.max_threads)
@@ -121,18 +222,17 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 		defer close(filteredFilesCh)
 
 		// iterate the filesToFilter channel
-		for file := range filesCh {
+		for filePath := range filesCh {
 			err := availableThreads.Acquire(ctx, 1)
 			if err != nil {
 				fw.logger.Err(err).Msg("failed to limit threads")
 			}
-			go func(f string) {
+			go func(filePath string) {
 				defer availableThreads.Release(1)
-				// filesToFilter that do not match the glob pattern are filtered
-				if !globPatternMatcher.MatchesPath(f) {
-					filteredFilesCh <- f
+				if shouldKeepFn(filePath) {
+					filteredFilesCh <- filePath
 				}
-			}(file)
+			}(filePath)
 		}
 
 		// wait until the last thread is done
@@ -143,6 +243,96 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 	}()
 
 	return filteredFilesCh
+}
+
+// trackedFilesMatching returns tracked files (relative to fw.path) that match gitignoreMatcher,
+// bounding memory to that intersection. Returns nil if fw.path isn't a git repo (fail-open).
+func (fw *FileFilter) trackedFilesMatching(gitignoreMatcher *gitignore.GitIgnore) map[string]bool {
+	start := time.Now()
+
+	absScanRoot, err := filepath.Abs(fw.path)
+	if err != nil {
+		fw.logger.Warn().Err(err).Msg("could not resolve absolute scan path to check for tracked files; " +
+			"gitignore-matched files will be excluded as usual")
+		return nil
+	}
+
+	repo, err := git.PlainOpenWithOptions(absScanRoot, &git.PlainOpenOptions{DetectDotGit: true})
+	if err != nil {
+		if errors.Is(err, git.ErrRepositoryNotExists) {
+			fw.logger.Debug().Msg("not a git repository; gitignore-matched files will be excluded as usual")
+			return nil
+		}
+		fw.logger.Warn().Err(err).Msg("could not open git repository to check for tracked files; " +
+			"gitignore-matched files will be excluded as usual")
+		return nil
+	}
+
+	worktree, err := repo.Worktree()
+	if err != nil {
+		fw.logger.Warn().Err(err).Msg("could not read git worktree to check for tracked files")
+		return nil
+	}
+
+	idx, err := repo.Storer.Index()
+	if err != nil {
+		fw.logger.Warn().Err(err).Msg("could not read git index to check for tracked files")
+		return nil
+	}
+
+	repoRoot := worktree.Filesystem.Root()
+
+	// go-git resolves symlinks in the repo root (e.g. macOS's /var -> /private/var); match that
+	// so a symlinked scan root doesn't make every entry look outside the scan root.
+	scanRootForCompare := absScanRoot
+	if resolved, err := filepath.EvalSymlinks(absScanRoot); err == nil {
+		scanRootForCompare = resolved
+	}
+
+	trackedNames := make([]string, len(idx.Entries))
+	for i, entry := range idx.Entries {
+		trackedNames[i] = entry.Name
+	}
+
+	tracked := matchTrackedEntries(trackedNames, repoRoot, scanRootForCompare, fw.path, gitignoreMatcher)
+	trackedFileNames := SortedMapKeys(tracked)
+
+	fw.logger.Debug().
+		Int("trackedGitignoreMatches", len(tracked)).
+		Strs("trackedGitignoreFiles", trackedFileNames).
+		Dur("duration", time.Since(start)).
+		Msg("checked git index for tracked files matching .gitignore rules")
+
+	if len(trackedFileNames) > 0 {
+		fw.logger.Warn().
+			Strs("trackedGitignoreFiles", trackedFileNames).
+			Msg("some git-tracked files match a .gitignore rule and will still be scanned")
+	}
+
+	return tracked
+}
+
+// matchTrackedEntries returns, out of trackedNames (repo-root-relative paths from a git index),
+// those that fall under scanRoot and match gitignoreMatcher — keyed by path relative to fwPath,
+// the same shape GetAllFiles produces.
+func matchTrackedEntries(trackedNames []string, repoRoot, scanRoot, fwPath string, gitignoreMatcher *gitignore.GitIgnore) map[string]bool {
+	tracked := make(map[string]bool)
+	for _, name := range trackedNames {
+		entryAbsPath := filepath.Join(repoRoot, filepath.FromSlash(name))
+
+		relToScanRoot, err := filepath.Rel(scanRoot, entryAbsPath)
+		if err != nil || strings.HasPrefix(relToScanRoot, "..") {
+			continue // outside the directory being scanned
+		}
+		relSlash := filepath.ToSlash(relToScanRoot)
+
+		// re-anchor to fwPath so this matches the path shape GetAllFiles produces.
+		candidatePath := filepath.Join(fwPath, filepath.FromSlash(relSlash))
+		if gitignoreMatcher.MatchesPath(candidatePath) {
+			tracked[relSlash] = true
+		}
+	}
+	return tracked
 }
 
 // buildGlobs iterates a list of ignore filesToFilter and returns a list of glob patterns that can be used to test for ignored filesToFilter

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -169,16 +169,8 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 // GetFilteredFilesBySource is like GetFilteredFiles, but rules.Other always excludes while
 // rules.Gitignore excludes only untracked files (CLI-1411: git only ignores untracked files).
 func (fw *FileFilter) GetFilteredFilesBySource(filesCh chan string, rules SourcedRules) chan string {
-	matchers := matchersBySource{
-		Other:     gitignore.CompileIgnoreLines(rules.Other...),
-		Gitignore: gitignore.CompileIgnoreLines(rules.Gitignore...),
-	}
-	trackedGitignoreMatches := fw.trackedFilesMatching(matchers.Gitignore)
-
-	shouldKeepFn := func(filePath string) bool {
-		return shouldKeepBySource(filePath, fw.path, matchers, trackedGitignoreMatches)
-	}
-	return fw.filterFiles(filesCh, shouldKeepFn)
+	filter := fw.NewFilterBySource(rules)
+	return fw.filterFiles(filesCh, filter.ShouldKeep)
 }
 
 // shouldKeepBySource: matchers.Other always excludes; matchers.Gitignore excludes unless
@@ -627,4 +619,35 @@ func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string)
 		}
 	}
 	return globs
+}
+
+// FilterBySource is a reusable, precompiled by-source filter: matchers and a git-tracked-files
+// snapshot are built once, so ShouldKeep can be called cheaply many times afterward (no I/O per
+// call). Use this instead of GetFilteredFilesBySource when you evaluate paths one at a time over
+// a long lifetime — e.g. a file watcher reacting to individual events — rather than draining a
+// batch channel; calling GetFilteredFilesBySource per path would re-read the git index every time.
+type FilterBySource struct {
+	scanRoot                string
+	matchers                matchersBySource
+	trackedGitignoreMatches map[string]bool
+}
+
+// NewFilterBySource builds a FilterBySource from rules, reading the git index once. Rebuild it
+// whenever rules changes (e.g. on the same cadence you'd already rebuild your own ignore matcher).
+func (fw *FileFilter) NewFilterBySource(rules SourcedRules) *FilterBySource {
+	matchers := matchersBySource{
+		Other:     gitignore.CompileIgnoreLines(rules.Other...),
+		Gitignore: gitignore.CompileIgnoreLines(rules.Gitignore...),
+	}
+	return &FilterBySource{
+		scanRoot:                fw.path,
+		matchers:                matchers,
+		trackedGitignoreMatches: fw.trackedFilesMatching(matchers.Gitignore),
+	}
+}
+
+// ShouldKeep reports whether filePath should be kept (not excluded), using this FilterBySource's
+// precompiled matchers and tracked-files snapshot. Does no I/O — safe to call per event.
+func (f *FilterBySource) ShouldKeep(filePath string) bool {
+	return shouldKeepBySource(filePath, f.scanRoot, f.matchers, f.trackedGitignoreMatches)
 }

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path"
@@ -9,7 +10,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-git/go-git/v5"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	gitignore "github.com/sabhiram/go-gitignore"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -210,6 +214,119 @@ exclude:
 		)
 
 		assert.ElementsMatch(t, expectedRules, actualRules)
+	})
+}
+
+// TestFileFilter_GetRulesBySource asserts globs land in the right SourcedRules bucket:
+// .gitignore-sourced globs in Gitignore, everything else (.snyk, .dcignore, default rules) in Other.
+func TestFileFilter_GetRulesBySource(t *testing.T) {
+	tempDir := t.TempDir()
+	createFileInPath(t, filepath.Join(tempDir, "test1.ts"), []byte{})
+
+	t.Run("no rule files: only default rules, in Other", func(t *testing.T) {
+		fileFilter := NewFileFilter(tempDir, &log.Logger)
+		rules, err := fileFilter.GetRulesBySource([]string{})
+		assert.NoError(t, err)
+
+		assert.ElementsMatch(t, fileFilter.defaultRules, rules.Other)
+		assert.Empty(t, rules.Gitignore)
+	})
+
+	t.Run(".gitignore rules land in Gitignore, not Other", func(t *testing.T) {
+		root := t.TempDir()
+		createFileInPath(t, filepath.Join(root, "test1.ts"), []byte{})
+		createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("test1.ts\n"))
+
+		fileFilter := NewFileFilter(root, &log.Logger)
+		rules, err := fileFilter.GetRulesBySource([]string{".gitignore"})
+		assert.NoError(t, err)
+
+		expectedGitignore := []string{
+			fmt.Sprintf("%s/**/test1.ts/**", filepath.ToSlash(root)),
+			fmt.Sprintf("%s/**/test1.ts", filepath.ToSlash(root)),
+		}
+		assert.ElementsMatch(t, expectedGitignore, rules.Gitignore)
+		assert.ElementsMatch(t, fileFilter.defaultRules, rules.Other)
+	})
+
+	t.Run(".dcignore rules land in Other, not Gitignore", func(t *testing.T) {
+		root := t.TempDir()
+		createFileInPath(t, filepath.Join(root, "test1.ts"), []byte{})
+		createFileInPath(t, filepath.Join(root, ".dcignore"), []byte("test1.ts\n"))
+
+		fileFilter := NewFileFilter(root, &log.Logger)
+		rules, err := fileFilter.GetRulesBySource([]string{".dcignore"})
+		assert.NoError(t, err)
+
+		expectedOther := append(
+			[]string{
+				fmt.Sprintf("%s/**/test1.ts/**", filepath.ToSlash(root)),
+				fmt.Sprintf("%s/**/test1.ts", filepath.ToSlash(root)),
+			},
+			fileFilter.defaultRules...,
+		)
+		assert.ElementsMatch(t, expectedOther, rules.Other)
+		assert.Empty(t, rules.Gitignore)
+	})
+
+	t.Run(".snyk rules land in Other, not Gitignore", func(t *testing.T) {
+		root := t.TempDir()
+		createFileInPath(t, filepath.Join(root, "test1.ts"), []byte{})
+		createFileInPath(t, filepath.Join(root, ".snyk"), []byte(`version: v1.25.1
+ignore: {}
+exclude:
+  code:
+    - test1.ts
+`))
+
+		fileFilter := NewFileFilter(root, &log.Logger)
+		rules, err := fileFilter.GetRulesBySource([]string{".snyk"})
+		assert.NoError(t, err)
+
+		expectedOther := append(
+			[]string{
+				fmt.Sprintf("%s/**/test1.ts/**", filepath.ToSlash(root)),
+				fmt.Sprintf("%s/**/test1.ts", filepath.ToSlash(root)),
+			},
+			fileFilter.defaultRules...,
+		)
+		assert.ElementsMatch(t, expectedOther, rules.Other)
+		assert.Empty(t, rules.Gitignore)
+	})
+
+	t.Run(".gitignore, .dcignore, and .snyk together split into the right buckets", func(t *testing.T) {
+		root := t.TempDir()
+		createFileInPath(t, filepath.Join(root, "gitignored.ts"), []byte{})
+		createFileInPath(t, filepath.Join(root, "dcignored.ts"), []byte{})
+		createFileInPath(t, filepath.Join(root, "snyked.ts"), []byte{})
+		createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("gitignored.ts\n"))
+		createFileInPath(t, filepath.Join(root, ".dcignore"), []byte("dcignored.ts\n"))
+		createFileInPath(t, filepath.Join(root, ".snyk"), []byte(`version: v1.25.1
+ignore: {}
+exclude:
+  code:
+    - snyked.ts
+`))
+
+		fileFilter := NewFileFilter(root, &log.Logger)
+		rules, err := fileFilter.GetRulesBySource([]string{".gitignore", ".dcignore", ".snyk"})
+		assert.NoError(t, err)
+
+		expectedGitignore := []string{
+			fmt.Sprintf("%s/**/gitignored.ts/**", filepath.ToSlash(root)),
+			fmt.Sprintf("%s/**/gitignored.ts", filepath.ToSlash(root)),
+		}
+		expectedOther := append(
+			[]string{
+				fmt.Sprintf("%s/**/dcignored.ts/**", filepath.ToSlash(root)),
+				fmt.Sprintf("%s/**/dcignored.ts", filepath.ToSlash(root)),
+				fmt.Sprintf("%s/**/snyked.ts/**", filepath.ToSlash(root)),
+				fmt.Sprintf("%s/**/snyked.ts", filepath.ToSlash(root)),
+			},
+			fileFilter.defaultRules...,
+		)
+		assert.ElementsMatch(t, expectedGitignore, rules.Gitignore)
+		assert.ElementsMatch(t, expectedOther, rules.Other)
 	})
 }
 
@@ -843,6 +960,234 @@ func TestFileFilter_GetFilteredFiles_uncPaths(t *testing.T) {
 			t.Skip("admin share (C$) not accessible; cannot exercise genuine UNC")
 		}
 		assertFiltered(t, unc)
+	})
+}
+
+// initGitRepoWithTrackedFiles creates a real git repository at dir and stages (adds to the
+// index) each of trackedFiles, without committing — index membership alone is enough for
+// "tracked" purposes and mirrors a file added with `git add` but not yet committed.
+func initGitRepoWithTrackedFiles(t *testing.T, dir string, trackedFiles []string) {
+	t.Helper()
+
+	repo, err := git.PlainInit(dir, false)
+	assert.NoError(t, err)
+
+	worktree, err := repo.Worktree()
+	assert.NoError(t, err)
+
+	for _, f := range trackedFiles {
+		_, err = worktree.Add(filepath.ToSlash(f))
+		assert.NoError(t, err)
+	}
+}
+
+func TestShouldKeepBySource(t *testing.T) {
+	matchers := matchersBySource{
+		Other:     gitignore.CompileIgnoreLines("/root/**/*.snyk-excluded"),
+		Gitignore: gitignore.CompileIgnoreLines("/root/**/*.log"),
+	}
+
+	t.Run("matches neither: kept", func(t *testing.T) {
+		assert.True(t, shouldKeepBySource("/root/app.js", "/root", matchers, nil))
+	})
+
+	t.Run("matches other: excluded, even if tracked", func(t *testing.T) {
+		tracked := map[string]bool{"app.snyk-excluded": true}
+		assert.False(t, shouldKeepBySource("/root/app.snyk-excluded", "/root", matchers, tracked))
+	})
+
+	t.Run("matches gitignore, tracked: kept", func(t *testing.T) {
+		tracked := map[string]bool{"config.log": true}
+		assert.True(t, shouldKeepBySource("/root/config.log", "/root", matchers, tracked))
+	})
+
+	t.Run("matches gitignore, untracked: excluded", func(t *testing.T) {
+		tracked := map[string]bool{"other.log": true}
+		assert.False(t, shouldKeepBySource("/root/config.log", "/root", matchers, tracked))
+	})
+
+	t.Run("matches gitignore, tracked lookup is nil (fail-open): excluded", func(t *testing.T) {
+		assert.False(t, shouldKeepBySource("/root/config.log", "/root", matchers, nil))
+	})
+}
+
+func TestIsTrackedMatch(t *testing.T) {
+	tracked := map[string]bool{"config.log": true}
+
+	t.Run("tracked: true", func(t *testing.T) {
+		assert.True(t, isTrackedMatch("/root/config.log", "/root", tracked))
+	})
+
+	t.Run("untracked: false", func(t *testing.T) {
+		assert.False(t, isTrackedMatch("/root/other.log", "/root", tracked))
+	})
+
+	t.Run("nil lookup (no git repo): false", func(t *testing.T) {
+		assert.False(t, isTrackedMatch("/root/config.log", "/root", nil))
+	})
+}
+
+// TestMatchTrackedEntries exercises the path arithmetic in matchTrackedEntries directly, with no
+// git repo or filesystem involved — repoRoot/scanRoot/fwPath are plain strings. The returned map
+// is keyed relative to scanRoot; fwPath only affects the candidate path fed into gitignoreMatcher.
+func TestMatchTrackedEntries(t *testing.T) {
+	matcher := gitignore.CompileIgnoreLines("/repo/**/*.log")
+
+	t.Run("tracked entry matching gitignore is included, keyed relative to scanRoot", func(t *testing.T) {
+		tracked := matchTrackedEntries([]string{"config.log"}, "/repo", "/repo", "/repo", matcher)
+		assert.True(t, tracked["config.log"])
+	})
+
+	t.Run("tracked entry not matching gitignore is excluded", func(t *testing.T) {
+		tracked := matchTrackedEntries([]string{"app.js"}, "/repo", "/repo", "/repo", matcher)
+		assert.Empty(t, tracked)
+	})
+
+	t.Run("entry outside scanRoot is skipped", func(t *testing.T) {
+		tracked := matchTrackedEntries([]string{"other/app.log"}, "/repo", "/repo/sub", "/repo/sub", matcher)
+		assert.Empty(t, tracked)
+	})
+
+	t.Run("scanRoot nested inside repoRoot: key is relative to scanRoot, not repoRoot", func(t *testing.T) {
+		tracked := matchTrackedEntries([]string{"sub/config.log"}, "/repo", "/repo/sub", "/repo/sub", matcher)
+		assert.True(t, tracked["config.log"])
+	})
+
+	t.Run("fwPath mismatched with gitignoreMatcher's anchor: candidate path doesn't match, so nothing is tracked", func(t *testing.T) {
+		tracked := matchTrackedEntries([]string{"sub/config.log"}, "/repo", "/repo/sub", "/elsewhere", matcher)
+		assert.Empty(t, tracked, "candidatePath is built from fwPath, so fwPath must agree with the matcher's own anchor")
+	})
+}
+
+// TestFileFilter_GetFilteredFilesBySource covers CLI-1411: a file tracked in git that matches a
+// .gitignore rule must be preserved (rescued), while an untracked file matching the same rule
+// stays excluded, and .snyk/.dcignore exclusions always win regardless of tracked status.
+func TestFileFilter_GetFilteredFilesBySource(t *testing.T) {
+	filterBySource := func(t *testing.T, root string, ruleFiles []string) map[string]bool {
+		t.Helper()
+		fileFilter := NewFileFilter(root, &log.Logger)
+		rules, err := fileFilter.GetRulesBySource(ruleFiles)
+		assert.NoError(t, err)
+
+		kept := make(map[string]bool)
+		for f := range fileFilter.GetFilteredFilesBySource(fileFilter.GetAllFiles(), rules) {
+			rel, relErr := filepath.Rel(root, f)
+			assert.NoError(t, relErr)
+			kept[filepath.ToSlash(rel)] = true
+		}
+		return kept
+	}
+
+	t.Run("tracked file matching .gitignore is rescued", func(t *testing.T) {
+		root := t.TempDir()
+		createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("*.log\n"))
+		createFileInPath(t, filepath.Join(root, "config.log"), []byte("x"))    // tracked, matches *.log
+		createFileInPath(t, filepath.Join(root, "untracked.log"), []byte("x")) // untracked, matches *.log
+		createFileInPath(t, filepath.Join(root, "app.js"), []byte("x"))
+		initGitRepoWithTrackedFiles(t, root, []string{"config.log", "app.js", ".gitignore"})
+
+		kept := filterBySource(t, root, []string{".gitignore"})
+
+		assert.True(t, kept["config.log"], "tracked file matching .gitignore must be rescued")
+		assert.False(t, kept["untracked.log"], "untracked file matching .gitignore must still be excluded")
+		assert.True(t, kept["app.js"])
+	})
+
+	t.Run(".snyk exclusion always wins over tracked-file rescue", func(t *testing.T) {
+		root := t.TempDir()
+		createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("*.log\n"))
+		createFileInPath(t, filepath.Join(root, ".snyk"), []byte(`version: v1.25.1
+ignore: {}
+exclude:
+  code:
+    - config.log
+`))
+		createFileInPath(t, filepath.Join(root, "config.log"), []byte("x"))
+		initGitRepoWithTrackedFiles(t, root, []string{"config.log", ".gitignore", ".snyk"})
+
+		kept := filterBySource(t, root, []string{".gitignore", ".snyk"})
+
+		assert.False(t, kept["config.log"], ".snyk exclusion must win even though the file is tracked")
+	})
+
+	t.Run(".dcignore exclusion always wins over tracked-file rescue", func(t *testing.T) {
+		root := t.TempDir()
+		createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("*.log\n"))
+		createFileInPath(t, filepath.Join(root, ".dcignore"), []byte("config.log\n"))
+		createFileInPath(t, filepath.Join(root, "config.log"), []byte("x"))
+		initGitRepoWithTrackedFiles(t, root, []string{"config.log", ".gitignore", ".dcignore"})
+
+		kept := filterBySource(t, root, []string{".gitignore", ".dcignore"})
+
+		assert.False(t, kept["config.log"], ".dcignore exclusion must win even though the file is tracked")
+	})
+
+	t.Run("nested .gitignore: tracked file rescue survives multiple ignore files", func(t *testing.T) {
+		root := t.TempDir()
+		createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("*.log\n"))
+		createFileInPath(t, filepath.Join(root, "pkg", ".gitignore"), []byte("*.tmp\n"))
+		createFileInPath(t, filepath.Join(root, "pkg", "build.tmp"), []byte("x")) // tracked, matches pkg/.gitignore rule
+		createFileInPath(t, filepath.Join(root, "config.log"), []byte("x"))       // tracked, matches root rule
+		initGitRepoWithTrackedFiles(t, root, []string{
+			"config.log", "pkg/build.tmp", ".gitignore", "pkg/.gitignore",
+		})
+
+		kept := filterBySource(t, root, []string{".gitignore"})
+
+		assert.True(t, kept["config.log"], "tracked file matching the root .gitignore must be rescued")
+		assert.True(t, kept["pkg/build.tmp"], "tracked file matching a nested .gitignore must be rescued")
+	})
+
+	t.Run("non-git directory fails open, logged at debug (not warn): not being a git repo is expected", func(t *testing.T) {
+		root := t.TempDir() // no git init at all
+		createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("*.log\n"))
+		createFileInPath(t, filepath.Join(root, "config.log"), []byte("x"))
+		createFileInPath(t, filepath.Join(root, "app.js"), []byte("x"))
+
+		var logBuf bytes.Buffer
+		logger := zerolog.New(&logBuf)
+		fileFilter := NewFileFilter(root, &logger)
+		rules, err := fileFilter.GetRulesBySource([]string{".gitignore"})
+		assert.NoError(t, err)
+
+		kept := make(map[string]bool)
+		for f := range fileFilter.GetFilteredFilesBySource(fileFilter.GetAllFiles(), rules) {
+			rel, relErr := filepath.Rel(root, f)
+			assert.NoError(t, relErr)
+			kept[filepath.ToSlash(rel)] = true
+		}
+
+		assert.False(t, kept["config.log"], "no git repo means no rescue; file must still be excluded")
+		assert.True(t, kept["app.js"])
+		assert.Contains(t, logBuf.String(), "not a git repository", "the fail-open reason must be logged")
+		assert.Contains(t, logBuf.String(), `"level":"debug"`, "not being a git repo is the common case, not a warning")
+		assert.NotContains(t, logBuf.String(), `"level":"warn"`)
+	})
+
+	t.Run("broken git repo fails open, logged at warn: a real repo that can't be read is a genuine problem", func(t *testing.T) {
+		root := t.TempDir()
+		createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("*.log\n"))
+		createFileInPath(t, filepath.Join(root, "config.log"), []byte("x"))
+		// a malformed worktree-style .git file (missing the required "gitdir: " prefix) makes
+		// go-git fail with something other than ErrRepositoryNotExists.
+		createFileInPath(t, filepath.Join(root, ".git"), []byte("not a valid gitdir pointer\n"))
+
+		var logBuf bytes.Buffer
+		logger := zerolog.New(&logBuf)
+		fileFilter := NewFileFilter(root, &logger)
+		rules, err := fileFilter.GetRulesBySource([]string{".gitignore"})
+		assert.NoError(t, err)
+
+		kept := make(map[string]bool)
+		for f := range fileFilter.GetFilteredFilesBySource(fileFilter.GetAllFiles(), rules) {
+			rel, relErr := filepath.Rel(root, f)
+			assert.NoError(t, relErr)
+			kept[filepath.ToSlash(rel)] = true
+		}
+
+		assert.False(t, kept["config.log"], "broken repo means no rescue; file must still be excluded")
+		assert.Contains(t, logBuf.String(), "could not open git repository", "the fail-open reason must be logged")
+		assert.Contains(t, logBuf.String(), `"level":"warn"`, "a real repo that fails to open is a genuine problem")
 	})
 }
 

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -1191,6 +1191,55 @@ exclude:
 	})
 }
 
+// TestFileFilter_NewFilterBySource covers the per-path, build-once/call-many-times shape (e.g. a
+// file watcher reacting to individual events), as opposed to GetFilteredFilesBySource's
+// batch-channel shape.
+func TestFileFilter_NewFilterBySource(t *testing.T) {
+	root := t.TempDir()
+	createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("*.log\n"))
+	createFileInPath(t, filepath.Join(root, "config.log"), []byte("x"))    // tracked, matches *.log
+	createFileInPath(t, filepath.Join(root, "untracked.log"), []byte("x")) // untracked, matches *.log
+	createFileInPath(t, filepath.Join(root, "app.js"), []byte("x"))
+	initGitRepoWithTrackedFiles(t, root, []string{"config.log", "app.js", ".gitignore"})
+
+	fileFilter := NewFileFilter(root, &log.Logger)
+	rules, err := fileFilter.GetRulesBySource([]string{".gitignore"})
+	assert.NoError(t, err)
+
+	filter := fileFilter.NewFilterBySource(rules)
+
+	// The same FilterBySource is reused across repeated single-path calls, simulating a watcher
+	// evaluating one event at a time — no git index read happens on these calls.
+	assert.True(t, filter.ShouldKeep(filepath.Join(root, "config.log")), "tracked file matching .gitignore must be rescued")
+	assert.False(t, filter.ShouldKeep(filepath.Join(root, "untracked.log")), "untracked file matching .gitignore must still be excluded")
+	assert.True(t, filter.ShouldKeep(filepath.Join(root, "app.js")))
+	assert.True(t, filter.ShouldKeep(filepath.Join(root, "config.log")), "calling ShouldKeep again on the same filter must be stable")
+}
+
+// TestFileFilter_NewFilterBySource_NoIOAfterConstruction proves the actual point of
+// FilterBySource: the git index is read once, at construction, not on every ShouldKeep call. It
+// deletes .git after building the filter, so if ShouldKeep re-read git per call (the batch-shaped
+// cost this type exists to avoid for a long-lived, per-event caller), the rescue would break.
+func TestFileFilter_NewFilterBySource_NoIOAfterConstruction(t *testing.T) {
+	root := t.TempDir()
+	createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("*.log\n"))
+	createFileInPath(t, filepath.Join(root, "config.log"), []byte("x")) // tracked, matches *.log
+	initGitRepoWithTrackedFiles(t, root, []string{"config.log", ".gitignore"})
+
+	fileFilter := NewFileFilter(root, &log.Logger)
+	rules, err := fileFilter.GetRulesBySource([]string{".gitignore"})
+	assert.NoError(t, err)
+
+	filter := fileFilter.NewFilterBySource(rules) // reads the git index once, here
+
+	assert.NoError(t, os.RemoveAll(filepath.Join(root, ".git")))
+
+	for i := range 5 {
+		assert.True(t, filter.ShouldKeep(filepath.Join(root, "config.log")),
+			"call %d: rescue must still work from the cached snapshot even though .git no longer exists", i)
+	}
+}
+
 func BenchmarkFileFilter_GetFilteredFiles(b *testing.B) {
 	b.Log("Creating filesystem...")
 	rootDir := b.TempDir()


### PR DESCRIPTION
### Description

Adds `GetRulesBySource`/`GetFilteredFilesBySource` to `pkg/utils.FileFilter` (CLI-1411): a file tracked in git that matches a `.gitignore` rule is no longer silently excluded from scans, since git itself only ignores untracked files. `.snyk`/`.dcignore` exclusions and the default `.git` rule still always exclude, tracked or not.

Existing callers see zero behavior change until they opt in by switching to the new by-source methods. The new `FF_GITIGNORE_RESPECT_TRACKED_FILES` flag constant is added for consumers to gate that switch; no consumer wiring is included in this PR.

Tracked-file lookup reads the git index via `go-git` (already a dependency), bounded to the intersection of tracked ∩ gitignore-matched files, and fails open (falls back to today's exclusion behavior) if the scan path isn't a git repository or the index can't be read — logged at debug, since not being a git repo is the common case. A genuinely broken repo (exists but can't be opened/read) logs at warn instead. When any file is rescued, a warn-level log also surfaces the specific files, since that's a real change in what gets scanned.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.
  
 
Plugging in code-client-go, we can see the output:
```
INTERNAL_SNYK_GITIGNORE_RESPECT_TRACKED_FILES_ENABLED=1 snyk code test . -d --log-level=trace 2>&1 | grep -iE "tracked|BundleFileFrom"
2026-07-29T08:30:01Z code.test:1 - checked git index for tracked files matching .gitignore rules duration=1.175 trackedGitignoreFiles=["tracked.log"] trackedGitignoreMatches=1
2026-07-29T08:30:01Z code.test:1 - some git-tracked files match a .gitignore rule and will still be scanned trackedGitignoreFiles=["tracked.log"]
2026-07-29T08:30:01Z code.test:1 - filePath=app.js hash=5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03 method=BundleFileFrom
```