### PR TITLE
docs: add Cursor Cloud environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,3 +250,28 @@ Local development against a consumer (e.g. the CLI) — add to the consumer's `g
 ```
 replace github.com/snyk/go-application-framework => ../../go-application-framework
 ```
+
+---
+
+## Cursor Cloud specific instructions
+
+Durable, non-obvious notes for agents running in the Cursor Cloud Linux VM. The
+update script already runs `go mod download`; the items below are one-off/setup
+context and gotchas, not install steps to repeat.
+
+- **Go toolchain — pin the exact patch.** `go.mod` declares bare `go 1.26`. With
+  `GOTOOLCHAIN=auto` Go tries to fetch a non-existent `go1.26` toolchain from the
+  **blocked** `go.dev` and fails. The environment pins `GOTOOLCHAIN=go1.26.5`
+  (served by `proxy.golang.org`); keep it set (`go env -w GOTOOLCHAIN=go1.26.5`).
+- **golangci-lint host is blocked.** `make tools` installs golangci-lint via a
+  `curl … golangci-lint.run` script whose host is blocked. Instead install the
+  pinned version straight from the module proxy into `.bin/` (where the Makefile
+  expects it): `GOBIN=$(pwd)/.bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1`.
+- **Standard commands** are in [Quick reference](#quick-reference): `make build`,
+  `make lint`, `make test`. Build and lint pass cleanly; `make test` is green
+  **except** `pkg/networking.Test_GetHTTPClient`, which does a live
+  `GET https://www.snyk.io` that 301-redirects to bare `snyk.io`. `snyk.io` is
+  **blocked** in this VM, so that one test panics/fails — it is an environment
+  limitation, not a code defect, and passes once `snyk.io` egress is allowed.
+- **Reachable hosts:** `proxy.golang.org`, `github.com`, `raw.githubusercontent.com`.
+  **Blocked:** `go.dev`, bare `snyk.io`, `golangci-lint.run`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing durable, non-obvious setup notes for agents running in the Cursor Cloud Linux VM.

## Why

The default toolchain/hosts don't work out of the box in the restricted-egress VM. These notes save future agents from re-discovering the workarounds.

## Notes captured

- Pin `GOTOOLCHAIN=go1.26.5` (bare `go 1.26` + `auto` tries the blocked `go.dev`).
- Install `golangci-lint@v2.10.1` via the Go module proxy into `.bin/` (the `golangci-lint.run` installer host is blocked).
- `make build`/`make lint`/`make test` all pass **except** `pkg/networking.Test_GetHTTPClient`, which does a live GET to the blocked bare `snyk.io` — an environment limitation, not a code defect.

## Verification

`make build` (ok), `make lint` (`0 issues`), `make test` (51/52 packages pass; only the network-gated test fails as documented).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26b90e67-230c-4eb5-8199-42f535d12e57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26b90e67-230c-4eb5-8199-42f535d12e57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

