### PR TITLE
feat: add findings.filter.delta workflow for line-range delta filtering

### DIFF
--- a/internal/utils/findings/delta.go
+++ b/internal/utils/findings/delta.go
@@ -1,0 +1,184 @@
+package findings
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/snyk/go-application-framework/pkg/local_workflows/local_models"
+)
+
+// Range is an inclusive, 1-based line range.
+type Range struct {
+	Start int `json:"start"`
+	End   int `json:"end"`
+}
+
+// fileScope is the per-file scope value: either all lines or a list of merged ranges.
+type fileScope struct {
+	all    bool
+	ranges []Range
+}
+
+func (f *fileScope) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		if s == "all" {
+			f.all = true
+			return nil
+		}
+		return fmt.Errorf("invalid file scope string %q; expected \"all\"", s)
+	}
+
+	var ranges []Range
+	if err := json.Unmarshal(data, &ranges); err != nil {
+		return fmt.Errorf("file scope must be \"all\" or [{\"start\":N,\"end\":M},...]")
+	}
+	for _, r := range ranges {
+		if r.Start <= 0 || r.End <= 0 {
+			return fmt.Errorf("line numbers must be positive (got start=%d end=%d)", r.Start, r.End)
+		}
+		if r.Start > r.End {
+			return fmt.Errorf("start %d > end %d in range", r.Start, r.End)
+		}
+	}
+	f.ranges = mergeRanges(ranges)
+	return nil
+}
+
+type changedScopeJSON struct {
+	Version *int                       `json:"version"`
+	Files   map[string]json.RawMessage `json:"files"`
+}
+
+// ChangedScope holds validated delta input.
+type ChangedScope struct {
+	files map[string]fileScope
+}
+
+// ParseChangedScope validates and parses the changed-lines JSON input.
+// Returns an error for malformed input; callers should fail closed.
+func ParseChangedScope(data []byte) (ChangedScope, error) {
+	var raw changedScopeJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return ChangedScope{}, fmt.Errorf("changed-lines input is not valid JSON: %w", err)
+	}
+	if raw.Version == nil {
+		return ChangedScope{}, fmt.Errorf("changed-lines input missing required \"version\" field")
+	}
+	if *raw.Version != 1 {
+		return ChangedScope{}, fmt.Errorf("changed-lines version must be 1 (got %d)", *raw.Version)
+	}
+	if raw.Files == nil {
+		return ChangedScope{}, fmt.Errorf("changed-lines input missing required \"files\" object")
+	}
+	if len(raw.Files) == 0 {
+		return ChangedScope{}, fmt.Errorf("changed-lines input contained no files; omit the flag for a full scan")
+	}
+
+	scope := ChangedScope{files: make(map[string]fileScope, len(raw.Files))}
+	for path, rawScope := range raw.Files {
+		var fs fileScope
+		if err := json.Unmarshal(rawScope, &fs); err != nil {
+			return ChangedScope{}, fmt.Errorf("invalid scope for file %q: %w", path, err)
+		}
+		scope.files[NormalizeRelPath(path)] = fs
+	}
+	return scope, nil
+}
+
+// NormalizeRelPath converts a file path to relative, forward-slash, no-leading-./ form.
+// Backslashes are always converted to forward-slashes regardless of OS.
+func NormalizeRelPath(p string) string {
+	p = strings.ReplaceAll(p, "\\", "/")
+	for strings.HasPrefix(p, "./") {
+		p = p[2:]
+	}
+	p = strings.TrimLeft(p, "/")
+	return p
+}
+
+// mergeRanges merges overlapping/adjacent inclusive ranges and returns them sorted.
+func mergeRanges(ranges []Range) []Range {
+	if len(ranges) == 0 {
+		return ranges
+	}
+	sorted := make([]Range, len(ranges))
+	copy(sorted, ranges)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Start != sorted[j].Start {
+			return sorted[i].Start < sorted[j].Start
+		}
+		return sorted[i].End < sorted[j].End
+	})
+	merged := []Range{sorted[0]}
+	for _, r := range sorted[1:] {
+		last := &merged[len(merged)-1]
+		if r.Start <= last.End+1 { // adjacent or overlapping
+			if r.End > last.End {
+				last.End = r.End
+			}
+		} else {
+			merged = append(merged, r)
+		}
+	}
+	return merged
+}
+
+// FileInScope returns true if the normalised file path exists in the scope.
+func (s ChangedScope) FileInScope(file string) bool {
+	_, ok := s.files[file]
+	return ok
+}
+
+// Intersects returns true if [findStart, findEnd] intersects any range for the given normalised file.
+func (s ChangedScope) Intersects(file string, findStart, findEnd int) bool {
+	fs, ok := s.files[file]
+	if !ok {
+		return false
+	}
+	if fs.all {
+		return true
+	}
+	for _, r := range fs.ranges {
+		if findStart <= r.End && findEnd >= r.Start {
+			return true
+		}
+	}
+	return false
+}
+
+// GetDeltaFilter returns a FindingsFilterFunc for LOCAL_FINDING_MODEL findings.
+// A finding is kept if any of its source locations intersects the changed scope.
+// A finding whose file is in scope but has no line data is kept (false positive
+// beats false negative for a security gate).
+func GetDeltaFilter(scope ChangedScope) FindingsFilterFunc {
+	return func(finding local_models.FindingResource) bool {
+		if finding.Attributes.Locations == nil || len(*finding.Attributes.Locations) == 0 {
+			return false
+		}
+		for _, loc := range *finding.Attributes.Locations {
+			if loc.SourceLocations == nil {
+				continue
+			}
+			sl := loc.SourceLocations
+			normPath := NormalizeRelPath(sl.Filepath)
+			if !scope.FileInScope(normPath) {
+				continue
+			}
+			// file in scope, no line data — keep
+			if sl.OriginalStartLine == 0 && sl.OriginalEndLine == 0 {
+				return true
+			}
+			end := sl.OriginalEndLine
+			if end == 0 {
+				end = sl.OriginalStartLine
+			}
+			if scope.Intersects(normPath, sl.OriginalStartLine, end) {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/internal/utils/findings/delta_test.go
+++ b/internal/utils/findings/delta_test.go
@@ -1,0 +1,303 @@
+package findings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/go-application-framework/pkg/local_workflows/local_models"
+)
+
+// --- ParseChangedScope ---
+
+func TestParseChangedScope_ValidSimple(t *testing.T) {
+	input := `{"version":1,"files":{"src/app.py":[{"start":10,"end":24}]}}`
+	scope, err := ParseChangedScope([]byte(input))
+	require.NoError(t, err)
+	assert.True(t, scope.FileInScope("src/app.py"))
+	assert.False(t, scope.FileInScope("other.py"))
+}
+
+func TestParseChangedScope_AllSentinel(t *testing.T) {
+	input := `{"version":1,"files":{"src/new.py":"all"}}`
+	scope, err := ParseChangedScope([]byte(input))
+	require.NoError(t, err)
+	assert.True(t, scope.Intersects("src/new.py", 1, 9999))
+}
+
+func TestParseChangedScope_MultipleFiles(t *testing.T) {
+	input := `{"version":1,"files":{"a.py":[{"start":1,"end":5}],"b.py":"all"}}`
+	scope, err := ParseChangedScope([]byte(input))
+	require.NoError(t, err)
+	assert.True(t, scope.FileInScope("a.py"))
+	assert.True(t, scope.FileInScope("b.py"))
+	assert.False(t, scope.FileInScope("c.py"))
+}
+
+func TestParseChangedScope_ErrorNotJSON(t *testing.T) {
+	_, err := ParseChangedScope([]byte("not json"))
+	assert.Error(t, err)
+}
+
+func TestParseChangedScope_ErrorVersionMissing(t *testing.T) {
+	_, err := ParseChangedScope([]byte(`{"files":{"a.py":"all"}}`))
+	assert.ErrorContains(t, err, "version")
+}
+
+func TestParseChangedScope_ErrorVersionWrong(t *testing.T) {
+	_, err := ParseChangedScope([]byte(`{"version":2,"files":{"a.py":"all"}}`))
+	assert.ErrorContains(t, err, "version must be 1")
+}
+
+func TestParseChangedScope_ErrorFilesMissing(t *testing.T) {
+	_, err := ParseChangedScope([]byte(`{"version":1}`))
+	assert.ErrorContains(t, err, "files")
+}
+
+func TestParseChangedScope_ErrorFilesEmpty(t *testing.T) {
+	_, err := ParseChangedScope([]byte(`{"version":1,"files":{}}`))
+	assert.ErrorContains(t, err, "no files")
+}
+
+func TestParseChangedScope_ErrorNegativeLine(t *testing.T) {
+	_, err := ParseChangedScope([]byte(`{"version":1,"files":{"a.py":[{"start":-1,"end":5}]}}`))
+	assert.Error(t, err)
+}
+
+func TestParseChangedScope_ErrorZeroLine(t *testing.T) {
+	_, err := ParseChangedScope([]byte(`{"version":1,"files":{"a.py":[{"start":0,"end":5}]}}`))
+	assert.Error(t, err)
+}
+
+func TestParseChangedScope_ErrorStartGreaterThanEnd(t *testing.T) {
+	_, err := ParseChangedScope([]byte(`{"version":1,"files":{"a.py":[{"start":10,"end":5}]}}`))
+	assert.Error(t, err)
+}
+
+func TestParseChangedScope_ErrorBadAllString(t *testing.T) {
+	_, err := ParseChangedScope([]byte(`{"version":1,"files":{"a.py":"none"}}`))
+	assert.Error(t, err)
+}
+
+func TestParseChangedScope_ErrorTruncatedJSON(t *testing.T) {
+	_, err := ParseChangedScope([]byte(`{"version":1,"files":{"a.py":[{"start":1`))
+	assert.Error(t, err)
+}
+
+// --- NormalizeRelPath ---
+
+func TestNormalizeRelPath(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"src/app.py", "src/app.py"},
+		{"./src/app.py", "src/app.py"},
+		{"../../src/app.py", "../../src/app.py"}, // ../ not stripped, only ./
+		{"/absolute/path.py", "absolute/path.py"},
+		{"src\\windows\\path.py", "src/windows/path.py"}, // backslashes always converted
+		{"./", ""},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			assert.Equal(t, tc.want, NormalizeRelPath(tc.input))
+		})
+	}
+}
+
+// --- mergeRanges ---
+
+func TestMergeRanges(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []Range
+		output []Range
+	}{
+		{
+			name:   "single range",
+			input:  []Range{{1, 5}},
+			output: []Range{{1, 5}},
+		},
+		{
+			name:   "non-overlapping sorted",
+			input:  []Range{{1, 5}, {10, 20}},
+			output: []Range{{1, 5}, {10, 20}},
+		},
+		{
+			name:   "overlapping",
+			input:  []Range{{1, 10}, {8, 20}},
+			output: []Range{{1, 20}},
+		},
+		{
+			name:   "adjacent (end+1 = start)",
+			input:  []Range{{1, 5}, {6, 10}},
+			output: []Range{{1, 10}},
+		},
+		{
+			name:   "unsorted input",
+			input:  []Range{{10, 20}, {1, 5}},
+			output: []Range{{1, 5}, {10, 20}},
+		},
+		{
+			name:   "three overlapping into one",
+			input:  []Range{{1, 10}, {5, 15}, {12, 20}},
+			output: []Range{{1, 20}},
+		},
+		{
+			name:   "contained range removed",
+			input:  []Range{{1, 20}, {5, 10}},
+			output: []Range{{1, 20}},
+		},
+		{
+			name:   "empty input",
+			input:  []Range{},
+			output: []Range{},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.output, mergeRanges(tc.input))
+		})
+	}
+}
+
+// --- intersects ---
+
+func TestIntersects(t *testing.T) {
+	scope, err := ParseChangedScope([]byte(`{"version":1,"files":{"src/a.py":[{"start":10,"end":24},{"start":80,"end":80}],"src/b.py":"all"}}`))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name  string
+		file  string
+		start int
+		end   int
+		want  bool
+	}{
+		{"exact range match", "src/a.py", 10, 24, true},
+		{"finding spans changed range", "src/a.py", 8, 12, true},
+		{"finding inside range", "src/a.py", 15, 20, true},
+		{"boundary: finding ends at start of range", "src/a.py", 5, 10, true},
+		{"boundary: finding starts at end of range", "src/a.py", 24, 30, true},
+		{"no intersection before range", "src/a.py", 1, 9, false},
+		{"no intersection after range", "src/a.py", 25, 30, false},
+		{"second range single line match", "src/a.py", 80, 80, true},
+		{"second range: finding spans it", "src/a.py", 79, 81, true},
+		{"between ranges", "src/a.py", 25, 79, false},
+		{"all-scope file always matches", "src/b.py", 1, 9999, true},
+		{"file not in scope", "src/c.py", 10, 20, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, scope.Intersects(tc.file, tc.start, tc.end))
+		})
+	}
+}
+
+// --- GetDeltaFilter ---
+
+func makeLocalFinding(filepath string, startLine, endLine int) local_models.FindingResource {
+	sl := &local_models.IoSnykReactiveFindingSourceLocation{
+		Filepath:            filepath,
+		OriginalStartLine:   startLine,
+		OriginalEndLine:     endLine,
+	}
+	loc := local_models.IoSnykReactiveFindingLocation{
+		SourceLocations: sl,
+	}
+	locs := []local_models.IoSnykReactiveFindingLocation{loc}
+	return local_models.FindingResource{
+		Attributes: local_models.TypesFindingAttributes{
+			Locations: &locs,
+		},
+	}
+}
+
+func TestGetDeltaFilter_IntersectionNotContainment(t *testing.T) {
+	scope, err := ParseChangedScope([]byte(`{"version":1,"files":{"src/a.py":[{"start":10,"end":10}]}}`))
+	require.NoError(t, err)
+	f := GetDeltaFilter(scope)
+
+	// finding spans changed line (8-12 intersects 10-10)
+	assert.True(t, f(makeLocalFinding("src/a.py", 8, 12)))
+	// finding exactly on changed line
+	assert.True(t, f(makeLocalFinding("src/a.py", 10, 10)))
+	// finding before changed line
+	assert.False(t, f(makeLocalFinding("src/a.py", 1, 9)))
+	// finding after changed line
+	assert.False(t, f(makeLocalFinding("src/a.py", 11, 20)))
+}
+
+func TestGetDeltaFilter_AllSentinel(t *testing.T) {
+	scope, err := ParseChangedScope([]byte(`{"version":1,"files":{"src/new.py":"all"}}`))
+	require.NoError(t, err)
+	f := GetDeltaFilter(scope)
+	assert.True(t, f(makeLocalFinding("src/new.py", 1, 9999)))
+}
+
+func TestGetDeltaFilter_FileNotInScope(t *testing.T) {
+	scope, err := ParseChangedScope([]byte(`{"version":1,"files":{"src/a.py":[{"start":10,"end":20}]}}`))
+	require.NoError(t, err)
+	f := GetDeltaFilter(scope)
+	assert.False(t, f(makeLocalFinding("other.py", 10, 20)))
+}
+
+func TestGetDeltaFilter_PathNormalization(t *testing.T) {
+	scope, err := ParseChangedScope([]byte(`{"version":1,"files":{"src/a.py":[{"start":10,"end":20}]}}`))
+	require.NoError(t, err)
+	f := GetDeltaFilter(scope)
+	// finding uses ./src/a.py — should normalize and match
+	assert.True(t, f(makeLocalFinding("./src/a.py", 10, 20)))
+}
+
+func TestGetDeltaFilter_NoLocationData(t *testing.T) {
+	scope, err := ParseChangedScope([]byte(`{"version":1,"files":{"src/a.py":[{"start":10,"end":20}]}}`))
+	require.NoError(t, err)
+	f := GetDeltaFilter(scope)
+
+	// finding with file in scope but zero line numbers — keep
+	assert.True(t, f(makeLocalFinding("src/a.py", 0, 0)))
+}
+
+func TestGetDeltaFilter_NilLocations(t *testing.T) {
+	scope, err := ParseChangedScope([]byte(`{"version":1,"files":{"src/a.py":[{"start":10,"end":20}]}}`))
+	require.NoError(t, err)
+	f := GetDeltaFilter(scope)
+
+	finding := local_models.FindingResource{
+		Attributes: local_models.TypesFindingAttributes{
+			Locations: nil,
+		},
+	}
+	assert.False(t, f(finding))
+}
+
+func TestGetDeltaFilter_MultiLocationFinding(t *testing.T) {
+	// finding has two locations; only the second intersects
+	scope, err := ParseChangedScope([]byte(`{"version":1,"files":{"src/b.py":[{"start":50,"end":60}]}}`))
+	require.NoError(t, err)
+	f := GetDeltaFilter(scope)
+
+	sl1 := &local_models.IoSnykReactiveFindingSourceLocation{Filepath: "src/a.py", OriginalStartLine: 10, OriginalEndLine: 20}
+	sl2 := &local_models.IoSnykReactiveFindingSourceLocation{Filepath: "src/b.py", OriginalStartLine: 55, OriginalEndLine: 55}
+	locs := []local_models.IoSnykReactiveFindingLocation{
+		{SourceLocations: sl1},
+		{SourceLocations: sl2},
+	}
+	finding := local_models.FindingResource{
+		Attributes: local_models.TypesFindingAttributes{Locations: &locs},
+	}
+	assert.True(t, f(finding))
+}
+
+func TestGetDeltaFilter_MultiRangeFile(t *testing.T) {
+	scope, err := ParseChangedScope([]byte(`{"version":1,"files":{"src/a.py":[{"start":1,"end":5},{"start":50,"end":60}]}}`))
+	require.NoError(t, err)
+	f := GetDeltaFilter(scope)
+
+	assert.True(t, f(makeLocalFinding("src/a.py", 3, 3)))
+	assert.True(t, f(makeLocalFinding("src/a.py", 55, 55)))
+	assert.False(t, f(makeLocalFinding("src/a.py", 10, 40)))
+}

--- a/internal/utils/findings/delta_test.go
+++ b/internal/utils/findings/delta_test.go
@@ -200,9 +200,9 @@ func TestIntersects(t *testing.T) {
 
 func makeLocalFinding(filepath string, startLine, endLine int) local_models.FindingResource {
 	sl := &local_models.IoSnykReactiveFindingSourceLocation{
-		Filepath:            filepath,
-		OriginalStartLine:   startLine,
-		OriginalEndLine:     endLine,
+		Filepath:          filepath,
+		OriginalStartLine: startLine,
+		OriginalEndLine:   endLine,
 	}
 	loc := local_models.IoSnykReactiveFindingLocation{
 		SourceLocations: sl,

--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -67,6 +67,8 @@ const (
 	PREVIEW_FEATURES_ENABLED string = "internal_preview_features_enabled" // PREVIEW_FEATURES_ENABLED (boolean) indicates if preview features shall be enabled, this can be used to limit features to the preview version only
 	FLAG_INCLUDE_IGNORES     string = "include-ignores"                   // FLAG_INCLUDE_IGNORES (boolean) sets/returns if ignores shall be displayed or not
 	FLAG_SEVERITY_THRESHOLD  string = "severity-threshold"                // FLAG_SEVERITY_THRESHOLD (string) sets/returns the severity threshold
+	FLAG_CHANGED_LINES_FILE  string = "changed-lines-file"               // FLAG_CHANGED_LINES_FILE (string) path to JSON file describing changed line ranges for delta filtering
+	FLAG_CHANGED_LINES       string = "changed-lines"                    // FLAG_CHANGED_LINES (string) inline JSON string describing changed line ranges for delta filtering
 	FLAG_REMOTE_REPO_URL     string = "remote-repo-url"                   // FLAG_REMOTE_REPO_URL (string) sets/returns the remote repository URL
 	INPUT_DIRECTORY          string = "targetDirectory"                   // INPUT_DIRECTORY ([]string) sets/returns the input directories that the application shall process
 	CUSTOM_CONFIG_FILES      string = "internal_custom_config_files"

--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -67,8 +67,8 @@ const (
 	PREVIEW_FEATURES_ENABLED string = "internal_preview_features_enabled" // PREVIEW_FEATURES_ENABLED (boolean) indicates if preview features shall be enabled, this can be used to limit features to the preview version only
 	FLAG_INCLUDE_IGNORES     string = "include-ignores"                   // FLAG_INCLUDE_IGNORES (boolean) sets/returns if ignores shall be displayed or not
 	FLAG_SEVERITY_THRESHOLD  string = "severity-threshold"                // FLAG_SEVERITY_THRESHOLD (string) sets/returns the severity threshold
-	FLAG_CHANGED_LINES_FILE  string = "changed-lines-file"               // FLAG_CHANGED_LINES_FILE (string) path to JSON file describing changed line ranges for delta filtering
-	FLAG_CHANGED_LINES       string = "changed-lines"                    // FLAG_CHANGED_LINES (string) inline JSON string describing changed line ranges for delta filtering
+	FLAG_CHANGED_LINES_FILE  string = "changed-lines-file"                // FLAG_CHANGED_LINES_FILE (string) path to JSON file describing changed line ranges for delta filtering
+	FLAG_CHANGED_LINES       string = "changed-lines"                     // FLAG_CHANGED_LINES (string) inline JSON string describing changed line ranges for delta filtering
 	FLAG_REMOTE_REPO_URL     string = "remote-repo-url"                   // FLAG_REMOTE_REPO_URL (string) sets/returns the remote repository URL
 	INPUT_DIRECTORY          string = "targetDirectory"                   // INPUT_DIRECTORY ([]string) sets/returns the input directories that the application shall process
 	CUSTOM_CONFIG_FILES      string = "internal_custom_config_files"

--- a/pkg/local_workflows/delta_filter_workflow.go
+++ b/pkg/local_workflows/delta_filter_workflow.go
@@ -1,0 +1,222 @@
+package localworkflows
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/rs/zerolog"
+	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+	"github.com/spf13/pflag"
+
+	"github.com/snyk/go-application-framework/internal/utils/findings"
+	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/content_type"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/local_models"
+	"github.com/snyk/go-application-framework/pkg/utils/ufm"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+)
+
+const (
+	DeltaFilterFindingsWorkflowName = "findings.filter.delta"
+)
+
+var WORKFLOWID_FILTER_FINDINGS_DELTA = workflow.NewWorkflowIdentifier(DeltaFilterFindingsWorkflowName)
+
+// InitDeltaFilterFindingsWorkflow registers the delta filter workflow with the engine.
+func InitDeltaFilterFindingsWorkflow(engine workflow.Engine) error {
+	flags := pflag.NewFlagSet(DeltaFilterFindingsWorkflowName, pflag.ExitOnError)
+	flags.String(configuration.FLAG_CHANGED_LINES_FILE, "", "Path to JSON file describing changed line ranges for delta filtering")
+	flags.String(configuration.FLAG_CHANGED_LINES, "", "Inline JSON describing changed line ranges for delta filtering")
+	_, err := engine.Register(WORKFLOWID_FILTER_FINDINGS_DELTA, workflow.ConfigurationOptionsFromFlagset(flags), deltaFilterFindingsEntryPoint)
+	return err
+}
+
+// filteredTestResult wraps a testapi.TestResult and returns only delta-filtered findings.
+type filteredTestResult struct {
+	testapi.TestResult
+	filtered []testapi.FindingData
+	complete bool
+}
+
+func (f *filteredTestResult) Findings(_ context.Context) ([]testapi.FindingData, bool, error) {
+	return f.filtered, f.complete, nil
+}
+
+func deltaFilterFindingsEntryPoint(invocationCtx workflow.InvocationContext, input []workflow.Data) ([]workflow.Data, error) {
+	config := invocationCtx.GetConfiguration()
+	logger := invocationCtx.GetEnhancedLogger()
+
+	scopeData, err := resolveChangedLinesInput(config)
+	if err != nil {
+		return nil, err
+	}
+	if scopeData == nil {
+		logger.Println("Delta filter: no changed-lines input, passing through")
+		return input, nil
+	}
+
+	scope, err := findings.ParseChangedScope(scopeData)
+	if err != nil {
+		return nil, snyk_errors.Error{
+			Title:          "Invalid changed-lines input",
+			Classification: "ActionableByUser",
+			Level:          "error",
+			Detail:         fmt.Sprintf("changed-lines input is malformed: %s", err.Error()),
+		}
+	}
+
+	output := make([]workflow.Data, 0, len(input))
+	for _, data := range input {
+		mimeType := data.GetContentType()
+		switch {
+		case strings.HasPrefix(mimeType, content_type.LOCAL_FINDING_MODEL):
+			filtered, filterErr := applyDeltaToLocalFindings(data, scope, logger)
+			if filterErr != nil {
+				logger.Warn().Err(filterErr).Msg("Delta filter: failed to filter LOCAL_FINDING_MODEL, passing through")
+				output = append(output, data)
+				continue
+			}
+			output = append(output, filtered)
+
+		case strings.HasPrefix(mimeType, content_type.UFM_RESULT):
+			filtered, filterErr := applyDeltaToUFMResult(data, scope, logger)
+			if filterErr != nil {
+				logger.Warn().Err(filterErr).Msg("Delta filter: failed to filter UFM_RESULT, passing through")
+				output = append(output, data)
+				continue
+			}
+			output = append(output, filtered)
+
+		default:
+			output = append(output, data)
+		}
+	}
+	return output, nil
+}
+
+// resolveChangedLinesInput reads raw JSON bytes from --changed-lines-file or --changed-lines.
+// Returns nil if neither flag is set (no-op pass-through).
+func resolveChangedLinesInput(config configuration.Configuration) ([]byte, error) {
+	if filePath := config.GetString(configuration.FLAG_CHANGED_LINES_FILE); filePath != "" {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, snyk_errors.Error{
+				Title:          "Cannot read changed-lines file",
+				Classification: "ActionableByUser",
+				Level:          "error",
+				Detail:         fmt.Sprintf("--changed-lines-file %q: %s", filePath, err.Error()),
+			}
+		}
+		return data, nil
+	}
+	if inline := config.GetString(configuration.FLAG_CHANGED_LINES); inline != "" {
+		return []byte(inline), nil
+	}
+	return nil, nil
+}
+
+func applyDeltaToLocalFindings(data workflow.Data, scope findings.ChangedScope, logger *zerolog.Logger) (workflow.Data, error) {
+	payload, ok := data.GetPayload().([]byte)
+	if !ok {
+		return nil, fmt.Errorf("unexpected payload type %T", data.GetPayload())
+	}
+
+	var findingsModel local_models.LocalFinding
+	if err := json.Unmarshal(payload, &findingsModel); err != nil {
+		return nil, fmt.Errorf("unmarshal LOCAL_FINDING_MODEL: %w", err)
+	}
+
+	before := len(findingsModel.Findings)
+	filter := findings.GetDeltaFilter(scope)
+	applyFilters(&findingsModel, []findings.FindingsFilterFunc{filter})
+	local_models.UpdateFindingSummary(&findingsModel)
+	logger.Debug().Msgf("Delta filter: LOCAL_FINDING_MODEL %d -> %d findings", before, len(findingsModel.Findings))
+
+	filtered, err := json.Marshal(findingsModel)
+	if err != nil {
+		return nil, fmt.Errorf("marshal filtered findings: %w", err)
+	}
+
+	return workflow.NewData(
+		workflow.NewTypeIdentifier(WORKFLOWID_FILTER_FINDINGS_DELTA, DeltaFilterFindingsWorkflowName),
+		content_type.LOCAL_FINDING_MODEL,
+		filtered,
+		workflow.WithInputData(data),
+	), nil
+}
+
+func applyDeltaToUFMResult(data workflow.Data, scope findings.ChangedScope, logger *zerolog.Logger) (workflow.Data, error) {
+	results := ufm.GetTestResultsFromWorkflowData(data)
+	if results == nil {
+		return data, nil
+	}
+
+	ctx := context.Background()
+	filteredResults := make([]testapi.TestResult, 0, len(results))
+	for _, result := range results {
+		findingsList, complete, err := result.Findings(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("fetch UFM findings: %w", err)
+		}
+
+		var kept []testapi.FindingData
+		for _, f := range findingsList {
+			if ufmFindingInDeltaScope(f, scope) {
+				kept = append(kept, f)
+			}
+		}
+		logger.Debug().Msgf("Delta filter: UFM_RESULT %d -> %d findings", len(findingsList), len(kept))
+
+		filteredResults = append(filteredResults, &filteredTestResult{
+			TestResult: result,
+			filtered:   kept,
+			complete:   complete,
+		})
+	}
+
+	newData := ufm.CreateWorkflowDataFromTestResults(WORKFLOWID_FILTER_FINDINGS_DELTA, filteredResults)
+	if newData == nil {
+		// All results empty after filtering — return minimal valid UFM_RESULT
+		return workflow.NewData(
+			workflow.NewTypeIdentifier(WORKFLOWID_FILTER_FINDINGS_DELTA, DeltaFilterFindingsWorkflowName),
+			content_type.UFM_RESULT,
+			[]byte("[]"),
+			workflow.WithInputData(data),
+		), nil
+	}
+	return newData, nil
+}
+
+// ufmFindingInDeltaScope returns true if any source location in the UFM finding
+// intersects the changed scope.
+func ufmFindingInDeltaScope(finding testapi.FindingData, scope findings.ChangedScope) bool {
+	if finding.Attributes == nil || len(finding.Attributes.Locations) == 0 {
+		return false
+	}
+	for _, loc := range finding.Attributes.Locations {
+		sl, err := loc.AsSourceLocation()
+		if err != nil {
+			continue
+		}
+		normPath := findings.NormalizeRelPath(sl.FilePath)
+		if !scope.FileInScope(normPath) {
+			continue
+		}
+		// file in scope, no line data — keep
+		if sl.FromLine == 0 && (sl.ToLine == nil || *sl.ToLine == 0) {
+			return true
+		}
+		end := sl.FromLine
+		if sl.ToLine != nil && *sl.ToLine > 0 {
+			end = *sl.ToLine
+		}
+		if scope.Intersects(normPath, sl.FromLine, end) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/local_workflows/delta_filter_workflow_test.go
+++ b/pkg/local_workflows/delta_filter_workflow_test.go
@@ -74,7 +74,9 @@ func TestDeltaFilterWorkflow_NoFlagPassThrough(t *testing.T) {
 
 	// verify finding count unchanged
 	var out local_models.LocalFinding
-	require.NoError(t, json.Unmarshal(output[0].GetPayload().([]byte), &out))
+	payload, ok := output[0].GetPayload().([]byte)
+	require.True(t, ok, "expected []byte payload")
+	require.NoError(t, json.Unmarshal(payload, &out))
 	assert.Equal(t, total, len(out.Findings))
 }
 
@@ -90,7 +92,9 @@ func TestDeltaFilterWorkflow_FilterByLine(t *testing.T) {
 	require.Len(t, output, 1)
 
 	var out local_models.LocalFinding
-	require.NoError(t, json.Unmarshal(output[0].GetPayload().([]byte), &out))
+	payload, ok := output[0].GetPayload().([]byte)
+	require.True(t, ok, "expected []byte payload")
+	require.NoError(t, json.Unmarshal(payload, &out))
 	assert.True(t, len(out.Findings) > 0, "expected at least one finding on line 18")
 	assert.True(t, len(out.Findings) < len(findingsModel.Findings), "expected fewer findings after delta filter")
 }
@@ -106,7 +110,9 @@ func TestDeltaFilterWorkflow_AllSentinel(t *testing.T) {
 	require.Len(t, output, 1)
 
 	var out local_models.LocalFinding
-	require.NoError(t, json.Unmarshal(output[0].GetPayload().([]byte), &out))
+	payload, ok := output[0].GetPayload().([]byte)
+	require.True(t, ok, "expected []byte payload")
+	require.NoError(t, json.Unmarshal(payload, &out))
 	assert.True(t, len(out.Findings) > 0)
 }
 
@@ -121,7 +127,9 @@ func TestDeltaFilterWorkflow_FileNotInScope(t *testing.T) {
 	require.Len(t, output, 1)
 
 	var out local_models.LocalFinding
-	require.NoError(t, json.Unmarshal(output[0].GetPayload().([]byte), &out))
+	payload, ok := output[0].GetPayload().([]byte)
+	require.True(t, ok, "expected []byte payload")
+	require.NoError(t, json.Unmarshal(payload, &out))
 	assert.Len(t, out.Findings, 0)
 }
 
@@ -167,7 +175,9 @@ func TestDeltaFilterWorkflow_SummaryUpdatedAfterFilter(t *testing.T) {
 	require.Len(t, output, 1)
 
 	var out local_models.LocalFinding
-	require.NoError(t, json.Unmarshal(output[0].GetPayload().([]byte), &out))
+	payload, ok := output[0].GetPayload().([]byte)
+	require.True(t, ok, "expected []byte payload")
+	require.NoError(t, json.Unmarshal(payload, &out))
 
 	// sum of summary counts should equal number of findings
 	var totalFromSummary uint32

--- a/pkg/local_workflows/delta_filter_workflow_test.go
+++ b/pkg/local_workflows/delta_filter_workflow_test.go
@@ -1,0 +1,178 @@
+package localworkflows
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/content_type"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/local_models"
+	"github.com/snyk/go-application-framework/pkg/mocks"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+)
+
+func setupDeltaMockContext(t *testing.T, changedLinesJSON string) *mocks.MockInvocationContext {
+	t.Helper()
+	logger := zerolog.Nop()
+	config := configuration.New()
+	if changedLinesJSON != "" {
+		config.Set(configuration.FLAG_CHANGED_LINES, changedLinesJSON)
+	}
+	ctrl := gomock.NewController(t)
+	invCtx := mocks.NewMockInvocationContext(ctrl)
+	invCtx.EXPECT().GetConfiguration().Return(config).AnyTimes()
+	invCtx.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
+	return invCtx
+}
+
+func makeFindingsData(t *testing.T, findings local_models.LocalFinding) workflow.Data {
+	t.Helper()
+	b, err := json.Marshal(findings)
+	require.NoError(t, err)
+	return workflow.NewData(
+		workflow.NewTypeIdentifier(WORKFLOWID_FILTER_FINDINGS_DELTA, DeltaFilterFindingsWorkflowName),
+		content_type.LOCAL_FINDING_MODEL,
+		b,
+	)
+}
+
+func buildLocalFinding(t *testing.T) local_models.LocalFinding {
+	t.Helper()
+	sarifBytes := loadJsonFile(t, "sarif-juice-shop.json")
+	summaryBytes := loadJsonFile(t, "juice-shop-summary.json")
+	findings, err := TransformSarifToLocalFindingModel(sarifBytes, summaryBytes)
+	require.NoError(t, err)
+	return findings
+}
+
+func TestDeltaFilterWorkflowRegistration(t *testing.T) {
+	config := configuration.NewWithOpts()
+	engine := workflow.NewWorkFlowEngine(config)
+	err := InitDeltaFilterFindingsWorkflow(engine)
+	assert.NoError(t, err)
+	entry, ok := engine.GetWorkflow(WORKFLOWID_FILTER_FINDINGS_DELTA)
+	assert.True(t, ok)
+	assert.NotNil(t, entry)
+}
+
+func TestDeltaFilterWorkflow_NoFlagPassThrough(t *testing.T) {
+	// no changed-lines flag → all findings returned unchanged
+	invCtx := setupDeltaMockContext(t, "")
+	findingsModel := buildLocalFinding(t)
+	total := len(findingsModel.Findings)
+	input := []workflow.Data{makeFindingsData(t, findingsModel)}
+
+	output, err := deltaFilterFindingsEntryPoint(invCtx, input)
+	require.NoError(t, err)
+	assert.Equal(t, input, output) // must be same slice, no copying
+	assert.Len(t, output, 1)
+
+	// verify finding count unchanged
+	var out local_models.LocalFinding
+	require.NoError(t, json.Unmarshal(output[0].GetPayload().([]byte), &out))
+	assert.Equal(t, total, len(out.Findings))
+}
+
+func TestDeltaFilterWorkflow_FilterByLine(t *testing.T) {
+	// juice-shop finding 0: routes/likeProductReviews.ts line 18
+	// request only line 18 of that file → only findings on that line survive
+	invCtx := setupDeltaMockContext(t, `{"version":1,"files":{"routes/likeProductReviews.ts":[{"start":18,"end":18}]}}`)
+	findingsModel := buildLocalFinding(t)
+	input := []workflow.Data{makeFindingsData(t, findingsModel)}
+
+	output, err := deltaFilterFindingsEntryPoint(invCtx, input)
+	require.NoError(t, err)
+	require.Len(t, output, 1)
+
+	var out local_models.LocalFinding
+	require.NoError(t, json.Unmarshal(output[0].GetPayload().([]byte), &out))
+	assert.True(t, len(out.Findings) > 0, "expected at least one finding on line 18")
+	assert.True(t, len(out.Findings) < len(findingsModel.Findings), "expected fewer findings after delta filter")
+}
+
+func TestDeltaFilterWorkflow_AllSentinel(t *testing.T) {
+	// "all" sentinel → every finding in that file passes
+	invCtx := setupDeltaMockContext(t, `{"version":1,"files":{"routes/likeProductReviews.ts":"all"}}`)
+	findingsModel := buildLocalFinding(t)
+	input := []workflow.Data{makeFindingsData(t, findingsModel)}
+
+	output, err := deltaFilterFindingsEntryPoint(invCtx, input)
+	require.NoError(t, err)
+	require.Len(t, output, 1)
+
+	var out local_models.LocalFinding
+	require.NoError(t, json.Unmarshal(output[0].GetPayload().([]byte), &out))
+	assert.True(t, len(out.Findings) > 0)
+}
+
+func TestDeltaFilterWorkflow_FileNotInScope(t *testing.T) {
+	// no matching file → zero findings
+	invCtx := setupDeltaMockContext(t, `{"version":1,"files":{"does/not/exist.ts":[{"start":1,"end":10}]}}`)
+	findingsModel := buildLocalFinding(t)
+	input := []workflow.Data{makeFindingsData(t, findingsModel)}
+
+	output, err := deltaFilterFindingsEntryPoint(invCtx, input)
+	require.NoError(t, err)
+	require.Len(t, output, 1)
+
+	var out local_models.LocalFinding
+	require.NoError(t, json.Unmarshal(output[0].GetPayload().([]byte), &out))
+	assert.Len(t, out.Findings, 0)
+}
+
+func TestDeltaFilterWorkflow_MalformedInputFailsClosed(t *testing.T) {
+	invCtx := setupDeltaMockContext(t, `{not valid json`)
+	findingsModel := buildLocalFinding(t)
+	input := []workflow.Data{makeFindingsData(t, findingsModel)}
+
+	_, err := deltaFilterFindingsEntryPoint(invCtx, input)
+	assert.Error(t, err)
+}
+
+func TestDeltaFilterWorkflow_EmptyFilesFailsClosed(t *testing.T) {
+	invCtx := setupDeltaMockContext(t, `{"version":1,"files":{}}`)
+	findingsModel := buildLocalFinding(t)
+	input := []workflow.Data{makeFindingsData(t, findingsModel)}
+
+	_, err := deltaFilterFindingsEntryPoint(invCtx, input)
+	assert.Error(t, err)
+}
+
+func TestDeltaFilterWorkflow_NonFindingDataPassThrough(t *testing.T) {
+	invCtx := setupDeltaMockContext(t, `{"version":1,"files":{"a.py":[{"start":1,"end":10}]}}`)
+	randomData := workflow.NewData(
+		workflow.NewTypeIdentifier(WORKFLOWID_FILTER_FINDINGS_DELTA, "random"),
+		"application/random",
+		[]byte("random"),
+	)
+	output, err := deltaFilterFindingsEntryPoint(invCtx, []workflow.Data{randomData})
+	require.NoError(t, err)
+	require.Len(t, output, 1)
+	assert.Equal(t, randomData, output[0])
+}
+
+func TestDeltaFilterWorkflow_SummaryUpdatedAfterFilter(t *testing.T) {
+	// After filtering, the summary counts should reflect remaining findings
+	invCtx := setupDeltaMockContext(t, `{"version":1,"files":{"routes/likeProductReviews.ts":[{"start":18,"end":18}]}}`)
+	findingsModel := buildLocalFinding(t)
+	input := []workflow.Data{makeFindingsData(t, findingsModel)}
+
+	output, err := deltaFilterFindingsEntryPoint(invCtx, input)
+	require.NoError(t, err)
+	require.Len(t, output, 1)
+
+	var out local_models.LocalFinding
+	require.NoError(t, json.Unmarshal(output[0].GetPayload().([]byte), &out))
+
+	// sum of summary counts should equal number of findings
+	var totalFromSummary uint32
+	for _, v := range out.Summary.Counts.CountBy.Severity {
+		totalFromSummary += v
+	}
+	assert.Equal(t, uint32(len(out.Findings)), totalFromSummary, "summary counts should match filtered findings")
+}

--- a/pkg/local_workflows/local_workflows.go
+++ b/pkg/local_workflows/local_workflows.go
@@ -18,6 +18,7 @@ func Init(engine workflow.Engine) error {
 		InitConfigWorkflow,
 		InitDataTransformationWorkflow,
 		InitFilterFindingsWorkflow,
+		InitDeltaFilterFindingsWorkflow,
 		doctor_workflow.InitDoctorWorkflow,
 	}
 


### PR DESCRIPTION
## What

Adds `findings.filter.delta` — a product-agnostic line-range delta filter operating on the GAF workflow layer. Given explicit changed files + line ranges, returns only findings whose location intersects changed lines. Handles both `LOCAL_FINDING_MODEL` (Snyk Code) and `UFM_RESULT` (Secrets) content types so both products are covered without any changes to their extensions.

## Why

Brings the line-granularity filtering currently done in the Secure At Inception Claude Code hook into the CLI as a reusable primitive. File granularity already exists via `code-client-go` `changedFiles`/`limitToFiles`; this adds the line layer. Any finding-producing product (SAST, Secrets, …) gets "only show me what I changed" without product-specific code.

## Contract

Explicit JSON input (`--changed-lines-file` / `--changed-lines`), no git. Schema v1:

```json
{
  "version": 1,
  "files": {
    "src/app.py":      [{ "start": 10, "end": 24 }, { "start": 80, "end": 80 }],
    "src/new_file.py": "all"
  }
}
```

**Fail behaviour (split by case):**
- Absent input → no-op pass-through (normal full scan, identical to today)
- Malformed input → fail closed (catalog error, non-zero exit, no misleading clean result)
- Empty `files: {}` → fail closed ("omit the flag for a full scan")

**Finding with file in scope but no line data → kept** (false positive beats false negative for a security gate).

## Files changed

| File | Purpose |
|------|---------|
| `internal/utils/findings/delta.go` | Core: `ParseChangedScope`, `NormalizeRelPath`, `mergeRanges`, `ChangedScope`, `GetDeltaFilter` (LocalFinding adapter) |
| `internal/utils/findings/delta_test.go` | 30+ table-driven tests: parse/validate, merge-ranges, path normalisation, intersection, GetDeltaFilter edge cases |
| `pkg/local_workflows/delta_filter_workflow.go` | `findings.filter.delta` workflow; dispatches on content type; UFM adapter via `filteredTestResult` wrapper |
| `pkg/local_workflows/delta_filter_workflow_test.go` | Workflow-level tests using real juice-shop SARIF fixture |
| `pkg/configuration/constants.go` | `FLAG_CHANGED_LINES_FILE`, `FLAG_CHANGED_LINES` constants |
| `pkg/local_workflows/local_workflows.go` | Registers `InitDeltaFilterFindingsWorkflow` |

## Tests

- `go test ./internal/utils/findings/` — all pass (intersection-not-containment, multi-range, `"all"` sentinel, path normalisation, malformed input enumeration)
- `go test ./pkg/local_workflows/` — all pass (registration, no-flag pass-through, line filter, file not in scope, malformed fail-closed, summary recomputed)

## Known follow-ups

- **UFM summary counts** — after delta filtering UFM findings, `EffectiveSummary`/`RawSummary` on the TestResult still reflect pre-filter counts. For `snyk secrets test --json` consumers the count fields will be stale. Fixing requires a summary-update path on the TestResult interface or post-filter reconstruction.
- **CLI wiring** — companion PR in the CLI repo inserts this workflow into `runWorkflowAndProcessData` between the severity filter and output workflow.

## Companion PR

CLI PR wires this workflow into the command chain for `snyk code test` and `snyk secrets test` (both share `runWorkflowAndProcessData`).