### PR TITLE
chore: report file filter duration metrics via analytics [CLI-1740]

### DIFF
--- a/internal/metrics/recorder_fake.go
+++ b/internal/metrics/recorder_fake.go
@@ -1,13 +1,20 @@
 package metrics
 
+import "sync"
+
 // RecorderFake is a simple in-memory Recorder for use in tests.
+// Like the production recorder it may be written to concurrently, so its values are mutex guarded.
 type RecorderFake struct {
+	mu           sync.Mutex
 	IntValues    map[string]int
 	StringValues map[string]string
 	BoolValues   map[string]bool
 }
 
 func (r *RecorderFake) AddExtensionIntegerValue(key string, value int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if r.IntValues == nil {
 		r.IntValues = make(map[string]int)
 	}
@@ -15,6 +22,9 @@ func (r *RecorderFake) AddExtensionIntegerValue(key string, value int) {
 }
 
 func (r *RecorderFake) AddExtensionStringValue(key string, value string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if r.StringValues == nil {
 		r.StringValues = make(map[string]string)
 	}
@@ -22,6 +32,9 @@ func (r *RecorderFake) AddExtensionStringValue(key string, value string) {
 }
 
 func (r *RecorderFake) AddExtensionBoolValue(key string, value bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if r.BoolValues == nil {
 		r.BoolValues = make(map[string]bool)
 	}

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -75,12 +75,14 @@ type DotSnykRule struct {
 }
 
 const (
-	metricFileFilterPrefix                = "file-filter"
-	metricFileFilterDurationMs            = "durationMs"
-	metricFileFilterFileCount             = "fileCount"
-	metricFileFilterMetacharacterFix      = "metacharacterFix"
-	metricFileFilterRespectTrackedFiles   = "respectTrackedFiles"
-	metricFileFilterTrackedFilesKeptCount = "trackedFilesKeptCount"
+	metricFileFilterPrefix = "file-filter" // prefix for all file-filter analytics keys
+
+	metricFileFilterDurationMs            = "durationMs"            // elapsed time for GetFilteredFiles: exclusion-predicate build (incl. git index read) and filtering, including caller drain of the result channel
+	metricFileFilterSurvivingFileCount    = "survivingFileCount"    // number of files that passed exclusion in this filter run
+	metricFileFilterRulesBuildDurationMs  = "rulesBuildDurationMs"  // elapsed time for GetRules: directory walk, ignore discovery, and buildGlobs
+	metricFileFilterMetacharacterFix      = "metacharacterFix"      // whether FF_FILE_FILTER_METACHARACTER_FIX was enabled for this run
+	metricFileFilterRespectTrackedFiles   = "respectTrackedFiles"   // whether FF_GITIGNORE_RESPECT_TRACKED_FILES was enabled for this run
+	metricFileFilterTrackedFilesKeptCount = "trackedFilesKeptCount" // tracked files kept despite a matching .gitignore rule
 )
 
 type FileFilterOption func(*FileFilter) error
@@ -206,6 +208,21 @@ func (fw *FileFilter) GetAllFiles() chan string {
 
 // GetRules builds a list of glob patterns that can be used to filter filesToFilter
 func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
+	// Both feature flags change how rules are built (see buildGlobs), so the rules scope reports
+	// them alongside the build duration rather than relying on a GetFilteredFiles run that may
+	// never happen or may read a different flag value.
+	scopeID := newFileFilterMetricScopeID()
+	start := time.Now()
+	defer fw.recordMetricLazy(scopeID, metricFileFilterRulesBuildDurationMs, func() int {
+		return int(time.Since(start).Milliseconds())
+	})
+	fw.recordBoolMetricLazy(scopeID, metricFileFilterMetacharacterFix, func() bool {
+		return fw.config.GetBool(FF_FILE_FILTER_METACHARACTER_FIX)
+	})
+	fw.recordBoolMetricLazy(scopeID, metricFileFilterRespectTrackedFiles, func() bool {
+		return fw.config.GetBool(FF_GITIGNORE_RESPECT_TRACKED_FILES)
+	})
+
 	files := fw.GetAllFiles()
 
 	// iterate filesToFilter channel and find ignore filesToFilter
@@ -236,17 +253,6 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 
 	var filteredFilesCh = make(chan string)
 
-	var isFileExcluded func(string) bool
-	var trackedFilesKeptCount atomic.Int64
-	if fw.config.GetBool(FF_GITIGNORE_RESPECT_TRACKED_FILES) {
-		isFileExcluded = fw.trackedFileExclusionPredicate(globs, &trackedFilesKeptCount)
-	} else {
-		globPatternMatcher := gitignore.CompileIgnoreLines(globs...)
-		isFileExcluded = func(filePath string) bool {
-			return globPatternMatcher.MatchesPath(filePath)
-		}
-	}
-
 	go func() {
 		ctx := context.Background()
 		availableThreads := semaphore.NewWeighted(fw.max_threads)
@@ -254,6 +260,19 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 		var resolvedFileCount atomic.Int64
 
 		defer close(filteredFilesCh)
+
+		// Building the predicate is part of the run: with FF_GITIGNORE_RESPECT_TRACKED_FILES it
+		// opens the repository and reads the git index, so it is timed alongside the filtering.
+		var isFileExcluded func(string) bool
+		var trackedFilesKeptCount atomic.Int64
+		if fw.config.GetBool(FF_GITIGNORE_RESPECT_TRACKED_FILES) {
+			isFileExcluded = fw.trackedFileExclusionPredicate(globs, &trackedFilesKeptCount)
+		} else {
+			globPatternMatcher := gitignore.CompileIgnoreLines(globs...)
+			isFileExcluded = func(filePath string) bool {
+				return globPatternMatcher.MatchesPath(filePath)
+			}
+		}
 
 		// iterate the filesToFilter channel
 		for file := range filesCh {
@@ -286,7 +305,7 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 		fw.recordMetricLazy(runScopeID, metricFileFilterDurationMs, func() int {
 			return int(time.Since(start).Milliseconds())
 		})
-		fw.recordMetricLazy(runScopeID, metricFileFilterFileCount, func() int {
+		fw.recordMetricLazy(runScopeID, metricFileFilterSurvivingFileCount, func() int {
 			return int(resolvedFileCount.Load())
 		})
 		fw.recordMetricLazy(runScopeID, metricFileFilterTrackedFilesKeptCount, func() int {

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -44,7 +44,6 @@ type FileFilter struct {
 	dotSnykSections []DotSnykExcludeSectionName
 	config          configuration.Configuration
 	metricsRecorder metrics.Recorder
-	metricScopeID   string
 }
 
 // DotSnykExcludeSectionName is the name of an `exclude` section in a .snyk
@@ -75,14 +74,13 @@ type DotSnykRule struct {
 	Exclude map[DotSnykExcludeSectionName]yaml.Node `yaml:"exclude"`
 }
 
-// TODO: These metric keys are not read anywhere yet; actual recording is coming in a follow-up PR [CLI-1740].
-//
-//nolint:unused // plumbing for a follow-up PR that wires these into recordMetricLazy/recordBoolMetricLazy call sites [CLI-1740]
 const (
-	metricFileFilterPrefix           = "file-filter"
-	metricFileFilterDurationMs       = "durationMs"
-	metricFileFilterFileCount        = "fileCount"
-	metricFileFilterMetacharacterFix = "metacharacterFix"
+	metricFileFilterPrefix                = "file-filter"
+	metricFileFilterDurationMs            = "durationMs"
+	metricFileFilterFileCount             = "fileCount"
+	metricFileFilterMetacharacterFix      = "metacharacterFix"
+	metricFileFilterRespectTrackedFiles   = "respectTrackedFiles"
+	metricFileFilterTrackedFilesKeptCount = "trackedFilesKeptCount"
 )
 
 type FileFilterOption func(*FileFilter) error
@@ -132,23 +130,22 @@ func WithMetrics(recorder metrics.Recorder) FileFilterOption {
 	}
 }
 
-//nolint:unused // plumbing for a follow-up PR that adds the call sites [CLI-1740]
-func (fw *FileFilter) recordMetricLazy(key string, getMetric func() int) {
+func (fw *FileFilter) recordMetricLazy(scopeID, key string, getMetric func() int) {
 	if fw.metricsRecorder != nil {
-		fw.metricsRecorder.AddExtensionIntegerValue(fw.metricKey(key), getMetric())
+		fw.metricsRecorder.AddExtensionIntegerValue(metricKey(scopeID, key), getMetric())
 	}
 }
 
-//nolint:unused // plumbing for a follow-up PR that adds the call sites [CLI-1740]
-func (fw *FileFilter) recordBoolMetricLazy(key string, getMetric func() bool) {
+func (fw *FileFilter) recordBoolMetricLazy(scopeID, key string, getMetric func() bool) {
 	if fw.metricsRecorder != nil {
-		fw.metricsRecorder.AddExtensionBoolValue(fw.metricKey(key), getMetric())
+		fw.metricsRecorder.AddExtensionBoolValue(metricKey(scopeID, key), getMetric())
 	}
 }
 
-//nolint:unused // plumbing for a follow-up PR that adds the call sites [CLI-1740]
-func (fw *FileFilter) metricKey(key string) string {
-	return fmt.Sprintf("%s.%s.%s", metricFileFilterPrefix, fw.metricScopeID, key)
+// metricKey namespaces a metric under the scope of the filter run that recorded it, so that
+// repeated runs do not overwrite each other in a recorder that keeps only the last value per key.
+func metricKey(scopeID, key string) string {
+	return fmt.Sprintf("%s.%s.%s", metricFileFilterPrefix, scopeID, key)
 }
 
 func newFileFilterMetricScopeID() string {
@@ -163,7 +160,6 @@ func NewFileFilter(path string, logger *zerolog.Logger, options ...FileFilterOpt
 		logger:          logger,
 		max_threads:     int64(runtime.NumCPU()),
 		dotSnykSections: []DotSnykExcludeSectionName{DotSnykExcludeCode, DotSnykExcludeGlobal}, // init default with DotSnykExcludeCode and DotSnykExcludeGlobal to keep it backwards compatible
-		metricScopeID:   newFileFilterMetricScopeID(),
 	}
 
 	options = append([]FileFilterOption{WithConfig(nil)}, options...)
@@ -234,11 +230,16 @@ func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
 
 // GetFilteredFiles returns a filtered channel of filepaths from a given channel of filespaths and glob patterns to filter on
 func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan string {
+	// Each run reports under its own scope, so that concurrent or repeated runs of this FileFilter
+	// neither race on shared state nor overwrite each other's values in the recorder.
+	runScopeID := newFileFilterMetricScopeID()
+
 	var filteredFilesCh = make(chan string)
 
 	var isFileExcluded func(string) bool
+	var trackedFilesKeptCount atomic.Int64
 	if fw.config.GetBool(FF_GITIGNORE_RESPECT_TRACKED_FILES) {
-		isFileExcluded = fw.trackedFileExclusionPredicate(globs)
+		isFileExcluded = fw.trackedFileExclusionPredicate(globs, &trackedFilesKeptCount)
 	} else {
 		globPatternMatcher := gitignore.CompileIgnoreLines(globs...)
 		isFileExcluded = func(filePath string) bool {
@@ -249,6 +250,8 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 	go func() {
 		ctx := context.Background()
 		availableThreads := semaphore.NewWeighted(fw.max_threads)
+		start := time.Now()
+		var resolvedFileCount atomic.Int64
 
 		defer close(filteredFilesCh)
 
@@ -263,6 +266,7 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 				// filesToFilter that do not match the glob pattern are filtered
 				if !isFileExcluded(f) {
 					filteredFilesCh <- f
+					resolvedFileCount.Add(1)
 				}
 			}(file)
 		}
@@ -272,6 +276,22 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 		if err != nil {
 			fw.logger.Err(err).Msg("failed to wait for all threads")
 		}
+
+		fw.recordBoolMetricLazy(runScopeID, metricFileFilterMetacharacterFix, func() bool {
+			return fw.config.GetBool(FF_FILE_FILTER_METACHARACTER_FIX)
+		})
+		fw.recordBoolMetricLazy(runScopeID, metricFileFilterRespectTrackedFiles, func() bool {
+			return fw.config.GetBool(FF_GITIGNORE_RESPECT_TRACKED_FILES)
+		})
+		fw.recordMetricLazy(runScopeID, metricFileFilterDurationMs, func() int {
+			return int(time.Since(start).Milliseconds())
+		})
+		fw.recordMetricLazy(runScopeID, metricFileFilterFileCount, func() int {
+			return int(resolvedFileCount.Load())
+		})
+		fw.recordMetricLazy(runScopeID, metricFileFilterTrackedFilesKeptCount, func() int {
+			return int(trackedFilesKeptCount.Load())
+		})
 	}()
 
 	return filteredFilesCh
@@ -311,7 +331,12 @@ func (fw *FileFilter) buildGlobs(ignoreFiles []string) ([]string, error) {
 	return globs, nil
 }
 
-func (fw *FileFilter) trackedFileExclusionPredicate(globs []string) func(string) bool {
+// trackedFileExclusionPredicate builds the exclusion predicate used when
+// FF_GITIGNORE_RESPECT_TRACKED_FILES is enabled. keptCount is incremented for every file that a
+// .gitignore rule would have excluded but that is kept because git tracks it, i.e. it is
+// exempted from the .gitignore rule and not excluded by any other rule (e.g. a .snyk or
+// .dcignore rule).
+func (fw *FileFilter) trackedFileExclusionPredicate(globs []string, keptCount *atomic.Int64) func(string) bool {
 	gitignoreGlobs := make([]string, 0)
 	allGlobs := make([]string, 0, len(globs))
 
@@ -377,7 +402,11 @@ func (fw *FileFilter) trackedFileExclusionPredicate(globs []string) func(string)
 		}
 
 		if trackedFilesToPreserve[filepath.ToSlash(relativePath)] {
-			return otherMatcher.MatchesPath(normalizedPath)
+			excluded := otherMatcher.MatchesPath(normalizedPath)
+			if !excluded {
+				keptCount.Add(1)
+			}
+			return excluded
 		}
 
 		return allMatcher.MatchesPath(normalizedPath)

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -2,12 +2,10 @@ package utils
 
 import (
 	"fmt"
-	"maps"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -2180,14 +2178,21 @@ func metricsByScope(t *testing.T, recorder *metrics.RecorderFake) map[string]fil
 	return runs
 }
 
-// singleFilterRun returns the metrics of the one run a recorder is expected to have seen.
-func singleFilterRun(t *testing.T, recorder *metrics.RecorderFake) filterRunMetrics {
+// singleRun returns the metrics of the one run a recorder is expected to have seen that recorded
+// the given metric. The metric picks the kind of run: metricFileFilterDurationMs is recorded by
+// GetFilteredFiles, metricFileFilterRulesBuildDurationMs by GetRules.
+func singleRun(t *testing.T, recorder *metrics.RecorderFake, metric string) filterRunMetrics {
 	t.Helper()
 
-	runs := metricsByScope(t, recorder)
-	require.Len(t, runs, 1)
+	var matched []filterRunMetrics
+	for _, run := range metricsByScope(t, recorder) {
+		if _, ok := run.ints[metric]; ok {
+			matched = append(matched, run)
+		}
+	}
+	require.Len(t, matched, 1, "expected exactly one run recording %q", metric)
 
-	return slices.Collect(maps.Values(runs))[0]
+	return matched[0]
 }
 
 func TestFileFilter_Metrics(t *testing.T) {
@@ -2220,17 +2225,25 @@ func TestFileFilter_Metrics(t *testing.T) {
 
 			runFileFilter(t, fileFilter, ".gitignore")
 
-			run := singleFilterRun(t, recorder)
+			run := singleRun(t, recorder, metricFileFilterDurationMs)
 			assert.Equal(t, map[string]bool{
 				metricFileFilterMetacharacterFix:    test.metacharacterFix,
 				metricFileFilterRespectTrackedFiles: test.respectTrackedFiles,
 			}, run.bools)
 			// .gitignore and file.txt pass the filter, ignored.txt does not
-			assert.Equal(t, 2, run.ints[metricFileFilterFileCount])
+			assert.Equal(t, 2, run.ints[metricFileFilterSurvivingFileCount])
 			assert.Contains(t, run.ints, metricFileFilterDurationMs)
 			// newRepo isn't a git repository, so no tracked file is ever exempted from a gitignore rule
 			assert.Equal(t, 0, run.ints[metricFileFilterTrackedFilesKeptCount])
 			assert.Len(t, run.ints, 3)
+
+			// Building the rules reports its duration and the flags it built them with, under a scope of its own.
+			rulesRun := singleRun(t, recorder, metricFileFilterRulesBuildDurationMs)
+			assert.Equal(t, map[string]bool{
+				metricFileFilterMetacharacterFix:    test.metacharacterFix,
+				metricFileFilterRespectTrackedFiles: test.respectTrackedFiles,
+			}, rulesRun.bools)
+			assert.Len(t, rulesRun.ints, 1)
 		})
 	}
 
@@ -2248,13 +2261,20 @@ func TestFileFilter_Metrics(t *testing.T) {
 		drainFilteredFiles(t, fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), rules))
 		runFileFilter(t, NewFileFilter(newRepo(t), &log.Logger, WithConfig(config), WithMetrics(recorder)), ".gitignore")
 
-		// two runs of one FileFilter plus one run of another, none of them overwriting the values of the others
+		// two GetFilteredFiles runs of one FileFilter, one GetRules, and one full runFileFilter
+		// (GetRules + GetFilteredFiles), each under its own scope
 		runs := metricsByScope(t, recorder)
-		assert.Len(t, runs, 3)
+		assert.Len(t, runs, 5)
+
+		filterRuns := 0
 		for scopeID, run := range runs {
-			assert.Equal(t, 2, run.ints[metricFileFilterFileCount], "scope %s", scopeID)
-			assert.True(t, run.bools[metricFileFilterMetacharacterFix], "scope %s", scopeID)
+			if count, ok := run.ints[metricFileFilterSurvivingFileCount]; ok {
+				filterRuns++
+				assert.Equal(t, 2, count, "scope %s", scopeID)
+				assert.True(t, run.bools[metricFileFilterMetacharacterFix], "scope %s", scopeID)
+			}
 		}
+		assert.Equal(t, 3, filterRuns)
 	})
 
 	t.Run("without a recorder filtering is unaffected", func(t *testing.T) {
@@ -2283,7 +2303,7 @@ func TestFileFilter_Metrics(t *testing.T) {
 		assert.Equal(t, map[string]bool{
 			metricFileFilterMetacharacterFix:    true,
 			metricFileFilterRespectTrackedFiles: false,
-		}, singleFilterRun(t, recorder).bools)
+		}, singleRun(t, recorder, metricFileFilterDurationMs).bools)
 	})
 
 	// One FileFilter may be started from several goroutines at once: no run may race on shared
@@ -2373,7 +2393,8 @@ func TestFileFilter_Metrics_TrackedFilesKeptCount(t *testing.T) {
 
 			runFileFilter(t, fileFilter, test.ruleFiles...)
 
-			assert.Equal(t, test.expectedCount, singleFilterRun(t, recorder).ints[metricFileFilterTrackedFilesKeptCount])
+			run := singleRun(t, recorder, metricFileFilterDurationMs)
+			assert.Equal(t, test.expectedCount, run.ints[metricFileFilterTrackedFilesKeptCount])
 		})
 	}
 }

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -2,11 +2,14 @@ package utils
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/snyk/go-application-framework/internal/metrics"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 )
 
@@ -2099,7 +2103,12 @@ func assertGitTrackedFiles(t *testing.T, root string, ruleFiles []string, featur
 
 	for _, metacharacterFixEnabled := range []bool{false, true} {
 		t.Run(fmt.Sprintf("metacharacter_fix=%t", metacharacterFixEnabled), func(t *testing.T) {
-			filteredFiles := filterGitTrackedFiles(t, root, ruleFiles, featureFlagEnabled, metacharacterFixEnabled)
+			config := newTestConfig(map[string]bool{
+				FF_FILE_FILTER_METACHARACTER_FIX:   metacharacterFixEnabled,
+				FF_GITIGNORE_RESPECT_TRACKED_FILES: featureFlagEnabled,
+			})
+
+			filteredFiles := runFileFilter(t, NewFileFilter(root, &log.Logger, WithConfig(config)), ruleFiles...)
 			actual := make([]string, 0, len(filteredFiles))
 			for _, file := range filteredFiles {
 				relativePath, err := filepath.Rel(root, file)
@@ -2112,21 +2121,259 @@ func assertGitTrackedFiles(t *testing.T, root string, ruleFiles []string, featur
 	}
 }
 
-func filterGitTrackedFiles(t *testing.T, root string, ruleFiles []string, featureFlagEnabled, metacharacterFixEnabled bool) []string {
+// runFileFilter applies ruleFiles with the given FileFilter and returns the files that survive filtering.
+func runFileFilter(t *testing.T, fileFilter *FileFilter, ruleFiles ...string) []string {
 	t.Helper()
 
-	config := newTestConfig(map[string]bool{
-		FF_FILE_FILTER_METACHARACTER_FIX:   metacharacterFixEnabled,
-		FF_GITIGNORE_RESPECT_TRACKED_FILES: featureFlagEnabled,
-	})
-	fileFilter := NewFileFilter(root, &log.Logger, WithConfig(config))
 	rules, err := fileFilter.GetRules(ruleFiles)
 	require.NoError(t, err)
 
+	return drainFilteredFiles(t, fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), rules))
+}
+
+func drainFilteredFiles(t *testing.T, filesCh <-chan string) []string {
+	t.Helper()
+
 	var filteredFiles []string
-	for file := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), rules) {
+	for file := range filesCh {
 		filteredFiles = append(filteredFiles, file)
 	}
 
 	return filteredFiles
+}
+
+// filterRunMetrics holds what a single FileFilter run recorded, keyed by metric name.
+type filterRunMetrics struct {
+	ints  map[string]int
+	bools map[string]bool
+}
+
+// metricsByScope groups everything a recorder saw by run scope, asserting the
+// "file-filter.<scopeID>.<metric>" shape of every key on the way. Scope IDs are allocated
+// inside a run and never exposed, so tests discover them here rather than predicting them.
+func metricsByScope(t *testing.T, recorder *metrics.RecorderFake) map[string]filterRunMetrics {
+	t.Helper()
+
+	runs := make(map[string]filterRunMetrics)
+	runFor := func(key string) (filterRunMetrics, string) {
+		parts := strings.Split(key, ".")
+		require.Len(t, parts, 3, "metric key %q must be %s.<scopeID>.<metric>", key, metricFileFilterPrefix)
+		require.Equal(t, metricFileFilterPrefix, parts[0])
+
+		run, ok := runs[parts[1]]
+		if !ok {
+			run = filterRunMetrics{ints: map[string]int{}, bools: map[string]bool{}}
+			runs[parts[1]] = run
+		}
+		return run, parts[2]
+	}
+
+	for key, value := range recorder.IntValues {
+		run, metric := runFor(key)
+		run.ints[metric] = value
+	}
+	for key, value := range recorder.BoolValues {
+		run, metric := runFor(key)
+		run.bools[metric] = value
+	}
+
+	return runs
+}
+
+// singleFilterRun returns the metrics of the one run a recorder is expected to have seen.
+func singleFilterRun(t *testing.T, recorder *metrics.RecorderFake) filterRunMetrics {
+	t.Helper()
+
+	runs := metricsByScope(t, recorder)
+	require.Len(t, runs, 1)
+
+	return slices.Collect(maps.Values(runs))[0]
+}
+
+func TestFileFilter_Metrics(t *testing.T) {
+	// newRepo creates a directory holding a .gitignore plus one file that survives filtering.
+	newRepo := func(t *testing.T) string {
+		t.Helper()
+		root := t.TempDir()
+		createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("ignored.txt\n"))
+		createFileInPath(t, filepath.Join(root, "ignored.txt"), []byte("x"))
+		createFileInPath(t, filepath.Join(root, "file.txt"), []byte("x"))
+		return root
+	}
+
+	// The two feature flags carry opposite values so that a mix-up between their metric keys cannot pass.
+	for _, test := range []struct {
+		name                string
+		metacharacterFix    bool
+		respectTrackedFiles bool
+	}{
+		{name: "metacharacter fix only", metacharacterFix: true},
+		{name: "respect tracked files only", respectTrackedFiles: true},
+	} {
+		t.Run("records every metric under run-scoped keys, "+test.name, func(t *testing.T) {
+			recorder := &metrics.RecorderFake{}
+			config := newTestConfig(map[string]bool{
+				FF_FILE_FILTER_METACHARACTER_FIX:   test.metacharacterFix,
+				FF_GITIGNORE_RESPECT_TRACKED_FILES: test.respectTrackedFiles,
+			})
+			fileFilter := NewFileFilter(newRepo(t), &log.Logger, WithConfig(config), WithMetrics(recorder))
+
+			runFileFilter(t, fileFilter, ".gitignore")
+
+			run := singleFilterRun(t, recorder)
+			assert.Equal(t, map[string]bool{
+				metricFileFilterMetacharacterFix:    test.metacharacterFix,
+				metricFileFilterRespectTrackedFiles: test.respectTrackedFiles,
+			}, run.bools)
+			// .gitignore and file.txt pass the filter, ignored.txt does not
+			assert.Equal(t, 2, run.ints[metricFileFilterFileCount])
+			assert.Contains(t, run.ints, metricFileFilterDurationMs)
+			// newRepo isn't a git repository, so no tracked file is ever exempted from a gitignore rule
+			assert.Equal(t, 0, run.ints[metricFileFilterTrackedFilesKeptCount])
+			assert.Len(t, run.ints, 3)
+		})
+	}
+
+	// Neither several FileFilter instances nor repeated runs of one instance may overwrite each other's values.
+	// The rules are built once and reused, so every run has to report on its own rather than relying on GetRules.
+	t.Run("every run reports under its own scope", func(t *testing.T) {
+		recorder := &metrics.RecorderFake{}
+		config := newTestConfig(map[string]bool{FF_FILE_FILTER_METACHARACTER_FIX: true})
+		fileFilter := NewFileFilter(newRepo(t), &log.Logger, WithConfig(config), WithMetrics(recorder))
+
+		rules, err := fileFilter.GetRules([]string{".gitignore"})
+		require.NoError(t, err)
+
+		drainFilteredFiles(t, fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), rules))
+		drainFilteredFiles(t, fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), rules))
+		runFileFilter(t, NewFileFilter(newRepo(t), &log.Logger, WithConfig(config), WithMetrics(recorder)), ".gitignore")
+
+		// two runs of one FileFilter plus one run of another, none of them overwriting the values of the others
+		runs := metricsByScope(t, recorder)
+		assert.Len(t, runs, 3)
+		for scopeID, run := range runs {
+			assert.Equal(t, 2, run.ints[metricFileFilterFileCount], "scope %s", scopeID)
+			assert.True(t, run.bools[metricFileFilterMetacharacterFix], "scope %s", scopeID)
+		}
+	})
+
+	t.Run("without a recorder filtering is unaffected", func(t *testing.T) {
+		root := newRepo(t)
+
+		for _, fileFilter := range []*FileFilter{
+			NewFileFilter(root, &log.Logger),
+			NewFileFilter(root, &log.Logger, WithMetrics(nil)),
+		} {
+			assert.ElementsMatch(t, []string{
+				filepath.Join(root, ".gitignore"),
+				filepath.Join(root, "file.txt"),
+			}, runFileFilter(t, fileFilter, ".gitignore"))
+		}
+	})
+
+	t.Run("records bool metrics when no ignore files produce globs", func(t *testing.T) {
+		recorder := &metrics.RecorderFake{}
+		config := newTestConfig(map[string]bool{FF_FILE_FILTER_METACHARACTER_FIX: true})
+		root := t.TempDir()
+		createFileInPath(t, filepath.Join(root, "file.txt"), []byte("x"))
+		fileFilter := NewFileFilter(root, &log.Logger, WithConfig(config), WithMetrics(recorder))
+
+		drainFilteredFiles(t, fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), nil))
+
+		assert.Equal(t, map[string]bool{
+			metricFileFilterMetacharacterFix:    true,
+			metricFileFilterRespectTrackedFiles: false,
+		}, singleFilterRun(t, recorder).bools)
+	})
+
+	// One FileFilter may be started from several goroutines at once: no run may race on shared
+	// state or land in the scope of another. Run under -race to cover the former.
+	t.Run("concurrent filter runs use distinct metric scopes", func(t *testing.T) {
+		const concurrentRuns = 4
+		recorder := &metrics.RecorderFake{}
+		fileFilter := NewFileFilter(newRepo(t), &log.Logger, WithMetrics(recorder))
+
+		var wg sync.WaitGroup
+		wg.Add(concurrentRuns)
+		for range concurrentRuns {
+			go func() {
+				defer wg.Done()
+				drainFilteredFiles(t, fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), []string{"**/.git/**"}))
+			}()
+		}
+		wg.Wait()
+
+		runs := metricsByScope(t, recorder)
+		assert.Len(t, runs, concurrentRuns)
+		for scopeID, run := range runs {
+			assert.Contains(t, run.ints, metricFileFilterDurationMs, "scope %s", scopeID)
+		}
+	})
+}
+
+func TestFileFilter_Metrics_TrackedFilesKeptCount(t *testing.T) {
+	tests := []struct {
+		name           string
+		testCase       gitTrackedFilesTestCase
+		ruleFiles      []string
+		featureEnabled bool
+		expectedCount  int
+	}{
+		{
+			// regular.txt is tracked but no gitignore rule matches it, so it is not a kept file
+			name: "counts every tracked file a gitignore rule would have excluded",
+			testCase: gitTrackedFilesTestCase{
+				files: map[string]string{
+					"tracked.log":      "tracked but ignored",
+					"also-tracked.log": "tracked but ignored",
+					"untracked.log":    "untracked and ignored",
+					"regular.txt":      "regular file",
+				},
+				trackedFiles: []string{"tracked.log", "also-tracked.log", "regular.txt"},
+				ruleFiles:    map[string]string{".gitignore": "*.log\n"},
+			},
+			ruleFiles:      []string{".gitignore"},
+			featureEnabled: true,
+			expectedCount:  2,
+		},
+		{
+			// vendored.log is exempted from .gitignore, but the .dcignore rule still excludes it
+			name: "does not count a tracked file another rule still excludes",
+			testCase: gitTrackedFilesTestCase{
+				files:        map[string]string{"vendored.log": "vendored", "regular.txt": "regular"},
+				trackedFiles: []string{"vendored.log"},
+				ruleFiles: map[string]string{
+					".gitignore": "vendored.log\n",
+					".dcignore":  "vendored.log\n",
+				},
+			},
+			ruleFiles:      []string{".gitignore", ".dcignore"},
+			featureEnabled: true,
+			expectedCount:  0,
+		},
+		{
+			name: "does not count tracked files while the feature is disabled",
+			testCase: gitTrackedFilesTestCase{
+				files:        map[string]string{"tracked.log": "tracked but ignored"},
+				trackedFiles: []string{"tracked.log"},
+				ruleFiles:    map[string]string{".gitignore": "*.log\n"},
+			},
+			ruleFiles:      []string{".gitignore"},
+			featureEnabled: false,
+			expectedCount:  0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root, _ := setupGitTrackedFilesTestCase(t, test.testCase)
+			recorder := &metrics.RecorderFake{}
+			config := newTestConfig(map[string]bool{FF_GITIGNORE_RESPECT_TRACKED_FILES: test.featureEnabled})
+			fileFilter := NewFileFilter(root, &log.Logger, WithConfig(config), WithMetrics(recorder))
+
+			runFileFilter(t, fileFilter, test.ruleFiles...)
+
+			assert.Equal(t, test.expectedCount, singleFilterRun(t, recorder).ints[metricFileFilterTrackedFilesKeptCount])
+		})
+	}
 }

--- a/pkg/workflow/invocationcontextimpl_test.go
+++ b/pkg/workflow/invocationcontextimpl_test.go
@@ -3,12 +3,14 @@ package workflow
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/snyk/go-application-framework/pkg/analytics"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/utils"
 )
@@ -72,5 +74,32 @@ func TestInvocationContextImpl_GetFileFilter(t *testing.T) {
 
 		assert.Contains(t, filteredFiles(t, fileFilter), nodeModulesFile,
 			"the option passed by the caller must win over the invocation's configuration")
+	})
+
+	// The FileFilter records into the invocation's Analytics, so the metrics have to show up in its instrumentation.
+	t.Run("reports filter metrics through the analytics of the invocation", func(t *testing.T) {
+		base, _ := setup(t)
+		invocationAnalytics := analytics.New()
+		ictx := &invocationContextImpl{
+			Configuration: configuration.NewWithOpts(),
+			logger:        &zerolog.Logger{},
+			Analytics:     invocationAnalytics,
+		}
+
+		fileFilter := ictx.GetFileFilter(base)
+		filteredFiles(t, fileFilter)
+
+		obj, err := analytics.GetV2InstrumentationObject(invocationAnalytics.GetInstrumentation())
+		require.NoError(t, err)
+
+		var recorded []string
+		for key := range *obj.Data.Attributes.Interaction.Extension {
+			// keys are scoped per filter run: file-filter.<scopeID>.<metric>
+			parts := strings.Split(key, ".")
+			if len(parts) == 3 && parts[0] == "file-filter" {
+				recorded = append(recorded, parts[2])
+			}
+		}
+		assert.ElementsMatch(t, []string{"durationMs", "fileCount", "metacharacterFix", "respectTrackedFiles", "trackedFilesKeptCount"}, recorded)
 	})
 }

--- a/pkg/workflow/invocationcontextimpl_test.go
+++ b/pkg/workflow/invocationcontextimpl_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -92,14 +93,38 @@ func TestInvocationContextImpl_GetFileFilter(t *testing.T) {
 		obj, err := analytics.GetV2InstrumentationObject(invocationAnalytics.GetInstrumentation())
 		require.NoError(t, err)
 
-		var recorded []string
+		recorded := map[string][]string{}
 		for key := range *obj.Data.Attributes.Interaction.Extension {
 			// keys are scoped per filter run: file-filter.<scopeID>.<metric>
 			parts := strings.Split(key, ".")
 			if len(parts) == 3 && parts[0] == "file-filter" {
-				recorded = append(recorded, parts[2])
+				recorded[parts[1]] = append(recorded[parts[1]], parts[2])
 			}
 		}
-		assert.ElementsMatch(t, []string{"durationMs", "fileCount", "metacharacterFix", "respectTrackedFiles", "trackedFilesKeptCount"}, recorded)
+
+		// GetRules and GetFilteredFiles each report under a scope of their own; scope IDs are
+		// allocated inside the run, so the scopes are told apart by their duration metric.
+		require.Len(t, recorded, 2)
+		var rulesScope, filterScope []string
+		for _, metricNames := range recorded {
+			if slices.Contains(metricNames, "rulesBuildDurationMs") {
+				rulesScope = metricNames
+			} else {
+				filterScope = metricNames
+			}
+		}
+
+		assert.ElementsMatch(t, []string{
+			"rulesBuildDurationMs",
+			"metacharacterFix",
+			"respectTrackedFiles",
+		}, rulesScope)
+		assert.ElementsMatch(t, []string{
+			"durationMs",
+			"survivingFileCount",
+			"trackedFilesKeptCount",
+			"metacharacterFix",
+			"respectTrackedFiles",
+		}, filterScope)
 	})
 }


### PR DESCRIPTION
### Description

Report file filter duration metrics via analytics.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.
  
  CLI PR: https://github.com/snyk/cli/pull/7076

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to optional analytics recording; filtering logic is unchanged when no recorder is configured, and behavior is heavily covered by new tests including concurrency.
> 
> **Overview**
> **FileFilter** now records analytics extension metrics when `WithMetrics` is set (invocation context passes **Analytics** automatically). Previously this was only stubbed plumbing.
> 
> Each **GetRules** and **GetFilteredFiles** run gets its own scope ID (`file-filter.<scopeID>.<metric>`) so repeated or concurrent runs do not overwrite keys. **GetRules** reports `rulesBuildDurationMs` plus metacharacter-fix and respect-tracked-files flags. **GetFilteredFiles** reports `durationMs`, `survivingFileCount`, `trackedFilesKeptCount`, and the same flags. Tracked-file preservation increments `trackedFilesKeptCount` only when a git-tracked file would be dropped by `.gitignore` but is kept and not excluded by other rules.
> 
> `RecorderFake` is mutex-protected for concurrent metric writes in tests. Tests cover scoped keys, concurrent runs, tracked-file counting, and that invocation analytics receives the expected extension keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d198f992a5450ce4b867f9d639ec1588114f4f97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->