### PR TITLE
chore: retract v1.0.1 to make v1.0.0 retraction effective

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/snyk/go-application-framework
 
 go 1.26
 
-retract v1.0.0 // Accidental release: GAF intentionally stays on major version 0
+retract (
+	v1.0.1 // Retraction marker: use v0.x versions
+	v1.0.0 // Accidental release: GAF intentionally stays on major version 0
+)
 
 require (
 	github.com/charmbracelet/lipgloss v1.1.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

This PR adds `retract v1.0.1` to make the v1.0.0 retraction actually effective.

**Why v1.0.1 is needed:**

The retraction of v1.0.0 in [#688](https://github.com/snyk/go-application-framework/pull/688) was merged to main, but it's not working yet because of how Go's module resolution works:

1. When resolving `@latest`, Go picks the highest semver version → v1.0.0
2. Go reads the `go.mod` of that version to check for retract directives
3. v1.0.0's `go.mod` doesn't have `retract v1.0.0` (can't retract itself)
4. The retract directive was added to main *after* v1.0.0 was released

**The solution:**

Create a v1.0.1 release that retracts both v1.0.0 and v1.0.1:
- `@latest` will resolve to v1.0.1
- v1.0.1's `go.mod` contains both retractions
- Go falls back to v0.11.0 as the latest non-retracted version
- GAF stays on major version 0 as intended

**After merge:**
1. Merge this PR
2. Create and push a `v1.0.1` tag: `git tag v1.0.1 && git push origin v1.0.1`
3. The Go proxy will fetch v1.0.1 and recognize both retractions
4. pkg.go.dev will update to show v0.11.0 as the latest recommended version

### Checklist

- [x] No tests needed (go.mod metadata change only)
- [x] No code generation needed  
- [x] No linting needed (go.mod syntax is valid)
- [ ] CLI testing not applicable (retract directive has no runtime effect on existing code)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://snyk.slack.com/archives/C08M2BF0RDM/p1785766991049799?thread_ts=1785766991.049799&cid=C08M2BF0RDM)

<div><a href="https://cursor.com/agents/bc-e95e8c0f-4ffb-5c4f-80f9-3ca9149407c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e95e8c0f-4ffb-5c4f-80f9-3ca9149407c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

