### PR TITLE
fix: Gate ignore-rule metacharacter fix behind an opt-in flag

### DIFF
--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -1,5 +1,7 @@
 package configuration
 
+import "github.com/snyk/go-application-framework/pkg/featureflags"
+
 const (
 	// ---------
 	// platform related configuration that is normally not required to be accessed directly
@@ -95,12 +97,12 @@ const (
 	// Feature flag to enable native implementation for code, used in code-client-go's code workflow
 	FF_CODE_NATIVE_IMPLEMENTATION string = "internal_snyk_code_native_implementation"
 	// Feature flag to enable the fix for ignore rules/paths containing regex metacharacters
-	FF_FILE_FILTER_METACHARACTER_FIX string = "internal_snyk_file_filter_metacharacter_fix_enabled"
+	FF_FILE_FILTER_METACHARACTER_FIX string = featureflags.FileFilterMetacharacterFix
 
 	// ---------
 	// feature flag names (platform-registered names backing the config keys above)
 	// ---------
 
 	// Feature flag name backing FF_FILE_FILTER_METACHARACTER_FIX
-	SNYK_FILE_FILTER_METACHARACTER_FIX string = "snykFileFilterMetacharacterFix"
+	SNYK_FILE_FILTER_METACHARACTER_FIX string = featureflags.FileFilterMetacharacterFixBackendName
 )

--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -94,4 +94,13 @@ const (
 	FF_CODE_CONSISTENT_IGNORES string = "internal_snyk_code_ignores_enabled"
 	// Feature flag to enable native implementation for code, used in code-client-go's code workflow
 	FF_CODE_NATIVE_IMPLEMENTATION string = "internal_snyk_code_native_implementation"
+	// Feature flag to enable the fix for ignore rules/paths containing regex metacharacters
+	FF_FILE_FILTER_METACHARACTER_FIX string = "internal_snyk_file_filter_metacharacter_fix_enabled"
+
+	// ---------
+	// feature flag names (platform-registered names backing the config keys above)
+	// ---------
+
+	// Feature flag name backing FF_FILE_FILTER_METACHARACTER_FIX
+	SNYK_FILE_FILTER_METACHARACTER_FIX string = "snykFileFilterMetacharacterFix"
 )

--- a/pkg/featureflags/featureflags.go
+++ b/pkg/featureflags/featureflags.go
@@ -1,0 +1,18 @@
+// Package featureflags is a minimal, dependency-free home for feature-flag surfaces shared
+// between packages that can't import pkg/configuration directly (pkg/configuration already
+// depends on pkg/utils transitively, via internal/utils, so pkg/utils importing
+// pkg/configuration back would be an import cycle).
+package featureflags
+
+// FeatureFlagReader is satisfied by any configuration.Configuration.
+type FeatureFlagReader interface {
+	GetBool(key string) bool
+}
+
+const (
+	// FileFilterMetacharacterFix backs configuration.FF_FILE_FILTER_METACHARACTER_FIX.
+	FileFilterMetacharacterFix string = "internal_snyk_file_filter_metacharacter_fix_enabled"
+
+	// FileFilterMetacharacterFixBackendName backs configuration.SNYK_FILE_FILTER_METACHARACTER_FIX.
+	FileFilterMetacharacterFixBackendName string = "snykFileFilterMetacharacterFix"
+)

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -86,7 +86,12 @@ func WithDotSnykSections(sections []DotSnykExcludeSectionName) FileFilterOption 
 	}
 }
 
+// Deprecated: Use NewFileFilterFromConfig instead
 func NewFileFilter(path string, logger *zerolog.Logger, options ...FileFilterOption) *FileFilter {
+	return newFileFilterInternal(path, logger, options...)
+}
+
+func newFileFilterInternal(path string, logger *zerolog.Logger, options ...FileFilterOption) *FileFilter {
 	filter := &FileFilter{
 		path:            path,
 		defaultRules:    []string{"**/.git/**"},
@@ -105,11 +110,15 @@ func NewFileFilter(path string, logger *zerolog.Logger, options ...FileFilterOpt
 	return filter
 }
 
-// NewFileFilterFromConfig is like NewFileFilter, but resolves feature-flag-gated behavior (like
-// the ignore-rule metacharacter fix) from config directly, so callers don't need a code change
-// here when a future flag of this kind is added.
+// NewFileFilterFromConfig resolves feature-flag-gated behavior (like the ignore-rule
+// metacharacter fix) from config, so future flags of this kind need no caller changes. config
+// may be nil, in which case such behavior stays at its default.
 func NewFileFilterFromConfig(path string, logger *zerolog.Logger, config featureflags.FeatureFlagReader, options ...FileFilterOption) *FileFilter {
-	filter := NewFileFilter(path, logger, options...)
+	filter := newFileFilterInternal(path, logger, options...)
+	if config == nil {
+		logger.Debug().Msg("File Filter called without a config (nil)")
+		return filter
+	}
 	filter.enableIgnoreRuleMetacharacterFix = config.GetBool(featureflags.FileFilterMetacharacterFix)
 	return filter
 }

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -23,11 +23,12 @@ import (
 var defaultInvalidRules = []string{}
 
 type FileFilter struct {
-	path            string
-	defaultRules    []string
-	logger          *zerolog.Logger
-	max_threads     int64
-	dotSnykSections []DotSnykExcludeSectionName
+	path                             string
+	defaultRules                     []string
+	logger                           *zerolog.Logger
+	max_threads                      int64
+	dotSnykSections                  []DotSnykExcludeSectionName
+	enableIgnoreRuleMetacharacterFix bool
 }
 
 // DotSnykExcludeSectionName is the name of an `exclude` section in a .snyk
@@ -79,6 +80,17 @@ func WithThreadNumber(maxThreadCount int) FileFilterOption {
 func WithDotSnykSections(sections []DotSnykExcludeSectionName) FileFilterOption {
 	return func(filter *FileFilter) error {
 		filter.dotSnykSections = sections
+		return nil
+	}
+}
+
+// WithIgnoreRuleMetacharacterFix toggles the fix for ignore rules/paths containing regex
+// metacharacters (parentheses, "+", "|", "{", "}", "$", etc.).
+// Disabled (the default) reproduces the legacy behavior.
+// Callers should enable this deliberately (e.g. gated on configuration.FF_FILE_FILTER_METACHARACTER_FIX).
+func WithIgnoreRuleMetacharacterFix(enabled bool) FileFilterOption {
+	return func(filter *FileFilter) error {
+		filter.enableIgnoreRuleMetacharacterFix = enabled
 		return nil
 	}
 }
@@ -202,7 +214,7 @@ func (fw *FileFilter) buildGlobs(ignoreFiles []string) ([]string, error) {
 			parsedRules := fw.parseDotSnykFile(content, filepath.Dir(ignoreFile))
 			globs = append(globs, parsedRules...)
 		} else { // .gitignore, .dcignore, etc. are just a list of ignore rules
-			parsedRules := parseIgnoreFile(content, filepath.Dir(ignoreFile))
+			parsedRules := parseIgnoreFile(content, filepath.Dir(ignoreFile), fw.enableIgnoreRuleMetacharacterFix)
 			globs = append(globs, parsedRules...)
 		}
 	}
@@ -257,7 +269,7 @@ func (fw *FileFilter) parseDotSnykFile(content []byte, filePath string) []string
 			continue
 		}
 
-		globs = append(globs, parseIgnoreRuleToGlobs(rule.Path, filePath, defaultInvalidRules)...)
+		globs = append(globs, parseIgnoreRuleToGlobs(rule.Path, filePath, defaultInvalidRules, fw.enableIgnoreRuleMetacharacterFix)...)
 	}
 	return globs
 }
@@ -362,8 +374,8 @@ func parseExpireTime(expiresStr string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("failed to parse expires time '%s': %w", expiresStr, lastErr)
 }
 
-// parseIgnoreFile builds a list of glob patterns from a given .gitignore style file
-func parseIgnoreFile(content []byte, filePath string) []string {
+// parseIgnoreFile builds a list of glob patterns from a given .gitignore style file.
+func parseIgnoreFile(content []byte, filePath string, enableMetacharacterFix bool) []string {
 	var ignores []string
 	lines := strings.Split(string(content), "\n")
 
@@ -374,7 +386,7 @@ func parseIgnoreFile(content []byte, filePath string) []string {
 		if strings.HasPrefix(line, "#") || strings.TrimSpace(line) == "" {
 			continue
 		}
-		globs := parseIgnoreRuleToGlobs(line, filePath, invalidRules)
+		globs := parseIgnoreRuleToGlobs(line, filePath, invalidRules, enableMetacharacterFix)
 		ignores = append(ignores, globs...)
 	}
 	return ignores
@@ -394,9 +406,10 @@ var ruleRegexMetaChars = map[byte]bool{
 	'}': true,
 }
 
-// escapeSpecialGlobChars escapes regex metacharacters in an ignore rule that gitignore treats as
-// literal, so they match literally instead of being interpreted by go-gitignore's regex engine.
-func escapeSpecialGlobChars(rule string) string {
+// escapeIgnoreRuleMetaChars escapes regex metacharacters in an ignore rule that gitignore treats
+// as literal, so they match literally instead of being interpreted by go-gitignore's regex
+// engine. This is the fixed behavior, gated behind WithIgnoreRuleMetacharacterFix.
+func escapeIgnoreRuleMetaChars(rule string) string {
 	var result strings.Builder
 	for i := 0; i < len(rule); i++ {
 		ch := rule[i]
@@ -404,6 +417,24 @@ func escapeSpecialGlobChars(rule string) string {
 			result.WriteByte('\\')
 		}
 		result.WriteByte(ch)
+	}
+	return result.String()
+}
+
+// escapeSpecialGlobCharsLegacy escapes special characters that should be treated literally in
+// glob patterns. Special Characters to escape: $
+// This is the legacy behavior, to be removed in future releases.
+func escapeSpecialGlobCharsLegacy(rule string) string {
+	var result strings.Builder
+	for i := 0; i < len(rule); i++ {
+		ch := rule[i]
+		switch ch {
+		case '$':
+			result.WriteByte('\\')
+			result.WriteByte(ch)
+		default:
+			result.WriteByte(ch)
+		}
 	}
 	return result.String()
 }
@@ -420,7 +451,7 @@ func joinGlob(parts ...string) string {
 
 // parseIgnoreRuleToGlobs contains the business logic to build glob patterns from a given ignore file
 // we try to implement the same logic as gitignore pattern format - https://git-scm.com/docs/gitignore#_pattern_format
-func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string) (globs []string) {
+func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string, enableMetacharacterFix bool) (globs []string) {
 	// Mappings from .gitignore format to glob format:
 	// `/foo/` => `/foo/**` (meaning: Ignore root (not sub) foo dir and its paths underneath.)
 	// `/foo`	=> `/foo/**`, `/foo` (meaning: Ignore root (not sub) file and dir and its paths underneath.)
@@ -430,6 +461,10 @@ func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string)
 	// If a rule is invalid, we skip it
 	if slices.Contains(invalidRules, strings.TrimSpace(rule)) {
 		return globs
+	}
+
+	if !enableMetacharacterFix {
+		return parseIgnoreRuleToGlobsLegacy(rule, filePath)
 	}
 
 	prefix := ""
@@ -462,7 +497,7 @@ func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string)
 		// case `/foo/`, `/foo` => `{baseDir}/foo/**`
 		// case `**/foo/`, `**/foo` => `{baseDir}/**/foo/**`
 		if !endingGlobstar {
-			glob := prefix + joinGlob(baseDir, escapeSpecialGlobChars(rule), all)
+			glob := prefix + joinGlob(baseDir, escapeIgnoreRuleMetaChars(rule), all)
 			globs = append(globs, glob)
 		}
 		// case `/foo` => `{baseDir}/foo`
@@ -470,20 +505,74 @@ func parseIgnoreRuleToGlobs(rule string, filePath string, invalidRules []string)
 		// case `/foo/**` => `{baseDir}/foo/**`
 		// case `**/foo/**` => `{baseDir}/**/foo/**`
 		if !endingSlash {
-			glob := prefix + joinGlob(baseDir, escapeSpecialGlobChars(rule))
+			glob := prefix + joinGlob(baseDir, escapeIgnoreRuleMetaChars(rule))
 			globs = append(globs, glob)
 		}
 	} else {
 		// case `foo/`, `foo` => `{baseDir}/**/foo/**`
 		if !endingGlobstar {
-			glob := prefix + joinGlob(baseDir, all, escapeSpecialGlobChars(rule), all)
+			glob := prefix + joinGlob(baseDir, all, escapeIgnoreRuleMetaChars(rule), all)
 			globs = append(globs, glob)
 		}
 		// case `foo` => `{baseDir}/**/foo`
 		// case `foo/**` => `{baseDir}/**/foo/**`
 		if !endingSlash {
-			glob := prefix + joinGlob(baseDir, all, escapeSpecialGlobChars(rule))
+			glob := prefix + joinGlob(baseDir, all, escapeIgnoreRuleMetaChars(rule))
 			globs = append(globs, glob)
+		}
+	}
+	return globs
+}
+
+// parseIgnoreRuleToGlobsLegacy to be removed in future releases.
+func parseIgnoreRuleToGlobsLegacy(rule string, filePath string) (globs []string) {
+	prefix := ""
+	const negation = "!"
+	const slash = "/"
+	const all = "**"
+	baseDir := filepath.ToSlash(filePath)
+
+	if strings.HasPrefix(rule, negation) {
+		rule = rule[1:]
+		prefix = negation
+	}
+
+	// Special case: "/" pattern has no effect in gitignore
+	if rule == slash {
+		return globs
+	}
+
+	startingSlash := strings.HasPrefix(rule, slash)
+	startingGlobstar := strings.HasPrefix(rule, all)
+	endingSlash := strings.HasSuffix(rule, slash)
+	endingGlobstar := strings.HasSuffix(rule, all)
+
+	if startingSlash || startingGlobstar {
+		// case `/foo/`, `/foo` => `{baseDir}/foo/**`
+		// case `**/foo/`, `**/foo` => `{baseDir}/**/foo/**`
+		if !endingGlobstar {
+			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, rule, all))
+			globs = append(globs, escapeSpecialGlobCharsLegacy(glob))
+		}
+		// case `/foo` => `{baseDir}/foo`
+		// case `**/foo` => `{baseDir}/**/foo`
+		// case `/foo/**` => `{baseDir}/foo/**`
+		// case `**/foo/**` => `{baseDir}/**/foo/**`
+		if !endingSlash {
+			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, rule))
+			globs = append(globs, escapeSpecialGlobCharsLegacy(glob))
+		}
+	} else {
+		// case `foo/`, `foo` => `{baseDir}/**/foo/**`
+		if !endingGlobstar {
+			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, all, rule, all))
+			globs = append(globs, escapeSpecialGlobCharsLegacy(glob))
+		}
+		// case `foo` => `{baseDir}/**/foo`
+		// case `foo/**` => `{baseDir}/**/foo/**`
+		if !endingSlash {
+			glob := filepath.ToSlash(prefix + filepath.Join(baseDir, all, rule))
+			globs = append(globs, escapeSpecialGlobCharsLegacy(glob))
 		}
 	}
 	return globs

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -17,6 +17,8 @@ import (
 	gitignore "github.com/sabhiram/go-gitignore"
 	"golang.org/x/sync/semaphore"
 	"gopkg.in/yaml.v3"
+
+	"github.com/snyk/go-application-framework/pkg/featureflags"
 )
 
 // by default, all rules are valid
@@ -84,17 +86,6 @@ func WithDotSnykSections(sections []DotSnykExcludeSectionName) FileFilterOption 
 	}
 }
 
-// WithIgnoreRuleMetacharacterFix toggles the fix for ignore rules/paths containing regex
-// metacharacters (parentheses, "+", "|", "{", "}", "$", etc.).
-// Disabled (the default) reproduces the legacy behavior.
-// Callers should enable this deliberately (e.g. gated on configuration.FF_FILE_FILTER_METACHARACTER_FIX).
-func WithIgnoreRuleMetacharacterFix(enabled bool) FileFilterOption {
-	return func(filter *FileFilter) error {
-		filter.enableIgnoreRuleMetacharacterFix = enabled
-		return nil
-	}
-}
-
 func NewFileFilter(path string, logger *zerolog.Logger, options ...FileFilterOption) *FileFilter {
 	filter := &FileFilter{
 		path:            path,
@@ -111,6 +102,15 @@ func NewFileFilter(path string, logger *zerolog.Logger, options ...FileFilterOpt
 		}
 	}
 
+	return filter
+}
+
+// NewFileFilterFromConfig is like NewFileFilter, but resolves feature-flag-gated behavior (like
+// the ignore-rule metacharacter fix) from config directly, so callers don't need a code change
+// here when a future flag of this kind is added.
+func NewFileFilterFromConfig(path string, logger *zerolog.Logger, config featureflags.FeatureFlagReader, options ...FileFilterOption) *FileFilter {
+	filter := NewFileFilter(path, logger, options...)
+	filter.enableIgnoreRuleMetacharacterFix = config.GetBool(featureflags.FileFilterMetacharacterFix)
 	return filter
 }
 

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -86,9 +86,17 @@ func WithDotSnykSections(sections []DotSnykExcludeSectionName) FileFilterOption 
 	}
 }
 
-// Deprecated: Use NewFileFilterFromConfig instead
+// Deprecated: Use NewFileFilterFromConfig instead.
 func NewFileFilter(path string, logger *zerolog.Logger, options ...FileFilterOption) *FileFilter {
-	return newFileFilterInternal(path, logger, options...)
+	filter := newFileFilterInternal(path, logger, options...)
+
+	// TODO: Temporary - this keeps the metacharacter
+	// fix enabled for callers of this deprecated constructor (e.g. Preview CLI) that haven't migrated
+	// to NewFileFilterFromConfig yet, so they keep the behavior they already rely on today. Remove
+	// once all such callers have migrated.
+	filter.enableIgnoreRuleMetacharacterFix = true
+
+	return filter
 }
 
 func newFileFilterInternal(path string, logger *zerolog.Logger, options ...FileFilterOption) *FileFilter {

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -36,7 +36,7 @@ func TestFileFilter_GetAllFiles(t *testing.T) {
 		tempFile2 := filepath.Join(tempDir, "test2.ts")
 		createFileInPath(t, tempFile2, []byte{})
 
-		fileFilter := NewFileFilter(tempDir, &log.Logger)
+		fileFilter := newFileFilterInternal(tempDir, &log.Logger)
 		actualFiles := fileFilter.GetAllFiles()
 		expectedFiles := []string{tempFile1, tempFile2}
 
@@ -49,7 +49,7 @@ func TestFileFilter_GetAllFiles(t *testing.T) {
 	})
 
 	t.Run("handles empty path", func(t *testing.T) {
-		fileFilter := NewFileFilter("", &log.Logger)
+		fileFilter := newFileFilterInternal("", &log.Logger)
 		actualFiles := fileFilter.GetAllFiles()
 
 		var actualFilesChanLen int
@@ -70,7 +70,7 @@ func TestFileFilter_GetRules_gitignoreFormat(t *testing.T) {
 
 	t.Run("includes default rules", func(t *testing.T) {
 		// create fileFilter
-		fileFilter := NewFileFilter(tempDir, &log.Logger)
+		fileFilter := newFileFilterInternal(tempDir, &log.Logger)
 		actualRules, err := fileFilter.GetRules([]string{})
 		assert.NoError(t, err)
 
@@ -84,7 +84,7 @@ func TestFileFilter_GetRules_gitignoreFormat(t *testing.T) {
 
 		// create fileFilter
 		ruleFiles := []string{".gitignore"}
-		fileFilter := NewFileFilter(tempDir, &log.Logger)
+		fileFilter := newFileFilterInternal(tempDir, &log.Logger)
 		actualRules, err := fileFilter.GetRules(ruleFiles)
 		assert.NoError(t, err)
 
@@ -111,7 +111,7 @@ func TestFileFilter_GetRules_gitignoreFormat(t *testing.T) {
 
 		// create fileFilter
 		ruleFiles := []string{".gitignore"}
-		fileFilter := NewFileFilter(tempDir, &log.Logger)
+		fileFilter := newFileFilterInternal(tempDir, &log.Logger)
 		actualRules, err := fileFilter.GetRules(ruleFiles)
 		assert.NoError(t, err)
 
@@ -156,7 +156,7 @@ exclude:
 
 		// create fileFilter
 		ruleFiles := []string{".snyk"}
-		fileFilter := NewFileFilter(tempDir, &log.Logger)
+		fileFilter := newFileFilterInternal(tempDir, &log.Logger)
 		actualRules, err := fileFilter.GetRules(ruleFiles)
 		assert.NoError(t, err)
 
@@ -196,7 +196,7 @@ exclude:
 
 		// create fileFilter
 		ruleFiles := []string{".snyk"}
-		fileFilter := NewFileFilter(tempDir, &log.Logger)
+		fileFilter := newFileFilterInternal(tempDir, &log.Logger)
 		actualRules, err := fileFilter.GetRules(ruleFiles)
 		assert.NoError(t, err)
 
@@ -283,7 +283,7 @@ func TestFileFilter_GetRules_dotSnykSections(t *testing.T) {
 			ignoreFile := filepath.Join(tempDir, ".snyk")
 			createFileInPath(t, ignoreFile, []byte(snykContent))
 
-			fileFilter := NewFileFilter(tempDir, &log.Logger, test.options...)
+			fileFilter := newFileFilterInternal(tempDir, &log.Logger, test.options...)
 			actualRules, err := fileFilter.GetRules([]string{".snyk"})
 			assert.NoError(t, err)
 
@@ -301,7 +301,7 @@ func TestFileFilter_GetRules_dotSnykSections(t *testing.T) {
 		ignoreFile := filepath.Join(tempDir, ".snyk")
 		createFileInPath(t, ignoreFile, []byte(snykContent))
 
-		fileFilter := NewFileFilter(tempDir, &log.Logger)
+		fileFilter := newFileFilterInternal(tempDir, &log.Logger)
 		actualRules, err := fileFilter.GetRules([]string{".snyk"})
 		assert.NoError(t, err)
 
@@ -360,7 +360,7 @@ func TestFileFilter_GetRules_dotSnykMalformedSection(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			fileFilter := NewFileFilter(tempDir, &log.Logger, test.options...)
+			fileFilter := newFileFilterInternal(tempDir, &log.Logger, test.options...)
 			actualRules, err := fileFilter.GetRules([]string{".snyk"})
 			assert.NoError(t, err)
 
@@ -377,7 +377,7 @@ func TestFileFilter_GetFilteredFiles(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			setupTestFileSystem(t, testCase)
 
-			fileFilter := NewFileFilter(testCase.repoPath, &log.Logger)
+			fileFilter := newFileFilterInternal(testCase.repoPath, &log.Logger)
 
 			files := fileFilter.GetAllFiles()
 
@@ -441,7 +441,7 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 			createFileInPath(t, appFile, []byte("x"))
 			createFileInPath(t, gitignore, []byte("node_modules\n"))
 
-			fileFilter := NewFileFilter(base, &log.Logger)
+			fileFilter := newFileFilterInternal(base, &log.Logger)
 			fileFilter.enableIgnoreRuleMetacharacterFix = true
 			globs, err := fileFilter.GetRules([]string{".gitignore"})
 			assert.NoError(t, err)
@@ -898,7 +898,7 @@ func TestFileFilter_GetFilteredFiles_ignoreRuleScenarios(t *testing.T) {
 				createFileInPath(t, filepath.Join(root, filepath.FromSlash(p)), []byte(content))
 			}
 
-			fileFilter := NewFileFilter(root, &log.Logger)
+			fileFilter := newFileFilterInternal(root, &log.Logger)
 			fileFilter.enableIgnoreRuleMetacharacterFix = true
 			globs, err := fileFilter.GetRules(tc.ruleFiles)
 			assert.NoError(t, err)
@@ -934,7 +934,7 @@ func TestFileFilter_GetFilteredFiles_uncPaths(t *testing.T) {
 	// the FileFilter rooted at scanRoot (which may be a UNC-style alias of base).
 	assertFiltered := func(t *testing.T, scanRoot string) {
 		t.Helper()
-		fileFilter := NewFileFilter(scanRoot, &log.Logger)
+		fileFilter := newFileFilterInternal(scanRoot, &log.Logger)
 		fileFilter.enableIgnoreRuleMetacharacterFix = true
 		globs, err := fileFilter.GetRules([]string{".gitignore"})
 		assert.NoError(t, err)
@@ -1031,7 +1031,7 @@ func BenchmarkFileFilter_GetFilteredFiles(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		fileFilter := NewFileFilter(rootDir, &log.Logger, WithThreadNumber(runtime.NumCPU()))
+		fileFilter := newFileFilterInternal(rootDir, &log.Logger, WithThreadNumber(runtime.NumCPU()))
 
 		b.StartTimer()
 		globs, err := fileFilter.GetRules(ruleFiles)
@@ -1507,7 +1507,7 @@ func TestFileFilter_MetacharacterFixToggle(t *testing.T) {
 
 	t.Run("fix disabled (default) reproduces the legacy behavior", func(t *testing.T) {
 		base, nodeModulesFile, appFile := setup(t)
-		fileFilter := NewFileFilter(base, &log.Logger)
+		fileFilter := newFileFilterInternal(base, &log.Logger)
 
 		filtered := filterFiles(t, fileFilter)
 		assert.Contains(t, filtered, appFile, "app.js should be scanned")
@@ -1517,7 +1517,7 @@ func TestFileFilter_MetacharacterFixToggle(t *testing.T) {
 
 	t.Run("fix disabled explicitly behaves the same as the default", func(t *testing.T) {
 		base, nodeModulesFile, appFile := setup(t)
-		fileFilter := NewFileFilter(base, &log.Logger)
+		fileFilter := newFileFilterInternal(base, &log.Logger)
 		fileFilter.enableIgnoreRuleMetacharacterFix = false
 
 		filtered := filterFiles(t, fileFilter)
@@ -1527,7 +1527,7 @@ func TestFileFilter_MetacharacterFixToggle(t *testing.T) {
 
 	t.Run("fix enabled excludes node_modules correctly", func(t *testing.T) {
 		base, nodeModulesFile, appFile := setup(t)
-		fileFilter := NewFileFilter(base, &log.Logger)
+		fileFilter := newFileFilterInternal(base, &log.Logger)
 		fileFilter.enableIgnoreRuleMetacharacterFix = true
 
 		filtered := filterFiles(t, fileFilter)
@@ -1559,7 +1559,7 @@ func TestFileFilter_SlashPatternInGitIgnore(t *testing.T) {
 		createFileInPath(t, gitignorePath, []byte("/"))
 
 		// Test file filtering
-		fileFilter := NewFileFilter(tempDir, &log.Logger)
+		fileFilter := newFileFilterInternal(tempDir, &log.Logger)
 		rules, err := fileFilter.GetRules([]string{".gitignore"})
 		assert.NoError(t, err)
 
@@ -1604,7 +1604,7 @@ func TestFileFilter_SlashPatternInGitIgnore(t *testing.T) {
 		createFileInPath(t, gitignorePath, []byte("/*"))
 
 		// Test file filtering
-		fileFilter := NewFileFilter(tempDir, &log.Logger)
+		fileFilter := newFileFilterInternal(tempDir, &log.Logger)
 		rules, err := fileFilter.GetRules([]string{".gitignore"})
 		assert.NoError(t, err)
 

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -441,7 +441,7 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 			createFileInPath(t, appFile, []byte("x"))
 			createFileInPath(t, gitignore, []byte("node_modules\n"))
 
-			fileFilter := NewFileFilter(base, &log.Logger)
+			fileFilter := NewFileFilter(base, &log.Logger, WithIgnoreRuleMetacharacterFix(true))
 			globs, err := fileFilter.GetRules([]string{".gitignore"})
 			assert.NoError(t, err)
 
@@ -897,7 +897,7 @@ func TestFileFilter_GetFilteredFiles_ignoreRuleScenarios(t *testing.T) {
 				createFileInPath(t, filepath.Join(root, filepath.FromSlash(p)), []byte(content))
 			}
 
-			fileFilter := NewFileFilter(root, &log.Logger)
+			fileFilter := NewFileFilter(root, &log.Logger, WithIgnoreRuleMetacharacterFix(true))
 			globs, err := fileFilter.GetRules(tc.ruleFiles)
 			assert.NoError(t, err)
 
@@ -932,7 +932,7 @@ func TestFileFilter_GetFilteredFiles_uncPaths(t *testing.T) {
 	// the FileFilter rooted at scanRoot (which may be a UNC-style alias of base).
 	assertFiltered := func(t *testing.T, scanRoot string) {
 		t.Helper()
-		fileFilter := NewFileFilter(scanRoot, &log.Logger)
+		fileFilter := NewFileFilter(scanRoot, &log.Logger, WithIgnoreRuleMetacharacterFix(true))
 		globs, err := fileFilter.GetRules([]string{".gitignore"})
 		assert.NoError(t, err)
 
@@ -1415,11 +1415,121 @@ func TestParseIgnoreRuleToGlobs(t *testing.T) {
 			if tc.skipNonWindows && runtime.GOOS != "windows" {
 				t.Skip("UNC paths only exist on Windows")
 			}
-			globs := parseIgnoreRuleToGlobs(tc.rule, tc.baseDir, tc.invalidRules)
+			globs := parseIgnoreRuleToGlobs(tc.rule, tc.baseDir, tc.invalidRules, true)
 			assert.ElementsMatch(t, tc.expectedGlobs, globs,
 				"Test Name: %s, Rule: %q, Expected: %v, Got: %v", tc.name, tc.rule, tc.expectedGlobs, globs)
 		})
 	}
+}
+
+// TestParseIgnoreRuleToGlobs_legacyBehavior locks in the pre-fix (enableMetacharacterFix=false)
+// behavior byte-for-byte. To be removed in future releases.
+func TestParseIgnoreRuleToGlobs_legacyBehavior(t *testing.T) {
+	testCases := []struct {
+		name          string
+		rule          string
+		baseDir       string
+		expectedGlobs []string
+	}{
+		{
+			// Only "$" is escaped in the legacy path; other regex metacharacters are left as-is
+			// and can be misinterpreted by the regex-based matcher.
+			name:    "only dollar sign is escaped",
+			rule:    "*$",
+			baseDir: "/tmp/test",
+			expectedGlobs: []string{
+				"/tmp/test/**/*\\$",
+				"/tmp/test/**/*\\$/**",
+			},
+		},
+		{
+			// Parentheses are regex metacharacters that the legacy path does not escape, so a
+			// path/rule containing them can silently fail to match as expected.
+			name:    "parentheses are not escaped",
+			rule:    "node_modules",
+			baseDir: "/tmp/OneDrive - Foobar (Team1)/project",
+			expectedGlobs: []string{
+				"/tmp/OneDrive - Foobar (Team1)/project/**/node_modules/**",
+				"/tmp/OneDrive - Foobar (Team1)/project/**/node_modules",
+			},
+		},
+		{
+			name:    "root directory pattern",
+			rule:    "/foo",
+			baseDir: "/tmp/test",
+			expectedGlobs: []string{
+				"/tmp/test/foo/**",
+				"/tmp/test/foo",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			globs := parseIgnoreRuleToGlobs(tc.rule, tc.baseDir, []string{}, false)
+			assert.ElementsMatch(t, tc.expectedGlobs, globs,
+				"Test Name: %s, Rule: %q, Expected: %v, Got: %v", tc.name, tc.rule, tc.expectedGlobs, globs)
+		})
+	}
+}
+
+// TestFileFilter_MetacharacterFixToggle is the end-to-end regression net for the feature-flag
+// gate around the special-character-path fix (CLI-1648): with the option left at its default
+// (false / legacy behavior) a ".gitignore" rule for a directory containing regex metacharacters
+// must reproduce the old behavior (the directory is NOT excluded), while explicitly enabling
+// WithIgnoreRuleMetacharacterFix(true) must apply the fix (the directory IS excluded).
+func TestFileFilter_MetacharacterFixToggle(t *testing.T) {
+	setup := func(t *testing.T) (base, nodeModulesFile, appFile string) {
+		t.Helper()
+		base = filepath.Join(t.TempDir(), "OneDrive - Foobar (Team1)", "repo")
+		nodeModulesFile = filepath.Join(base, "node_modules", "lib", "index.js")
+		appFile = filepath.Join(base, "app.js")
+		createFileInPath(t, nodeModulesFile, []byte("x"))
+		createFileInPath(t, appFile, []byte("x"))
+		createFileInPath(t, filepath.Join(base, ".gitignore"), []byte("node_modules\n"))
+		return base, nodeModulesFile, appFile
+	}
+
+	filterFiles := func(t *testing.T, fileFilter *FileFilter) []string {
+		t.Helper()
+		globs, err := fileFilter.GetRules([]string{".gitignore"})
+		assert.NoError(t, err)
+
+		var filtered []string
+		for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+			filtered = append(filtered, f)
+		}
+		return filtered
+	}
+
+	t.Run("fix disabled (default) reproduces the legacy behavior", func(t *testing.T) {
+		base, nodeModulesFile, appFile := setup(t)
+		fileFilter := NewFileFilter(base, &log.Logger)
+
+		filtered := filterFiles(t, fileFilter)
+		assert.Contains(t, filtered, appFile, "app.js should be scanned")
+		assert.Contains(t, filtered, nodeModulesFile,
+			"legacy behavior: node_modules is NOT excluded when the base path has metacharacters")
+	})
+
+	t.Run("fix disabled explicitly behaves the same as the default", func(t *testing.T) {
+		base, nodeModulesFile, appFile := setup(t)
+		fileFilter := NewFileFilter(base, &log.Logger, WithIgnoreRuleMetacharacterFix(false))
+
+		filtered := filterFiles(t, fileFilter)
+		assert.Contains(t, filtered, appFile, "app.js should be scanned")
+		assert.Contains(t, filtered, nodeModulesFile, "legacy behavior reproduced")
+	})
+
+	t.Run("fix enabled excludes node_modules correctly", func(t *testing.T) {
+		base, nodeModulesFile, appFile := setup(t)
+		fileFilter := NewFileFilter(base, &log.Logger, WithIgnoreRuleMetacharacterFix(true))
+
+		filtered := filterFiles(t, fileFilter)
+		assert.Contains(t, filtered, appFile, "app.js should be scanned")
+		assert.NotContains(t, filtered, nodeModulesFile,
+			"fix enabled: node_modules must be excluded even though the base path has metacharacters")
+	})
 }
 
 func TestFileFilter_SlashPatternInGitIgnore(t *testing.T) {

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -441,7 +441,8 @@ func TestFileFilter_GetFilteredFiles_pathWithRegexMetaChars(t *testing.T) {
 			createFileInPath(t, appFile, []byte("x"))
 			createFileInPath(t, gitignore, []byte("node_modules\n"))
 
-			fileFilter := NewFileFilter(base, &log.Logger, WithIgnoreRuleMetacharacterFix(true))
+			fileFilter := NewFileFilter(base, &log.Logger)
+			fileFilter.enableIgnoreRuleMetacharacterFix = true
 			globs, err := fileFilter.GetRules([]string{".gitignore"})
 			assert.NoError(t, err)
 
@@ -897,7 +898,8 @@ func TestFileFilter_GetFilteredFiles_ignoreRuleScenarios(t *testing.T) {
 				createFileInPath(t, filepath.Join(root, filepath.FromSlash(p)), []byte(content))
 			}
 
-			fileFilter := NewFileFilter(root, &log.Logger, WithIgnoreRuleMetacharacterFix(true))
+			fileFilter := NewFileFilter(root, &log.Logger)
+			fileFilter.enableIgnoreRuleMetacharacterFix = true
 			globs, err := fileFilter.GetRules(tc.ruleFiles)
 			assert.NoError(t, err)
 
@@ -932,7 +934,8 @@ func TestFileFilter_GetFilteredFiles_uncPaths(t *testing.T) {
 	// the FileFilter rooted at scanRoot (which may be a UNC-style alias of base).
 	assertFiltered := func(t *testing.T, scanRoot string) {
 		t.Helper()
-		fileFilter := NewFileFilter(scanRoot, &log.Logger, WithIgnoreRuleMetacharacterFix(true))
+		fileFilter := NewFileFilter(scanRoot, &log.Logger)
+		fileFilter.enableIgnoreRuleMetacharacterFix = true
 		globs, err := fileFilter.GetRules([]string{".gitignore"})
 		assert.NoError(t, err)
 
@@ -1477,7 +1480,7 @@ func TestParseIgnoreRuleToGlobs_legacyBehavior(t *testing.T) {
 // gate around the special-character-path fix (CLI-1648): with the option left at its default
 // (false / legacy behavior) a ".gitignore" rule for a directory containing regex metacharacters
 // must reproduce the old behavior (the directory is NOT excluded), while explicitly enabling
-// WithIgnoreRuleMetacharacterFix(true) must apply the fix (the directory IS excluded).
+// enableIgnoreRuleMetacharacterFix must apply the fix (the directory IS excluded).
 func TestFileFilter_MetacharacterFixToggle(t *testing.T) {
 	setup := func(t *testing.T) (base, nodeModulesFile, appFile string) {
 		t.Helper()
@@ -1514,7 +1517,8 @@ func TestFileFilter_MetacharacterFixToggle(t *testing.T) {
 
 	t.Run("fix disabled explicitly behaves the same as the default", func(t *testing.T) {
 		base, nodeModulesFile, appFile := setup(t)
-		fileFilter := NewFileFilter(base, &log.Logger, WithIgnoreRuleMetacharacterFix(false))
+		fileFilter := NewFileFilter(base, &log.Logger)
+		fileFilter.enableIgnoreRuleMetacharacterFix = false
 
 		filtered := filterFiles(t, fileFilter)
 		assert.Contains(t, filtered, appFile, "app.js should be scanned")
@@ -1523,7 +1527,8 @@ func TestFileFilter_MetacharacterFixToggle(t *testing.T) {
 
 	t.Run("fix enabled excludes node_modules correctly", func(t *testing.T) {
 		base, nodeModulesFile, appFile := setup(t)
-		fileFilter := NewFileFilter(base, &log.Logger, WithIgnoreRuleMetacharacterFix(true))
+		fileFilter := NewFileFilter(base, &log.Logger)
+		fileFilter.enableIgnoreRuleMetacharacterFix = true
 
 		filtered := filterFiles(t, fileFilter)
 		assert.Contains(t, filtered, appFile, "app.js should be scanned")


### PR DESCRIPTION
### Description

Adds `NewFileFilterFromConfig`, which resolves feature-flag-gated `FileFilter` behavior (currently the ignore-rule metacharacter fix) directly from a `configuration.Configuration`, so future flags of this kind don't need caller changes. `config` may be `nil`, which keeps such behavior at its default.

`NewFileFilter` is now deprecated in favor of it. Flag keys shared across packages live in a new `pkg/featureflags` package (avoids an import cycle with `pkg/configuration`).

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.

PR in CLI: https://github.com/snyk/cli/pull/7039


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which files are excluded when paths or rules contain regex metacharacters; behavior depends on the flag and which constructor callers use, so incorrect rollout could alter scan scope.
> 
> **Overview**
> Introduces **`NewFileFilterFromConfig`**, which reads feature-flag-gated behavior (starting with the ignore-rule metacharacter fix) from configuration via a small **`pkg/featureflags`** package, avoiding an import cycle with `pkg/configuration`. **`NewFileFilter`** is deprecated but still forces the metacharacter fix on for unmigrated callers.
> 
> When the flag is off (the default for `newFileFilterInternal` / nil config), ignore parsing uses a **legacy** glob path that only escapes `$`; when on, rules and base paths escape the full set of regex metacharacters gitignore treats as literal before matching with go-gitignore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 820cf89e54a8c202e53b2a669d54d47e319763a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->