### PR TITLE
feat: Keep git-tracked files that a .gitignore rule would exclude

### DIFF
--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -181,6 +181,7 @@ func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
 		return nil, err
 	}
 
+	fw.trackedFilesToKeep = nil
 	if fw.config.GetBool(FF_GITIGNORE_RESPECT_TRACKED_FILES) {
 		fw.trackedFilesToKeep = fw.findTrackedFilesToKeep(globs)
 	}
@@ -356,16 +357,26 @@ func (fw *FileFilter) readGitTrackedPaths() (paths []string) {
 		scanRoot = resolved
 	}
 
-	repoRoot := worktree.Filesystem.Root()
-	upwards := ".." + string(filepath.Separator)
-	for _, entry := range index.Entries {
-		entryPath := filepath.Join(repoRoot, filepath.FromSlash(entry.Name))
+	relScanRoot, err := filepath.Rel(worktree.Filesystem.Root(), scanRoot)
+	if err != nil {
+		fw.logger.Warn().Err(err).Msg("could not locate the scan path inside the git repository")
+		return nil
+	}
 
-		relToScanRoot, relErr := filepath.Rel(scanRoot, entryPath)
-		if relErr != nil || relToScanRoot == ".." || strings.HasPrefix(relToScanRoot, upwards) {
+	scanRootPrefix := ""
+	if relScanRoot != "." {
+		if strings.HasPrefix(relScanRoot, "..") {
+			fw.logger.Debug().Msg("the scan path lies outside the git repository")
+			return nil
+		}
+		scanRootPrefix = filepath.ToSlash(relScanRoot) + "/"
+	}
+
+	for _, entry := range index.Entries {
+		if !strings.HasPrefix(entry.Name, scanRootPrefix) {
 			continue // outside the directory being scanned
 		}
-		paths = append(paths, filepath.ToSlash(relToScanRoot))
+		paths = append(paths, strings.TrimPrefix(entry.Name, scanRootPrefix))
 	}
 
 	return paths

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-git/go-git/v5"
 	"github.com/rs/zerolog"
 	gitignore "github.com/sabhiram/go-gitignore"
 	"golang.org/x/sync/semaphore"
@@ -36,6 +38,8 @@ type FileFilter struct {
 	max_threads     int64
 	dotSnykSections []DotSnykExcludeSectionName
 	config          configuration.Configuration
+	// git-tracked files a .gitignore rule would exclude, relative to path. Set by GetRules.
+	trackedFilesToKeep map[string]bool
 }
 
 // DotSnykExcludeSectionName is the name of an `exclude` section in a .snyk
@@ -177,7 +181,11 @@ func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
 		return nil, err
 	}
 
-	return append(fw.defaultRules, globs...), nil
+	if fw.config.GetBool(FF_GITIGNORE_RESPECT_TRACKED_FILES) {
+		fw.trackedFilesToKeep = fw.findTrackedFilesToKeep(globs)
+	}
+
+	return slices.Concat(fw.defaultRules, globs.inParseOrder), nil
 }
 
 // GetFilteredFiles returns a filtered channel of filepaths from a given channel of filespaths and glob patterns to filter on
@@ -201,7 +209,7 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 			go func(f string) {
 				defer availableThreads.Release(1)
 				// filesToFilter that do not match the glob pattern are filtered
-				if !globPatternMatcher.MatchesPath(f) {
+				if !globPatternMatcher.MatchesPath(f) || fw.isTrackedFileToKeep(f) {
 					filteredFilesCh <- f
 				}
 			}(file)
@@ -218,31 +226,149 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 }
 
 // buildGlobs iterates a list of ignore filesToFilter and returns a list of glob patterns that can be used to test for ignored filesToFilter
-func (fw *FileFilter) buildGlobs(ignoreFiles []string) ([]string, error) {
+func (fw *FileFilter) buildGlobs(ignoreFiles []string) (parsedGlobs, error) {
 	if len(ignoreFiles) == 0 {
-		return nil, nil
+		return parsedGlobs{}, nil
 	}
 
 	enableMetacharacterFix := fw.config.GetBool(FF_FILE_FILTER_METACHARACTER_FIX)
 
-	var globs = make([]string, 0)
+	var gitignoreGlobs, otherGlobs, globsInParseOrder []string
 	for _, ignoreFile := range ignoreFiles {
 		var content []byte
 		content, err := os.ReadFile(ignoreFile)
 		if err != nil {
-			return nil, err
+			return parsedGlobs{}, err
 		}
 
-		if filepath.Base(ignoreFile) == ".snyk" { // .snyk files are yaml files and should be parsed differently
-			parsedRules := fw.parseDotSnykFile(content, filepath.Dir(ignoreFile), enableMetacharacterFix)
-			globs = append(globs, parsedRules...)
-		} else { // .gitignore, .dcignore, etc. are just a list of ignore rules
-			parsedRules := parseIgnoreFile(content, filepath.Dir(ignoreFile), enableMetacharacterFix)
-			globs = append(globs, parsedRules...)
+		dir := filepath.Dir(ignoreFile)
+		fileName := filepath.Base(ignoreFile)
+
+		var parsedRules []string
+		if fileName == ".snyk" { // .snyk files are yaml files and should be parsed differently
+			parsedRules = fw.parseDotSnykFile(content, dir, enableMetacharacterFix)
+		} else {
+			parsedRules = parseIgnoreFile(content, dir, enableMetacharacterFix)
+		}
+
+		globsInParseOrder = append(globsInParseOrder, parsedRules...)
+		if fileName == ".gitignore" {
+			gitignoreGlobs = append(gitignoreGlobs, parsedRules...)
+		} else {
+			otherGlobs = append(otherGlobs, parsedRules...)
 		}
 	}
 
-	return globs, nil
+	return parsedGlobs{inParseOrder: globsInParseOrder, gitignore: gitignoreGlobs, other: otherGlobs}, nil
+}
+
+// isTrackedFileToKeep reports whether filePath is a git-tracked file that a .gitignore rule
+// excludes, and so must be kept anyway.
+func (fw *FileFilter) isTrackedFileToKeep(filePath string) bool {
+	if len(fw.trackedFilesToKeep) == 0 {
+		return false
+	}
+
+	relToScanRoot, err := filepath.Rel(fw.path, filePath)
+	if err != nil {
+		return false
+	}
+
+	return fw.trackedFilesToKeep[filepath.ToSlash(relToScanRoot)]
+}
+
+// findTrackedFilesToKeep returns the git-tracked files that a .gitignore rule excludes but no
+// other ignore source does, keyed by path relative to fw.path.
+func (fw *FileFilter) findTrackedFilesToKeep(parsed parsedGlobs) map[string]bool {
+	if len(parsed.gitignore) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+	trackedPaths := fw.readGitTrackedPaths()
+	if len(trackedPaths) == 0 {
+		return nil
+	}
+
+	gitignoreMatcher := gitignore.CompileIgnoreLines(parsed.gitignore...)
+	otherMatcher := gitignore.CompileIgnoreLines(slices.Concat(fw.defaultRules, parsed.other)...)
+
+	trackedFilesToKeep := make(map[string]bool)
+	for _, trackedPath := range trackedPaths {
+		candidate := filepath.Join(fw.path, filepath.FromSlash(trackedPath))
+
+		// exclusions from other sources are Snyk's own, so being tracked by git does not undo them
+		if !gitignoreMatcher.MatchesPath(candidate) || otherMatcher.MatchesPath(candidate) {
+			continue
+		}
+
+		trackedFilesToKeep[trackedPath] = true
+	}
+
+	fw.logger.Debug().
+		Int("trackedFilesInIndex", len(trackedPaths)).
+		Int("trackedFilesToKeep", len(trackedFilesToKeep)).
+		Dur("duration", time.Since(start)).
+		Msg("checked the git index for tracked files matching .gitignore rules")
+
+	if len(trackedFilesToKeep) > 0 {
+		fw.logger.Warn().
+			Strs("trackedFilesToKeep", SortedMapKeys(trackedFilesToKeep)).
+			Msg("some git-tracked files match a .gitignore rule and will still be scanned, because git does not ignore tracked files")
+	}
+
+	return trackedFilesToKeep
+}
+
+// readGitTrackedPaths returns every file in the git index that lies inside fw.path, relative to fw.path
+func (fw *FileFilter) readGitTrackedPaths() (paths []string) {
+	absScanRoot, err := filepath.Abs(fw.path)
+	if err != nil {
+		fw.logger.Warn().Err(err).Msg("could not resolve the absolute scan path")
+		return nil
+	}
+
+	repo, err := git.PlainOpenWithOptions(absScanRoot, &git.PlainOpenOptions{DetectDotGit: true})
+	if err != nil {
+		if errors.Is(err, git.ErrRepositoryNotExists) {
+			fw.logger.Debug().Msg("not a git repository")
+			return nil
+		}
+		fw.logger.Warn().Err(err).Msg("could not open the git repository")
+		return nil
+	}
+
+	worktree, err := repo.Worktree()
+	if err != nil {
+		fw.logger.Warn().Err(err).Msg("could not read the git worktree")
+		return nil
+	}
+
+	index, err := repo.Storer.Index()
+	if err != nil {
+		fw.logger.Warn().Err(err).Msg("could not read the git index")
+		return nil
+	}
+
+	// go-git resolves symlinks in the repo root (e.g. macOS's /var -> /private/var), so match that
+	scanRoot := absScanRoot
+	if resolved, resolveErr := filepath.EvalSymlinks(absScanRoot); resolveErr == nil {
+		scanRoot = resolved
+	}
+
+	repoRoot := worktree.Filesystem.Root()
+	upwards := ".." + string(filepath.Separator)
+	for _, entry := range index.Entries {
+		entryPath := filepath.Join(repoRoot, filepath.FromSlash(entry.Name))
+
+		relToScanRoot, relErr := filepath.Rel(scanRoot, entryPath)
+		if relErr != nil || relToScanRoot == ".." || strings.HasPrefix(relToScanRoot, upwards) {
+			continue // outside the directory being scanned
+		}
+		paths = append(paths, filepath.ToSlash(relToScanRoot))
+	}
+
+	return paths
 }
 
 // parseDotSnykFile builds a list of glob patterns from a given .snyk style file
@@ -600,4 +726,10 @@ func parseIgnoreRuleToGlobsLegacy(rule string, filePath string) (globs []string)
 		}
 	}
 	return globs
+}
+
+type parsedGlobs struct {
+	inParseOrder []string
+	gitignore    []string
+	other        []string
 }

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -1936,3 +1936,41 @@ func TestFileFilter_readGitTrackedPaths(t *testing.T) {
 		assert.Empty(t, newFilter(root).readGitTrackedPaths())
 	})
 }
+
+// TestFileFilter_GetRules_trackedFilesClearedWhenFlagOff covers reusing one FileFilter across
+// GetRules calls: turning the flag off must restore the previous exclusion behavior rather than
+// leaving the tracked files recorded by an earlier call in place.
+func TestFileFilter_GetRules_trackedFilesClearedWhenFlagOff(t *testing.T) {
+	root := t.TempDir()
+	trackedLog := filepath.Join(root, "config.log")
+	createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("*.log\n"))
+	createFileInPath(t, trackedLog, []byte("x"))
+	initGitRepoWithTrackedFiles(t, root, []string{"config.log"})
+
+	config := newTestConfig(map[string]bool{
+		FF_FILE_FILTER_METACHARACTER_FIX:   true,
+		FF_GITIGNORE_RESPECT_TRACKED_FILES: true,
+	})
+	fileFilter := NewFileFilter(root, &log.Logger, WithConfig(config))
+
+	filterFiles := func(t *testing.T) []string {
+		t.Helper()
+		rules, err := fileFilter.GetRules([]string{".gitignore"})
+		assert.NoError(t, err)
+
+		var filtered []string
+		for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), rules) {
+			filtered = append(filtered, f)
+		}
+		return filtered
+	}
+
+	assert.Contains(t, filterFiles(t), trackedLog)
+	assert.NotEmpty(t, fileFilter.trackedFilesToKeep)
+
+	config.Set(FF_GITIGNORE_RESPECT_TRACKED_FILES, false)
+
+	assert.NotContains(t, filterFiles(t), trackedLog,
+		"turning the flag off must restore the previous exclusion behavior")
+	assert.Empty(t, fileFilter.trackedFilesToKeep)
+}

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/plumbing/format/index"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 
@@ -1696,4 +1699,240 @@ func TestDotSnykExclude_isExpired(t *testing.T) {
 			assert.Equal(t, test.expected, isExpired)
 		})
 	}
+}
+
+// initGitRepoWithTrackedFiles initializes a git repository at root and adds trackedPaths (relative
+// to root) to its index. Entries are written directly rather than via Worktree.Add so that a file
+// already matching a .gitignore rule still becomes tracked.
+func initGitRepoWithTrackedFiles(tb testing.TB, root string, trackedPaths []string) {
+	tb.Helper()
+	repo, err := git.PlainInit(root, false)
+	assert.NoError(tb, err)
+
+	idx, err := repo.Storer.Index()
+	assert.NoError(tb, err)
+
+	for _, trackedPath := range trackedPaths {
+		idx.Entries = append(idx.Entries, &index.Entry{Name: trackedPath, Mode: filemode.Regular})
+	}
+	assert.NoError(tb, repo.Storer.SetIndex(idx))
+}
+
+func TestFileFilter_GetRules_gitignoreRespectsTrackedFiles(t *testing.T) {
+	// config.log is tracked and untracked.log is not, while both match the .gitignore rule "*.log"
+	setup := func(t *testing.T) (root, trackedLog, untrackedLog, appFile string) {
+		t.Helper()
+		root = t.TempDir()
+		trackedLog = filepath.Join(root, "config.log")
+		untrackedLog = filepath.Join(root, "untracked.log")
+		appFile = filepath.Join(root, "app.js")
+		createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("*.log\n"))
+		createFileInPath(t, trackedLog, []byte("x"))
+		createFileInPath(t, untrackedLog, []byte("x"))
+		createFileInPath(t, appFile, []byte("x"))
+		initGitRepoWithTrackedFiles(t, root, []string{".gitignore", "config.log", "app.js"})
+		return root, trackedLog, untrackedLog, appFile
+	}
+
+	// the metacharacter fix is on so the rules go through the current parser, not the legacy one
+	newFilter := func(root string, respectTrackedFiles bool) *FileFilter {
+		return NewFileFilter(root, &log.Logger, WithConfig(newTestConfig(map[string]bool{
+			FF_FILE_FILTER_METACHARACTER_FIX:   true,
+			FF_GITIGNORE_RESPECT_TRACKED_FILES: respectTrackedFiles,
+		})))
+	}
+
+	filterFiles := func(t *testing.T, fileFilter *FileFilter, ruleFiles []string) []string {
+		t.Helper()
+		rules, err := fileFilter.GetRules(ruleFiles)
+		assert.NoError(t, err)
+
+		var filtered []string
+		for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), rules) {
+			filtered = append(filtered, f)
+		}
+		return filtered
+	}
+
+	t.Run("flag off keeps the previous behavior", func(t *testing.T) {
+		root, trackedLog, untrackedLog, appFile := setup(t)
+
+		filtered := filterFiles(t, newFilter(root, false), []string{".gitignore"})
+
+		assert.Contains(t, filtered, appFile)
+		assert.NotContains(t, filtered, trackedLog, "previous behavior: a tracked file matching .gitignore is excluded")
+		assert.NotContains(t, filtered, untrackedLog)
+	})
+
+	t.Run("flag on keeps tracked files and still excludes untracked ones", func(t *testing.T) {
+		root, trackedLog, untrackedLog, appFile := setup(t)
+
+		filtered := filterFiles(t, newFilter(root, true), []string{".gitignore"})
+
+		assert.Contains(t, filtered, trackedLog, "git does not ignore tracked files, so it must still be scanned")
+		assert.Contains(t, filtered, appFile)
+		assert.NotContains(t, filtered, untrackedLog, "an untracked file matching .gitignore must stay excluded")
+	})
+
+	t.Run("the returned rules are the same whether the flag is on or off", func(t *testing.T) {
+		root, _, _, _ := setup(t)
+
+		off, err := newFilter(root, false).GetRules([]string{".gitignore"})
+		assert.NoError(t, err)
+		on, err := newFilter(root, true).GetRules([]string{".gitignore"})
+		assert.NoError(t, err)
+
+		assert.Equal(t, off, on, "tracked files are kept by the filter, not by altering the rules")
+	})
+
+	t.Run("only the ignored tracked files are recorded", func(t *testing.T) {
+		root, trackedLog, untrackedLog, appFile := setup(t)
+
+		fileFilter := newFilter(root, true)
+		_, err := fileFilter.GetRules([]string{".gitignore"})
+		assert.NoError(t, err)
+
+		assert.Equal(t, map[string]bool{"config.log": true}, fileFilter.trackedFilesToKeep,
+			"app.js is tracked but no .gitignore rule excludes it, so it needs no exception")
+		assert.True(t, fileFilter.isTrackedFileToKeep(trackedLog))
+		assert.False(t, fileFilter.isTrackedFileToKeep(untrackedLog))
+		assert.False(t, fileFilter.isTrackedFileToKeep(appFile))
+	})
+
+	t.Run("an exclusion from another source still applies to a tracked file", func(t *testing.T) {
+		root, trackedLog, _, appFile := setup(t)
+		createFileInPath(t, filepath.Join(root, ".snyk"), []byte("exclude:\n  global:\n    - config.log\n"))
+
+		filtered := filterFiles(t, newFilter(root, true), []string{".gitignore", ".snyk"})
+
+		assert.Contains(t, filtered, appFile)
+		assert.NotContains(t, filtered, trackedLog,
+			".snyk is Snyk's own exclusion, so being tracked by git must not override it")
+	})
+
+	t.Run("outside a git repository the previous behavior is kept", func(t *testing.T) {
+		root := t.TempDir()
+		trackedLog := filepath.Join(root, "config.log")
+		createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("*.log\n"))
+		createFileInPath(t, trackedLog, []byte("x"))
+		// deliberately no git repository here
+
+		fileFilter := newFilter(root, true)
+		filtered := filterFiles(t, fileFilter, []string{".gitignore"})
+
+		assert.NotContains(t, filtered, trackedLog, "without a git index there is nothing to keep")
+		assert.Empty(t, fileFilter.trackedFilesToKeep)
+	})
+
+	t.Run("without .gitignore rules nothing is un-ignored", func(t *testing.T) {
+		root := t.TempDir()
+		trackedLog := filepath.Join(root, "config.log")
+		createFileInPath(t, filepath.Join(root, ".dcignore"), []byte("*.log\n"))
+		createFileInPath(t, trackedLog, []byte("x"))
+		initGitRepoWithTrackedFiles(t, root, []string{"config.log"})
+
+		fileFilter := newFilter(root, true)
+		filtered := filterFiles(t, fileFilter, []string{".dcignore"})
+
+		assert.NotContains(t, filtered, trackedLog, ".dcignore is not git, so tracking does not keep it")
+		assert.Empty(t, fileFilter.trackedFilesToKeep)
+	})
+
+	t.Run("a tracked file in a subdirectory is kept", func(t *testing.T) {
+		root := t.TempDir()
+		trackedLog := filepath.Join(root, "src", "nested", "config.log")
+		untrackedLog := filepath.Join(root, "src", "nested", "other.log")
+		createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("*.log\n"))
+		createFileInPath(t, trackedLog, []byte("x"))
+		createFileInPath(t, untrackedLog, []byte("x"))
+		initGitRepoWithTrackedFiles(t, root, []string{"src/nested/config.log"})
+
+		fileFilter := newFilter(root, true)
+		filtered := filterFiles(t, fileFilter, []string{".gitignore"})
+
+		assert.Contains(t, filtered, trackedLog)
+		assert.NotContains(t, filtered, untrackedLog)
+		assert.Equal(t, map[string]bool{"src/nested/config.log": true}, fileFilter.trackedFilesToKeep,
+			"keys stay forward-slashed on every platform, matching how they are looked up")
+	})
+
+	t.Run("tracked files outside the scanned directory are left alone", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		scanRoot := filepath.Join(repoRoot, "src")
+		insideLog := filepath.Join(scanRoot, "inside.log")
+		createFileInPath(t, filepath.Join(scanRoot, ".gitignore"), []byte("*.log\n"))
+		createFileInPath(t, insideLog, []byte("x"))
+		createFileInPath(t, filepath.Join(repoRoot, "outside.log"), []byte("x"))
+		initGitRepoWithTrackedFiles(t, repoRoot, []string{"src/inside.log", "outside.log"})
+
+		fileFilter := newFilter(scanRoot, true)
+		filtered := filterFiles(t, fileFilter, []string{".gitignore"})
+
+		assert.Contains(t, filtered, insideLog, "a tracked file inside the scanned directory is kept")
+		assert.Equal(t, map[string]bool{"inside.log": true}, fileFilter.trackedFilesToKeep,
+			"a tracked file outside the scanned directory is irrelevant")
+	})
+
+	t.Run("flag unset behaves like the flag being off", func(t *testing.T) {
+		root, trackedLog, _, _ := setup(t)
+
+		fileFilter := NewFileFilter(root, &log.Logger, WithConfig(newTestConfig(nil)))
+
+		filtered := filterFiles(t, fileFilter, []string{".gitignore"})
+		assert.NotContains(t, filtered, trackedLog)
+		assert.Empty(t, fileFilter.trackedFilesToKeep)
+	})
+
+	t.Run("no config keeps the previous behavior", func(t *testing.T) {
+		root, trackedLog, _, _ := setup(t)
+
+		fileFilter := NewFileFilter(root, &log.Logger)
+
+		filtered := filterFiles(t, fileFilter, []string{".gitignore"})
+		assert.NotContains(t, filtered, trackedLog,
+			"without a config the behavior defaults to disabled, reproducing the previous behavior")
+		assert.Empty(t, fileFilter.trackedFilesToKeep)
+	})
+}
+
+func TestFileFilter_readGitTrackedPaths(t *testing.T) {
+	newFilter := func(root string) *FileFilter {
+		return NewFileFilter(root, &log.Logger, WithConfig(newTestConfig(map[string]bool{
+			FF_GITIGNORE_RESPECT_TRACKED_FILES: true,
+		})))
+	}
+
+	t.Run("reads the tracked files inside the scan root", func(t *testing.T) {
+		root := t.TempDir()
+		initGitRepoWithTrackedFiles(t, root, []string{"app.js", "src/nested/config.log"})
+
+		assert.ElementsMatch(t, []string{"app.js", "src/nested/config.log"}, newFilter(root).readGitTrackedPaths())
+	})
+
+	t.Run("reads nothing outside a git repository", func(t *testing.T) {
+		assert.Empty(t, newFilter(t.TempDir()).readGitTrackedPaths())
+	})
+
+	t.Run("reads nothing from a bare repository", func(t *testing.T) {
+		root := t.TempDir()
+		_, err := git.PlainInit(root, true)
+		assert.NoError(t, err)
+
+		assert.Empty(t, newFilter(root).readGitTrackedPaths())
+	})
+
+	t.Run("reads nothing when the git index is corrupt", func(t *testing.T) {
+		root := t.TempDir()
+		initGitRepoWithTrackedFiles(t, root, []string{"app.js"})
+		createFileInPath(t, filepath.Join(root, ".git", "index"), []byte("not a git index"))
+
+		assert.Empty(t, newFilter(root).readGitTrackedPaths())
+	})
+
+	t.Run("reads nothing when the repository cannot be opened", func(t *testing.T) {
+		root := t.TempDir()
+		createFileInPath(t, filepath.Join(root, ".git"), []byte("gitdir: \x00 not a path\n"))
+
+		assert.Empty(t, newFilter(root).readGitTrackedPaths())
+	})
 }


### PR DESCRIPTION
### Description

Git only ignores files it does not track, but `FileFilter` excluded any file matching a `.gitignore` rule. A file committed before the rule existed was therefore hidden from scans. This aligns the filter with git's behavior.

`GetRules` now records the git-tracked files that a `.gitignore` rule excludes, and `GetFilteredFiles` keeps them. Exclusions from `.snyk`, `.dcignore` and the built-in defaults still apply to tracked files, since those are Snyk's own exclusions rather than git's. That is resolved when the set is built, so filtering still works from the flat rule list it is handed.

Gated behind `FF_GITIGNORE_RESPECT_TRACKED_FILES`, default off. With the flag off, no config, or no readable git repository, behavior is unchanged. `GetRules` returns byte-identical rules either way, which a test asserts.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which files are included in scans when the flag is enabled; logic is well-tested and default-off, but incorrect index or path handling could over-include sensitive files.
> 
> **Overview**
> Aligns `FileFilter` with git: files already in the index stay scannable when a `.gitignore` rule would exclude them, while untracked matches remain excluded.
> 
> When `FF_GITIGNORE_RESPECT_TRACKED_FILES` is on, `GetRules` reads the git index via go-git, finds tracked paths that match `.gitignore` but not `.snyk`, `.dcignore`, or default rules, and stores them in `trackedFilesToKeep`. `GetFilteredFiles` still uses the same glob list but re-includes those paths. `buildGlobs` now splits rules into `.gitignore` vs other sources for that logic. Flag defaults off; no repo, corrupt index, or flag off preserves prior behavior. Warns when tracked exceptions are applied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ded795afeafed9d27e6c3a90bd1536ed1d0a80e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->