### PR TITLE
feat: file filter doesn't exclude tracked files though .gitignore rules

### DIFF
--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-git/go-git/v5"
+	gitindex "github.com/go-git/go-git/v5/plumbing/format/index"
 	"github.com/rs/zerolog"
 	gitignore "github.com/sabhiram/go-gitignore"
 	"golang.org/x/sync/semaphore"
@@ -25,6 +27,14 @@ const (
 	FF_FILE_FILTER_METACHARACTER_FIX   string = "internal_snyk_file_filter_metacharacter_fix_enabled"   // FF_FILE_FILTER_METACHARACTER_FIX (boolean) enables the fix for ignore rules and paths containing regex metacharacters
 	FF_GITIGNORE_RESPECT_TRACKED_FILES string = "internal_snyk_gitignore_respect_tracked_files_enabled" // FF_GITIGNORE_RESPECT_TRACKED_FILES (boolean) enables tracked-file-aware .gitignore filtering (CLI-1411)
 )
+
+// GitignoreGlobPrefix tags a glob returned by GetRules as sourced from a .gitignore file, so the
+// rule list carries its own provenance and git's exclusions can be told apart from other rules. The
+// leading "#" makes the line a comment to gitignore.CompileIgnoreLines, so the tag is inert for any
+// matcher that does not look for it.
+//
+// Tags are only emitted while FF_GITIGNORE_RESPECT_TRACKED_FILES is enabled.
+const GitignoreGlobPrefix = "#gitignore:"
 
 // by default, all rules are valid
 var defaultInvalidRules = []string{}
@@ -183,14 +193,15 @@ func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
 // GetFilteredFiles returns a filtered channel of filepaths from a given channel of filespaths and glob patterns to filter on
 func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan string {
 	var filteredFilesCh = make(chan string)
+	globs = slices.Clone(globs)
 
-	// create pattern matcher used to match filesToFilter to glob patterns
-	globPatternMatcher := gitignore.CompileIgnoreLines(globs...)
 	go func() {
 		ctx := context.Background()
 		availableThreads := semaphore.NewWeighted(fw.max_threads)
 
 		defer close(filteredFilesCh)
+
+		isExcluded := fw.newFileExclusionCheck(globs)
 
 		// iterate the filesToFilter channel
 		for file := range filesCh {
@@ -201,7 +212,7 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 			go func(f string) {
 				defer availableThreads.Release(1)
 				// filesToFilter that do not match the glob pattern are filtered
-				if !globPatternMatcher.MatchesPath(f) {
+				if !isExcluded(f) {
 					filteredFilesCh <- f
 				}
 			}(file)
@@ -217,6 +228,112 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 	return filteredFilesCh
 }
 
+// newFileExclusionCheck keeps non-.gitignore exclusions final and applies .gitignore only to untracked files.
+func (fw *FileFilter) newFileExclusionCheck(globs []string) func(filePath string) bool {
+	nonGitignoreMatcher := gitignore.CompileIgnoreLines(globs...)
+
+	var gitignoreRules []string
+	for _, glob := range globs {
+		if rule, tagged := strings.CutPrefix(glob, GitignoreGlobPrefix); tagged {
+			gitignoreRules = append(gitignoreRules, rule)
+		}
+	}
+
+	if len(gitignoreRules) == 0 {
+		return nonGitignoreMatcher.MatchesPath
+	}
+
+	gitignoreMatcher := gitignore.CompileIgnoreLines(gitignoreRules...)
+	trackedFilesToKeep := fw.findTrackedFilesToKeep(gitignoreMatcher, nonGitignoreMatcher)
+
+	return func(filePath string) bool {
+		if nonGitignoreMatcher.MatchesPath(filePath) {
+			return true
+		}
+
+		return gitignoreMatcher.MatchesPath(filePath) &&
+			!fw.isTrackedFileToKeep(filePath, trackedFilesToKeep)
+	}
+}
+
+// findTrackedFilesToKeep returns tracked files excluded only by .gitignore.
+func (fw *FileFilter) findTrackedFilesToKeep(gitignoreMatcher, nonGitignoreMatcher *gitignore.GitIgnore) map[string]struct{} {
+	index, scanRootPrefix, ok := fw.openGitIndex()
+	if !ok {
+		return nil
+	}
+
+	trackedFilesToKeep := map[string]struct{}{}
+	for _, entry := range index.Entries {
+		relPath, inScanRoot := strings.CutPrefix(entry.Name, scanRootPrefix)
+		if !inScanRoot {
+			continue
+		}
+
+		filePath := filepath.Join(fw.path, filepath.FromSlash(relPath))
+		if gitignoreMatcher.MatchesPath(filePath) && !nonGitignoreMatcher.MatchesPath(filePath) {
+			trackedFilesToKeep[relPath] = struct{}{}
+		}
+	}
+
+	return trackedFilesToKeep
+}
+
+func (fw *FileFilter) isTrackedFileToKeep(filePath string, trackedFilesToKeep map[string]struct{}) bool {
+	relPath, err := filepath.Rel(fw.path, filepath.FromSlash(filePath))
+	if err != nil {
+		return false
+	}
+
+	_, keep := trackedFilesToKeep[filepath.ToSlash(relPath)]
+	return keep
+}
+
+// openGitIndex returns no index when Git metadata is unavailable, preserving legacy filtering.
+func (fw *FileFilter) openGitIndex() (index *gitindex.Index, scanRootPrefix string, ok bool) {
+	absScanRoot, err := filepath.Abs(fw.path)
+	if err != nil {
+		return nil, "", false
+	}
+
+	repo, err := git.PlainOpenWithOptions(absScanRoot, &git.PlainOpenOptions{DetectDotGit: true})
+	if err != nil {
+		return nil, "", false
+	}
+
+	worktree, err := repo.Worktree()
+	if err != nil {
+		return nil, "", false
+	}
+
+	index, err = repo.Storer.Index()
+	if err != nil {
+		return nil, "", false
+	}
+
+	// go-git resolves symlinks in the repository root (e.g. macOS's /var -> /private/var), so the
+	// scan root has to be resolved the same way before the two can be compared
+	scanRoot := absScanRoot
+	if resolved, resolveErr := filepath.EvalSymlinks(absScanRoot); resolveErr == nil {
+		scanRoot = resolved
+	}
+
+	relScanRoot, err := filepath.Rel(worktree.Filesystem.Root(), scanRoot)
+	if err != nil {
+		return nil, "", false
+	}
+
+	if relScanRoot == "." {
+		return index, "", true
+	}
+
+	if relScanRoot == ".." || strings.HasPrefix(relScanRoot, ".."+string(filepath.Separator)) {
+		return nil, "", false
+	}
+
+	return index, filepath.ToSlash(relScanRoot) + "/", true
+}
+
 // buildGlobs iterates a list of ignore filesToFilter and returns a list of glob patterns that can be used to test for ignored filesToFilter
 func (fw *FileFilter) buildGlobs(ignoreFiles []string) ([]string, error) {
 	if len(ignoreFiles) == 0 {
@@ -224,6 +341,7 @@ func (fw *FileFilter) buildGlobs(ignoreFiles []string) ([]string, error) {
 	}
 
 	enableMetacharacterFix := fw.config.GetBool(FF_FILE_FILTER_METACHARACTER_FIX)
+	tagGitignoreGlobs := fw.config.GetBool(FF_GITIGNORE_RESPECT_TRACKED_FILES)
 
 	var globs = make([]string, 0)
 	for _, ignoreFile := range ignoreFiles {
@@ -238,6 +356,11 @@ func (fw *FileFilter) buildGlobs(ignoreFiles []string) ([]string, error) {
 			globs = append(globs, parsedRules...)
 		} else { // .gitignore, .dcignore, etc. are just a list of ignore rules
 			parsedRules := parseIgnoreFile(content, filepath.Dir(ignoreFile), enableMetacharacterFix)
+			if tagGitignoreGlobs && filepath.Base(ignoreFile) == ".gitignore" {
+				for i, rule := range parsedRules {
+					parsedRules[i] = GitignoreGlobPrefix + rule
+				}
+			}
 			globs = append(globs, parsedRules...)
 		}
 	}

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -166,7 +166,8 @@ func (fw *FileFilter) GetAllFiles() chan string {
 	return filesCh
 }
 
-// GetRules builds a list of glob patterns that can be used to filter filesToFilter
+// GetRules builds a list of glob patterns that can be used to filter filesToFilter.
+// When tracked-file handling is enabled, .gitignore rules carry provenance consumed by GetFilteredFiles.
 func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
 	files := fw.GetAllFiles()
 
@@ -201,7 +202,7 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 
 		defer close(filteredFilesCh)
 
-		isExcluded := fw.newFileExclusionCheck(globs)
+		isFileExcluded := fw.newFileExclusionPredicate(globs)
 
 		// iterate the filesToFilter channel
 		for file := range filesCh {
@@ -212,7 +213,7 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 			go func(f string) {
 				defer availableThreads.Release(1)
 				// filesToFilter that do not match the glob pattern are filtered
-				if !isExcluded(f) {
+				if !isFileExcluded(f) {
 					filteredFilesCh <- f
 				}
 			}(file)
@@ -228,65 +229,62 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 	return filteredFilesCh
 }
 
-// newFileExclusionCheck keeps non-.gitignore exclusions final and applies .gitignore only to untracked files.
-func (fw *FileFilter) newFileExclusionCheck(globs []string) func(filePath string) bool {
-	nonGitignoreMatcher := gitignore.CompileIgnoreLines(globs...)
-
-	var gitignoreRules []string
-	for _, glob := range globs {
+// newFileExclusionPredicate returns whether a path should be excluded from the scan.
+func (fw *FileFilter) newFileExclusionPredicate(globs []string) func(filePath string) bool {
+	originalRules := make([]string, len(globs))
+	hasGitignoreRules := false
+	for i, glob := range globs {
 		if rule, tagged := strings.CutPrefix(glob, GitignoreGlobPrefix); tagged {
-			gitignoreRules = append(gitignoreRules, rule)
+			originalRules[i] = rule
+			hasGitignoreRules = true
+		} else {
+			originalRules[i] = glob
 		}
 	}
 
-	if len(gitignoreRules) == 0 {
-		return nonGitignoreMatcher.MatchesPath
+	originalMatcher := gitignore.CompileIgnoreLines(originalRules...)
+	if !hasGitignoreRules {
+		return originalMatcher.MatchesPath
 	}
 
-	gitignoreMatcher := gitignore.CompileIgnoreLines(gitignoreRules...)
-	trackedFilesToKeep := fw.findTrackedFilesToKeep(gitignoreMatcher, nonGitignoreMatcher)
+	trackedFileExclusionMatcher := gitignore.CompileIgnoreLines(globs...)
+	trackedFilePaths := fw.readTrackedFilePaths()
 
 	return func(filePath string) bool {
-		if nonGitignoreMatcher.MatchesPath(filePath) {
-			return true
+		if fw.isTrackedFile(filePath, trackedFilePaths) {
+			return trackedFileExclusionMatcher.MatchesPath(filePath)
 		}
 
-		return gitignoreMatcher.MatchesPath(filePath) &&
-			!fw.isTrackedFileToKeep(filePath, trackedFilesToKeep)
+		return originalMatcher.MatchesPath(filePath)
 	}
 }
 
-// findTrackedFilesToKeep returns tracked files excluded only by .gitignore.
-func (fw *FileFilter) findTrackedFilesToKeep(gitignoreMatcher, nonGitignoreMatcher *gitignore.GitIgnore) map[string]struct{} {
+// readTrackedFilePaths keeps the Git index order, which is already sorted for binary search.
+func (fw *FileFilter) readTrackedFilePaths() []string {
 	index, scanRootPrefix, ok := fw.openGitIndex()
 	if !ok {
 		return nil
 	}
 
-	trackedFilesToKeep := map[string]struct{}{}
+	trackedFilePaths := make([]string, 0, len(index.Entries))
 	for _, entry := range index.Entries {
 		relPath, inScanRoot := strings.CutPrefix(entry.Name, scanRootPrefix)
-		if !inScanRoot {
-			continue
-		}
-
-		filePath := filepath.Join(fw.path, filepath.FromSlash(relPath))
-		if gitignoreMatcher.MatchesPath(filePath) && !nonGitignoreMatcher.MatchesPath(filePath) {
-			trackedFilesToKeep[relPath] = struct{}{}
+		if inScanRoot {
+			trackedFilePaths = append(trackedFilePaths, relPath)
 		}
 	}
 
-	return trackedFilesToKeep
+	return trackedFilePaths
 }
 
-func (fw *FileFilter) isTrackedFileToKeep(filePath string, trackedFilesToKeep map[string]struct{}) bool {
+func (fw *FileFilter) isTrackedFile(filePath string, trackedFilePaths []string) bool {
 	relPath, err := filepath.Rel(fw.path, filepath.FromSlash(filePath))
 	if err != nil {
 		return false
 	}
 
-	_, keep := trackedFilesToKeep[filepath.ToSlash(relPath)]
-	return keep
+	_, found := slices.BinarySearch(trackedFilePaths, filepath.ToSlash(relPath))
+	return found
 }
 
 // openGitIndex returns no index when Git metadata is unavailable, preserving legacy filtering.
@@ -341,7 +339,7 @@ func (fw *FileFilter) buildGlobs(ignoreFiles []string) ([]string, error) {
 	}
 
 	enableMetacharacterFix := fw.config.GetBool(FF_FILE_FILTER_METACHARACTER_FIX)
-	tagGitignoreGlobs := fw.config.GetBool(FF_GITIGNORE_RESPECT_TRACKED_FILES)
+	respectGitignoreTrackedFiles := fw.config.GetBool(FF_GITIGNORE_RESPECT_TRACKED_FILES)
 
 	var globs = make([]string, 0)
 	for _, ignoreFile := range ignoreFiles {
@@ -356,7 +354,7 @@ func (fw *FileFilter) buildGlobs(ignoreFiles []string) ([]string, error) {
 			globs = append(globs, parsedRules...)
 		} else { // .gitignore, .dcignore, etc. are just a list of ignore rules
 			parsedRules := parseIgnoreFile(content, filepath.Dir(ignoreFile), enableMetacharacterFix)
-			if tagGitignoreGlobs && filepath.Base(ignoreFile) == ".gitignore" {
+			if respectGitignoreTrackedFiles && filepath.Base(ignoreFile) == ".gitignore" {
 				for i, rule := range parsedRules {
 					parsedRules[i] = GitignoreGlobPrefix + rule
 				}

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -9,8 +9,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/plumbing/format/index"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
 )
@@ -1696,4 +1700,370 @@ func TestDotSnykExclude_isExpired(t *testing.T) {
 			assert.Equal(t, test.expected, isExpired)
 		})
 	}
+}
+
+// initGitRepoWithTrackedFiles initializes a git repository at root and adds trackedPaths (relative
+// to root, forward-slashed) to its index. Entries are written straight to the index rather than
+// through Worktree.Add, so that a file already matching a .gitignore rule still becomes tracked -
+// which is the situation this feature exists for.
+func initGitRepoWithTrackedFiles(tb testing.TB, root string, trackedPaths []string) {
+	tb.Helper()
+	repo, err := git.PlainInit(root, false)
+	require.NoError(tb, err)
+
+	idx, err := repo.Storer.Index()
+	require.NoError(tb, err)
+
+	for _, trackedPath := range trackedPaths {
+		idx.Entries = append(idx.Entries, &index.Entry{Name: trackedPath, Mode: filemode.Regular})
+	}
+	require.NoError(tb, repo.Storer.SetIndex(idx))
+}
+
+// newTrackedFilesFilter builds a FileFilter with the metacharacter fix on, so the rules go through
+// the current parser rather than the legacy one.
+func newTrackedFilesFilter(root string, respectTrackedFiles bool) *FileFilter {
+	return NewFileFilter(root, &log.Logger, WithConfig(newTestConfig(map[string]bool{
+		FF_FILE_FILTER_METACHARACTER_FIX:   true,
+		FF_GITIGNORE_RESPECT_TRACKED_FILES: respectTrackedFiles,
+	})))
+}
+
+// filterFilesWith runs the full GetRules -> GetFilteredFiles round trip, the way consumers do.
+func filterFilesWith(tb testing.TB, fileFilter *FileFilter, ruleFiles []string) []string {
+	tb.Helper()
+	rules, err := fileFilter.GetRules(ruleFiles)
+	require.NoError(tb, err)
+
+	var filtered []string
+	for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), rules) {
+		filtered = append(filtered, f)
+	}
+	return filtered
+}
+
+// TestFileFilter_gitignoreRespectsTrackedFiles is the behavioral matrix over the flag, whether git
+// tracks the file, and which source excludes it. With the flag off every rule shares one ordered
+// matcher, so whichever ignore file GetRules read last wins; with it on Snyk's own exclusions are a
+// final veto and the .gitignore rules only reach files git does not track.
+func TestFileFilter_gitignoreRespectsTrackedFiles(t *testing.T) {
+	const scanned, excluded = true, false
+	const dotSnykExcludesTarget = "exclude:\n  global:\n    - config.log\n"
+
+	tests := []struct {
+		name string
+		// ignoreFiles maps an ignore file name to its content; all of them are passed as rule files
+		ignoreFiles         map[string]string
+		respectTrackedFiles bool
+		tracked             bool
+		want                bool
+	}{
+		{
+			name:        "flag off excludes a tracked file",
+			ignoreFiles: map[string]string{".gitignore": "*.log\n"},
+			tracked:     true,
+			want:        excluded,
+		}, {
+			name:        "flag off lets a .gitignore negation override .dcignore",
+			ignoreFiles: map[string]string{".gitignore": "*.log\n!config.log\n", ".dcignore": "config.log\n"},
+			tracked:     true,
+			// .dcignore sorts before .gitignore, so GetRules reads it first and the one ordered
+			// matcher lets the later negation win. The flag replaces that accident of file naming
+			// with a precedence someone actually chose.
+			want: scanned,
+		}, {
+			name:                "a tracked file is scanned",
+			ignoreFiles:         map[string]string{".gitignore": "*.log\n"},
+			respectTrackedFiles: true,
+			tracked:             true,
+			want:                scanned,
+		}, {
+			name:                "an untracked file stays excluded",
+			ignoreFiles:         map[string]string{".gitignore": "*.log\n"},
+			respectTrackedFiles: true,
+			want:                excluded,
+		}, {
+			name:                ".dcignore vetoes a tracked file",
+			ignoreFiles:         map[string]string{".gitignore": "*.log\n", ".dcignore": "config.log\n"},
+			respectTrackedFiles: true,
+			tracked:             true,
+			want:                excluded,
+		}, {
+			name:                ".dcignore vetoes a .gitignore negation",
+			ignoreFiles:         map[string]string{".gitignore": "*.log\n!config.log\n", ".dcignore": "config.log\n"},
+			respectTrackedFiles: true,
+			tracked:             true,
+			want:                excluded,
+		}, {
+			name:                ".snyk vetoes a .gitignore negation",
+			ignoreFiles:         map[string]string{".gitignore": "*.log\n!config.log\n", ".snyk": dotSnykExcludesTarget},
+			respectTrackedFiles: true,
+			tracked:             true,
+			want:                excluded,
+		}, {
+			name:                "a negation inside .dcignore still applies",
+			ignoreFiles:         map[string]string{".gitignore": "*.log\n", ".dcignore": "*.log\n!config.log\n"},
+			respectTrackedFiles: true,
+			tracked:             true,
+			want:                scanned,
+		}, {
+			name:                "a .gitignore negation un-ignores an untracked file",
+			ignoreFiles:         map[string]string{".gitignore": "*.log\n!config.log\n"},
+			respectTrackedFiles: true,
+			want:                scanned,
+		}, {
+			name:                "only .gitignore rules are held back by tracking",
+			ignoreFiles:         map[string]string{".dcignore": "*.log\n"},
+			respectTrackedFiles: true,
+			tracked:             true,
+			want:                excluded,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			target := filepath.Join(root, "config.log")
+			control := filepath.Join(root, "app.js")
+			createFileInPath(t, target, []byte("x"))
+			createFileInPath(t, control, []byte("x"))
+
+			var ruleFiles []string
+			for name, content := range test.ignoreFiles {
+				createFileInPath(t, filepath.Join(root, name), []byte(content))
+				ruleFiles = append(ruleFiles, name)
+			}
+
+			var trackedPaths []string
+			if test.tracked {
+				trackedPaths = []string{"config.log"}
+			}
+			initGitRepoWithTrackedFiles(t, root, trackedPaths)
+
+			filtered := filterFilesWith(t, newTrackedFilesFilter(root, test.respectTrackedFiles), ruleFiles)
+
+			assert.Contains(t, filtered, control, "a file no rule matches is always scanned")
+			if test.want == scanned {
+				assert.Contains(t, filtered, target)
+			} else {
+				assert.NotContains(t, filtered, target)
+			}
+		})
+	}
+
+	t.Run("the flag defaults to disabled", func(t *testing.T) {
+		root := t.TempDir()
+		trackedLog := filepath.Join(root, "config.log")
+		createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("*.log\n"))
+		createFileInPath(t, trackedLog, []byte("x"))
+		initGitRepoWithTrackedFiles(t, root, []string{"config.log"})
+
+		assert.NotContains(t, filterFilesWith(t, NewFileFilter(root, &log.Logger), []string{".gitignore"}),
+			trackedLog, "without a config the previous behavior has to be the one consumers get")
+	})
+
+	t.Run("a tracked file in a subdirectory of the scan root is scanned", func(t *testing.T) {
+		root := t.TempDir()
+		trackedLog := filepath.Join(root, "src", "nested", "config.log")
+		untrackedLog := filepath.Join(root, "src", "nested", "other.log")
+		createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("*.log\n"))
+		createFileInPath(t, trackedLog, []byte("x"))
+		createFileInPath(t, untrackedLog, []byte("x"))
+		initGitRepoWithTrackedFiles(t, root, []string{"src/nested/config.log"})
+
+		filtered := filterFilesWith(t, newTrackedFilesFilter(root, true), []string{".gitignore"})
+
+		assert.Contains(t, filtered, trackedLog)
+		assert.NotContains(t, filtered, untrackedLog)
+	})
+
+	t.Run("the built-in .git default cannot be negated away", func(t *testing.T) {
+		newRoot := func(t *testing.T) (root, gitInternalFile string) {
+			t.Helper()
+			root = t.TempDir()
+			initGitRepoWithTrackedFiles(t, root, nil)
+			gitInternalFile = filepath.Join(root, ".git", "internal.txt")
+			createFileInPath(t, gitInternalFile, []byte("x"))
+			createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("!.git/internal.txt\n"))
+			return root, gitInternalFile
+		}
+
+		rootOn, gitInternalFileOn := newRoot(t)
+		assert.NotContains(t, filterFilesWith(t, newTrackedFilesFilter(rootOn, true), []string{".gitignore"}),
+			gitInternalFileOn, "the built-in defaults are part of the veto")
+
+		rootOff, gitInternalFileOff := newRoot(t)
+		assert.Contains(t, filterFilesWith(t, newTrackedFilesFilter(rootOff, false), []string{".gitignore"}),
+			gitInternalFileOff, "previous behavior: the later negation beats the built-in default")
+	})
+
+	t.Run("tagged rules preserve the feature decision if the config changes", func(t *testing.T) {
+		root := t.TempDir()
+		trackedLog := filepath.Join(root, "config.log")
+		untrackedLog := filepath.Join(root, "other.log")
+		createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("*.log\n"))
+		createFileInPath(t, trackedLog, []byte("x"))
+		createFileInPath(t, untrackedLog, []byte("x"))
+		initGitRepoWithTrackedFiles(t, root, []string{"config.log"})
+
+		config := newTestConfig(map[string]bool{
+			FF_FILE_FILTER_METACHARACTER_FIX:   true,
+			FF_GITIGNORE_RESPECT_TRACKED_FILES: true,
+		})
+		fileFilter := NewFileFilter(root, &log.Logger, WithConfig(config))
+		rules, err := fileFilter.GetRules([]string{".gitignore"})
+		require.NoError(t, err)
+
+		config.Set(FF_GITIGNORE_RESPECT_TRACKED_FILES, false)
+
+		var filtered []string
+		for f := range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), rules) {
+			filtered = append(filtered, f)
+		}
+
+		assert.Contains(t, filtered, trackedLog)
+		assert.NotContains(t, filtered, untrackedLog)
+	})
+
+	t.Run("tracked lookup accepts forward-slash paths", func(t *testing.T) {
+		root := t.TempDir()
+		trackedLog := filepath.Join(root, "config.log")
+		createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("*.log\n"))
+		createFileInPath(t, trackedLog, []byte("x"))
+		initGitRepoWithTrackedFiles(t, root, []string{"config.log"})
+
+		fileFilter := newTrackedFilesFilter(root, true)
+		rules, err := fileFilter.GetRules([]string{".gitignore"})
+		require.NoError(t, err)
+		files := make(chan string, 1)
+		files <- filepath.ToSlash(trackedLog)
+		close(files)
+
+		var filtered []string
+		for file := range fileFilter.GetFilteredFiles(files, rules) {
+			filtered = append(filtered, file)
+		}
+
+		assert.Contains(t, filtered, filepath.ToSlash(trackedLog))
+	})
+
+	t.Run("index fallback works without a logger", func(t *testing.T) {
+		root := t.TempDir()
+		logFile := filepath.Join(root, "config.log")
+		createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("*.log\n"))
+		createFileInPath(t, logFile, []byte("x"))
+
+		config := newTestConfig(map[string]bool{
+			FF_FILE_FILTER_METACHARACTER_FIX:   true,
+			FF_GITIGNORE_RESPECT_TRACKED_FILES: true,
+		})
+		fileFilter := NewFileFilter(root, nil, WithConfig(config))
+
+		assert.NotContains(t, filterFilesWith(t, fileFilter, []string{".gitignore"}), logFile)
+	})
+
+	t.Run("a scan rooted in a subdirectory finds its own tracked files", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		scanRoot := filepath.Join(repoRoot, "src")
+		insideLog := filepath.Join(scanRoot, "inside.log")
+		createFileInPath(t, filepath.Join(scanRoot, ".gitignore"), []byte("*.log\n"))
+		createFileInPath(t, insideLog, []byte("x"))
+		initGitRepoWithTrackedFiles(t, repoRoot, []string{"src/inside.log"})
+
+		filtered := filterFilesWith(t, newTrackedFilesFilter(scanRoot, true), []string{".gitignore"})
+
+		assert.Contains(t, filtered, insideLog, "the index prefix has to be cut for entries to be found")
+	})
+}
+
+func TestFileFilter_GetRules_gitignoreGlobPrefix(t *testing.T) {
+	newRoot := func(t *testing.T) string {
+		t.Helper()
+		root := t.TempDir()
+		createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("*.log\n"))
+		createFileInPath(t, filepath.Join(root, ".dcignore"), []byte("*.tmp\n"))
+		createFileInPath(t, filepath.Join(root, ".snyk"), []byte("exclude:\n  global:\n    - vendor\n"))
+		return root
+	}
+	ruleFiles := []string{".gitignore", ".dcignore", ".snyk"}
+
+	t.Run("flag off tags nothing", func(t *testing.T) {
+		rules, err := newTrackedFilesFilter(newRoot(t), false).GetRules(ruleFiles)
+		require.NoError(t, err)
+
+		for _, rule := range rules {
+			assert.NotContains(t, rule, GitignoreGlobPrefix)
+		}
+	})
+
+	t.Run("flag on tags the .gitignore-sourced globs only, and nothing else changes", func(t *testing.T) {
+		root := newRoot(t)
+
+		off, err := newTrackedFilesFilter(root, false).GetRules(ruleFiles)
+		require.NoError(t, err)
+		on, err := newTrackedFilesFilter(root, true).GetRules(ruleFiles)
+		require.NoError(t, err)
+
+		var tagged, untagged, stripped []string
+		for _, rule := range on {
+			bare, isTagged := strings.CutPrefix(rule, GitignoreGlobPrefix)
+			if isTagged {
+				tagged = append(tagged, bare)
+			} else {
+				untagged = append(untagged, bare)
+			}
+			stripped = append(stripped, bare)
+		}
+
+		assert.NotEmpty(t, tagged)
+		for _, rule := range tagged {
+			assert.Contains(t, rule, ".log", "only the *.log rule comes from .gitignore")
+		}
+		for _, rule := range untagged {
+			assert.NotContains(t, rule, ".log")
+		}
+		assert.Equal(t, off, stripped, "stripping the tags has to give back exactly the previous rules")
+	})
+}
+
+func TestFileFilter_openGitIndex(t *testing.T) {
+	newFilter := func(root string) *FileFilter { return newTrackedFilesFilter(root, true) }
+
+	t.Run("a scan root whose name starts with .. is still inside the repository", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		initGitRepoWithTrackedFiles(t, repoRoot, []string{"..cache/app.js"})
+		scanRoot := filepath.Join(repoRoot, "..cache")
+		require.NoError(t, os.MkdirAll(scanRoot, 0755))
+
+		_, scanRootPrefix, ok := newFilter(scanRoot).openGitIndex()
+
+		assert.True(t, ok, "only a leading \"..\" path segment means outside the repository")
+		assert.Equal(t, "..cache/", scanRootPrefix)
+	})
+
+	// every fallback leaves the caller applying .gitignore rules to tracked files, as before
+	t.Run("falls back", func(t *testing.T) {
+		t.Run("outside a git repository", func(t *testing.T) {
+			_, _, ok := newFilter(t.TempDir()).openGitIndex()
+			assert.False(t, ok)
+		})
+
+		t.Run("on a bare repository", func(t *testing.T) {
+			root := t.TempDir()
+			_, err := git.PlainInit(root, true)
+			require.NoError(t, err)
+
+			_, _, ok := newFilter(root).openGitIndex()
+			assert.False(t, ok)
+		})
+
+		t.Run("on an unreadable index", func(t *testing.T) {
+			root := t.TempDir()
+			initGitRepoWithTrackedFiles(t, root, []string{"app.js"})
+			createFileInPath(t, filepath.Join(root, ".git", "index"), []byte("not a git index"))
+
+			_, _, ok := newFilter(root).openGitIndex()
+			assert.False(t, ok)
+		})
+	})
 }

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -1742,10 +1742,8 @@ func filterFilesWith(tb testing.TB, fileFilter *FileFilter, ruleFiles []string) 
 	return filtered
 }
 
-// TestFileFilter_gitignoreRespectsTrackedFiles is the behavioral matrix over the flag, whether git
-// tracks the file, and which source excludes it. With the flag off every rule shares one ordered
-// matcher, so whichever ignore file GetRules read last wins; with it on Snyk's own exclusions are a
-// final veto and the .gitignore rules only reach files git does not track.
+// TestFileFilter_gitignoreRespectsTrackedFiles covers legacy ordering for untracked files and
+// source-specific overrides for tracked files.
 func TestFileFilter_gitignoreRespectsTrackedFiles(t *testing.T) {
 	const scanned, excluded = true, false
 	const dotSnykExcludesTarget = "exclude:\n  global:\n    - config.log\n"
@@ -1763,14 +1761,6 @@ func TestFileFilter_gitignoreRespectsTrackedFiles(t *testing.T) {
 			ignoreFiles: map[string]string{".gitignore": "*.log\n"},
 			tracked:     true,
 			want:        excluded,
-		}, {
-			name:        "flag off lets a .gitignore negation override .dcignore",
-			ignoreFiles: map[string]string{".gitignore": "*.log\n!config.log\n", ".dcignore": "config.log\n"},
-			tracked:     true,
-			// .dcignore sorts before .gitignore, so GetRules reads it first and the one ordered
-			// matcher lets the later negation win. The flag replaces that accident of file naming
-			// with a precedence someone actually chose.
-			want: scanned,
 		}, {
 			name:                "a tracked file is scanned",
 			ignoreFiles:         map[string]string{".gitignore": "*.log\n"},
@@ -1877,7 +1867,7 @@ func TestFileFilter_gitignoreRespectsTrackedFiles(t *testing.T) {
 		assert.NotContains(t, filtered, untrackedLog)
 	})
 
-	t.Run("the built-in .git default cannot be negated away", func(t *testing.T) {
+	t.Run("the built-in default keeps its previous ordering for an untracked file", func(t *testing.T) {
 		newRoot := func(t *testing.T) (root, gitInternalFile string) {
 			t.Helper()
 			root = t.TempDir()
@@ -1888,13 +1878,11 @@ func TestFileFilter_gitignoreRespectsTrackedFiles(t *testing.T) {
 			return root, gitInternalFile
 		}
 
-		rootOn, gitInternalFileOn := newRoot(t)
-		assert.NotContains(t, filterFilesWith(t, newTrackedFilesFilter(rootOn, true), []string{".gitignore"}),
-			gitInternalFileOn, "the built-in defaults are part of the veto")
-
-		rootOff, gitInternalFileOff := newRoot(t)
-		assert.Contains(t, filterFilesWith(t, newTrackedFilesFilter(rootOff, false), []string{".gitignore"}),
-			gitInternalFileOff, "previous behavior: the later negation beats the built-in default")
+		for _, enabled := range []bool{false, true} {
+			root, gitInternalFile := newRoot(t)
+			assert.Contains(t, filterFilesWith(t, newTrackedFilesFilter(root, enabled), []string{".gitignore"}),
+				gitInternalFile, "the later .gitignore negation keeps winning for an untracked file")
+		}
 	})
 
 	t.Run("tagged rules preserve the feature decision if the config changes", func(t *testing.T) {
@@ -1974,6 +1962,39 @@ func TestFileFilter_gitignoreRespectsTrackedFiles(t *testing.T) {
 
 		assert.Contains(t, filtered, insideLog, "the index prefix has to be cut for entries to be found")
 	})
+}
+
+func TestFileFilter_crossSourceOrderingIsUnchangedForUntrackedFiles(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("feature=%t", enabled), func(t *testing.T) {
+			root := t.TempDir()
+			keptFile := filepath.Join(root, "gen", "keep.js")
+			excludedFile := filepath.Join(root, "gen", "drop.js")
+			createFileInPath(t, filepath.Join(root, ".dcignore"), []byte("gen/*.js\n"))
+			createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("!gen/keep.js\n"))
+			createFileInPath(t, keptFile, []byte("x"))
+			createFileInPath(t, excludedFile, []byte("x"))
+			initGitRepoWithTrackedFiles(t, root, nil)
+
+			filtered := filterFilesWith(t, newTrackedFilesFilter(root, enabled), []string{".dcignore", ".gitignore"})
+
+			assert.Contains(t, filtered, keptFile)
+			assert.NotContains(t, filtered, excludedFile)
+		})
+	}
+}
+
+func TestFileFilter_crossSourceNegationDoesNotRescueTrackedFile(t *testing.T) {
+	root := t.TempDir()
+	trackedFile := filepath.Join(root, "gen", "keep.js")
+	createFileInPath(t, filepath.Join(root, ".dcignore"), []byte("gen/*.js\n"))
+	createFileInPath(t, filepath.Join(root, ".gitignore"), []byte("!gen/keep.js\n"))
+	createFileInPath(t, trackedFile, []byte("x"))
+	initGitRepoWithTrackedFiles(t, root, []string{"gen/keep.js"})
+
+	filtered := filterFilesWith(t, newTrackedFilesFilter(root, true), []string{".dcignore", ".gitignore"})
+
+	assert.NotContains(t, filtered, trackedFile)
 }
 
 func TestFileFilter_GetRules_gitignoreGlobPrefix(t *testing.T) {
@@ -2122,9 +2143,9 @@ func BenchmarkFileFilterEndToEnd(b *testing.B) {
 
 const benchmarkLogFileInterval = 20
 
-// BenchmarkFileFilterBuildExclusionCheck isolates matcher construction and tracked-file discovery.
+// BenchmarkFileFilterBuildExclusionPredicate isolates matcher construction and tracked-file discovery.
 // Repository and rule creation happen before timing; every twentieth index entry matches *.log.
-func BenchmarkFileFilterBuildExclusionCheck(b *testing.B) {
+func BenchmarkFileFilterBuildExclusionPredicate(b *testing.B) {
 	for _, indexSize := range []int{10_000, 100_000, 500_000} {
 		for _, enabled := range []bool{false, true} {
 			name := fmt.Sprintf("index=%d/flag=%t", indexSize, enabled)
@@ -2140,18 +2161,18 @@ func BenchmarkFileFilterBuildExclusionCheck(b *testing.B) {
 					b.Fatal(err)
 				}
 
-				check := fileFilter.newFileExclusionCheck(rules)
+				isFileExcluded := fileFilter.newFileExclusionPredicate(rules)
 				trackedLog := filepath.Join(root, filepath.FromSlash(trackedPaths[0]))
 				expectedExcluded := !enabled
-				if excluded := check(trackedLog); excluded != expectedExcluded {
+				if excluded := isFileExcluded(trackedLog); excluded != expectedExcluded {
 					b.Fatalf("tracked .log exclusion = %t, want %t", excluded, expectedExcluded)
 				}
 
 				b.ReportAllocs()
 				b.ResetTimer()
 				for b.Loop() {
-					timedCheck := fileFilter.newFileExclusionCheck(rules)
-					runtime.KeepAlive(timedCheck)
+					timedIsFileExcluded := fileFilter.newFileExclusionPredicate(rules)
+					runtime.KeepAlive(timedIsFileExcluded)
 				}
 			})
 		}

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -2067,3 +2067,105 @@ func TestFileFilter_openGitIndex(t *testing.T) {
 		})
 	})
 }
+
+// BenchmarkFileFilterEndToEnd measures rule discovery, both filesystem walks, index processing,
+// concurrent filtering, and output consumption. Its rule matches none of the generated files, so
+// both flag states emit the same output and the delta isolates feature overhead.
+func BenchmarkFileFilterEndToEnd(b *testing.B) {
+	const filesPerFolder = 100
+	for _, fileCount := range []int{1_000, 10_000, 100_000} {
+		b.Run(fmt.Sprintf("files=%d", fileCount), func(b *testing.B) {
+			rootDir := b.TempDir()
+			folderCount := fileCount / filesPerFolder
+			err := generateFilesAndFolders(rootDir, filesPerFolder, folderCount)
+			require.NoError(b, err)
+
+			createFileInPath(b, filepath.Join(rootDir, ".gitignore"), []byte("*.log\n"))
+			ruleFiles := []string{".gitignore"}
+
+			trackedPaths := make([]string, 0, fileCount)
+			for i := 1; i <= folderCount; i++ {
+				for j := 1; j <= filesPerFolder; j++ {
+					trackedPaths = append(trackedPaths, fmt.Sprintf("folder_%d/file_%d.txt", i, j))
+				}
+			}
+			initGitRepoWithTrackedFiles(b, rootDir, trackedPaths)
+
+			for _, enabled := range []bool{false, true} {
+				b.Run(fmt.Sprintf("feature=%t", enabled), func(b *testing.B) {
+					expectedFiles := fileCount + 1
+
+					b.ReportAllocs()
+					b.ResetTimer()
+					for b.Loop() {
+						fileFilter := newTrackedFilesFilter(rootDir, enabled)
+						globs, err := fileFilter.GetRules(ruleFiles)
+						if err != nil {
+							b.Fatal(err)
+						}
+
+						actualFiles := 0
+						for range fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), globs) {
+							actualFiles++
+						}
+						if actualFiles != expectedFiles {
+							b.Fatalf("filtered %d files, want %d", actualFiles, expectedFiles)
+						}
+					}
+					b.ReportMetric(float64(fileCount), "generated_files/op")
+					b.ReportMetric(float64(expectedFiles), "output_files/op")
+				})
+			}
+		})
+	}
+}
+
+const benchmarkLogFileInterval = 20
+
+// BenchmarkFileFilterBuildExclusionCheck isolates matcher construction and tracked-file discovery.
+// Repository and rule creation happen before timing; every twentieth index entry matches *.log.
+func BenchmarkFileFilterBuildExclusionCheck(b *testing.B) {
+	for _, indexSize := range []int{10_000, 100_000, 500_000} {
+		for _, enabled := range []bool{false, true} {
+			name := fmt.Sprintf("index=%d/flag=%t", indexSize, enabled)
+			b.Run(name, func(b *testing.B) {
+				root := b.TempDir()
+				createFileInPath(b, filepath.Join(root, ".gitignore"), []byte("*.log\n"))
+				trackedPaths := benchmarkTrackedPaths(indexSize)
+				initGitRepoWithTrackedFiles(b, root, trackedPaths)
+
+				fileFilter := newTrackedFilesFilter(root, enabled)
+				rules, err := fileFilter.GetRules([]string{".gitignore"})
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				check := fileFilter.newFileExclusionCheck(rules)
+				trackedLog := filepath.Join(root, filepath.FromSlash(trackedPaths[0]))
+				expectedExcluded := !enabled
+				if excluded := check(trackedLog); excluded != expectedExcluded {
+					b.Fatalf("tracked .log exclusion = %t, want %t", excluded, expectedExcluded)
+				}
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					timedCheck := fileFilter.newFileExclusionCheck(rules)
+					runtime.KeepAlive(timedCheck)
+				}
+			})
+		}
+	}
+}
+
+func benchmarkTrackedPaths(count int) []string {
+	paths := make([]string, count)
+	for i := range count {
+		if i%benchmarkLogFileInterval == 0 {
+			paths[i] = fmt.Sprintf("src/pkg%d/debug%d.log", i%500, i)
+		} else {
+			paths[i] = fmt.Sprintf("src/pkg%d/file%d.go", i%500, i)
+		}
+	}
+	return paths
+}


### PR DESCRIPTION
### **User description**
### Description

_Provide description of this PR and changes._

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI - https://github.com/snyk/cli/pull/7085


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes which files are included in scans (core CLI behavior) when the flag is enabled, though it defaults off and falls back when Git/index access fails. Cross-source ignore ordering for tracked files is new and could surprise consumers if misconfigured.
> 
> **Overview**
> Adds **tracked-file-aware `.gitignore` handling** behind `FF_GITIGNORE_RESPECT_TRACKED_FILES` (CLI-1411). When enabled, rules from `.gitignore` are tagged with `#gitignore:` in `GetRules`; `GetFilteredFiles` uses a new exclusion predicate that reads the Git index and **does not apply `.gitignore` rules to indexed (tracked) paths**, while untracked paths still follow the full rule list.
> 
> **`.dcignore` and `.snyk` exclusions are unchanged** and still exclude tracked files, including cases where `.gitignore` would negate an ignore. If Git metadata is missing or the index cannot be opened, behavior falls back to the previous all-rules matcher.
> 
> Also clones the glob list before filtering (safe reuse of rules) and adds subdirectory scan-root support via `openGitIndex`, plus broad tests and benchmarks for the new path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9b1d30707cd64c10076edc9bab47172d08874c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Introduce tracked-file-aware .gitignore filtering.

- .gitignore rules now only exclude untracked files.

- Tracked files are always scanned unless explicitly excluded.

- Adds comprehensive tests for the new logic.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[FF_GITIGNORE_RESPECT_TRACKED_FILES enabled?] -->|Yes| B(Check Git Index);
  A -->|No| D(Apply all ignore rules);
  B -->|Untracked File| C(.gitignore filters untracked files);
  B -->|Tracked File| C;
  C --> E(Result: Filtered/Scanned);
  D --> E;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>file_filter.go</strong><dd><code>Implement tracked-file-aware .gitignore filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/utils/file_filter.go

<ul><li>Implements logic to distinguish between tracked and untracked files.<br> <li> Introduces <code>GitignoreGlobPrefix</code> for tagging gitignore rules.<br> <li> Adds functions <code>openGitIndex</code>, <code>findTrackedFilesToKeep</code>, <br><code>newFileExclusionCheck</code>.<br> <li> Modifies <code>GetFilteredFiles</code> and <code>buildGlobs</code> to incorporate new logic and <br>tagging.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/685/changes#diff-bf9226d9c8e73c07414a93ee5a315c13c9ad2be1c6ead9066e92b1adf6b296cd">+126/-3</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>file_filter_test.go</strong><dd><code>Add tests for tracked-file-aware gitignore filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/utils/file_filter_test.go

<ul><li>Adds helper functions to initialize Git repos and create filters.<br> <li> Includes extensive test cases for the new .gitignore filtering logic,<br>  <br> covering flag states, file tracking, and different ignore file types.<br> <li> Tests <code>openGitIndex</code> fallback behavior and subdirectory scanning.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/685/changes#diff-0525df151b63831e042ffd8a2c7cab466a29f8d6f710cb726c359b6becffa89c">+370/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

