### PR TITLE
test(connectivity): isolate all checker env vars in TestDetectProxyConfig

### DIFF
--- a/pkg/local_workflows/connectivity_check_extension/connectivity/checker_test.go
+++ b/pkg/local_workflows/connectivity_check_extension/connectivity/checker_test.go
@@ -149,10 +149,13 @@ func TestDetectProxyConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Clear all proxy-related environment variables for test isolation
-			proxyEnvVars := []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "NO_PROXY", "no_proxy"}
-			for _, key := range proxyEnvVars {
-				t.Setenv(key, "")
+			// Clear every variable the checker reads, so the host environment
+			// cannot leak into the result. Derived from envVarSpecs so that
+			// variables added there stay isolated.
+			for _, spec := range envVarSpecs {
+				for _, key := range spec.names {
+					t.Setenv(key, "")
+				}
 			}
 
 			// Set test environment


### PR DESCRIPTION
### Description

`TestDetectProxyConfig` cleared the environment before each subtest, but only the proxy variables:

```go
proxyEnvVars := []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "NO_PROXY", "no_proxy"}
```

`DetectProxyConfig` iterates `envVarSpecs`, which also covers `NODE_EXTRA_CA_CERTS`, `KRB5_CONFIG` and `KRB5CCNAME`. Those three were never cleared, so the host machine's environment leaked into the result.

On any machine with `NODE_EXTRA_CA_CERTS` set — a corporate TLS-inspection CA bundle, for instance — six of the seven subtests fail:

```
Error: Not equal:
       expected: ""
       actual  : "/Users/…/zscaler-ca-bundle.pem"
Messages: NodeExtraCACerts mismatch
```

Unsetting the variable makes the same suite pass untouched, which is a confusing way to discover the test was never isolated. CI does not set these variables, which is why this has gone unnoticed.

The cleared list is now derived from `envVarSpecs` itself, so a variable added to the production spec is isolated automatically rather than quietly reintroducing this. It also removes the duplicated list of variable names.

Found while running the full suite to validate an unrelated change (#673).

**Update after merging `main`:** while this branch was open, `main` independently picked up the same isolation bug via an unrelated PR (#692) and fixed it too — with a hardcoded `envVarsToClean` list whose own comment flags it as needing manual sync with `envVarSpecs`. So the original failure this PR reported no longer reproduces on `main`. What this PR still adds: replacing that hardcoded, manually-synced list with the `envVarSpecs`-derived loop, so the sync-drift risk `main`'s own comment calls out can't recur. Merged `main` in; the merge commit resolves the conflict between the two approaches by keeping this loop and `main`'s newer "Node and Kerberos env vars set" test case.

### Checklist

- [x] Tests added and all succeed (`make test`) — `connectivity_check_extension/...` passes with `NODE_EXTRA_CA_CERTS` still set in my shell, which reproduced the failure before this change
- [ ] Regenerated mocks, etc. (`make generate`) — n/a
- [x] Linted (`make lint`) — 0 issues
- [ ] Test your changes work for the CLI — n/a, test-only change; no shipped code or public API touched

Made with [Cursor](https://cursor.com)
