### PR TITLE
feat(sarif): add reviewedBy and reviewedOn to suppression details [IGNR-2204]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/go-application-framework
 
-go 1.26
+go 1.26.2
 
 require (
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -13,7 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.34.0
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
-	github.com/snyk/code-client-go v1.24.5
+	github.com/snyk/code-client-go v1.31.1
 	github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
@@ -25,7 +25,7 @@ require (
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.2
-	github.com/go-git/go-git/v5 v5.19.0
+	github.com/go-git/go-git/v5 v5.19.1
 	github.com/gofrs/flock v0.12.1
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmm
 github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.19.0 h1:+WkVUQZSy/F1Gb13udrMKjIM2PrzsNfDKFSfo5tkMtc=
-github.com/go-git/go-git/v5 v5.19.0/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
+github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
 github.com/go-openapi/jsonpointer v0.21.1 h1:whnzv/pNXtK2FbX/W9yJfRmE2gsmkfahjMKB0fZvcic=
 github.com/go-openapi/jsonpointer v0.21.1/go.mod h1:50I1STOfbY1ycR8jGz8DaMeLCdXiI6aDteEdRNNzpdk=
 github.com/go-openapi/swag v0.23.1 h1:lpsStH0n2ittzTnbaSloVZLuB5+fvSY/+hnagBjSNZU=
@@ -231,8 +231,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
-github.com/snyk/code-client-go v1.24.5 h1:ySsfTeaNmi3nWSuM3YaVIiSAG+H/ikD2hACxqneIZJw=
-github.com/snyk/code-client-go v1.24.5/go.mod h1:YYggK3UbOHl5rg7uBhLzsKZBFNavcwFUse/EWCKWdzw=
+github.com/snyk/code-client-go v1.31.1 h1:fJHx9kZwcYikKGvIIXDxMxpSNbj5gxChEsV8xrYDRnw=
+github.com/snyk/code-client-go v1.31.1/go.mod h1:sAl5uS+Bc+3Owy1HS0UjrFihuWdq5CkIF4jzEZT2meY=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260205094614-116c03822905 h1:pUe6iOWHEOFY0t4u4ssXeTqpMmZBu1xq06VBFI9zUik=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260205094614-116c03822905/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=

--- a/internal/local_findings/source/openapi/rest/test.spec.yaml
+++ b/internal/local_findings/source/openapi/rest/test.spec.yaml
@@ -2008,6 +2008,10 @@ components:
           type: string
         ignoredBy:
           $ref: '#/components/schemas/types.User'
+        reviewedOn:
+          type: string
+        reviewedBy:
+          $ref: '#/components/schemas/types.Reviewer'
       description: Suppression meta data
     types.TestContext:
       type: object
@@ -2263,6 +2267,16 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/io.snyk.reactive.FindingSourceLocation'
+    types.Reviewer:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+      description: Reviewer definition
     types.User:
       type: object
       required:

--- a/internal/presenters/presenter_local_finding_test.go
+++ b/internal/presenters/presenter_local_finding_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/local_models"
+	"github.com/snyk/go-application-framework/pkg/utils"
 	sarif_utils "github.com/snyk/go-application-framework/pkg/utils/sarif"
 )
 
@@ -468,6 +469,221 @@ func TestJsonWriter(t *testing.T) {
 		assert.Equal(t, len(input), bytesWritten)
 		assert.Equal(t, input, buffer.Bytes())
 	})
+}
+
+func TestPresenterLocalFinding_ComponentReviewDetails(t *testing.T) {
+	tests := []struct {
+		name               string
+		reviewedBy         *local_models.TypesReviewer
+		reviewedOn         *string
+		expectedReviewedBy *string
+		expectedReviewedOn *string
+	}{
+		{
+			name:               "name and email renders the name only",
+			reviewedBy:         &local_models.TypesReviewer{Name: "Jane Reviewer", Email: utils.Ptr("jane@example.com")},
+			reviewedOn:         utils.Ptr("2023-02-02T10:30:00Z"),
+			expectedReviewedBy: utils.Ptr("Reviewed by: Jane Reviewer"),
+			expectedReviewedOn: utils.Ptr("Reviewed on: February 02, 2023"),
+		},
+		{
+			name:               "name only, nil email",
+			reviewedBy:         &local_models.TypesReviewer{Name: "John Reviewer", Email: nil},
+			expectedReviewedBy: utils.Ptr("Reviewed by: John Reviewer"),
+		},
+		{
+			name:               "unparsable reviewedOn is rendered verbatim",
+			reviewedOn:         utils.Ptr("not-a-timestamp"),
+			expectedReviewedOn: utils.Ptr("Reviewed on: not-a-timestamp"),
+		},
+		{
+			name: "nil reviewedBy and reviewedOn",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			input, err := sarifToLocalFinding(t, "testdata/with-ignores-with-status-accepted.json")
+			require.NoError(t, err)
+
+			suppressedCount := 0
+			for i := range input.Findings {
+				suppression := input.Findings[i].Attributes.Suppression
+				if suppression == nil || suppression.Details == nil {
+					continue
+				}
+				suppression.Details.ReviewedBy = tc.reviewedBy
+				suppression.Details.ReviewedOn = tc.reviewedOn
+				suppressedCount++
+			}
+			require.Positive(t, suppressedCount, "test fixture must contain suppressed findings with details")
+
+			lipgloss.SetColorProfile(termenv.Ascii)
+			config := configuration.NewInMemory()
+			config.Set(configuration.ORGANIZATION_SLUG, "test-org")
+			config.Set(configuration.FLAG_INCLUDE_IGNORES, true)
+			writer := new(bytes.Buffer)
+
+			p := presenters.NewLocalFindingsRenderer(
+				[]*local_models.LocalFinding{input},
+				config,
+				writer,
+			)
+
+			err = p.RenderTemplate(presenters.DefaultTemplateFiles, presenters.DefaultMimeType)
+			require.NoError(t, err)
+
+			result := writer.String()
+			require.Contains(t, result, "Ignored Issues")
+
+			if tc.expectedReviewedBy != nil {
+				assert.Contains(t, result, *tc.expectedReviewedBy)
+			} else {
+				assert.NotContains(t, result, "Reviewed by:")
+			}
+
+			if tc.expectedReviewedOn != nil {
+				assert.Contains(t, result, *tc.expectedReviewedOn)
+			} else {
+				assert.NotContains(t, result, "Reviewed on:")
+			}
+
+			if tc.reviewedBy != nil && tc.reviewedBy.Email != nil {
+				assert.NotContains(t, result, *tc.reviewedBy.Email, "the plain text output must not expose the reviewer email")
+			}
+		})
+	}
+}
+
+func TestPresenterLocalFinding_SarifReviewDetails(t *testing.T) {
+	type sarifReviewedBy struct {
+		Name  *string `json:"name"`
+		Email *string `json:"email"`
+	}
+	type sarifSuppressionProperties struct {
+		ReviewedBy *sarifReviewedBy `json:"reviewedBy"`
+		ReviewedOn *string          `json:"reviewedOn"`
+	}
+	type sarifSuppression struct {
+		Properties *sarifSuppressionProperties `json:"properties"`
+	}
+	type sarifResult struct {
+		Suppressions []sarifSuppression `json:"suppressions"`
+	}
+	type sarifRun struct {
+		Results []sarifResult `json:"results"`
+	}
+	type sarifDocument struct {
+		Runs []sarifRun `json:"runs"`
+	}
+
+	tests := []struct {
+		name               string
+		reviewedBy         *local_models.TypesReviewer
+		reviewedOn         *string
+		expectedName       *string
+		expectedEmail      *string
+		expectedReviewedOn *string
+	}{
+		{
+			name:               "name, email and reviewedOn",
+			reviewedBy:         &local_models.TypesReviewer{Name: "Jane Reviewer", Email: utils.Ptr("jane@example.com")},
+			reviewedOn:         utils.Ptr("2023-02-02T10:30:00Z"),
+			expectedName:       utils.Ptr("Jane Reviewer"),
+			expectedEmail:      utils.Ptr("jane@example.com"),
+			expectedReviewedOn: utils.Ptr("2023-02-02T10:30:00Z"),
+		},
+		{
+			name:          "name only, nil email",
+			reviewedBy:    &local_models.TypesReviewer{Name: "John Reviewer", Email: nil},
+			expectedName:  utils.Ptr("John Reviewer"),
+			expectedEmail: utils.Ptr(""),
+		},
+		{
+			name:          "name with special characters",
+			reviewedBy:    &local_models.TypesReviewer{Name: `O'Brien "The Reviewer"`, Email: utils.Ptr("obrien@example.com")},
+			expectedName:  utils.Ptr(`O'Brien "The Reviewer"`),
+			expectedEmail: utils.Ptr("obrien@example.com"),
+		},
+		{
+			name:          "empty name",
+			reviewedBy:    &local_models.TypesReviewer{Name: "", Email: utils.Ptr("empty@example.com")},
+			expectedName:  utils.Ptr(""),
+			expectedEmail: utils.Ptr("empty@example.com"),
+		},
+		{
+			name:       "nil reviewedBy and reviewedOn",
+			reviewedBy: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			input, err := sarifToLocalFinding(t, "testdata/with-ignores-with-status-accepted.json")
+			require.NoError(t, err)
+
+			suppressedCount := 0
+			for i := range input.Findings {
+				suppression := input.Findings[i].Attributes.Suppression
+				if suppression == nil || suppression.Details == nil {
+					continue
+				}
+				suppression.Details.ReviewedBy = tc.reviewedBy
+				suppression.Details.ReviewedOn = tc.reviewedOn
+				suppressedCount++
+			}
+			require.Positive(t, suppressedCount, "test fixture must contain suppressed findings with details")
+
+			config := configuration.NewInMemory()
+			config.Set(configuration.ORGANIZATION_SLUG, "test-org")
+			writer := new(bytes.Buffer)
+
+			p := presenters.NewLocalFindingsRenderer(
+				[]*local_models.LocalFinding{input},
+				config,
+				writer,
+			)
+
+			err = p.RenderTemplate(presenters.ApplicationSarifTemplates, presenters.ApplicationSarifMimeType)
+			require.NoError(t, err)
+
+			output := writer.Bytes()
+			require.True(t, json.Valid(output), "rendered SARIF must be valid JSON: %s", output)
+
+			var doc sarifDocument
+			require.NoError(t, json.Unmarshal(output, &doc))
+			require.NotEmpty(t, doc.Runs)
+
+			checked := 0
+			for _, run := range doc.Runs {
+				for _, result := range run.Results {
+					for _, suppression := range result.Suppressions {
+						require.NotNil(t, suppression.Properties)
+						checked++
+
+						if tc.expectedReviewedOn == nil {
+							assert.Nil(t, suppression.Properties.ReviewedOn)
+						} else {
+							require.NotNil(t, suppression.Properties.ReviewedOn)
+							assert.Equal(t, *tc.expectedReviewedOn, *suppression.Properties.ReviewedOn)
+						}
+
+						if tc.expectedName == nil {
+							assert.Nil(t, suppression.Properties.ReviewedBy)
+							continue
+						}
+						require.NotNil(t, suppression.Properties.ReviewedBy)
+						require.NotNil(t, suppression.Properties.ReviewedBy.Name)
+						assert.Equal(t, *tc.expectedName, *suppression.Properties.ReviewedBy.Name)
+						require.NotNil(t, suppression.Properties.ReviewedBy.Email)
+						require.NotNil(t, tc.expectedEmail)
+						assert.Equal(t, *tc.expectedEmail, *suppression.Properties.ReviewedBy.Email)
+					}
+				}
+			}
+			require.Positive(t, checked, "rendered SARIF must contain suppressions")
+		})
+	}
 }
 
 func TestSarifAutomationDetailsId(t *testing.T) {

--- a/internal/presenters/templates/finding.component.tmpl
+++ b/internal/presenters/templates/finding.component.tmpl
@@ -21,6 +21,12 @@
    {{- if or (eq .Attributes.Suppression.Status "accepted") (eq .Attributes.Suppression.Status "underReview")}}
 
    Expiration: {{- if .Attributes.Suppression.Details.Expiration }} {{ formatDatetime .Attributes.Suppression.Details.Expiration "2006-01-02T15:04:05.999999999Z07:00" "January 02, 2006" }} {{- else }} never {{- end }}
+   {{- if .Attributes.Suppression.Details.ReviewedOn }}
+   Reviewed on: {{ formatDatetime .Attributes.Suppression.Details.ReviewedOn "2006-01-02T15:04:05.999999999Z07:00" "January 02, 2006" }}
+   {{- end }}
+   {{- if .Attributes.Suppression.Details.ReviewedBy }}
+   Reviewed by: {{ .Attributes.Suppression.Details.ReviewedBy.Name }}
+   {{- end }}
    Category:   {{ .Attributes.Suppression.Details.Category }}
    Ignored on: {{ formatDatetime .Attributes.Suppression.Details.IgnoredOn "2006-01-02T15:04:05.999999999Z07:00" "January 02, 2006" }}
    Ignored by: {{ .Attributes.Suppression.Details.IgnoredBy.Name }}

--- a/internal/presenters/templates/local_finding.sarif.tmpl
+++ b/internal/presenters/templates/local_finding.sarif.tmpl
@@ -173,6 +173,19 @@
 								"properties": {
 									"category": {{ getQuotedString $finding.Attributes.Suppression.Details.Category }},
 									{{- if $finding.Attributes.Suppression.Details.Expiration }}"expiration": "{{ $finding.Attributes.Suppression.Details.Expiration }}",{{- end }}
+									{{- if $finding.Attributes.Suppression.Details.ReviewedOn }}
+									"reviewedOn": "{{ $finding.Attributes.Suppression.Details.ReviewedOn }}",
+									{{- end }}
+									{{- if $finding.Attributes.Suppression.Details.ReviewedBy }}
+									"reviewedBy": {
+										"name": {{ getQuotedString $finding.Attributes.Suppression.Details.ReviewedBy.Name }},
+										{{- if $finding.Attributes.Suppression.Details.ReviewedBy.Email }}
+										"email": {{ getQuotedString $finding.Attributes.Suppression.Details.ReviewedBy.Email }}
+										{{- else }}
+										"email": ""
+										{{- end }}
+									},
+									{{- end }}
 									"ignoredOn": "{{ $finding.Attributes.Suppression.Details.IgnoredOn }}",
 									"ignoredBy": {
 										  "name": {{ getQuotedString $finding.Attributes.Suppression.Details.IgnoredBy.Name }},

--- a/pkg/local_workflows/local_models/models.gen.go
+++ b/pkg/local_workflows/local_models/models.gen.go
@@ -1068,6 +1068,12 @@ type TypesReferenceId struct {
 	Index      int    `json:"index"`
 }
 
+// TypesReviewer Reviewer definition
+type TypesReviewer struct {
+	Email *string `json:"email,omitempty"`
+	Name  string  `json:"name"`
+}
+
 // TypesRules Based on Sarif rules
 type TypesRules struct {
 	DefaultConfiguration struct {
@@ -1181,6 +1187,10 @@ type TypesSuppressionDetails struct {
 	// IgnoredBy User definition
 	IgnoredBy TypesUser `json:"ignoredBy"`
 	IgnoredOn string    `json:"ignoredOn"`
+
+	// ReviewedBy Reviewer definition
+	ReviewedBy *TypesReviewer `json:"reviewedBy,omitempty"`
+	ReviewedOn *string        `json:"reviewedOn,omitempty"`
 }
 
 // TypesTestContext TestContext identifies the context in which this Test occurs.

--- a/pkg/local_workflows/local_models/transform.go
+++ b/pkg/local_workflows/local_models/transform.go
@@ -128,6 +128,13 @@ func mapSuppressions(res sarif.Result) *TypesSuppression {
 	if suppression.Guid != "" {
 		id = &suppression.Guid
 	}
+	var reviewedBy *TypesReviewer
+	if suppression.Properties.ReviewedBy != nil {
+		reviewedBy = &TypesReviewer{
+			Name:  suppression.Properties.ReviewedBy.Name,
+			Email: suppression.Properties.ReviewedBy.Email,
+		}
+	}
 	return &TypesSuppression{
 		Id: id,
 		Details: &TypesSuppressionDetails{
@@ -138,6 +145,8 @@ func mapSuppressions(res sarif.Result) *TypesSuppression {
 				Name:  suppression.Properties.IgnoredBy.Name,
 				Email: ignored_email,
 			},
+			ReviewedOn: suppression.Properties.ReviewedOn,
+			ReviewedBy: reviewedBy,
 		},
 		Justification: &suppression.Justification,
 		Status:        TypesSuppressionStatus(status),

--- a/pkg/local_workflows/local_models/transform_test.go
+++ b/pkg/local_workflows/local_models/transform_test.go
@@ -92,6 +92,44 @@ func Test_mapSuppressions(t *testing.T) {
 			},
 		},
 		{
+			name: "single suppression with reviewed details",
+			inputResult: sarif.Result{
+				Suppressions: []sarif.Suppression{
+					{
+						Guid:          validUUID2,
+						Justification: "Reviewed justification",
+						Status:        sarif.Accepted,
+						Properties: sarif.SuppressionProperties{
+							Category:   "reviewedCategory",
+							IgnoredOn:  "2023-02-01T00:00:00Z",
+							IgnoredBy:  sarif.IgnoredBy{Name: "Requester"},
+							ReviewedOn: utils.Ptr("2023-02-02T00:00:00Z"),
+							ReviewedBy: &sarif.Reviewer{Name: "Reviewer", Email: utils.Ptr("reviewer@example.com")},
+						},
+					},
+				},
+			},
+			expectedSupp: &TypesSuppression{
+				Id: &validUUID2,
+				Details: &TypesSuppressionDetails{
+					Category:   "reviewedCategory",
+					Expiration: nil,
+					IgnoredOn:  "2023-02-01T00:00:00Z",
+					IgnoredBy: TypesUser{
+						Name:  "Requester",
+						Email: "",
+					},
+					ReviewedOn: utils.Ptr("2023-02-02T00:00:00Z"),
+					ReviewedBy: &TypesReviewer{
+						Name:  "Reviewer",
+						Email: utils.Ptr("reviewer@example.com"),
+					},
+				},
+				Justification: utils.Ptr("Reviewed justification"),
+				Status:        TypesSuppressionStatus(sarif.Accepted),
+			},
+		},
+		{
 			name: "suppression with accepted status field but without id",
 			inputResult: sarif.Result{
 				Suppressions: []sarif.Suppression{


### PR DESCRIPTION
### Description

Add `reviewedBy`, `reviewedOn` to suppresion details

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-facing ignore metadata and SARIF round-trip via a major code-client-go bump; scope is localized to suppression presentation and mapping, with no auth or security logic changes.
> 
> **Overview**
> Extends **suppression metadata** with optional `reviewedOn` and `reviewedBy` so ignore/review workflows can show who reviewed an ignore and when, alongside existing ignored-by fields.
> 
> The OpenAPI spec and generated `TypesReviewer` / `TypesSuppressionDetails` models are updated; SARIF → local finding **transform** now copies `reviewedBy` and `reviewedOn` from `code-client-go` suppression properties. **CLI text** output (`finding.component.tmpl`) adds formatted “Reviewed on” / “Reviewed by” lines and shows only the reviewer **name** (not email). **SARIF export** (`local_finding.sarif.tmpl`) emits the same fields in suppression `properties`, including reviewer email when present.
> 
> Dependency bumps: **Go 1.26.2**, `github.com/snyk/code-client-go` **v1.31.1**, and `go-git` **v5.19.1**. Tests cover transform mapping, component rendering, and SARIF JSON for review fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdc71c43a6a5df704945e0d1759562c43b6f1e6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->