### PR TITLE
chore: retract v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/snyk/go-application-framework
 
 go 1.26
 
+retract v1.0.0 // Accidental release: GAF intentionally stays on major version 0
+
 require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/gkampitakis/go-snaps v0.5.3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

This PR adds a `retract` directive to `go.mod` to formally withdraw v1.0.0, which was accidentally released due to a `BREAKING CHANGE:` commit trailer in [#662](https://github.com/snyk/go-application-framework/pull/662).

**Why retract?**
- GAF intentionally stays on major version 0 (0.x.x) to indicate it is a shared library in active development
- The v1.0.0 tag has been deleted from the repository, but the version remains cached on pkg.go.dev
- The retract directive will mark v1.0.0 as withdrawn and prevent future usage

**Regarding pkg.go.dev updates:**
The retraction will only take effect on pkg.go.dev once this PR is **merged to main**. Go's module proxy caches module metadata and only updates when it fetches new versions from the main branch. Having the retract directive on a PR branch alone will not update pkg.go.dev.

### Checklist

- [x] No tests needed (go.mod metadata change only)
- [x] No code generation needed
- [x] No linting needed (go.mod syntax is valid)
- [ ] CLI testing not applicable (retract directive has no runtime effect on existing code)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://snyk.slack.com/archives/C08M2BF0RDM/p1785766991049799?thread_ts=1785766991.049799&cid=C08M2BF0RDM)

<div><a href="https://cursor.com/agents/bc-e95e8c0f-4ffb-5c4f-80f9-3ca9149407c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e95e8c0f-4ffb-5c4f-80f9-3ca9149407c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

