### PR TITLE
feat(fileupload): add path encoder and content transcoder options

### DIFF
--- a/internal/api/fileupload/uploadrevision/client.go
+++ b/internal/api/fileupload/uploadrevision/client.go
@@ -105,7 +105,7 @@ func (c *HTTPSealableClient) CreateRevision(ctx context.Context, orgID OrgID) (*
 	return &respBody, nil
 }
 
-// UploadFiles uploads the provided files to the specified revision. It will not close the file descriptors.
+// UploadFiles uploads the provided files to the specified revision.
 func (c *HTTPSealableClient) UploadFiles(ctx context.Context, orgID OrgID, revisionID RevisionID, files []UploadFile) error {
 	if orgID == uuid.Nil {
 		return ErrEmptyOrgID
@@ -174,7 +174,7 @@ func streamFilesToPipe(pipeWriter *io.PipeWriter, mpartWriter *multipart.Writer,
 			return
 		}
 
-		if _, err := io.Copy(part, file.File); err != nil {
+		if _, err := part.Write(file.Content); err != nil {
 			streamError = fmt.Errorf("failed to copy file content for %s: %w", file.Path, err)
 			return
 		}
@@ -197,20 +197,12 @@ func validateFiles(files []UploadFile) error {
 			return NewFilePathLengthLimitError(file.Path, len(file.Path), filePathLengthLimit)
 		}
 
-		fileInfo, err := file.File.Stat()
-		if err != nil {
-			return NewFileAccessError(file.Path, err)
+		fileSize := int64(len(file.Content))
+		if fileSize > fileSizeLimit {
+			return NewFileSizeLimitError(file.Path, fileSize, fileSizeLimit)
 		}
 
-		if !fileInfo.Mode().IsRegular() {
-			return NewSpecialFileError(file.Path, fileInfo.Mode())
-		}
-
-		if fileInfo.Size() > fileSizeLimit {
-			return NewFileSizeLimitError(file.Path, fileInfo.Size(), fileSizeLimit)
-		}
-
-		totalPayloadSize += fileInfo.Size()
+		totalPayloadSize += fileSize
 	}
 
 	if totalPayloadSize > totalPayloadSizeLimit {

--- a/internal/api/fileupload/uploadrevision/client.go
+++ b/internal/api/fileupload/uploadrevision/client.go
@@ -174,7 +174,7 @@ func streamFilesToPipe(pipeWriter *io.PipeWriter, mpartWriter *multipart.Writer,
 			return
 		}
 
-		if _, err := part.Write(file.Content); err != nil {
+		if _, err := io.Copy(part, file.Reader); err != nil {
 			streamError = fmt.Errorf("failed to copy file content for %s: %w", file.Path, err)
 			return
 		}
@@ -197,12 +197,11 @@ func validateFiles(files []UploadFile) error {
 			return NewFilePathLengthLimitError(file.Path, len(file.Path), filePathLengthLimit)
 		}
 
-		fileSize := int64(len(file.Content))
-		if fileSize > fileSizeLimit {
-			return NewFileSizeLimitError(file.Path, fileSize, fileSizeLimit)
+		if file.Size > fileSizeLimit {
+			return NewFileSizeLimitError(file.Path, file.Size, fileSizeLimit)
 		}
 
-		totalPayloadSize += fileSize
+		totalPayloadSize += file.Size
 	}
 
 	if totalPayloadSize > totalPayloadSizeLimit {

--- a/internal/api/fileupload/uploadrevision/client_test.go
+++ b/internal/api/fileupload/uploadrevision/client_test.go
@@ -1,6 +1,7 @@
 package uploadrevision_test
 
 import (
+	"bytes"
 	"compress/gzip"
 	"context"
 	"errors"
@@ -24,6 +25,15 @@ var (
 	orgID = uuid.MustParse("9102b78b-c28d-4392-a39f-08dd26fd9622")
 	revID = uuid.MustParse("ff1bd2c6-7a5f-48fb-9a5b-52d711c8b47f")
 )
+
+// uploadFile builds an UploadFile whose Size matches the content its Reader produces.
+func uploadFile(path string, content []byte) uploadrevision2.UploadFile {
+	return uploadrevision2.UploadFile{
+		Path:   path,
+		Size:   int64(len(content)),
+		Reader: bytes.NewReader(content),
+	}
+}
 
 func TestClient_CreateRevision(t *testing.T) {
 	srv, c := setupTestServer(t)
@@ -71,7 +81,7 @@ func TestClient_UploadFiles(t *testing.T) {
 		orgID,
 		revID,
 		[]uploadrevision2.UploadFile{
-			{Path: "foo/bar", Content: []byte("asdf")},
+			uploadFile("foo/bar", []byte("asdf")),
 		})
 
 	require.NoError(t, err)
@@ -85,8 +95,8 @@ func TestClient_UploadFiles_MultipleFiles(t *testing.T) {
 		orgID,
 		revID,
 		[]uploadrevision2.UploadFile{
-			{Path: "file1.txt", Content: []byte("content1")},
-			{Path: "file2.json", Content: []byte("content2")},
+			uploadFile("file1.txt", []byte("content1")),
+			uploadFile("file2.json", []byte("content2")),
 		})
 
 	require.NoError(t, err)
@@ -99,7 +109,7 @@ func TestClient_UploadFiles_EmptyOrgID(t *testing.T) {
 		uuid.Nil, // empty orgID
 		revID,
 		[]uploadrevision2.UploadFile{
-			{Path: "test.txt", Content: []byte("content")},
+			uploadFile("test.txt", []byte("content")),
 		})
 
 	assert.Error(t, err)
@@ -113,7 +123,7 @@ func TestClient_UploadFiles_EmptyRevisionID(t *testing.T) {
 		orgID,
 		uuid.Nil, // empty revisionID
 		[]uploadrevision2.UploadFile{
-			{Path: "test.txt", Content: []byte("content")},
+			uploadFile("test.txt", []byte("content")),
 		})
 
 	assert.Error(t, err)
@@ -129,7 +139,7 @@ func TestClient_UploadFiles_FileSizeLimit(t *testing.T) {
 		orgID,
 		revID,
 		[]uploadrevision2.UploadFile{
-			{Path: "large_file.txt", Content: largeContent},
+			uploadFile("large_file.txt", largeContent),
 		})
 
 	assert.Error(t, err)
@@ -146,10 +156,7 @@ func TestClient_UploadFiles_FileCountLimit(t *testing.T) {
 	files := make([]uploadrevision2.UploadFile, c.GetLimits().FileCountLimit+1)
 
 	for i := range c.GetLimits().FileCountLimit + 1 {
-		files[i] = uploadrevision2.UploadFile{
-			Path:    fmt.Sprintf("file%d.txt", i),
-			Content: []byte("content"),
-		}
+		files[i] = uploadFile(fmt.Sprintf("file%d.txt", i), []byte("content"))
 	}
 
 	err := c.UploadFiles(context.Background(), orgID, revID, files)
@@ -171,7 +178,7 @@ func TestClient_UploadFiles_FilePathLengthLimit(t *testing.T) {
 		orgID,
 		revID,
 		[]uploadrevision2.UploadFile{
-			{Path: longFilePath, Content: []byte("content")},
+			uploadFile(longFilePath, []byte("content")),
 		})
 
 	assert.Error(t, err)
@@ -194,7 +201,7 @@ func TestClient_UploadFiles_FilePathLengthExactlyAtLimit(t *testing.T) {
 		orgID,
 		revID,
 		[]uploadrevision2.UploadFile{
-			{Path: filePathAtLimit, Content: []byte("content")},
+			uploadFile(filePathAtLimit, []byte("content")),
 		})
 
 	assert.NoError(t, err)
@@ -213,10 +220,7 @@ func TestClient_UploadFiles_TotalPayloadSizeLimit(t *testing.T) {
 	numFiles := 8
 
 	for i := range numFiles {
-		files = append(files, uploadrevision2.UploadFile{
-			Path:    fmt.Sprintf("file%d.txt", i),
-			Content: make([]byte, fileSize),
-		})
+		files = append(files, uploadFile(fmt.Sprintf("file%d.txt", i), make([]byte, fileSize)))
 	}
 
 	err := c.UploadFiles(context.Background(), orgID, revID, files)
@@ -241,10 +245,7 @@ func TestClient_UploadFiles_TotalPayloadSizeExactlyAtLimit(t *testing.T) {
 	numFiles := 5
 
 	for i := 0; i < numFiles; i++ {
-		files = append(files, uploadrevision2.UploadFile{
-			Path:    fmt.Sprintf("file%d.txt", i),
-			Content: make([]byte, fileSize),
-		})
+		files = append(files, uploadFile(fmt.Sprintf("file%d.txt", i), make([]byte, fileSize)))
 	}
 
 	err := c.UploadFiles(context.Background(), orgID, revID, files)
@@ -259,7 +260,7 @@ func TestClient_UploadFiles_IndividualFileSizeExactlyAtLimit(t *testing.T) {
 
 	// Test boundary: individual file exactly 50MB (should succeed)
 	err := c.UploadFiles(context.Background(), orgID, revID, []uploadrevision2.UploadFile{
-		{Path: "exact_limit.bin", Content: make([]byte, c.GetLimits().FileSizeLimit)},
+		uploadFile("exact_limit.bin", make([]byte, c.GetLimits().FileSizeLimit)),
 	})
 
 	// Should succeed - exactly at limit is allowed

--- a/internal/api/fileupload/uploadrevision/client_test.go
+++ b/internal/api/fileupload/uploadrevision/client_test.go
@@ -3,7 +3,6 @@ package uploadrevision_test
 import (
 	"bytes"
 	"compress/gzip"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -39,7 +38,7 @@ func TestClient_CreateRevision(t *testing.T) {
 	srv, c := setupTestServer(t)
 	defer srv.Close()
 
-	resp, err := c.CreateRevision(context.Background(), orgID)
+	resp, err := c.CreateRevision(t.Context(), orgID)
 
 	require.NoError(t, err)
 	expectedID := uuid.MustParse("a7d975fb-2076-49b7-bc1f-31c395c3ce93")
@@ -49,7 +48,7 @@ func TestClient_CreateRevision(t *testing.T) {
 func TestClient_CreateRevision_EmptyOrgID(t *testing.T) {
 	c := uploadrevision2.NewClient(uploadrevision2.Config{})
 
-	resp, err := c.CreateRevision(context.Background(), uuid.Nil)
+	resp, err := c.CreateRevision(t.Context(), uuid.Nil)
 
 	assert.Error(t, err)
 	assert.Nil(t, resp)
@@ -64,7 +63,7 @@ func TestClient_CreateRevision_ServerError(t *testing.T) {
 		BaseURL: srv.URL,
 	})
 
-	resp, err := c.CreateRevision(context.Background(), orgID)
+	resp, err := c.CreateRevision(t.Context(), orgID)
 
 	assert.Nil(t, resp)
 	var httpErr *uploadrevision2.HTTPError
@@ -77,7 +76,7 @@ func TestClient_UploadFiles(t *testing.T) {
 	srv, c := setupTestServer(t)
 	defer srv.Close()
 
-	err := c.UploadFiles(context.Background(),
+	err := c.UploadFiles(t.Context(),
 		orgID,
 		revID,
 		[]uploadrevision2.UploadFile{
@@ -91,7 +90,7 @@ func TestClient_UploadFiles_MultipleFiles(t *testing.T) {
 	srv, c := setupTestServer(t)
 	defer srv.Close()
 
-	err := c.UploadFiles(context.Background(),
+	err := c.UploadFiles(t.Context(),
 		orgID,
 		revID,
 		[]uploadrevision2.UploadFile{
@@ -105,7 +104,7 @@ func TestClient_UploadFiles_MultipleFiles(t *testing.T) {
 func TestClient_UploadFiles_EmptyOrgID(t *testing.T) {
 	c := uploadrevision2.NewClient(uploadrevision2.Config{})
 
-	err := c.UploadFiles(context.Background(),
+	err := c.UploadFiles(t.Context(),
 		uuid.Nil, // empty orgID
 		revID,
 		[]uploadrevision2.UploadFile{
@@ -119,7 +118,7 @@ func TestClient_UploadFiles_EmptyOrgID(t *testing.T) {
 func TestClient_UploadFiles_EmptyRevisionID(t *testing.T) {
 	c := uploadrevision2.NewClient(uploadrevision2.Config{})
 
-	err := c.UploadFiles(context.Background(),
+	err := c.UploadFiles(t.Context(),
 		orgID,
 		uuid.Nil, // empty revisionID
 		[]uploadrevision2.UploadFile{
@@ -135,7 +134,7 @@ func TestClient_UploadFiles_FileSizeLimit(t *testing.T) {
 
 	largeContent := make([]byte, c.GetLimits().FileSizeLimit+1)
 
-	err := c.UploadFiles(context.Background(),
+	err := c.UploadFiles(t.Context(),
 		orgID,
 		revID,
 		[]uploadrevision2.UploadFile{
@@ -159,7 +158,7 @@ func TestClient_UploadFiles_FileCountLimit(t *testing.T) {
 		files[i] = uploadFile(fmt.Sprintf("file%d.txt", i), []byte("content"))
 	}
 
-	err := c.UploadFiles(context.Background(), orgID, revID, files)
+	err := c.UploadFiles(t.Context(), orgID, revID, files)
 
 	assert.Error(t, err)
 	var fileCountErr *uploadrevision2.FileCountLimitError
@@ -174,7 +173,7 @@ func TestClient_UploadFiles_FilePathLengthLimit(t *testing.T) {
 	// Create a file path that exceeds the limit
 	longFilePath := strings.Repeat("a", c.GetLimits().FilePathLengthLimit+1)
 
-	err := c.UploadFiles(context.Background(),
+	err := c.UploadFiles(t.Context(),
 		orgID,
 		revID,
 		[]uploadrevision2.UploadFile{
@@ -197,7 +196,7 @@ func TestClient_UploadFiles_FilePathLengthExactlyAtLimit(t *testing.T) {
 	filePathAtLimit := strings.Repeat("a", c.GetLimits().FilePathLengthLimit)
 
 	// This should not error since the file path is exactly at the limit
-	err := c.UploadFiles(context.Background(),
+	err := c.UploadFiles(t.Context(),
 		orgID,
 		revID,
 		[]uploadrevision2.UploadFile{
@@ -223,7 +222,7 @@ func TestClient_UploadFiles_TotalPayloadSizeLimit(t *testing.T) {
 		files = append(files, uploadFile(fmt.Sprintf("file%d.txt", i), make([]byte, fileSize)))
 	}
 
-	err := c.UploadFiles(context.Background(), orgID, revID, files)
+	err := c.UploadFiles(t.Context(), orgID, revID, files)
 
 	assert.Error(t, err)
 	var totalSizeErr *uploadrevision2.TotalPayloadSizeLimitError
@@ -248,7 +247,7 @@ func TestClient_UploadFiles_TotalPayloadSizeExactlyAtLimit(t *testing.T) {
 		files = append(files, uploadFile(fmt.Sprintf("file%d.txt", i), make([]byte, fileSize)))
 	}
 
-	err := c.UploadFiles(context.Background(), orgID, revID, files)
+	err := c.UploadFiles(t.Context(), orgID, revID, files)
 
 	// Should succeed - exactly at limit is allowed
 	assert.NoError(t, err)
@@ -259,7 +258,7 @@ func TestClient_UploadFiles_IndividualFileSizeExactlyAtLimit(t *testing.T) {
 	defer srv.Close()
 
 	// Test boundary: individual file exactly 50MB (should succeed)
-	err := c.UploadFiles(context.Background(), orgID, revID, []uploadrevision2.UploadFile{
+	err := c.UploadFiles(t.Context(), orgID, revID, []uploadrevision2.UploadFile{
 		uploadFile("exact_limit.bin", make([]byte, c.GetLimits().FileSizeLimit)),
 	})
 
@@ -270,7 +269,7 @@ func TestClient_UploadFiles_IndividualFileSizeExactlyAtLimit(t *testing.T) {
 func TestClient_UploadFiles_EmptyFileList(t *testing.T) {
 	c := uploadrevision2.NewClient(uploadrevision2.Config{})
 
-	err := c.UploadFiles(context.Background(), orgID, revID, []uploadrevision2.UploadFile{})
+	err := c.UploadFiles(t.Context(), orgID, revID, []uploadrevision2.UploadFile{})
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, uploadrevision2.ErrNoFilesUploaded)
@@ -280,7 +279,7 @@ func TestClient_SealRevision(t *testing.T) {
 	srv, c := setupTestServer(t)
 	defer srv.Close()
 
-	resp, err := c.SealRevision(context.Background(), orgID, revID)
+	resp, err := c.SealRevision(t.Context(), orgID, revID)
 
 	require.NoError(t, err)
 	assert.Equal(t, revID, resp.Data.ID)
@@ -290,7 +289,7 @@ func TestClient_SealRevision(t *testing.T) {
 func TestClient_SealRevision_EmptyOrgID(t *testing.T) {
 	c := uploadrevision2.NewClient(uploadrevision2.Config{})
 
-	resp, err := c.SealRevision(context.Background(),
+	resp, err := c.SealRevision(t.Context(),
 		uuid.Nil, // empty orgID
 		revID,
 	)
@@ -303,7 +302,7 @@ func TestClient_SealRevision_EmptyOrgID(t *testing.T) {
 func TestClient_SealRevision_EmptyRevisionID(t *testing.T) {
 	c := uploadrevision2.NewClient(uploadrevision2.Config{})
 
-	resp, err := c.SealRevision(context.Background(),
+	resp, err := c.SealRevision(t.Context(),
 		orgID,
 		uuid.Nil, // empty revisionID
 	)

--- a/internal/api/fileupload/uploadrevision/client_test.go
+++ b/internal/api/fileupload/uploadrevision/client_test.go
@@ -6,17 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"mime"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path"
-	"runtime"
 	"strings"
 	"testing"
-	"testing/fstest"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -72,17 +67,11 @@ func TestClient_UploadFiles(t *testing.T) {
 	srv, c := setupTestServer(t)
 	defer srv.Close()
 
-	mockFS := fstest.MapFS{
-		"foo/bar": {Data: []byte("asdf")},
-	}
-	fd, err := mockFS.Open("foo/bar")
-	require.NoError(t, err)
-
-	err = c.UploadFiles(context.Background(),
+	err := c.UploadFiles(context.Background(),
 		orgID,
 		revID,
 		[]uploadrevision2.UploadFile{
-			{Path: "foo/bar", File: fd},
+			{Path: "foo/bar", Content: []byte("asdf")},
 		})
 
 	require.NoError(t, err)
@@ -92,22 +81,12 @@ func TestClient_UploadFiles_MultipleFiles(t *testing.T) {
 	srv, c := setupTestServer(t)
 	defer srv.Close()
 
-	mockFS := fstest.MapFS{
-		"file1.txt":  {Data: []byte("content1")},
-		"file2.json": {Data: []byte("content2")},
-	}
-
-	file1, err := mockFS.Open("file1.txt")
-	require.NoError(t, err)
-	file2, err := mockFS.Open("file2.json")
-	require.NoError(t, err)
-
-	err = c.UploadFiles(context.Background(),
+	err := c.UploadFiles(context.Background(),
 		orgID,
 		revID,
 		[]uploadrevision2.UploadFile{
-			{Path: "file1.txt", File: file1},
-			{Path: "file2.json", File: file2},
+			{Path: "file1.txt", Content: []byte("content1")},
+			{Path: "file2.json", Content: []byte("content2")},
 		})
 
 	require.NoError(t, err)
@@ -116,17 +95,11 @@ func TestClient_UploadFiles_MultipleFiles(t *testing.T) {
 func TestClient_UploadFiles_EmptyOrgID(t *testing.T) {
 	c := uploadrevision2.NewClient(uploadrevision2.Config{})
 
-	mockFS := fstest.MapFS{
-		"test.txt": {Data: []byte("content")},
-	}
-	file, err := mockFS.Open("test.txt")
-	require.NoError(t, err)
-
-	err = c.UploadFiles(context.Background(),
+	err := c.UploadFiles(context.Background(),
 		uuid.Nil, // empty orgID
 		revID,
 		[]uploadrevision2.UploadFile{
-			{Path: "test.txt", File: file},
+			{Path: "test.txt", Content: []byte("content")},
 		})
 
 	assert.Error(t, err)
@@ -136,17 +109,11 @@ func TestClient_UploadFiles_EmptyOrgID(t *testing.T) {
 func TestClient_UploadFiles_EmptyRevisionID(t *testing.T) {
 	c := uploadrevision2.NewClient(uploadrevision2.Config{})
 
-	mockFS := fstest.MapFS{
-		"test.txt": {Data: []byte("content")},
-	}
-	file, err := mockFS.Open("test.txt")
-	require.NoError(t, err)
-
-	err = c.UploadFiles(context.Background(),
+	err := c.UploadFiles(context.Background(),
 		orgID,
 		uuid.Nil, // empty revisionID
 		[]uploadrevision2.UploadFile{
-			{Path: "test.txt", File: file},
+			{Path: "test.txt", Content: []byte("content")},
 		})
 
 	assert.Error(t, err)
@@ -157,18 +124,12 @@ func TestClient_UploadFiles_FileSizeLimit(t *testing.T) {
 	c := uploadrevision2.NewClient(uploadrevision2.Config{})
 
 	largeContent := make([]byte, c.GetLimits().FileSizeLimit+1)
-	mockFS := fstest.MapFS{
-		"large_file.txt": {Data: largeContent},
-	}
 
-	file, err := mockFS.Open("large_file.txt")
-	require.NoError(t, err)
-
-	err = c.UploadFiles(context.Background(),
+	err := c.UploadFiles(context.Background(),
 		orgID,
 		revID,
 		[]uploadrevision2.UploadFile{
-			{Path: "large_file.txt", File: file},
+			{Path: "large_file.txt", Content: largeContent},
 		})
 
 	assert.Error(t, err)
@@ -183,18 +144,11 @@ func TestClient_UploadFiles_FileCountLimit(t *testing.T) {
 	c := uploadrevision2.NewClient(uploadrevision2.Config{})
 
 	files := make([]uploadrevision2.UploadFile, c.GetLimits().FileCountLimit+1)
-	mockFS := fstest.MapFS{}
 
 	for i := range c.GetLimits().FileCountLimit + 1 {
-		filename := fmt.Sprintf("file%d.txt", i)
-		mockFS[filename] = &fstest.MapFile{Data: []byte("content")}
-
-		file, err := mockFS.Open(filename)
-		require.NoError(t, err)
-
 		files[i] = uploadrevision2.UploadFile{
-			Path: filename,
-			File: file,
+			Path:    fmt.Sprintf("file%d.txt", i),
+			Content: []byte("content"),
 		}
 	}
 
@@ -213,18 +167,11 @@ func TestClient_UploadFiles_FilePathLengthLimit(t *testing.T) {
 	// Create a file path that exceeds the limit
 	longFilePath := strings.Repeat("a", c.GetLimits().FilePathLengthLimit+1)
 
-	mockFS := fstest.MapFS{
-		"short_file.txt": {Data: []byte("content")},
-	}
-
-	file, err := mockFS.Open("short_file.txt")
-	require.NoError(t, err)
-
-	err = c.UploadFiles(context.Background(),
+	err := c.UploadFiles(context.Background(),
 		orgID,
 		revID,
 		[]uploadrevision2.UploadFile{
-			{Path: longFilePath, File: file},
+			{Path: longFilePath, Content: []byte("content")},
 		})
 
 	assert.Error(t, err)
@@ -242,19 +189,12 @@ func TestClient_UploadFiles_FilePathLengthExactlyAtLimit(t *testing.T) {
 	// Create a file name that is exactly at the limit
 	filePathAtLimit := strings.Repeat("a", c.GetLimits().FilePathLengthLimit)
 
-	mockFS := fstest.MapFS{
-		"short_file.txt": {Data: []byte("content")},
-	}
-
-	file, err := mockFS.Open("short_file.txt")
-	require.NoError(t, err)
-
 	// This should not error since the file path is exactly at the limit
-	err = c.UploadFiles(context.Background(),
+	err := c.UploadFiles(context.Background(),
 		orgID,
 		revID,
 		[]uploadrevision2.UploadFile{
-			{Path: filePathAtLimit, File: file},
+			{Path: filePathAtLimit, Content: []byte("content")},
 		})
 
 	assert.NoError(t, err)
@@ -265,7 +205,6 @@ func TestClient_UploadFiles_TotalPayloadSizeLimit(t *testing.T) {
 
 	// Create multiple files that individually are under the size limit,
 	// but together exceed the total payload size limit
-	mockFS := fstest.MapFS{}
 	files := []uploadrevision2.UploadFile{}
 
 	// Use files that are 30MB each (under the 50MB individual limit)
@@ -274,15 +213,9 @@ func TestClient_UploadFiles_TotalPayloadSizeLimit(t *testing.T) {
 	numFiles := 8
 
 	for i := range numFiles {
-		filename := fmt.Sprintf("file%d.txt", i)
-		mockFS[filename] = &fstest.MapFile{Data: make([]byte, fileSize)}
-
-		file, err := mockFS.Open(filename)
-		require.NoError(t, err)
-
 		files = append(files, uploadrevision2.UploadFile{
-			Path: filename,
-			File: file,
+			Path:    fmt.Sprintf("file%d.txt", i),
+			Content: make([]byte, fileSize),
 		})
 	}
 
@@ -300,7 +233,6 @@ func TestClient_UploadFiles_TotalPayloadSizeExactlyAtLimit(t *testing.T) {
 	defer srv.Close()
 
 	// Test boundary: exactly 200MB (should succeed)
-	mockFS := fstest.MapFS{}
 	files := []uploadrevision2.UploadFile{}
 
 	// Create files that sum exactly to 200MB
@@ -309,15 +241,9 @@ func TestClient_UploadFiles_TotalPayloadSizeExactlyAtLimit(t *testing.T) {
 	numFiles := 5
 
 	for i := 0; i < numFiles; i++ {
-		filename := fmt.Sprintf("file%d.txt", i)
-		mockFS[filename] = &fstest.MapFile{Data: make([]byte, fileSize)}
-
-		file, err := mockFS.Open(filename)
-		require.NoError(t, err)
-
 		files = append(files, uploadrevision2.UploadFile{
-			Path: filename,
-			File: file,
+			Path:    fmt.Sprintf("file%d.txt", i),
+			Content: make([]byte, fileSize),
 		})
 	}
 
@@ -332,116 +258,11 @@ func TestClient_UploadFiles_IndividualFileSizeExactlyAtLimit(t *testing.T) {
 	defer srv.Close()
 
 	// Test boundary: individual file exactly 50MB (should succeed)
-	mockFS := fstest.MapFS{
-		"exact_limit.bin": {Data: make([]byte, c.GetLimits().FileSizeLimit)},
-	}
-
-	file, err := mockFS.Open("exact_limit.bin")
-	require.NoError(t, err)
-
-	err = c.UploadFiles(context.Background(), orgID, revID, []uploadrevision2.UploadFile{
-		{Path: "exact_limit.bin", File: file},
+	err := c.UploadFiles(context.Background(), orgID, revID, []uploadrevision2.UploadFile{
+		{Path: "exact_limit.bin", Content: make([]byte, c.GetLimits().FileSizeLimit)},
 	})
 
 	// Should succeed - exactly at limit is allowed
-	assert.NoError(t, err)
-}
-
-func TestClient_UploadFiles_SpecialFileError(t *testing.T) {
-	c := uploadrevision2.NewClient(uploadrevision2.Config{})
-
-	tests := []struct {
-		name          string
-		setupFS       func() (fstest.MapFS, string)
-		setupRealFile func() string
-	}{
-		{
-			name: "directory file",
-			setupFS: func() (fstest.MapFS, string) {
-				return fstest.MapFS{
-					"test-directory": &fstest.MapFile{
-						Mode: fs.ModeDir,
-					},
-				}, "test-directory"
-			},
-		},
-	}
-
-	// on non windows os test this case
-	if runtime.GOOS != "windows" {
-		tests = append(tests, struct {
-			name          string
-			setupFS       func() (fstest.MapFS, string)
-			setupRealFile func() string
-		}{
-			name: "device file",
-			setupRealFile: func() string {
-				return "/dev/null"
-			},
-		})
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var file fs.File
-			var filePath string
-			var err error
-
-			if tt.setupFS != nil {
-				mockFS, path := tt.setupFS()
-				filePath = path
-				file, err = mockFS.Open(path)
-				require.NoError(t, err)
-			} else if tt.setupRealFile != nil {
-				filePath = tt.setupRealFile()
-
-				realFile, openErr := os.Open(filePath)
-				require.NoError(t, openErr)
-				defer realFile.Close()
-				file = realFile
-			}
-
-			err = c.UploadFiles(context.Background(),
-				orgID,
-				revID,
-				[]uploadrevision2.UploadFile{
-					{Path: filePath, File: file},
-				})
-
-			assert.Error(t, err)
-
-			var sfe *uploadrevision2.SpecialFileError
-			assert.ErrorAs(t, err, &sfe)
-			assert.Equal(t, filePath, sfe.FilePath)
-		})
-	}
-}
-
-func TestClient_UploadFiles_Symlink(t *testing.T) {
-	srv, c := setupTestServer(t)
-	defer srv.Close()
-
-	tmpDir := t.TempDir()
-	tmpFile := path.Join(tmpDir, "temp-regular-file")
-
-	err := os.WriteFile(tmpFile, []byte("foo bar"), 0o600)
-	require.NoError(t, err)
-
-	tmpSlnPth := path.Join(tmpDir, "temp-symlink")
-	err = os.Symlink(tmpFile, tmpSlnPth)
-	require.NoError(t, err)
-
-	tmpSln, err := os.Open(tmpSlnPth)
-	require.NoError(t, err)
-	defer tmpSln.Close()
-
-	err = c.UploadFiles(context.Background(),
-		orgID,
-		revID,
-		[]uploadrevision2.UploadFile{
-			{Path: tmpSlnPth, File: tmpSln},
-		})
-
 	assert.NoError(t, err)
 }
 

--- a/internal/api/fileupload/uploadrevision/fake_client.go
+++ b/internal/api/fileupload/uploadrevision/fake_client.go
@@ -3,7 +3,6 @@ package uploadrevision
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/google/uuid"
 )
@@ -79,20 +78,12 @@ func (f *FakeSealableClient) UploadFiles(_ context.Context, orgID OrgID, revisio
 
 	var totalPayloadSize int64
 	for _, file := range files {
-		fileInfo, err := file.File.Stat()
-		if err != nil {
-			return NewFileAccessError(file.Path, err)
+		fileSize := int64(len(file.Content))
+		if fileSize > f.cfg.FileSizeLimit {
+			return NewFileSizeLimitError(file.Path, fileSize, f.cfg.FileSizeLimit)
 		}
 
-		if !fileInfo.Mode().IsRegular() {
-			return NewSpecialFileError(file.Path, fileInfo.Mode())
-		}
-
-		if fileInfo.Size() > f.cfg.FileSizeLimit {
-			return NewFileSizeLimitError(file.Path, fileInfo.Size(), f.cfg.FileSizeLimit)
-		}
-
-		totalPayloadSize += fileInfo.Size()
+		totalPayloadSize += fileSize
 	}
 
 	if totalPayloadSize > f.cfg.TotalPayloadSizeLimit {
@@ -100,13 +91,9 @@ func (f *FakeSealableClient) UploadFiles(_ context.Context, orgID OrgID, revisio
 	}
 
 	for _, file := range files {
-		bts, err := io.ReadAll(file.File)
-		if err != nil {
-			return err
-		}
 		rev.files = append(rev.files, LoadedFile{
 			Path:    file.Path,
-			Content: string(bts),
+			Content: string(file.Content),
 		})
 	}
 	return nil

--- a/internal/api/fileupload/uploadrevision/fake_client.go
+++ b/internal/api/fileupload/uploadrevision/fake_client.go
@@ -3,6 +3,7 @@ package uploadrevision
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/google/uuid"
 )
@@ -78,12 +79,11 @@ func (f *FakeSealableClient) UploadFiles(_ context.Context, orgID OrgID, revisio
 
 	var totalPayloadSize int64
 	for _, file := range files {
-		fileSize := int64(len(file.Content))
-		if fileSize > f.cfg.FileSizeLimit {
-			return NewFileSizeLimitError(file.Path, fileSize, f.cfg.FileSizeLimit)
+		if file.Size > f.cfg.FileSizeLimit {
+			return NewFileSizeLimitError(file.Path, file.Size, f.cfg.FileSizeLimit)
 		}
 
-		totalPayloadSize += fileSize
+		totalPayloadSize += file.Size
 	}
 
 	if totalPayloadSize > f.cfg.TotalPayloadSizeLimit {
@@ -91,9 +91,14 @@ func (f *FakeSealableClient) UploadFiles(_ context.Context, orgID OrgID, revisio
 	}
 
 	for _, file := range files {
+		content, err := io.ReadAll(file.Reader)
+		if err != nil {
+			return NewFileAccessError(file.Path, err)
+		}
+
 		rev.files = append(rev.files, LoadedFile{
 			Path:    file.Path,
-			Content: string(file.Content),
+			Content: string(content),
 		})
 	}
 	return nil

--- a/internal/api/fileupload/uploadrevision/types.go
+++ b/internal/api/fileupload/uploadrevision/types.go
@@ -1,8 +1,6 @@
 package uploadrevision
 
 import (
-	"io/fs"
-
 	"github.com/google/uuid"
 )
 
@@ -110,10 +108,10 @@ type ErrorResponseBody struct {
 	Errors []ResponseError `json:"errors"`
 }
 
-// UploadFile represents a file to be uploaded, containing both the path and file handle.
+// UploadFile represents a file to be uploaded, containing both the path and the content.
 type UploadFile struct {
-	Path string // The path of the uploaded file, relative to the root directory.
-	File fs.File
+	Path    string // The path of the uploaded file, relative to the root directory.
+	Content []byte // The content to upload, already read and transcoded.
 }
 
 const (

--- a/internal/api/fileupload/uploadrevision/types.go
+++ b/internal/api/fileupload/uploadrevision/types.go
@@ -1,6 +1,8 @@
 package uploadrevision
 
 import (
+	"io"
+
 	"github.com/google/uuid"
 )
 
@@ -108,10 +110,18 @@ type ErrorResponseBody struct {
 	Errors []ResponseError `json:"errors"`
 }
 
-// UploadFile represents a file to be uploaded, containing both the path and the content.
+// UploadFile represents a file to be uploaded: where it goes, how large its content is, and a
+// reader producing that content.
 type UploadFile struct {
-	Path    string // The path of the uploaded file, relative to the root directory.
-	Content []byte // The content to upload, already read and transcoded.
+	Path string // The path of the uploaded file, relative to the root directory.
+
+	// Size is the size in bytes of the content Reader produces. It is measured before the
+	// upload, so a file changing in between makes it disagree with what is streamed.
+	Size int64
+
+	// Reader produces the content to upload. It is read while the file is streamed, so the
+	// content is only held in memory for as long as that file is being uploaded.
+	Reader io.Reader
 }
 
 const (

--- a/pkg/apiclients/fileupload/batch.go
+++ b/pkg/apiclients/fileupload/batch.go
@@ -50,7 +50,22 @@ func readAndTranscode(path string, transcode ContentTranscoder) ([]byte, error) 
 		return nil, err
 	}
 
+	if transcode == nil {
+		return content, nil
+	}
+
 	return transcode(content)
+}
+
+// checkReadable confirms the file can be opened, so that an unreadable file is skipped during
+// batching rather than failing the whole batch when it is streamed.
+func checkReadable(path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+
+	return file.Close()
 }
 
 // transcodedFileReader reads and transcodes a file the first time it is read, so that a batched
@@ -119,15 +134,24 @@ func batchPaths(
 				continue
 			}
 
-			// Only the size is kept; the content is read again when the file is streamed.
-			content, err := readAndTranscode(path, contentTranscoder)
-			if err != nil {
-				logger.Debug().Msgf("failed to read file: %s", path)
+			if err := checkReadable(path); err != nil {
+				logger.Debug().Msgf("failed to open file: %s", path)
 				skipped = append(skipped, SkippedFile{Path: relPath, Reason: uploadrevision.NewFileAccessError(path, err)})
 				continue
 			}
 
-			fileSize := int64(len(content))
+			// Without a transcoder the uploaded content is the file as it is on disk, so the
+			// stat above already gives its size and the file does not need reading here.
+			fileSize := info.Size()
+			if contentTranscoder != nil {
+				content, err := readAndTranscode(path, contentTranscoder)
+				if err != nil {
+					logger.Debug().Msgf("failed to read file: %s", path)
+					skipped = append(skipped, SkippedFile{Path: relPath, Reason: uploadrevision.NewFileAccessError(path, err)})
+					continue
+				}
+				fileSize = int64(len(content))
+			}
 
 			ff := applyFilters(fileToFilter{Path: relPath, Size: fileSize}, filters...)
 			if ff != nil {

--- a/pkg/apiclients/fileupload/batch.go
+++ b/pkg/apiclients/fileupload/batch.go
@@ -1,6 +1,7 @@
 package fileupload
 
 import (
+	"bytes"
 	"iter"
 	"os"
 
@@ -41,6 +42,39 @@ func (b *uploadBatch) isEmpty() bool {
 type batchingResult struct {
 	batch        *uploadBatch
 	skippedFiles []SkippedFile
+}
+
+func readAndTranscode(path string, transcode ContentTranscoder) ([]byte, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return transcode(content)
+}
+
+// transcodedFileReader reads and transcodes a file the first time it is read, so that a batched
+// file holds neither its content nor a file descriptor until it is streamed.
+//
+// content is the read cursor, not a cache: ContentTranscoder transforms a whole []byte at once,
+// so the transcoded bytes cannot be produced incrementally and have to outlive the individual
+// Read calls io.Copy makes. They are released with the batch.
+type transcodedFileReader struct {
+	path      string
+	transcode ContentTranscoder
+	content   *bytes.Reader
+}
+
+func (r *transcodedFileReader) Read(p []byte) (int, error) {
+	if r.content == nil {
+		content, err := readAndTranscode(r.path, r.transcode)
+		if err != nil {
+			return 0, err
+		}
+		r.content = bytes.NewReader(content)
+	}
+
+	return r.content.Read(p)
 }
 
 func batchPaths(
@@ -85,16 +119,10 @@ func batchPaths(
 				continue
 			}
 
-			content, err := os.ReadFile(path)
+			// Only the size is kept; the content is read again when the file is streamed.
+			content, err := readAndTranscode(path, contentTranscoder)
 			if err != nil {
 				logger.Debug().Msgf("failed to read file: %s", path)
-				skipped = append(skipped, SkippedFile{Path: relPath, Reason: uploadrevision.NewFileAccessError(path, err)})
-				continue
-			}
-
-			content, err = contentTranscoder(content)
-			if err != nil {
-				logger.Debug().Msgf("failed to transcode file: %s", path)
 				skipped = append(skipped, SkippedFile{Path: relPath, Reason: uploadrevision.NewFileAccessError(path, err)})
 				continue
 			}
@@ -122,8 +150,9 @@ func batchPaths(
 			}
 
 			batch.addFile(uploadrevision.UploadFile{
-				Path:    relPath,
-				Content: content,
+				Path:   relPath,
+				Size:   fileSize,
+				Reader: &transcodedFileReader{path: path, transcode: contentTranscoder},
 			}, fileSize)
 		}
 

--- a/pkg/apiclients/fileupload/batch.go
+++ b/pkg/apiclients/fileupload/batch.go
@@ -24,9 +24,9 @@ func newUploadBatch(limits uploadrevision.Limits) *uploadBatch {
 	}
 }
 
-func (b *uploadBatch) addFile(file uploadrevision.UploadFile, fileSize int64) {
+func (b *uploadBatch) addFile(file uploadrevision.UploadFile) {
 	b.files = append(b.files, file)
-	b.currentSize += fileSize
+	b.currentSize += file.Size
 }
 
 func (b *uploadBatch) wouldExceedLimits(fileSize int64) bool {
@@ -92,6 +92,55 @@ func (r *transcodedFileReader) Read(p []byte) (int, error) {
 	return r.content.Read(p)
 }
 
+// createUploadFile turns a filesystem path into the file to upload, or reports why it cannot be
+// uploaded. The returned file holds no content and no descriptor; both are produced when it is
+// streamed.
+func createUploadFile(
+	rootPath string,
+	path string,
+	encodePath PathEncoder,
+	transcode ContentTranscoder,
+) (uploadrevision.UploadFile, *SkippedFile) {
+	relPath, err := utils.ToRelativeUnixPath(rootPath, path)
+	if err != nil {
+		// relPath is not known yet, so the raw path is the best identifier available.
+		return uploadrevision.UploadFile{}, &SkippedFile{Path: path, Reason: uploadrevision.NewFileAccessError(path, err)}
+	}
+
+	relPath = encodePath(relPath)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return uploadrevision.UploadFile{}, &SkippedFile{Path: relPath, Reason: uploadrevision.NewFileAccessError(path, err)}
+	}
+
+	// Reading a device file would never return, so this has to be decided before the read.
+	if !info.Mode().IsRegular() {
+		return uploadrevision.UploadFile{}, &SkippedFile{Path: relPath, Reason: uploadrevision.NewSpecialFileError(relPath, info.Mode())}
+	}
+
+	if err := checkReadable(path); err != nil {
+		return uploadrevision.UploadFile{}, &SkippedFile{Path: relPath, Reason: uploadrevision.NewFileAccessError(path, err)}
+	}
+
+	// Without a transcoder the uploaded content is the file as it is on disk, so the stat above
+	// already gives its size and the file does not need reading here.
+	fileSize := info.Size()
+	if transcode != nil {
+		content, err := readAndTranscode(path, transcode)
+		if err != nil {
+			return uploadrevision.UploadFile{}, &SkippedFile{Path: relPath, Reason: uploadrevision.NewFileAccessError(path, err)}
+		}
+		fileSize = int64(len(content))
+	}
+
+	return uploadrevision.UploadFile{
+		Path:   relPath,
+		Size:   fileSize,
+		Reader: &transcodedFileReader{path: path, transcode: transcode},
+	}, nil
+}
+
 func batchPaths(
 	rootPath string,
 	paths <-chan string,
@@ -111,55 +160,20 @@ func batchPaths(
 			Int64("total_payload_limit_bytes", limits.TotalPayloadSizeLimit).
 			Msg("Starting file batching")
 		for path := range paths {
-			relPath, err := utils.ToRelativeUnixPath(rootPath, path)
-			if err != nil {
-				logger.Debug().Msgf("failed to get relative unix path for file: %s", path)
-				skipped = append(skipped, SkippedFile{Path: path, Reason: uploadrevision.NewFileAccessError(path, err)})
+			file, skippedFile := createUploadFile(rootPath, path, pathEncoder, contentTranscoder)
+			if skippedFile != nil {
+				logger.Debug().Err(skippedFile.Reason).Msgf("skipping file: %s", path)
+				skipped = append(skipped, *skippedFile)
 				continue
 			}
 
-			relPath = pathEncoder(relPath)
-
-			info, err := os.Stat(path)
-			if err != nil {
-				logger.Debug().Msgf("failed to stat file: %s", path)
-				skipped = append(skipped, SkippedFile{Path: relPath, Reason: uploadrevision.NewFileAccessError(path, err)})
-				continue
-			}
-
-			// Reading a device file would never return, so this has to be decided before the read.
-			if !info.Mode().IsRegular() {
-				logger.Debug().Msgf("skipping special file: %s", path)
-				skipped = append(skipped, SkippedFile{Path: relPath, Reason: uploadrevision.NewSpecialFileError(path, info.Mode())})
-				continue
-			}
-
-			if err := checkReadable(path); err != nil {
-				logger.Debug().Msgf("failed to open file: %s", path)
-				skipped = append(skipped, SkippedFile{Path: relPath, Reason: uploadrevision.NewFileAccessError(path, err)})
-				continue
-			}
-
-			// Without a transcoder the uploaded content is the file as it is on disk, so the
-			// stat above already gives its size and the file does not need reading here.
-			fileSize := info.Size()
-			if contentTranscoder != nil {
-				content, err := readAndTranscode(path, contentTranscoder)
-				if err != nil {
-					logger.Debug().Msgf("failed to read file: %s", path)
-					skipped = append(skipped, SkippedFile{Path: relPath, Reason: uploadrevision.NewFileAccessError(path, err)})
-					continue
-				}
-				fileSize = int64(len(content))
-			}
-
-			ff := applyFilters(fileToFilter{Path: relPath, Size: fileSize}, filters...)
+			ff := applyFilters(fileToFilter{Path: file.Path, Size: file.Size}, filters...)
 			if ff != nil {
 				skipped = append(skipped, *ff)
 				continue
 			}
 
-			if batch.wouldExceedLimits(fileSize) {
+			if batch.wouldExceedLimits(file.Size) {
 				batchNumber++
 				logger.Debug().
 					Int("batch_number", batchNumber).
@@ -173,11 +187,7 @@ func batchPaths(
 				skipped = []SkippedFile{}
 			}
 
-			batch.addFile(uploadrevision.UploadFile{
-				Path:   relPath,
-				Size:   fileSize,
-				Reader: &transcodedFileReader{path: path, transcode: contentTranscoder},
-			}, fileSize)
+			batch.addFile(file)
 		}
 
 		if !batch.isEmpty() || len(skipped) > 0 {

--- a/pkg/apiclients/fileupload/batch.go
+++ b/pkg/apiclients/fileupload/batch.go
@@ -1,6 +1,8 @@
 package fileupload
 
 import (
+	"io"
+	"io/fs"
 	"iter"
 	"os"
 
@@ -49,11 +51,27 @@ type batchingResult struct {
 	skippedFiles []SkippedFile
 }
 
+// transcodedFile pairs a transcoded file with the file it was opened from, so that closing it
+// releases the file descriptor even when the transcoder's wrapper does not delegate Close.
+type transcodedFile struct {
+	fs.File
+	source io.Closer
+}
+
+func (t transcodedFile) Close() error {
+	err := t.File.Close()
+	// Ignored: the transcoder's wrapper may already have closed the source.
+	_ = t.source.Close()
+	return err
+}
+
 func batchPaths(
 	rootPath string,
 	paths <-chan string,
 	limits uploadrevision.Limits,
 	logger *zerolog.Logger,
+	pathEncoder PathEncoder,
+	contentTranscoder ContentTranscoder,
 	filters ...filter,
 ) iter.Seq[*batchingResult] {
 	return func(yield func(*batchingResult) bool) {
@@ -73,13 +91,24 @@ func batchPaths(
 				continue
 			}
 
-			f, err := os.Open(path)
+			relPath = pathEncoder(relPath)
+
+			osFile, err := os.Open(path)
 			if err != nil {
 				logger.Debug().Msgf("failed to open file: %s", path)
-				f.Close()
 				skipped = append(skipped, SkippedFile{Path: relPath, Reason: uploadrevision.NewFileAccessError(path, err)})
 				continue
 			}
+
+			transcoded, err := contentTranscoder(osFile)
+			if err != nil {
+				logger.Debug().Msgf("failed to transcode file: %s", path)
+				osFile.Close()
+				skipped = append(skipped, SkippedFile{Path: relPath, Reason: uploadrevision.NewFileAccessError(path, err)})
+				continue
+			}
+
+			f := transcodedFile{File: transcoded, source: osFile}
 
 			fstat, err := f.Stat()
 			if err != nil {

--- a/pkg/apiclients/fileupload/batch.go
+++ b/pkg/apiclients/fileupload/batch.go
@@ -1,8 +1,6 @@
 package fileupload
 
 import (
-	"io"
-	"io/fs"
 	"iter"
 	"os"
 
@@ -40,29 +38,9 @@ func (b *uploadBatch) isEmpty() bool {
 	return len(b.files) == 0
 }
 
-func (b *uploadBatch) closeRemainingFiles() {
-	for _, file := range b.files {
-		file.File.Close()
-	}
-}
-
 type batchingResult struct {
 	batch        *uploadBatch
 	skippedFiles []SkippedFile
-}
-
-// transcodedFile pairs a transcoded file with the file it was opened from, so that closing it
-// releases the file descriptor even when the transcoder's wrapper does not delegate Close.
-type transcodedFile struct {
-	fs.File
-	source io.Closer
-}
-
-func (t transcodedFile) Close() error {
-	err := t.File.Close()
-	// Ignored: the transcoder's wrapper may already have closed the source.
-	_ = t.source.Close()
-	return err
 }
 
 func batchPaths(
@@ -93,39 +71,43 @@ func batchPaths(
 
 			relPath = pathEncoder(relPath)
 
-			osFile, err := os.Open(path)
-			if err != nil {
-				logger.Debug().Msgf("failed to open file: %s", path)
-				skipped = append(skipped, SkippedFile{Path: relPath, Reason: uploadrevision.NewFileAccessError(path, err)})
-				continue
-			}
-
-			transcoded, err := contentTranscoder(osFile)
-			if err != nil {
-				logger.Debug().Msgf("failed to transcode file: %s", path)
-				osFile.Close()
-				skipped = append(skipped, SkippedFile{Path: relPath, Reason: uploadrevision.NewFileAccessError(path, err)})
-				continue
-			}
-
-			f := transcodedFile{File: transcoded, source: osFile}
-
-			fstat, err := f.Stat()
+			info, err := os.Stat(path)
 			if err != nil {
 				logger.Debug().Msgf("failed to stat file: %s", path)
-				f.Close()
 				skipped = append(skipped, SkippedFile{Path: relPath, Reason: uploadrevision.NewFileAccessError(path, err)})
 				continue
 			}
 
-			ff := applyFilters(fileToFilter{Path: relPath, Stat: fstat}, filters...)
+			// Reading a device file would never return, so this has to be decided before the read.
+			if !info.Mode().IsRegular() {
+				logger.Debug().Msgf("skipping special file: %s", path)
+				skipped = append(skipped, SkippedFile{Path: relPath, Reason: uploadrevision.NewSpecialFileError(path, info.Mode())})
+				continue
+			}
+
+			content, err := os.ReadFile(path)
+			if err != nil {
+				logger.Debug().Msgf("failed to read file: %s", path)
+				skipped = append(skipped, SkippedFile{Path: relPath, Reason: uploadrevision.NewFileAccessError(path, err)})
+				continue
+			}
+
+			content, err = contentTranscoder(content)
+			if err != nil {
+				logger.Debug().Msgf("failed to transcode file: %s", path)
+				skipped = append(skipped, SkippedFile{Path: relPath, Reason: uploadrevision.NewFileAccessError(path, err)})
+				continue
+			}
+
+			fileSize := int64(len(content))
+
+			ff := applyFilters(fileToFilter{Path: relPath, Size: fileSize}, filters...)
 			if ff != nil {
-				f.Close()
 				skipped = append(skipped, *ff)
 				continue
 			}
 
-			if batch.wouldExceedLimits(fstat.Size()) {
+			if batch.wouldExceedLimits(fileSize) {
 				batchNumber++
 				logger.Debug().
 					Int("batch_number", batchNumber).
@@ -140,9 +122,9 @@ func batchPaths(
 			}
 
 			batch.addFile(uploadrevision.UploadFile{
-				Path: relPath,
-				File: f,
-			}, fstat.Size())
+				Path:    relPath,
+				Content: content,
+			}, fileSize)
 		}
 
 		if !batch.isEmpty() || len(skipped) > 0 {

--- a/pkg/apiclients/fileupload/client.go
+++ b/pkg/apiclients/fileupload/client.go
@@ -3,7 +3,6 @@ package fileupload
 import (
 	"context"
 	"fmt"
-	"io/fs"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -54,7 +53,7 @@ func NewClient(httpClient *http.Client, cfg Config, opts ...Option) Client {
 	}
 
 	if client.contentTranscoder == nil {
-		client.contentTranscoder = func(file fs.File) (fs.File, error) { return file, nil }
+		client.contentTranscoder = func(content []byte) ([]byte, error) { return content, nil }
 	}
 
 	if client.uploadRevisionSealableClient == nil {
@@ -67,8 +66,6 @@ func NewClient(httpClient *http.Client, cfg Config, opts ...Option) Client {
 }
 
 func (c *HTTPClient) uploadBatch(ctx context.Context, revID RevisionID, batch *uploadBatch) error {
-	defer batch.closeRemainingFiles()
-
 	if batch.isEmpty() {
 		return nil
 	}
@@ -95,10 +92,10 @@ func (c *HTTPClient) addPathsToRevision(
 
 	fileSizeFilter := func(ff fileToFilter) *SkippedFile {
 		fileSizeLimit := c.uploadRevisionSealableClient.GetLimits().FileSizeLimit
-		if ff.Stat.Size() > fileSizeLimit {
+		if ff.Size > fileSizeLimit {
 			return &SkippedFile{
 				Path:   ff.Path,
-				Reason: uploadrevision2.NewFileSizeLimitError(ff.Path, ff.Stat.Size(), fileSizeLimit),
+				Reason: uploadrevision2.NewFileSizeLimitError(ff.Path, ff.Size, fileSizeLimit),
 			}
 		}
 

--- a/pkg/apiclients/fileupload/client.go
+++ b/pkg/apiclients/fileupload/client.go
@@ -3,6 +3,7 @@ package fileupload
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -23,6 +24,8 @@ type HTTPClient struct {
 	uploadRevisionSealableClient uploadrevision2.SealableClient
 	cfg                          Config
 	logger                       *zerolog.Logger
+	pathEncoder                  PathEncoder
+	contentTranscoder            ContentTranscoder
 }
 
 // Client defines the interface for the high level file upload client.
@@ -44,6 +47,14 @@ func NewClient(httpClient *http.Client, cfg Config, opts ...Option) Client {
 
 	if client.logger == nil {
 		client.logger = utils.Ptr(zerolog.Nop())
+	}
+
+	if client.pathEncoder == nil {
+		client.pathEncoder = func(path string) string { return path }
+	}
+
+	if client.contentTranscoder == nil {
+		client.contentTranscoder = func(file fs.File) (fs.File, error) { return file, nil }
 	}
 
 	if client.uploadRevisionSealableClient == nil {
@@ -111,7 +122,7 @@ func (c *HTTPClient) addPathsToRevision(
 		filePathLengthFilter,
 	}
 
-	for batchResult := range batchPaths(rootPath, pathsChan, c.uploadRevisionSealableClient.GetLimits(), c.logger, filters...) {
+	for batchResult := range batchPaths(rootPath, pathsChan, c.uploadRevisionSealableClient.GetLimits(), c.logger, c.pathEncoder, c.contentTranscoder, filters...) {
 		res.SkippedFiles = append(res.SkippedFiles, batchResult.skippedFiles...)
 
 		err := c.uploadBatch(ctx, revisionID, batchResult.batch)

--- a/pkg/apiclients/fileupload/client.go
+++ b/pkg/apiclients/fileupload/client.go
@@ -52,10 +52,6 @@ func NewClient(httpClient *http.Client, cfg Config, opts ...Option) Client {
 		client.pathEncoder = func(path string) string { return path }
 	}
 
-	if client.contentTranscoder == nil {
-		client.contentTranscoder = func(content []byte) ([]byte, error) { return content, nil }
-	}
-
 	if client.uploadRevisionSealableClient == nil {
 		client.uploadRevisionSealableClient = uploadrevision2.NewClient(uploadrevision2.Config{
 			BaseURL: cfg.BaseURL,

--- a/pkg/apiclients/fileupload/client.go
+++ b/pkg/apiclients/fileupload/client.go
@@ -98,7 +98,7 @@ func (c *HTTPClient) addPathsToRevision(
 		if ff.Stat.Size() > fileSizeLimit {
 			return &SkippedFile{
 				Path:   ff.Path,
-				Reason: uploadrevision2.NewFileSizeLimitError(ff.Stat.Name(), ff.Stat.Size(), fileSizeLimit),
+				Reason: uploadrevision2.NewFileSizeLimitError(ff.Path, ff.Stat.Size(), fileSizeLimit),
 			}
 		}
 

--- a/pkg/apiclients/fileupload/client_options_test.go
+++ b/pkg/apiclients/fileupload/client_options_test.go
@@ -1,0 +1,212 @@
+package fileupload_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	uploadrevision2 "github.com/snyk/go-application-framework/internal/api/fileupload/uploadrevision"
+	"github.com/snyk/go-application-framework/pkg/apiclients/fileupload"
+)
+
+type upperFile struct {
+	fs.File
+}
+
+func (u upperFile) Read(p []byte) (int, error) {
+	n, err := u.File.Read(p)
+	copy(p, bytes.ToUpper(p[:n]))
+	return n, err
+}
+
+// doubledFile reports twice the size of the underlying file, emulating a transcoder
+// whose content is larger than the content on disk.
+type doubledFile struct {
+	fs.File
+}
+
+func (d doubledFile) Stat() (fs.FileInfo, error) {
+	info, err := d.File.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	return doubledFileInfo{info}, nil
+}
+
+type doubledFileInfo struct {
+	fs.FileInfo
+}
+
+func (d doubledFileInfo) Size() int64 {
+	return d.FileInfo.Size() * 2
+}
+
+// noCloseFile emulates a transcoder wrapper that does not delegate Close.
+type noCloseFile struct {
+	fs.File
+}
+
+func (noCloseFile) Close() error {
+	return nil
+}
+
+func setupOptionsTest(
+	t *testing.T,
+	llcfg uploadrevision2.FakeClientConfig,
+	files []uploadrevision2.LoadedFile,
+	opts ...fileupload.Option,
+) (context.Context, *uploadrevision2.FakeSealableClient, fileupload.Client, *os.File) {
+	t.Helper()
+
+	fakeSealableClient := uploadrevision2.NewFakeSealableClient(llcfg)
+	client := fileupload.NewClient(
+		nil,
+		fileupload.Config{OrgID: uuid.New()},
+		append([]fileupload.Option{fileupload.WithUploadRevisionSealableClient(fakeSealableClient)}, opts...)...,
+	)
+
+	return context.Background(), fakeSealableClient, client, createTmpFiles(t, files)
+}
+
+var defaultLimits = uploadrevision2.FakeClientConfig{
+	Limits: uploadrevision2.Limits{
+		FileCountLimit:        10,
+		FileSizeLimit:         100,
+		TotalPayloadSizeLimit: 10_000,
+		FilePathLengthLimit:   50,
+	},
+}
+
+func encodeSpaces(p string) string {
+	return strings.ReplaceAll(p, " ", "%20")
+}
+
+func Test_CreateRevisionFromChan_Options(t *testing.T) {
+	files := []uploadrevision2.LoadedFile{
+		{Path: "my file.go", Content: "package main"},
+	}
+
+	t.Run("uploading a file from chan with an encoded path and transcoded content", func(t *testing.T) {
+		ctx, fakeSealableClient, client, dir := setupOptionsTest(t, defaultLimits, files,
+			fileupload.WithPathEncoder(encodeSpaces),
+			fileupload.WithContentTranscoder(func(f fs.File) (fs.File, error) { return upperFile{f}, nil }),
+		)
+
+		paths := make(chan string, 1)
+		paths <- path.Join(dir.Name(), "my file.go")
+		close(paths)
+
+		res, err := client.CreateRevisionFromChan(ctx, paths, dir.Name())
+		require.NoError(t, err)
+
+		uploadedFiles, err := fakeSealableClient.GetSealedRevisionFiles(res.RevisionID)
+		require.NoError(t, err)
+		require.Len(t, uploadedFiles, 1)
+		assert.Equal(t, "my%20file.go", uploadedFiles[0].Path)
+		assert.Equal(t, "PACKAGE MAIN", uploadedFiles[0].Content)
+	})
+
+	t.Run("uploading a file from chan whose encoded path exceeds the file path limit", func(t *testing.T) {
+		ctx, _, client, dir := setupOptionsTest(t, uploadrevision2.FakeClientConfig{
+			Limits: uploadrevision2.Limits{
+				FileCountLimit:        10,
+				FileSizeLimit:         100,
+				TotalPayloadSizeLimit: 10_000,
+				FilePathLengthLimit:   11,
+			},
+		}, files, fileupload.WithPathEncoder(encodeSpaces))
+
+		paths := make(chan string, 1)
+		paths <- path.Join(dir.Name(), "my file.go")
+		close(paths)
+
+		res, err := client.CreateRevisionFromChan(ctx, paths, dir.Name())
+		require.ErrorIs(t, err, fileupload.ErrNoFilesProvided)
+
+		var filePathErr *uploadrevision2.FilePathLengthLimitError
+		require.Len(t, res.SkippedFiles, 1)
+		ff := res.SkippedFiles[0]
+		assert.Equal(t, "my%20file.go", ff.Path)
+		assert.ErrorAs(t, ff.Reason, &filePathErr)
+		assert.Equal(t, "my%20file.go", filePathErr.FilePath)
+		assert.Equal(t, 12, filePathErr.Length)
+		assert.Equal(t, 11, filePathErr.Limit)
+	})
+
+	t.Run("uploading a file from chan whose transcoded content exceeds the file size limit", func(t *testing.T) {
+		ctx, _, client, dir := setupOptionsTest(t, uploadrevision2.FakeClientConfig{
+			Limits: uploadrevision2.Limits{
+				FileCountLimit:        10,
+				FileSizeLimit:         20,
+				TotalPayloadSizeLimit: 10_000,
+				FilePathLengthLimit:   50,
+			},
+		}, files, fileupload.WithContentTranscoder(func(f fs.File) (fs.File, error) { return doubledFile{f}, nil }))
+
+		paths := make(chan string, 1)
+		paths <- path.Join(dir.Name(), "my file.go")
+		close(paths)
+
+		res, err := client.CreateRevisionFromChan(ctx, paths, dir.Name())
+		require.ErrorIs(t, err, fileupload.ErrNoFilesProvided)
+
+		var fileSizeErr *uploadrevision2.FileSizeLimitError
+		require.Len(t, res.SkippedFiles, 1)
+		ff := res.SkippedFiles[0]
+		assert.Equal(t, "my file.go", ff.Path)
+		assert.ErrorAs(t, ff.Reason, &fileSizeErr)
+		assert.Equal(t, int64(24), fileSizeErr.FileSize)
+		assert.Equal(t, int64(20), fileSizeErr.Limit)
+	})
+
+	t.Run("uploading a file from chan the transcoder fails on", func(t *testing.T) {
+		transcodeErr := errors.New("cannot transcode")
+		ctx, _, client, dir := setupOptionsTest(t, defaultLimits, files,
+			fileupload.WithContentTranscoder(func(fs.File) (fs.File, error) { return nil, transcodeErr }),
+		)
+
+		paths := make(chan string, 1)
+		paths <- path.Join(dir.Name(), "my file.go")
+		close(paths)
+
+		res, err := client.CreateRevisionFromChan(ctx, paths, dir.Name())
+		require.ErrorIs(t, err, fileupload.ErrNoFilesProvided)
+
+		var fileAccessErr *uploadrevision2.FileAccessError
+		require.Len(t, res.SkippedFiles, 1)
+		ff := res.SkippedFiles[0]
+		assert.Equal(t, "my file.go", ff.Path)
+		require.ErrorAs(t, ff.Reason, &fileAccessErr)
+		assert.ErrorIs(t, fileAccessErr.Err, transcodeErr)
+	})
+
+	t.Run("uploading a file from chan with a transcoder not delegating close", func(t *testing.T) {
+		var transcoded []fs.File
+		ctx, _, client, dir := setupOptionsTest(t, defaultLimits, files,
+			fileupload.WithContentTranscoder(func(f fs.File) (fs.File, error) {
+				transcoded = append(transcoded, f)
+				return noCloseFile{f}, nil
+			}),
+		)
+
+		paths := make(chan string, 1)
+		paths <- path.Join(dir.Name(), "my file.go")
+		close(paths)
+
+		_, err := client.CreateRevisionFromChan(ctx, paths, dir.Name())
+		require.NoError(t, err)
+
+		require.Len(t, transcoded, 1)
+		assert.ErrorIs(t, transcoded[0].Close(), os.ErrClosed)
+	})
+}

--- a/pkg/apiclients/fileupload/client_options_test.go
+++ b/pkg/apiclients/fileupload/client_options_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 

--- a/pkg/apiclients/fileupload/client_options_test.go
+++ b/pkg/apiclients/fileupload/client_options_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -18,48 +17,6 @@ import (
 	uploadrevision2 "github.com/snyk/go-application-framework/internal/api/fileupload/uploadrevision"
 	"github.com/snyk/go-application-framework/pkg/apiclients/fileupload"
 )
-
-type upperFile struct {
-	fs.File
-}
-
-func (u upperFile) Read(p []byte) (int, error) {
-	n, err := u.File.Read(p)
-	copy(p, bytes.ToUpper(p[:n]))
-	return n, err
-}
-
-// doubledFile reports twice the size of the underlying file, emulating a transcoder
-// whose content is larger than the content on disk.
-type doubledFile struct {
-	fs.File
-}
-
-func (d doubledFile) Stat() (fs.FileInfo, error) {
-	info, err := d.File.Stat()
-	if err != nil {
-		return nil, err
-	}
-
-	return doubledFileInfo{info}, nil
-}
-
-type doubledFileInfo struct {
-	fs.FileInfo
-}
-
-func (d doubledFileInfo) Size() int64 {
-	return d.FileInfo.Size() * 2
-}
-
-// noCloseFile emulates a transcoder wrapper that does not delegate Close.
-type noCloseFile struct {
-	fs.File
-}
-
-func (noCloseFile) Close() error {
-	return nil
-}
 
 func setupOptionsTest(
 	t *testing.T,
@@ -100,7 +57,7 @@ func Test_CreateRevisionFromChan_Options(t *testing.T) {
 	t.Run("uploading a file from chan with an encoded path and transcoded content", func(t *testing.T) {
 		ctx, fakeSealableClient, client, dir := setupOptionsTest(t, defaultLimits, files,
 			fileupload.WithPathEncoder(encodeSpaces),
-			fileupload.WithContentTranscoder(func(f fs.File) (fs.File, error) { return upperFile{f}, nil }),
+			fileupload.WithContentTranscoder(func(c []byte) ([]byte, error) { return bytes.ToUpper(c), nil }),
 		)
 
 		paths := make(chan string, 1)
@@ -157,7 +114,10 @@ func Test_CreateRevisionFromChan_Options(t *testing.T) {
 			},
 		}, nestedFiles,
 			fileupload.WithPathEncoder(encodeSpaces),
-			fileupload.WithContentTranscoder(func(f fs.File) (fs.File, error) { return doubledFile{f}, nil }),
+			// Emulates a transcoder whose content is larger than the content on disk.
+			fileupload.WithContentTranscoder(func(c []byte) ([]byte, error) {
+				return append(bytes.Clone(c), c...), nil
+			}),
 		)
 
 		paths := make(chan string, 1)
@@ -180,7 +140,7 @@ func Test_CreateRevisionFromChan_Options(t *testing.T) {
 	t.Run("uploading a file from chan the transcoder fails on", func(t *testing.T) {
 		transcodeErr := errors.New("cannot transcode")
 		ctx, _, client, dir := setupOptionsTest(t, defaultLimits, files,
-			fileupload.WithContentTranscoder(func(fs.File) (fs.File, error) { return nil, transcodeErr }),
+			fileupload.WithContentTranscoder(func([]byte) ([]byte, error) { return nil, transcodeErr }),
 		)
 
 		paths := make(chan string, 1)
@@ -198,23 +158,42 @@ func Test_CreateRevisionFromChan_Options(t *testing.T) {
 		assert.ErrorIs(t, fileAccessErr.Err, transcodeErr)
 	})
 
-	t.Run("uploading a file from chan with a transcoder not delegating close", func(t *testing.T) {
-		var transcoded []fs.File
-		ctx, _, client, dir := setupOptionsTest(t, defaultLimits, files,
-			fileupload.WithContentTranscoder(func(f fs.File) (fs.File, error) {
-				transcoded = append(transcoded, f)
-				return noCloseFile{f}, nil
-			}),
-		)
+	t.Run("skips a path that is not a regular file", func(t *testing.T) {
+		ctx, _, client, dir := setupOptionsTest(t, defaultLimits, files)
+
+		require.NoError(t, os.Mkdir(path.Join(dir.Name(), "a dir"), 0o755))
 
 		paths := make(chan string, 1)
-		paths <- path.Join(dir.Name(), "my file.go")
+		paths <- path.Join(dir.Name(), "a dir")
 		close(paths)
 
-		_, err := client.CreateRevisionFromChan(ctx, paths, dir.Name())
+		res, err := client.CreateRevisionFromChan(ctx, paths, dir.Name())
+		require.ErrorIs(t, err, fileupload.ErrNoFilesProvided)
+
+		var specialFileErr *uploadrevision2.SpecialFileError
+		require.Len(t, res.SkippedFiles, 1)
+		require.ErrorAs(t, res.SkippedFiles[0].Reason, &specialFileErr)
+
+		var fileAccessErr *uploadrevision2.FileAccessError
+		assert.NotErrorAs(t, res.SkippedFiles[0].Reason, &fileAccessErr)
+	})
+
+	t.Run("uploads a symlink to a regular file", func(t *testing.T) {
+		ctx, fakeSealableClient, client, dir := setupOptionsTest(t, defaultLimits, files)
+
+		link := path.Join(dir.Name(), "link.go")
+		require.NoError(t, os.Symlink(path.Join(dir.Name(), "my file.go"), link))
+
+		paths := make(chan string, 1)
+		paths <- link
+		close(paths)
+
+		res, err := client.CreateRevisionFromChan(ctx, paths, dir.Name())
 		require.NoError(t, err)
 
-		require.Len(t, transcoded, 1)
-		assert.ErrorIs(t, transcoded[0].Close(), os.ErrClosed)
+		uploadedFiles, err := fakeSealableClient.GetSealedRevisionFiles(res.RevisionID)
+		require.NoError(t, err)
+		require.Len(t, uploadedFiles, 1)
+		assert.Equal(t, "package main", uploadedFiles[0].Content)
 	})
 }

--- a/pkg/apiclients/fileupload/client_options_test.go
+++ b/pkg/apiclients/fileupload/client_options_test.go
@@ -173,7 +173,10 @@ func Test_CreateRevisionFromChan_Options(t *testing.T) {
 
 		var specialFileErr *uploadrevision2.SpecialFileError
 		require.Len(t, res.SkippedFiles, 1)
+		assert.Equal(t, "a dir", res.SkippedFiles[0].Path)
 		require.ErrorAs(t, res.SkippedFiles[0].Reason, &specialFileErr)
+		// The reason must report the same path as the skipped file, not the absolute one.
+		assert.Equal(t, "a dir", specialFileErr.FilePath)
 
 		var fileAccessErr *uploadrevision2.FileAccessError
 		assert.NotErrorAs(t, res.SkippedFiles[0].Reason, &fileAccessErr)

--- a/pkg/apiclients/fileupload/client_options_test.go
+++ b/pkg/apiclients/fileupload/client_options_test.go
@@ -197,3 +197,41 @@ func Test_CreateRevisionFromChan_Options(t *testing.T) {
 		assert.Equal(t, "package main", uploadedFiles[0].Content)
 	})
 }
+
+func Test_CreateRevisionFromChan_UnreadableFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permissions do not prevent reading on windows")
+	}
+
+	files := []uploadrevision2.LoadedFile{
+		{Path: "my file.go", Content: "package main"},
+	}
+
+	// Batching reads the file only when a transcoder is configured, so both paths have to reach
+	// the same outcome for an unreadable file.
+	for name, opts := range map[string][]fileupload.Option{
+		"without a transcoder": nil,
+		"with a transcoder": {
+			fileupload.WithContentTranscoder(func(c []byte) ([]byte, error) { return bytes.ToUpper(c), nil }),
+		},
+	} {
+		t.Run("skips an unreadable file "+name, func(t *testing.T) {
+			ctx, _, client, dir := setupOptionsTest(t, defaultLimits, files, opts...)
+
+			filePath := path.Join(dir.Name(), "my file.go")
+			require.NoError(t, os.Chmod(filePath, 0o000))
+
+			paths := make(chan string, 1)
+			paths <- filePath
+			close(paths)
+
+			res, err := client.CreateRevisionFromChan(ctx, paths, dir.Name())
+			require.ErrorIs(t, err, fileupload.ErrNoFilesProvided)
+
+			var fileAccessErr *uploadrevision2.FileAccessError
+			require.Len(t, res.SkippedFiles, 1)
+			assert.Equal(t, "my file.go", res.SkippedFiles[0].Path)
+			assert.ErrorAs(t, res.SkippedFiles[0].Reason, &fileAccessErr)
+		})
+	}
+}

--- a/pkg/apiclients/fileupload/client_options_test.go
+++ b/pkg/apiclients/fileupload/client_options_test.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -144,6 +145,9 @@ func Test_CreateRevisionFromChan_Options(t *testing.T) {
 	})
 
 	t.Run("uploading a file from chan whose transcoded content exceeds the file size limit", func(t *testing.T) {
+		nestedFiles := []uploadrevision2.LoadedFile{
+			{Path: filepath.Join("sub dir", "my file.go"), Content: "package main"},
+		}
 		ctx, _, client, dir := setupOptionsTest(t, uploadrevision2.FakeClientConfig{
 			Limits: uploadrevision2.Limits{
 				FileCountLimit:        10,
@@ -151,10 +155,13 @@ func Test_CreateRevisionFromChan_Options(t *testing.T) {
 				TotalPayloadSizeLimit: 10_000,
 				FilePathLengthLimit:   50,
 			},
-		}, files, fileupload.WithContentTranscoder(func(f fs.File) (fs.File, error) { return doubledFile{f}, nil }))
+		}, nestedFiles,
+			fileupload.WithPathEncoder(encodeSpaces),
+			fileupload.WithContentTranscoder(func(f fs.File) (fs.File, error) { return doubledFile{f}, nil }),
+		)
 
 		paths := make(chan string, 1)
-		paths <- path.Join(dir.Name(), "my file.go")
+		paths <- path.Join(dir.Name(), "sub dir", "my file.go")
 		close(paths)
 
 		res, err := client.CreateRevisionFromChan(ctx, paths, dir.Name())
@@ -163,8 +170,9 @@ func Test_CreateRevisionFromChan_Options(t *testing.T) {
 		var fileSizeErr *uploadrevision2.FileSizeLimitError
 		require.Len(t, res.SkippedFiles, 1)
 		ff := res.SkippedFiles[0]
-		assert.Equal(t, "my file.go", ff.Path)
+		assert.Equal(t, "sub%20dir/my%20file.go", ff.Path)
 		assert.ErrorAs(t, ff.Reason, &fileSizeErr)
+		assert.Equal(t, "sub%20dir/my%20file.go", fileSizeErr.FilePath)
 		assert.Equal(t, int64(24), fileSizeErr.FileSize)
 		assert.Equal(t, int64(20), fileSizeErr.Limit)
 	})

--- a/pkg/apiclients/fileupload/client_options_test.go
+++ b/pkg/apiclients/fileupload/client_options_test.go
@@ -34,7 +34,7 @@ func setupOptionsTest(
 		append([]fileupload.Option{fileupload.WithUploadRevisionSealableClient(fakeSealableClient)}, opts...)...,
 	)
 
-	return context.Background(), fakeSealableClient, client, createTmpFiles(t, files)
+	return t.Context(), fakeSealableClient, client, createTmpFiles(t, files)
 }
 
 var defaultLimits = uploadrevision2.FakeClientConfig{

--- a/pkg/apiclients/fileupload/filter.go
+++ b/pkg/apiclients/fileupload/filter.go
@@ -1,12 +1,11 @@
 package fileupload
 
-import "os"
-
 // fileToFilter represents the metadata about a file that a Filter function gets
 // in order to decide if the file should be filtered or not.
 type fileToFilter struct {
 	Path string
-	Stat os.FileInfo
+	// Size is the size of the transcoded content, which is what gets uploaded.
+	Size int64
 }
 
 // SkippedFile represents a file that was skipped.

--- a/pkg/apiclients/fileupload/opts.go
+++ b/pkg/apiclients/fileupload/opts.go
@@ -1,6 +1,8 @@
 package fileupload
 
 import (
+	"io/fs"
+
 	"github.com/rs/zerolog"
 
 	"github.com/snyk/go-application-framework/internal/api/fileupload/uploadrevision"
@@ -20,5 +22,32 @@ func WithUploadRevisionSealableClient(client uploadrevision.SealableClient) Opti
 func WithLogger(logger *zerolog.Logger) Option {
 	return func(h *HTTPClient) {
 		h.logger = logger
+	}
+}
+
+// PathEncoder transforms a file's upload path, relative to the root directory. The encoded
+// path is the one filtered by the path length limit and reported for skipped files.
+type PathEncoder func(path string) string
+
+// ContentTranscoder wraps an opened file before its content is streamed. The client closes
+// both the returned file and the file it was opened from.
+//
+// Stat is called more than once, before any content is read. It must report the size and mode
+// of the transcoded content, always report the same size, and must not consume the content.
+type ContentTranscoder func(file fs.File) (fs.File, error)
+
+// WithPathEncoder allows encoding each file's upload path before it is sent, e.g. to URI-encode
+// it. It does not affect the filesystem path the file is read from.
+func WithPathEncoder(encode PathEncoder) Option {
+	return func(h *HTTPClient) {
+		h.pathEncoder = encode
+	}
+}
+
+// WithContentTranscoder allows transcoding each file's content before it is streamed, e.g. to
+// UTF-8. Files the transcoder fails on are skipped.
+func WithContentTranscoder(transcode ContentTranscoder) Option {
+	return func(h *HTTPClient) {
+		h.contentTranscoder = transcode
 	}
 }

--- a/pkg/apiclients/fileupload/opts.go
+++ b/pkg/apiclients/fileupload/opts.go
@@ -1,8 +1,6 @@
 package fileupload
 
 import (
-	"io/fs"
-
 	"github.com/rs/zerolog"
 
 	"github.com/snyk/go-application-framework/internal/api/fileupload/uploadrevision"
@@ -29,12 +27,9 @@ func WithLogger(logger *zerolog.Logger) Option {
 // path is the one filtered by the path length limit and reported for skipped files.
 type PathEncoder func(path string) string
 
-// ContentTranscoder wraps an opened file before its content is streamed. The client closes
-// both the returned file and the file it was opened from.
-//
-// Stat is called more than once, before any content is read. It must report the size and mode
-// of the transcoded content, always report the same size, and must not consume the content.
-type ContentTranscoder func(file fs.File) (fs.File, error)
+// ContentTranscoder transforms a file's content before it is uploaded. The returned content is
+// the one filtered by the file size limit and uploaded.
+type ContentTranscoder func(content []byte) ([]byte, error)
 
 // WithPathEncoder allows encoding each file's upload path before it is sent, e.g. to URI-encode
 // it. It does not affect the filesystem path the file is read from.
@@ -44,7 +39,7 @@ func WithPathEncoder(encode PathEncoder) Option {
 	}
 }
 
-// WithContentTranscoder allows transcoding each file's content before it is streamed, e.g. to
+// WithContentTranscoder allows transcoding each file's content before it is uploaded, e.g. to
 // UTF-8. Files the transcoder fails on are skipped.
 func WithContentTranscoder(transcode ContentTranscoder) Option {
 	return func(h *HTTPClient) {


### PR DESCRIPTION
### Description

Add `WithPathEncoder` and `WithContentTranscoder` to the high-level file upload client
(`pkg/apiclients/fileupload`), so callers can URI-encode upload paths and transcode content
(e.g. to UTF-8) without touching the internal upload revision client. Both default to no-op.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [ ] Test your changes work for the CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the internal upload revision `UploadFile` contract and shifts when/how file content is read and validated during batching and upload, which could affect callers or memory use when transcoding is enabled.
> 
> **Overview**
> Adds **`WithPathEncoder`** and **`WithContentTranscoder`** on the high-level `fileupload` client so upload paths and file bytes can be transformed (e.g. URI-encoding paths, transcoding to UTF-8) before limits and upload run. Encoded paths drive path-length filtering and skipped-file reporting; transcoded byte length drives size limits and what is sent.
> 
> Refactors upload batching so files are not opened for the whole batch: **`UploadFile`** now carries an explicit **`Size`** and **`io.Reader`** instead of **`fs.File`**, and the low-level upload revision client validates and streams from that reader. Batching builds lazy readers (`transcodedFileReader`) and moves regular-file / readability checks into **`createUploadFile`** in the high-level layer.
> 
> Filters now use transcoded content size rather than **`os.FileInfo`**. Tests are updated for the new **`UploadFile`** shape and expanded with option-focused coverage (encoded paths, transcoder failures, symlinks, unreadable files).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b57c739f8675d07d97d9c1bc42acebe4fafb4c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->