### PR TITLE
fix: add snykGitIgnoreTrackedFiles and snykFileFilterRespectParentExclusion feature flag related constants

### DIFF
--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -98,11 +98,15 @@ const (
 	FF_CODE_NATIVE_IMPLEMENTATION string = "internal_snyk_code_native_implementation"
 	// Feature flag to enable the fix for ignore rules/paths containing regex metacharacters
 	FF_FILE_FILTER_METACHARACTER_FIX string = featureflags.FileFilterMetacharacterFix
+	// Feature flag to enable tracked-file-aware .gitignore filtering (CLI-1411). Consumers gate
+	FF_GITIGNORE_RESPECT_TRACKED_FILES string = featureflags.GitIgnoreRespectTrackedFiles
+	// Feature flag to enable the fix for nested ignore files re-including files from excluded parent directories (CLI-1685)
+	FF_FILE_FILTER_RESPECT_PARENT_EXCLUSION_FIX string = featureflags.FileFilterRespectParentExclusionFix
 
 	// ---------
 	// feature flag names (platform-registered names backing the config keys above)
 	// ---------
-
-	// Feature flag name backing FF_FILE_FILTER_METACHARACTER_FIX
-	SNYK_FILE_FILTER_METACHARACTER_FIX string = featureflags.FileFilterMetacharacterFixBackendName
+	SNYK_FILE_FILTER_METACHARACTER_FIX            string = featureflags.FileFilterMetacharacterFixBackendName
+	SNYK_FILE_GITIGNORE_RESPECT_TRACKED_FILES     string = featureflags.GitIgnoreRespectTrackedFilesBackendName
+	SNYK_FILE_FILTER_RESPECT_PARENT_EXCLUSION_FIX string = featureflags.FileFilterRespectParentExclusionFixBackendName
 )

--- a/pkg/featureflags/featureflags.go
+++ b/pkg/featureflags/featureflags.go
@@ -9,10 +9,13 @@ type FeatureFlagReader interface {
 	GetBool(key string) bool
 }
 
+// These fields back pkg/configuration/constants.go
 const (
-	// FileFilterMetacharacterFix backs configuration.FF_FILE_FILTER_METACHARACTER_FIX.
-	FileFilterMetacharacterFix string = "internal_snyk_file_filter_metacharacter_fix_enabled"
+	FileFilterMetacharacterFix          string = "internal_snyk_file_filter_metacharacter_fix_enabled"
+	GitIgnoreRespectTrackedFiles        string = "internal_snyk_gitignore_respect_tracked_files_enabled"
+	FileFilterRespectParentExclusionFix string = "internal_snyk_file_filter_respect_parent_exclusion_enabled"
 
-	// FileFilterMetacharacterFixBackendName backs configuration.SNYK_FILE_FILTER_METACHARACTER_FIX.
-	FileFilterMetacharacterFixBackendName string = "snykFileFilterMetacharacterFix"
+	FileFilterMetacharacterFixBackendName          string = "snykFileFilterMetacharacterFix"
+	GitIgnoreRespectTrackedFilesBackendName        string = "snykGitIgnoreTrackedFiles"
+	FileFilterRespectParentExclusionFixBackendName string = "snykFileFilterRespectParentExclusion"
 )


### PR DESCRIPTION
### Description

_Provide description of this PR and changes._

### Checklist

- [ ] Tests added and all succeed (`make test`)
- [ ] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds configuration constants only; no runtime logic or default behavior changes until consumers read these flags.
> 
> **Overview**
> Registers **two new file-filtering feature flags** in the shared `featureflags` package and wires them through `pkg/configuration/constants` (internal config keys plus platform backend names), following the same pattern as `FF_FILE_FILTER_METACHARACTER_FIX`.
> 
> **`FF_GITIGNORE_RESPECT_TRACKED_FILES`** (`snykGitIgnoreTrackedFiles`) gates tracked-file-aware `.gitignore` filtering (CLI-1411). **`FF_FILE_FILTER_RESPECT_PARENT_EXCLUSION_FIX`** (`snykFileFilterRespectParentExclusion`) gates a fix for nested ignore files re-including paths from excluded parent directories (CLI-1685).
> 
> The existing metacharacter-fix flag block is lightly reorganized (aligned constants and grouped backend-name entries); behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbb8e85f0dc375daf53ebf3723ad62e051e5d3f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->