### PR TITLE
feat(networking): retry transient transport errors behind opt-in [IDE-2419]

### DIFF
--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -1,19 +1,26 @@
 package app
 
 import (
+	"bufio"
+	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"math"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -60,6 +67,106 @@ func newSequencedStatusServer(t *testing.T, statusSequence []int) (*httptest.Ser
 	}))
 	t.Cleanup(server.Close)
 	return server, &count
+}
+
+// resettingServerLog records the raw body bytes read from each connection
+// accepted by newResettingServer, in acceptance order.
+type resettingServerLog struct {
+	mu     sync.Mutex
+	bodies [][]byte
+}
+
+func (l *resettingServerLog) add(body []byte) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.bodies = append(l.bodies, body)
+}
+
+// Bodies returns a copy of the raw body bytes read so far, one entry per
+// accepted connection, in acceptance order.
+func (l *resettingServerLog) Bodies() [][]byte {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([][]byte, len(l.bodies))
+	copy(out, l.bodies)
+	return out
+}
+
+// newResettingServer returns a raw TCP listener (plain HTTP, no TLS) that
+// simulates a connection reset (RST) on the first resetsBeforeSuccess
+// connections, then serves a 200 OK on every connection after that. Each
+// connection is read through to the end of headers (and body, per
+// Content-Length) before it is either reset or answered, so a reset is
+// deterministically a read-side reset on a fully-written request rather than
+// a write race with the client. It returns the base URL, a pointer to the
+// number of accepted connections, and a log of the raw body bytes read per
+// connection.
+func newResettingServer(t *testing.T, resetsBeforeSuccess int) (baseURL string, connCount *int32, log *resettingServerLog) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	var count int32
+	log = &resettingServerLog{}
+
+	go func() {
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			idx := int(atomic.AddInt32(&count, 1))
+			go serveResettingConnection(conn, idx, resetsBeforeSuccess, log)
+		}
+	}()
+	t.Cleanup(func() { _ = listener.Close() })
+
+	return "http://" + listener.Addr().String(), &count, log
+}
+
+// serveResettingConnection reads a single HTTP request off conn (headers,
+// then body per Content-Length), records the body, and then either resets
+// the connection (idx <= resetsBeforeSuccess) or answers 200 OK.
+func serveResettingConnection(conn net.Conn, idx int, resetsBeforeSuccess int, log *resettingServerLog) {
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+	contentLength := 0
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return
+		}
+		trimmed := strings.TrimRight(line, "\r\n")
+		if trimmed == "" {
+			break
+		}
+		if name, value, found := strings.Cut(trimmed, ":"); found && strings.EqualFold(strings.TrimSpace(name), "Content-Length") {
+			parsed, convErr := strconv.Atoi(strings.TrimSpace(value))
+			if convErr == nil {
+				contentLength = parsed
+			}
+		}
+	}
+
+	body := make([]byte, contentLength)
+	if contentLength > 0 {
+		if _, err := io.ReadFull(reader, body); err != nil {
+			return
+		}
+	}
+	log.add(body)
+
+	if idx <= resetsBeforeSuccess {
+		// SetLinger(0) makes the following Close() emit a real RST instead of
+		// a graceful FIN, simulating a transient connection reset.
+		if tcpConn, ok := conn.(*net.TCPConn); ok {
+			_ = tcpConn.SetLinger(0) //nolint:errcheck // best-effort RST simulation on a test-only raw socket
+		}
+		return
+	}
+
+	_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")) //nolint:errcheck // best-effort write on a test-only raw socket
 }
 
 func createOAuthTokenWithAudience(t *testing.T, audience string) string {
@@ -1415,4 +1522,193 @@ func Test_initConfiguration_NetworkRetryOptIn_AcceptsStringValue(t *testing.T) {
 	assert.NotNil(t, engine)
 
 	assert.Equal(t, 3, config.GetInt(middleware.ConfigurationKeyRequestAttempts))
+}
+
+// Test_TransportRetry_OptIn_ConnectionResetRecovers is IDE-2419-ACC-001: an
+// opted-in application recovers from a connection reset on the first
+// attempt. Real-wiring test: exercises the composition root
+// (networking.go -> RetryMiddleware) end to end via a real TCP socket. Must
+// go RED if the opt-in read or the gated retry branch is removed.
+func Test_TransportRetry_OptIn_ConnectionResetRecovers(t *testing.T) {
+	baseURL, connCount, _ := newResettingServer(t, 1)
+
+	config := configuration.NewWithOpts()
+	config.Set(configuration.NETWORK_REQUEST_RETRIES_ENABLED, true)
+	config.Set(networkRequestRetryAfterSecondsKey, 1)
+
+	engine := CreateAppEngineWithOptions(WithConfiguration(config))
+	client := engine.GetNetworkAccess().GetUnauthorizedHttpClient()
+
+	resp, err := client.Get(baseURL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.GreaterOrEqual(t, atomic.LoadInt32(connCount), int32(2))
+}
+
+// Test_TransportRetry_OptIn_RetriedRequestSentInFull is IDE-2419-ACC-002: a
+// replayable request (POST carrying an Idempotency-Key) that is retried
+// after a connection reset arrives at the server with its original content
+// intact on the successful attempt.
+func Test_TransportRetry_OptIn_RetriedRequestSentInFull(t *testing.T) {
+	expectedBody := []byte(`{"hello":"world"}`)
+	baseURL, _, log := newResettingServer(t, 1)
+
+	config := configuration.NewWithOpts()
+	config.Set(configuration.NETWORK_REQUEST_RETRIES_ENABLED, true)
+	config.Set(networkRequestRetryAfterSecondsKey, 1)
+
+	engine := CreateAppEngineWithOptions(WithConfiguration(config))
+	client := engine.GetNetworkAccess().GetUnauthorizedHttpClient()
+
+	req, err := http.NewRequest(http.MethodPost, baseURL, bytes.NewReader(expectedBody))
+	require.NoError(t, err)
+	req.Header.Set("Idempotency-Key", "test-key")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	bodies := log.Bodies()
+	require.NotEmpty(t, bodies)
+	assert.Equal(t, expectedBody, bodies[len(bodies)-1])
+}
+
+// Test_TransportRetry_OptIn_PostNotRetried is IDE-2419-ACC-003: a POST
+// without an idempotency key is never retried after a connection reset, even
+// when opted in - the duplicate-write guarantee.
+func Test_TransportRetry_OptIn_PostNotRetried(t *testing.T) {
+	baseURL, connCount, _ := newResettingServer(t, 1)
+
+	config := configuration.NewWithOpts()
+	config.Set(configuration.NETWORK_REQUEST_RETRIES_ENABLED, true)
+	config.Set(networkRequestRetryAfterSecondsKey, 1)
+
+	engine := CreateAppEngineWithOptions(WithConfiguration(config))
+	client := engine.GetNetworkAccess().GetUnauthorizedHttpClient()
+
+	resp, err := client.Post(baseURL, "application/json", bytes.NewReader([]byte(`{"a":1}`))) //nolint:noctx // test-only request
+	if err == nil {
+		defer resp.Body.Close()
+	}
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(connCount))
+}
+
+// Test_TransportRetry_NotOptedIn_ConnectionResetFailsImmediately is
+// IDE-2419-ACC-004: a consumer that has not opted in sees byte-identical
+// behavior to today - a connection reset fails immediately (regression
+// guard).
+func Test_TransportRetry_NotOptedIn_ConnectionResetFailsImmediately(t *testing.T) {
+	baseURL, connCount, _ := newResettingServer(t, 1)
+
+	config := configuration.NewWithOpts()
+	config.Set(networkRequestRetryAfterSecondsKey, 1)
+
+	engine := CreateAppEngineWithOptions(WithConfiguration(config))
+	client := engine.GetNetworkAccess().GetUnauthorizedHttpClient()
+
+	resp, err := client.Get(baseURL)
+	if err == nil {
+		defer resp.Body.Close()
+	}
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(connCount))
+}
+
+// Test_TransportRetry_PreviewFeaturesOnly_ConnectionResetRecovers is
+// IDE-2419-ACC-005. Approved deviation from the plan's recommended Option A1:
+// the user confirmed Decision A2 - PREVIEW_FEATURES_ENABLED alone (without
+// NETWORK_REQUEST_RETRIES_ENABLED) also activates transport-error retry,
+// mirroring the existing OR condition already used by
+// defaultMaxNetworkRequestAttempts for the attempt-count default. The plan's
+// original ACC-005 (Test_TransportRetry_PreviewFeaturesOnly_ConnectionResetNotRetried)
+// pinned Option A1 and has been inverted accordingly.
+func Test_TransportRetry_PreviewFeaturesOnly_ConnectionResetRecovers(t *testing.T) {
+	baseURL, connCount, _ := newResettingServer(t, 1)
+
+	config := configuration.NewWithOpts()
+	config.Set(configuration.PREVIEW_FEATURES_ENABLED, true)
+	config.Set(networkRequestRetryAfterSecondsKey, 1)
+
+	engine := CreateAppEngineWithOptions(WithConfiguration(config))
+	client := engine.GetNetworkAccess().GetUnauthorizedHttpClient()
+
+	resp, err := client.Get(baseURL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.GreaterOrEqual(t, atomic.LoadInt32(connCount), int32(2))
+}
+
+// Test_TransportRetry_ExplicitAttemptCountOnly_ConnectionResetNotRetried is
+// IDE-2419-ACC-006: today's CLI self-enable path (an explicit attempt count,
+// ADR-1 Change 1) does not by itself activate transport-error retry
+// (regression guard).
+func Test_TransportRetry_ExplicitAttemptCountOnly_ConnectionResetNotRetried(t *testing.T) {
+	baseURL, connCount, _ := newResettingServer(t, 2)
+
+	config := configuration.NewWithOpts()
+	config.Set(middleware.ConfigurationKeyRequestAttempts, 3)
+	config.Set(networkRequestRetryAfterSecondsKey, 1)
+
+	engine := CreateAppEngineWithOptions(WithConfiguration(config))
+	client := engine.GetNetworkAccess().GetUnauthorizedHttpClient()
+
+	resp, err := client.Get(baseURL)
+	if err == nil {
+		defer resp.Body.Close()
+	}
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(connCount))
+}
+
+// Test_TransportRetry_OptIn_NeverRecovers_GivesUpAfterPolicyLimit is
+// IDE-2419-ACC-007: an opted-in application still gives up after the retry
+// budget is exhausted, surfacing the original transport error rather than a
+// RetryAttemptError.
+func Test_TransportRetry_OptIn_NeverRecovers_GivesUpAfterPolicyLimit(t *testing.T) {
+	baseURL, connCount, _ := newResettingServer(t, math.MaxInt32) // reset on every connection
+
+	config := configuration.NewWithOpts()
+	config.Set(configuration.NETWORK_REQUEST_RETRIES_ENABLED, true)
+	config.Set(networkRequestRetryAfterSecondsKey, 1)
+
+	engine := CreateAppEngineWithOptions(WithConfiguration(config))
+	client := engine.GetNetworkAccess().GetUnauthorizedHttpClient()
+
+	resp, err := client.Get(baseURL)
+	if err == nil {
+		defer resp.Body.Close()
+	}
+	require.Error(t, err)
+
+	var retryAttemptErr *middleware.RetryAttemptError
+	assert.False(t, errors.As(err, &retryAttemptErr), "exhaustion must surface the original transport error, not a RetryAttemptError")
+	assert.Equal(t, int32(3), atomic.LoadInt32(connCount))
+}
+
+// Test_TransportRetry_OptIn_ExplicitSingleAttemptForcesOff is
+// IDE-2419-ACC-008: an explicit single-attempt override still disables
+// transport-error retry even when opted in (escape hatch preserved).
+func Test_TransportRetry_OptIn_ExplicitSingleAttemptForcesOff(t *testing.T) {
+	baseURL, connCount, _ := newResettingServer(t, 1)
+
+	config := configuration.NewWithOpts()
+	config.Set(configuration.NETWORK_REQUEST_RETRIES_ENABLED, true)
+	config.Set(middleware.ConfigurationKeyRequestAttempts, 1)
+	config.Set(networkRequestRetryAfterSecondsKey, 1)
+
+	engine := CreateAppEngineWithOptions(WithConfiguration(config))
+	client := engine.GetNetworkAccess().GetUnauthorizedHttpClient()
+
+	resp, err := client.Get(baseURL)
+	if err == nil {
+		defer resp.Body.Close()
+	}
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(connCount))
 }

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -46,14 +46,11 @@ import (
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )
 
-// networkRequestRetryAfterSecondsKey mirrors middleware's unexported
-// configurationKeyRetryAfter. Tests that actually exercise a retry must set
-// this to a small value or the backoff will sleep for real seconds.
+// networkRequestRetryAfterSecondsKey: tests that exercise a retry must set
+// this small, or backoff sleeps for real seconds. Mirrors middleware's
+// unexported configurationKeyRetryAfter.
 const networkRequestRetryAfterSecondsKey = "internal_network_request_retry_after_seconds"
 
-// newSequencedStatusServer returns a test server whose responses follow
-// statusSequence in order; once exhausted, the last status repeats. It also
-// returns a pointer to the observed request count.
 func newSequencedStatusServer(t *testing.T, statusSequence []int) (*httptest.Server, *int32) {
 	t.Helper()
 	var count int32
@@ -82,8 +79,6 @@ func (l *resettingServerLog) add(body []byte) {
 	l.bodies = append(l.bodies, body)
 }
 
-// Bodies returns a copy of the raw body bytes read so far, one entry per
-// accepted connection, in acceptance order.
 func (l *resettingServerLog) Bodies() [][]byte {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -92,15 +87,9 @@ func (l *resettingServerLog) Bodies() [][]byte {
 	return out
 }
 
-// newResettingServer returns a raw TCP listener (plain HTTP, no TLS) that
-// simulates a connection reset (RST) on the first resetsBeforeSuccess
-// connections, then serves a 200 OK on every connection after that. Each
-// connection is read through to the end of headers (and body, per
-// Content-Length) before it is either reset or answered, so a reset is
-// deterministically a read-side reset on a fully-written request rather than
-// a write race with the client. It returns the base URL, a pointer to the
-// number of accepted connections, and a log of the raw body bytes read per
-// connection.
+// newResettingServer reads each connection through to the end of the request
+// so a reset is deterministically a read-side reset on a fully-written
+// request rather than a write race with the client.
 func newResettingServer(t *testing.T, resetsBeforeSuccess int) (baseURL string, connCount *int32, log *resettingServerLog) {
 	t.Helper()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -124,9 +113,6 @@ func newResettingServer(t *testing.T, resetsBeforeSuccess int) (baseURL string, 
 	return "http://" + listener.Addr().String(), &count, log
 }
 
-// serveResettingConnection reads a single HTTP request off conn (headers,
-// then body per Content-Length), records the body, and then either resets
-// the connection (idx <= resetsBeforeSuccess) or answers 200 OK.
 func serveResettingConnection(conn net.Conn, idx int, resetsBeforeSuccess int, log *resettingServerLog) {
 	defer conn.Close()
 
@@ -1241,7 +1227,7 @@ func Test_defaultMaxNetworkRequestAttempts(t *testing.T) {
 			previewEnabled: false,
 			expected:       1,
 		},
-		// IDE-1890-UNIT-001 precedence matrix (existing attempts / preview / opt-in / expected)
+		// precedence matrix (existing attempts / preview / opt-in / expected)
 		{
 			name:           "nil, not preview, opt-in absent, return 1",
 			existingValue:  nil,
@@ -1345,9 +1331,6 @@ func Test_defaultMaxNetworkRequestAttempts(t *testing.T) {
 	}
 }
 
-// Test_NetworkRetryOptIn_TransientFailureRecovers is IDE-1890-ACC-001: an
-// application that opts in to resilient network retries (with preview
-// features off) survives a single transient upstream failure.
 func Test_NetworkRetryOptIn_TransientFailureRecovers(t *testing.T) {
 	server, requestCount := newSequencedStatusServer(t, []int{http.StatusServiceUnavailable, http.StatusOK})
 
@@ -1366,9 +1349,6 @@ func Test_NetworkRetryOptIn_TransientFailureRecovers(t *testing.T) {
 	assert.GreaterOrEqual(t, atomic.LoadInt32(requestCount), int32(2))
 }
 
-// Test_NetworkRetryOptIn_NotOptedIn_SingleAttempt is IDE-1890-ACC-002: an
-// application that has not opted in behaves exactly as it does today
-// (regression guard).
 func Test_NetworkRetryOptIn_NotOptedIn_SingleAttempt(t *testing.T) {
 	server, requestCount := newSequencedStatusServer(t, []int{http.StatusServiceUnavailable, http.StatusOK})
 
@@ -1386,9 +1366,6 @@ func Test_NetworkRetryOptIn_NotOptedIn_SingleAttempt(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(requestCount))
 }
 
-// Test_NetworkRetryOptIn_PreviewFeaturesUnaffected is IDE-1890-ACC-003:
-// preview-feature users keep the resilience they already have, independent of
-// the new opt-in (regression guard).
 func Test_NetworkRetryOptIn_PreviewFeaturesUnaffected(t *testing.T) {
 	server, requestCount := newSequencedStatusServer(t, []int{http.StatusServiceUnavailable, http.StatusOK})
 
@@ -1407,8 +1384,6 @@ func Test_NetworkRetryOptIn_PreviewFeaturesUnaffected(t *testing.T) {
 	assert.GreaterOrEqual(t, atomic.LoadInt32(requestCount), int32(2))
 }
 
-// Test_NetworkRetryOptIn_ExplicitAttemptCountWins is IDE-1890-ACC-004: an
-// explicitly configured attempt count always wins over the opt-in.
 func Test_NetworkRetryOptIn_ExplicitAttemptCountWins(t *testing.T) {
 	server, requestCount := newSequencedStatusServer(t, []int{http.StatusServiceUnavailable, http.StatusOK})
 
@@ -1428,8 +1403,6 @@ func Test_NetworkRetryOptIn_ExplicitAttemptCountWins(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(requestCount))
 }
 
-// Test_NetworkRetryOptIn_NonRetryableResponseNotRetried is IDE-1890-ACC-005:
-// opting in does not cause requests to be retried that should not be.
 func Test_NetworkRetryOptIn_NonRetryableResponseNotRetried(t *testing.T) {
 	server, requestCount := newSequencedStatusServer(t, []int{http.StatusNotFound})
 
@@ -1448,8 +1421,6 @@ func Test_NetworkRetryOptIn_NonRetryableResponseNotRetried(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(requestCount))
 }
 
-// Test_NetworkRetryOptIn_GivesUpAfterPolicyLimit is IDE-1890-ACC-006: an
-// opted-in application still gives up rather than retrying forever.
 func Test_NetworkRetryOptIn_GivesUpAfterPolicyLimit(t *testing.T) {
 	server, requestCount := newSequencedStatusServer(t, []int{http.StatusServiceUnavailable})
 
@@ -1468,13 +1439,6 @@ func Test_NetworkRetryOptIn_GivesUpAfterPolicyLimit(t *testing.T) {
 	assert.Equal(t, int32(3), atomic.LoadInt32(requestCount))
 }
 
-// Test_initConfiguration_NetworkRetryOptIn_YieldsResilientAttempts is
-// IDE-1890-INT-001: real-wiring test. It exercises the composition root
-// (initConfiguration's AddDefaultValue registration for
-// middleware.ConfigurationKeyRequestAttempts) together with the real
-// defaultMaxNetworkRequestAttempts default-value function. It must go RED if
-// either the app.go:381 AddDefaultValue registration line, or the opt-in
-// condition inside defaultMaxNetworkRequestAttempts, is removed.
 func Test_initConfiguration_NetworkRetryOptIn_YieldsResilientAttempts(t *testing.T) {
 	config := configuration.NewWithOpts()
 	config.Set(configuration.NETWORK_REQUEST_RETRIES_ENABLED, true)
@@ -1485,8 +1449,6 @@ func Test_initConfiguration_NetworkRetryOptIn_YieldsResilientAttempts(t *testing
 	assert.Equal(t, 3, config.GetInt(middleware.ConfigurationKeyRequestAttempts))
 }
 
-// Test_initConfiguration_NetworkRetryOptIn_DefaultUnchangedWhenAbsent is
-// IDE-1890-INT-002: an untouched engine config yields today's default of 1.
 func Test_initConfiguration_NetworkRetryOptIn_DefaultUnchangedWhenAbsent(t *testing.T) {
 	config := configuration.NewWithOpts()
 
@@ -1496,9 +1458,6 @@ func Test_initConfiguration_NetworkRetryOptIn_DefaultUnchangedWhenAbsent(t *test
 	assert.Equal(t, 1, config.GetInt(middleware.ConfigurationKeyRequestAttempts))
 }
 
-// Test_initConfiguration_NetworkRetryOptIn_SurvivesConfigClone is
-// IDE-1890-INT-003: GAF clones config for cross-workflow invocation; the
-// opt-in must survive that clone.
 func Test_initConfiguration_NetworkRetryOptIn_SurvivesConfigClone(t *testing.T) {
 	config := configuration.NewWithOpts()
 	config.Set(configuration.NETWORK_REQUEST_RETRIES_ENABLED, true)
@@ -1511,9 +1470,6 @@ func Test_initConfiguration_NetworkRetryOptIn_SurvivesConfigClone(t *testing.T) 
 	assert.Equal(t, 3, cloned.GetInt(middleware.ConfigurationKeyRequestAttempts))
 }
 
-// Test_initConfiguration_NetworkRetryOptIn_AcceptsStringValue is
-// IDE-1890-INT-004: the opt-in can come from an environment variable or
-// configuration file, i.e. as the string "true" rather than a boolean.
 func Test_initConfiguration_NetworkRetryOptIn_AcceptsStringValue(t *testing.T) {
 	config := configuration.NewWithOpts()
 	config.Set(configuration.NETWORK_REQUEST_RETRIES_ENABLED, "true")
@@ -1524,11 +1480,6 @@ func Test_initConfiguration_NetworkRetryOptIn_AcceptsStringValue(t *testing.T) {
 	assert.Equal(t, 3, config.GetInt(middleware.ConfigurationKeyRequestAttempts))
 }
 
-// Test_TransportRetry_OptIn_ConnectionResetRecovers is IDE-2419-ACC-001: an
-// opted-in application recovers from a connection reset on the first
-// attempt. Real-wiring test: exercises the composition root
-// (networking.go -> RetryMiddleware) end to end via a real TCP socket. Must
-// go RED if the opt-in read or the gated retry branch is removed.
 func Test_TransportRetry_OptIn_ConnectionResetRecovers(t *testing.T) {
 	baseURL, connCount, _ := newResettingServer(t, 1)
 
@@ -1547,10 +1498,6 @@ func Test_TransportRetry_OptIn_ConnectionResetRecovers(t *testing.T) {
 	assert.GreaterOrEqual(t, atomic.LoadInt32(connCount), int32(2))
 }
 
-// Test_TransportRetry_OptIn_RetriedRequestSentInFull is IDE-2419-ACC-002: a
-// replayable request (POST carrying an Idempotency-Key) that is retried
-// after a connection reset arrives at the server with its original content
-// intact on the successful attempt.
 func Test_TransportRetry_OptIn_RetriedRequestSentInFull(t *testing.T) {
 	expectedBody := []byte(`{"hello":"world"}`)
 	baseURL, _, log := newResettingServer(t, 1)
@@ -1573,12 +1520,11 @@ func Test_TransportRetry_OptIn_RetriedRequestSentInFull(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	bodies := log.Bodies()
 	require.NotEmpty(t, bodies)
-	assert.Equal(t, expectedBody, bodies[len(bodies)-1])
+	for i, body := range bodies {
+		assert.Equal(t, expectedBody, body, "attempt %d", i+1)
+	}
 }
 
-// Test_TransportRetry_OptIn_PostNotRetried is IDE-2419-ACC-003: a POST
-// without an idempotency key is never retried after a connection reset, even
-// when opted in - the duplicate-write guarantee.
 func Test_TransportRetry_OptIn_PostNotRetried(t *testing.T) {
 	baseURL, connCount, _ := newResettingServer(t, 1)
 
@@ -1597,10 +1543,6 @@ func Test_TransportRetry_OptIn_PostNotRetried(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(connCount))
 }
 
-// Test_TransportRetry_NotOptedIn_ConnectionResetFailsImmediately is
-// IDE-2419-ACC-004: a consumer that has not opted in sees byte-identical
-// behavior to today - a connection reset fails immediately (regression
-// guard).
 func Test_TransportRetry_NotOptedIn_ConnectionResetFailsImmediately(t *testing.T) {
 	baseURL, connCount, _ := newResettingServer(t, 1)
 
@@ -1618,14 +1560,6 @@ func Test_TransportRetry_NotOptedIn_ConnectionResetFailsImmediately(t *testing.T
 	assert.Equal(t, int32(1), atomic.LoadInt32(connCount))
 }
 
-// Test_TransportRetry_PreviewFeaturesOnly_ConnectionResetRecovers is
-// IDE-2419-ACC-005. Approved deviation from the plan's recommended Option A1:
-// the user confirmed Decision A2 - PREVIEW_FEATURES_ENABLED alone (without
-// NETWORK_REQUEST_RETRIES_ENABLED) also activates transport-error retry,
-// mirroring the existing OR condition already used by
-// defaultMaxNetworkRequestAttempts for the attempt-count default. The plan's
-// original ACC-005 (Test_TransportRetry_PreviewFeaturesOnly_ConnectionResetNotRetried)
-// pinned Option A1 and has been inverted accordingly.
 func Test_TransportRetry_PreviewFeaturesOnly_ConnectionResetRecovers(t *testing.T) {
 	baseURL, connCount, _ := newResettingServer(t, 1)
 
@@ -1644,10 +1578,6 @@ func Test_TransportRetry_PreviewFeaturesOnly_ConnectionResetRecovers(t *testing.
 	assert.GreaterOrEqual(t, atomic.LoadInt32(connCount), int32(2))
 }
 
-// Test_TransportRetry_ExplicitAttemptCountOnly_ConnectionResetNotRetried is
-// IDE-2419-ACC-006: today's CLI self-enable path (an explicit attempt count,
-// ADR-1 Change 1) does not by itself activate transport-error retry
-// (regression guard).
 func Test_TransportRetry_ExplicitAttemptCountOnly_ConnectionResetNotRetried(t *testing.T) {
 	baseURL, connCount, _ := newResettingServer(t, 2)
 
@@ -1666,10 +1596,6 @@ func Test_TransportRetry_ExplicitAttemptCountOnly_ConnectionResetNotRetried(t *t
 	assert.Equal(t, int32(1), atomic.LoadInt32(connCount))
 }
 
-// Test_TransportRetry_OptIn_NeverRecovers_GivesUpAfterPolicyLimit is
-// IDE-2419-ACC-007: an opted-in application still gives up after the retry
-// budget is exhausted, surfacing the original transport error rather than a
-// RetryAttemptError.
 func Test_TransportRetry_OptIn_NeverRecovers_GivesUpAfterPolicyLimit(t *testing.T) {
 	baseURL, connCount, _ := newResettingServer(t, math.MaxInt32) // reset on every connection
 
@@ -1691,9 +1617,6 @@ func Test_TransportRetry_OptIn_NeverRecovers_GivesUpAfterPolicyLimit(t *testing.
 	assert.Equal(t, int32(3), atomic.LoadInt32(connCount))
 }
 
-// Test_TransportRetry_OptIn_ExplicitSingleAttemptForcesOff is
-// IDE-2419-ACC-008: an explicit single-attempt override still disables
-// transport-error retry even when opted in (escape hatch preserved).
 func Test_TransportRetry_OptIn_ExplicitSingleAttemptForcesOff(t *testing.T) {
 	baseURL, connCount, _ := newResettingServer(t, 1)
 

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -46,9 +46,8 @@ import (
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )
 
-// networkRequestRetryAfterSecondsKey: tests that exercise a retry must set
-// this small, or backoff sleeps for real seconds. Mirrors middleware's
-// unexported configurationKeyRetryAfter.
+// tests that exercise a retry must set this small, or backoff sleeps for real
+// seconds. Mirrors middleware's unexported configurationKeyRetryAfter.
 const networkRequestRetryAfterSecondsKey = "internal_network_request_retry_after_seconds"
 
 func newSequencedStatusServer(t *testing.T, statusSequence []int) (*httptest.Server, *int32) {
@@ -66,8 +65,6 @@ func newSequencedStatusServer(t *testing.T, statusSequence []int) (*httptest.Ser
 	return server, &count
 }
 
-// resettingServerLog records the raw body bytes read from each connection
-// accepted by newResettingServer, in acceptance order.
 type resettingServerLog struct {
 	mu     sync.Mutex
 	bodies [][]byte
@@ -87,9 +84,8 @@ func (l *resettingServerLog) Bodies() [][]byte {
 	return out
 }
 
-// newResettingServer reads each connection through to the end of the request
-// so a reset is deterministically a read-side reset on a fully-written
-// request rather than a write race with the client.
+// reads each connection to completion so the reset is deterministically
+// read-side, not a write race with the client.
 func newResettingServer(t *testing.T, resetsBeforeSuccess int) (baseURL string, connCount *int32, log *resettingServerLog) {
 	t.Helper()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -1227,7 +1223,6 @@ func Test_defaultMaxNetworkRequestAttempts(t *testing.T) {
 			previewEnabled: false,
 			expected:       1,
 		},
-		// precedence matrix (existing attempts / preview / opt-in / expected)
 		{
 			name:           "nil, not preview, opt-in absent, return 1",
 			existingValue:  nil,

--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -69,7 +69,9 @@ const (
 	// resilient network-retry policy. When true, the default value of
 	// middleware.ConfigurationKeyRequestAttempts becomes the multi-attempt default instead of a
 	// single attempt, without requiring PREVIEW_FEATURES_ENABLED. An explicitly configured
-	// attempts count always takes precedence over this switch.
+	// attempts count always takes precedence over this switch. This flag (or
+	// PREVIEW_FEATURES_ENABLED) also enables retrying transient transport-level errors
+	// (connection resets, network timeouts) on replayable requests.
 	NETWORK_REQUEST_RETRIES_ENABLED string = "internal_network_request_retries_enabled"
 	FLAG_INCLUDE_IGNORES            string = "include-ignores"    // FLAG_INCLUDE_IGNORES (boolean) sets/returns if ignores shall be displayed or not
 	FLAG_SEVERITY_THRESHOLD         string = "severity-threshold" // FLAG_SEVERITY_THRESHOLD (string) sets/returns the severity threshold

--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -66,12 +66,9 @@ const (
 	FLAG_EXPERIMENTAL        string = "experimental"                      // FLAG_EXPERIMENTAL (boolean) returns if experimental features shall be enabled or not, workflows should register this value as a flag to indicate that they might change before being GAed
 	PREVIEW_FEATURES_ENABLED string = "internal_preview_features_enabled" // PREVIEW_FEATURES_ENABLED (boolean) indicates if preview features shall be enabled, this can be used to limit features to the preview version only
 	// NETWORK_REQUEST_RETRIES_ENABLED (boolean) opts the application in to the framework's
-	// resilient network-retry policy. When true, the default value of
-	// middleware.ConfigurationKeyRequestAttempts becomes the multi-attempt default instead of a
-	// single attempt, without requiring PREVIEW_FEATURES_ENABLED. An explicitly configured
-	// attempts count always takes precedence over this switch. This flag (or
-	// PREVIEW_FEATURES_ENABLED) also enables retrying transient transport-level errors
-	// (connection resets, network timeouts) on replayable requests.
+	// resilient network-retry policy (multi-attempt default instead of a single attempt),
+	// without requiring PREVIEW_FEATURES_ENABLED (which has the same effect). An explicitly
+	// configured attempts count always wins over this switch.
 	NETWORK_REQUEST_RETRIES_ENABLED string = "internal_network_request_retries_enabled"
 	FLAG_INCLUDE_IGNORES            string = "include-ignores"    // FLAG_INCLUDE_IGNORES (boolean) sets/returns if ignores shall be displayed or not
 	FLAG_SEVERITY_THRESHOLD         string = "severity-threshold" // FLAG_SEVERITY_THRESHOLD (string) sets/returns the severity threshold

--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -63,17 +63,13 @@ const (
 	// general workflow configuration
 	// ---------
 
-	FLAG_EXPERIMENTAL        string = "experimental"                      // FLAG_EXPERIMENTAL (boolean) returns if experimental features shall be enabled or not, workflows should register this value as a flag to indicate that they might change before being GAed
-	PREVIEW_FEATURES_ENABLED string = "internal_preview_features_enabled" // PREVIEW_FEATURES_ENABLED (boolean) indicates if preview features shall be enabled, this can be used to limit features to the preview version only
-	// NETWORK_REQUEST_RETRIES_ENABLED (boolean) opts the application in to the framework's
-	// resilient network-retry policy (multi-attempt default instead of a single attempt),
-	// without requiring PREVIEW_FEATURES_ENABLED (which has the same effect). An explicitly
-	// configured attempts count always wins over this switch.
-	NETWORK_REQUEST_RETRIES_ENABLED string = "internal_network_request_retries_enabled"
-	FLAG_INCLUDE_IGNORES            string = "include-ignores"    // FLAG_INCLUDE_IGNORES (boolean) sets/returns if ignores shall be displayed or not
-	FLAG_SEVERITY_THRESHOLD         string = "severity-threshold" // FLAG_SEVERITY_THRESHOLD (string) sets/returns the severity threshold
-	FLAG_REMOTE_REPO_URL            string = "remote-repo-url"    // FLAG_REMOTE_REPO_URL (string) sets/returns the remote repository URL
-	INPUT_DIRECTORY                 string = "targetDirectory"    // INPUT_DIRECTORY ([]string) sets/returns the input directories that the application shall process
+	FLAG_EXPERIMENTAL               string = "experimental"                             // FLAG_EXPERIMENTAL (boolean) returns if experimental features shall be enabled or not, workflows should register this value as a flag to indicate that they might change before being GAed
+	PREVIEW_FEATURES_ENABLED        string = "internal_preview_features_enabled"        // PREVIEW_FEATURES_ENABLED (boolean) indicates if preview features shall be enabled, this can be used to limit features to the preview version only
+	NETWORK_REQUEST_RETRIES_ENABLED string = "internal_network_request_retries_enabled" // NETWORK_REQUEST_RETRIES_ENABLED (boolean) opts in to the framework's resilient network-retry policy without requiring PREVIEW_FEATURES_ENABLED
+	FLAG_INCLUDE_IGNORES            string = "include-ignores"                          // FLAG_INCLUDE_IGNORES (boolean) sets/returns if ignores shall be displayed or not
+	FLAG_SEVERITY_THRESHOLD         string = "severity-threshold"                       // FLAG_SEVERITY_THRESHOLD (string) sets/returns the severity threshold
+	FLAG_REMOTE_REPO_URL            string = "remote-repo-url"                          // FLAG_REMOTE_REPO_URL (string) sets/returns the remote repository URL
+	INPUT_DIRECTORY                 string = "targetDirectory"                          // INPUT_DIRECTORY ([]string) sets/returns the input directories that the application shall process
 	CUSTOM_CONFIG_FILES             string = "internal_custom_config_files"
 	WORKFLOW_USE_STDIO              string = "internal_wflstdio"
 	RAW_CMD_ARGS                    string = "internal_raw_cmd_args"

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -134,6 +134,9 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 		retryAfterSeconds = tmp
 	}
 
+	transportRetryEnabled := rm.config.GetBool(configuration.PREVIEW_FEATURES_ENABLED) ||
+		rm.config.GetBool(configuration.NETWORK_REQUEST_RETRIES_ENABLED)
+
 	body, getBody, cleanup, err := ensureGetBodyExists(req)
 	if err != nil {
 		return nil, err
@@ -175,8 +178,21 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 			response.Header.Set(retryCountHeaderKey, fmt.Sprintf("%d", actualAttempts))
 		}
 
-		// errors from the next round tripper cannot be retried
+		// errors from the next round tripper cannot be retried, unless the
+		// error is a transient transport-level failure (connection reset,
+		// network timeout) on a replayable request and the opt-in is enabled
 		if rtErr != nil {
+			attemptLimit := maxAttempts
+			if cachedMaxRetries != nil {
+				attemptLimit = *cachedMaxRetries
+			}
+			if transportRetryEnabled &&
+				actualAttempts < attemptLimit &&
+				isRetryableTransportError(rtErr) &&
+				isReplayableRequest(&localRequest) {
+				rm.logger.Debug().Err(rtErr).Msgf("Retrying request after transient transport error (attempt %d/%d)", actualAttempts, attemptLimit)
+				return response, rtErr
+			}
 			return response, backoff.Permanent(rtErr)
 		}
 

--- a/pkg/networking/middleware/retry_middleware.go
+++ b/pkg/networking/middleware/retry_middleware.go
@@ -178,9 +178,7 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 			response.Header.Set(retryCountHeaderKey, fmt.Sprintf("%d", actualAttempts))
 		}
 
-		// errors from the next round tripper cannot be retried, unless the
-		// error is a transient transport-level failure (connection reset,
-		// network timeout) on a replayable request and the opt-in is enabled
+		// errors from the next round tripper cannot be retried
 		if rtErr != nil {
 			attemptLimit := maxAttempts
 			if cachedMaxRetries != nil {
@@ -190,7 +188,7 @@ func (rm RetryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 				actualAttempts < attemptLimit &&
 				isRetryableTransportError(rtErr) &&
 				isReplayableRequest(&localRequest) {
-				rm.logger.Debug().Err(rtErr).Msgf("Retrying request after transient transport error (attempt %d/%d)", actualAttempts, attemptLimit)
+				rm.logger.Warn().Err(rtErr).Msgf("Retrying request after transient transport error (attempt %d/%d)", actualAttempts, attemptLimit)
 				return response, rtErr
 			}
 			return response, backoff.Permanent(rtErr)

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -1424,8 +1424,6 @@ func setupRetryMiddleware(
 	return NewRetryMiddleware(config, logger, rt, WithErrorHandler(errorHandler)), &attemptCount
 }
 
-// connResetErr is a synthetic transport error mirroring what net/http's
-// transport returns for a real TCP RST.
 func connResetErr() error {
 	return &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET}
 }
@@ -1482,7 +1480,6 @@ func Test_RetryMiddleware_TransportError_NotRetriedWhenOptInAbsent(t *testing.T)
 	assert.ErrorIs(t, err, syscall.ECONNRESET)
 }
 
-// fakeTimeoutError avoids depending on a real network timeout.
 type fakeTimeoutError struct{}
 
 func (fakeTimeoutError) Error() string   { return "fake timeout" }

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -3,15 +3,18 @@ package middleware
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -1420,4 +1423,395 @@ func setupRetryMiddleware(
 	config.Set(ConfigurationKeyRequestAttempts, maxAttempts)
 	config.Set(configurationKeyRetryAfter, 1)
 	return NewRetryMiddleware(config, logger, rt, WithErrorHandler(errorHandler)), &attemptCount
+}
+
+// connResetErr is a synthetic transport error mirroring what net/http's
+// transport returns for a real TCP RST: a *net.OpError wrapping
+// syscall.ECONNRESET.
+func connResetErr() error {
+	return &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET}
+}
+
+// Test_RetryMiddleware_TransportError_ConnResetRetriedWhenOptedIn is
+// IDE-2419-INT-001: opted in, a connection reset is retried and the request
+// eventually succeeds.
+func Test_RetryMiddleware_TransportError_ConnResetRetriedWhenOptedIn(t *testing.T) {
+	logger := zerolog.Nop()
+	attemptCount := 0
+
+	customRTFn := func(req *http.Request) (*http.Response, error) {
+		attemptCount++
+		if attemptCount <= 2 {
+			return nil, connResetErr()
+		}
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Request: req}, nil
+	}
+
+	rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+	config := configuration.NewWithOpts()
+	config.Set(configuration.NETWORK_REQUEST_RETRIES_ENABLED, true)
+	config.Set(ConfigurationKeyRequestAttempts, 3)
+	config.Set(configurationKeyRetryAfter, 1)
+
+	sut := NewRetryMiddleware(config, &logger, rt)
+	resp, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 3, attemptCount)
+}
+
+// Test_RetryMiddleware_TransportError_NotRetriedWhenOptInAbsent is
+// IDE-2419-INT-002: without the opt-in, a connection reset is returned
+// unwrapped after exactly one invocation, even with a multi-attempt budget
+// configured.
+func Test_RetryMiddleware_TransportError_NotRetriedWhenOptInAbsent(t *testing.T) {
+	logger := zerolog.Nop()
+	attemptCount := 0
+
+	//nolint:unparam // response is always nil: this fixture only simulates a transport-level failure
+	customRTFn := func(_ *http.Request) (*http.Response, error) {
+		attemptCount++
+		return nil, connResetErr()
+	}
+
+	rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+	config := configuration.NewWithOpts()
+	config.Set(ConfigurationKeyRequestAttempts, 3)
+	config.Set(configurationKeyRetryAfter, 1)
+
+	sut := NewRetryMiddleware(config, &logger, rt)
+	_, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
+
+	require.Error(t, err)
+	assert.Equal(t, 1, attemptCount)
+	assert.ErrorIs(t, err, syscall.ECONNRESET)
+}
+
+// fakeTimeoutError is a minimal net.Error whose Timeout() reports true, used to
+// exercise the timeout branch of the error axis without depending on a real
+// network timeout.
+type fakeTimeoutError struct{}
+
+func (fakeTimeoutError) Error() string   { return "fake timeout" }
+func (fakeTimeoutError) Timeout() bool   { return true }
+func (fakeTimeoutError) Temporary() bool { return true }
+
+// Test_RetryMiddleware_TransportError_ErrorAxis is IDE-2419-INT-003: the
+// error axis of the two-axis allow-list, pinning both the allow-list
+// (connection reset, network timeout, DNS timeout) and the deny-list
+// (DNS NotFound, caller cancellation, deadline, TLS failure) - including the
+// deny-before-allow ordering for a deadline error wrapped so it also
+// satisfies net.Error.Timeout().
+func Test_RetryMiddleware_TransportError_ErrorAxis(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		retried bool
+	}{
+		{"net timeout retried", fakeTimeoutError{}, true},
+		{"dns not found not retried", &net.DNSError{IsNotFound: true}, false},
+		{"context canceled not retried", context.Canceled, false},
+		{"context deadline exceeded not retried", context.DeadlineExceeded, false},
+		{"url error wrapping deadline exceeded not retried", &url.Error{Op: "Get", URL: "http://example.com", Err: context.DeadlineExceeded}, false},
+		{"tls certificate verification error not retried", &tls.CertificateVerificationError{}, false},
+		{"econnrefused not retried", syscall.ECONNREFUSED, false},
+		{"unexpected eof not retried", io.ErrUnexpectedEOF, false},
+		{"dns timeout retried", &net.DNSError{IsTimeout: true}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := zerolog.Nop()
+			attemptCount := 0
+			customRTFn := func(req *http.Request) (*http.Response, error) {
+				attemptCount++
+				if attemptCount == 1 {
+					return nil, tt.err
+				}
+				return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Request: req}, nil
+			}
+
+			rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+			config := configuration.NewWithOpts()
+			config.Set(configuration.NETWORK_REQUEST_RETRIES_ENABLED, true)
+			config.Set(ConfigurationKeyRequestAttempts, 3)
+			config.Set(configurationKeyRetryAfter, 1)
+
+			sut := NewRetryMiddleware(config, &logger, rt)
+			resp, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
+
+			if tt.retried {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+				assert.Equal(t, 2, attemptCount)
+			} else {
+				require.Error(t, err)
+				assert.Equal(t, 1, attemptCount)
+			}
+		})
+	}
+}
+
+// Test_RetryMiddleware_TransportError_RequestAxis is IDE-2419-INT-004: the
+// request axis of the two-axis allow-list - safe methods are always
+// replayable, everything else only with an idempotency key.
+func Test_RetryMiddleware_TransportError_RequestAxis(t *testing.T) {
+	tests := []struct {
+		name    string
+		method  string
+		headers map[string]string
+		retried bool
+	}{
+		{"GET retried", http.MethodGet, nil, true},
+		{"HEAD retried", http.MethodHead, nil, true},
+		{"OPTIONS retried", http.MethodOptions, nil, true},
+		{"TRACE retried", http.MethodTrace, nil, true},
+		{"POST not retried", http.MethodPost, nil, false},
+		{"PUT not retried", http.MethodPut, nil, false},
+		{"DELETE not retried", http.MethodDelete, nil, false},
+		{"POST with Idempotency-Key retried", http.MethodPost, map[string]string{"Idempotency-Key": "abc"}, true},
+		{"POST with X-Idempotency-Key retried", http.MethodPost, map[string]string{"X-Idempotency-Key": "abc"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attemptCount := 0
+			customRTFn := func(req *http.Request) (*http.Response, error) {
+				attemptCount++
+				if attemptCount == 1 {
+					return nil, connResetErr()
+				}
+				return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Request: req}, nil
+			}
+
+			logger := zerolog.Nop()
+			rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+			config := configuration.NewWithOpts()
+			config.Set(configuration.NETWORK_REQUEST_RETRIES_ENABLED, true)
+			config.Set(ConfigurationKeyRequestAttempts, 3)
+			config.Set(configurationKeyRetryAfter, 1)
+
+			sut := NewRetryMiddleware(config, &logger, rt)
+			req := httptest.NewRequest(tt.method, "/", nil)
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+
+			resp, err := sut.RoundTrip(req)
+
+			if tt.retried {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+				assert.Equal(t, 2, attemptCount)
+			} else {
+				require.Error(t, err)
+				assert.Equal(t, 1, attemptCount)
+			}
+		})
+	}
+}
+
+// Test_RetryMiddleware_TransportError_BodyReplayedOnEveryAttempt is
+// IDE-2419-INT-005: a replayable POST (carrying an Idempotency-Key) has its
+// full body available on every attempt, mirroring
+// TestRetryMiddleware_429_POST_BodyPreservedAcrossRetries for the transport
+// error path.
+func Test_RetryMiddleware_TransportError_BodyReplayedOnEveryAttempt(t *testing.T) {
+	expectedBody := []byte(`{"depGraph":{"pkgManager":{"name":"npm"},"nodes":[]}}`)
+	logger := zerolog.Nop()
+
+	var bodiesReceived [][]byte
+	attemptCount := 0
+
+	customRTFn := func(req *http.Request) (*http.Response, error) {
+		attemptCount++
+
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		bodiesReceived = append(bodiesReceived, body)
+
+		if attemptCount < 3 {
+			return nil, connResetErr()
+		}
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Request: req}, nil
+	}
+
+	rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+	config := configuration.NewWithOpts()
+	config.Set(configuration.NETWORK_REQUEST_RETRIES_ENABLED, true)
+	config.Set(ConfigurationKeyRequestAttempts, 3)
+	config.Set(configurationKeyRetryAfter, 1)
+
+	sut := NewRetryMiddleware(config, &logger, rt)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/test", bytes.NewReader(expectedBody))
+	req.Header.Set("Idempotency-Key", "test-key")
+
+	resp, err := sut.RoundTrip(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 3, attemptCount)
+	require.Len(t, bodiesReceived, 3)
+	for i, body := range bodiesReceived {
+		assert.Equal(t, expectedBody, body, "attempt %d", i+1)
+	}
+}
+
+// Test_RetryMiddleware_TransportError_ExhaustsAtMaxAttempts is
+// IDE-2419-INT-006: an opted-in request that never recovers exhausts at the
+// configured attempt budget and returns the original transport error with a
+// nil response.
+func Test_RetryMiddleware_TransportError_ExhaustsAtMaxAttempts(t *testing.T) {
+	logger := zerolog.Nop()
+	attemptCount := 0
+
+	//nolint:unparam // response is always nil: this fixture only simulates a transport-level failure
+	customRTFn := func(_ *http.Request) (*http.Response, error) {
+		attemptCount++
+		return nil, connResetErr()
+	}
+
+	rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+	config := configuration.NewWithOpts()
+	config.Set(configuration.NETWORK_REQUEST_RETRIES_ENABLED, true)
+	config.Set(ConfigurationKeyRequestAttempts, 3)
+	config.Set(configurationKeyRetryAfter, 1)
+
+	sut := NewRetryMiddleware(config, &logger, rt)
+	resp, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Equal(t, 3, attemptCount)
+	assert.ErrorIs(t, err, syscall.ECONNRESET)
+}
+
+// Test_RetryMiddleware_TransportError_RetryCountHeaderSetOnRecovery is
+// IDE-2419-INT-007: the successful response after a transport-error retry
+// carries the attempt-count header.
+func Test_RetryMiddleware_TransportError_RetryCountHeaderSetOnRecovery(t *testing.T) {
+	logger := zerolog.Nop()
+	attemptCount := 0
+
+	customRTFn := func(req *http.Request) (*http.Response, error) {
+		attemptCount++
+		if attemptCount == 1 {
+			return nil, connResetErr()
+		}
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Request: req}, nil
+	}
+
+	rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+	config := configuration.NewWithOpts()
+	config.Set(configuration.NETWORK_REQUEST_RETRIES_ENABLED, true)
+	config.Set(ConfigurationKeyRequestAttempts, 3)
+	config.Set(configurationKeyRetryAfter, 1)
+
+	sut := NewRetryMiddleware(config, &logger, rt)
+	resp, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "2", resp.Header.Get(retryCountHeaderKey))
+}
+
+// Test_RetryMiddleware_TransportError_SharesBudgetWith429Override is
+// IDE-2419-INT-008: a 429 override that bumps the retry budget to 3 is
+// shared with subsequent transport-error retries rather than each getting
+// its own independent budget.
+func Test_RetryMiddleware_TransportError_SharesBudgetWith429Override(t *testing.T) {
+	logger := zerolog.Nop()
+	attemptCount := 0
+
+	customRTFn := func(req *http.Request) (*http.Response, error) {
+		attemptCount++
+		if attemptCount == 1 {
+			return &http.Response{StatusCode: http.StatusTooManyRequests, Header: http.Header{}, Request: req}, nil
+		}
+		return nil, connResetErr()
+	}
+
+	rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+	config := configuration.NewWithOpts()
+	config.Set(configuration.NETWORK_REQUEST_RETRIES_ENABLED, true)
+	config.Set(ConfigurationKeyRequestAttempts, 1) // 429 override bumps this to 3
+	config.Set(configurationKeyRetryAfter, 1)
+
+	sut := NewRetryMiddleware(config, &logger, rt)
+	_, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
+
+	require.Error(t, err)
+	assert.Equal(t, 3, attemptCount)
+}
+
+// Test_RetryMiddleware_TransportError_ContextCancelledMidFlightStopsImmediately
+// is IDE-2419-INT-009: when the request context is canceled concurrently
+// with a retryable transport error, the retry loop stops immediately rather
+// than attempting again.
+func Test_RetryMiddleware_TransportError_ContextCancelledMidFlightStopsImmediately(t *testing.T) {
+	logger := zerolog.Nop()
+	ctx, cancel := context.WithCancel(context.Background())
+	attemptCount := 0
+
+	//nolint:unparam // response is always nil: this fixture only simulates a transport-level failure
+	customRTFn := func(_ *http.Request) (*http.Response, error) {
+		attemptCount++
+		cancel() // simulate cancellation racing with the transport failure
+		return nil, connResetErr()
+	}
+
+	rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+	config := configuration.NewWithOpts()
+	config.Set(configuration.NETWORK_REQUEST_RETRIES_ENABLED, true)
+	config.Set(ConfigurationKeyRequestAttempts, 5)
+	config.Set(configurationKeyRetryAfter, 1)
+
+	sut := NewRetryMiddleware(config, &logger, rt)
+	req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com/", nil)
+	require.NoError(t, reqErr)
+
+	_, err := sut.RoundTrip(req)
+
+	require.Error(t, err)
+	assert.Equal(t, 1, attemptCount)
+}
+
+// Test_RetryMiddleware_TransportError_PreviewFeaturesOnlyActivatesRetry pins
+// the approved deviation from the plan's Decision A1: PREVIEW_FEATURES_ENABLED
+// alone (without NETWORK_REQUEST_RETRIES_ENABLED) also activates
+// transport-error retry, mirroring the existing OR condition
+// defaultMaxNetworkRequestAttempts already uses for the attempt-count
+// default. This is the dedicated wiring test for that OR condition: it goes
+// RED if the gate inside RoundTrip is reverted to check
+// NETWORK_REQUEST_RETRIES_ENABLED only.
+func Test_RetryMiddleware_TransportError_PreviewFeaturesOnlyActivatesRetry(t *testing.T) {
+	logger := zerolog.Nop()
+	attemptCount := 0
+
+	customRTFn := func(req *http.Request) (*http.Response, error) {
+		attemptCount++
+		if attemptCount == 1 {
+			return nil, connResetErr()
+		}
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Request: req}, nil
+	}
+
+	rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
+	config := configuration.NewWithOpts()
+	config.Set(configuration.PREVIEW_FEATURES_ENABLED, true)
+	config.Set(ConfigurationKeyRequestAttempts, 3)
+	config.Set(configurationKeyRetryAfter, 1)
+
+	sut := NewRetryMiddleware(config, &logger, rt)
+	resp, err := sut.RoundTrip(httptest.NewRequest(http.MethodGet, "/", nil))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, attemptCount)
 }

--- a/pkg/networking/middleware/retry_middleware_test.go
+++ b/pkg/networking/middleware/retry_middleware_test.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -1426,17 +1425,14 @@ func setupRetryMiddleware(
 }
 
 // connResetErr is a synthetic transport error mirroring what net/http's
-// transport returns for a real TCP RST: a *net.OpError wrapping
-// syscall.ECONNRESET.
+// transport returns for a real TCP RST.
 func connResetErr() error {
 	return &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET}
 }
 
-// Test_RetryMiddleware_TransportError_ConnResetRetriedWhenOptedIn is
-// IDE-2419-INT-001: opted in, a connection reset is retried and the request
-// eventually succeeds.
 func Test_RetryMiddleware_TransportError_ConnResetRetriedWhenOptedIn(t *testing.T) {
-	logger := zerolog.Nop()
+	var buf bytes.Buffer
+	logger := zerolog.New(&buf).Level(zerolog.TraceLevel)
 	attemptCount := 0
 
 	customRTFn := func(req *http.Request) (*http.Response, error) {
@@ -1460,12 +1456,9 @@ func Test_RetryMiddleware_TransportError_ConnResetRetriedWhenOptedIn(t *testing.
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, 3, attemptCount)
+	assert.Contains(t, buf.String(), `"level":"warn"`, "transport-error retry must be logged at warn level")
 }
 
-// Test_RetryMiddleware_TransportError_NotRetriedWhenOptInAbsent is
-// IDE-2419-INT-002: without the opt-in, a connection reset is returned
-// unwrapped after exactly one invocation, even with a multi-attempt budget
-// configured.
 func Test_RetryMiddleware_TransportError_NotRetriedWhenOptInAbsent(t *testing.T) {
 	logger := zerolog.Nop()
 	attemptCount := 0
@@ -1489,21 +1482,13 @@ func Test_RetryMiddleware_TransportError_NotRetriedWhenOptInAbsent(t *testing.T)
 	assert.ErrorIs(t, err, syscall.ECONNRESET)
 }
 
-// fakeTimeoutError is a minimal net.Error whose Timeout() reports true, used to
-// exercise the timeout branch of the error axis without depending on a real
-// network timeout.
+// fakeTimeoutError avoids depending on a real network timeout.
 type fakeTimeoutError struct{}
 
 func (fakeTimeoutError) Error() string   { return "fake timeout" }
 func (fakeTimeoutError) Timeout() bool   { return true }
 func (fakeTimeoutError) Temporary() bool { return true }
 
-// Test_RetryMiddleware_TransportError_ErrorAxis is IDE-2419-INT-003: the
-// error axis of the two-axis allow-list, pinning both the allow-list
-// (connection reset, network timeout, DNS timeout) and the deny-list
-// (DNS NotFound, caller cancellation, deadline, TLS failure) - including the
-// deny-before-allow ordering for a deadline error wrapped so it also
-// satisfies net.Error.Timeout().
 func Test_RetryMiddleware_TransportError_ErrorAxis(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -1512,13 +1497,6 @@ func Test_RetryMiddleware_TransportError_ErrorAxis(t *testing.T) {
 	}{
 		{"net timeout retried", fakeTimeoutError{}, true},
 		{"dns not found not retried", &net.DNSError{IsNotFound: true}, false},
-		{"context canceled not retried", context.Canceled, false},
-		{"context deadline exceeded not retried", context.DeadlineExceeded, false},
-		{"url error wrapping deadline exceeded not retried", &url.Error{Op: "Get", URL: "http://example.com", Err: context.DeadlineExceeded}, false},
-		{"tls certificate verification error not retried", &tls.CertificateVerificationError{}, false},
-		{"econnrefused not retried", syscall.ECONNREFUSED, false},
-		{"unexpected eof not retried", io.ErrUnexpectedEOF, false},
-		{"dns timeout retried", &net.DNSError{IsTimeout: true}, true},
 	}
 
 	for _, tt := range tests {
@@ -1555,9 +1533,6 @@ func Test_RetryMiddleware_TransportError_ErrorAxis(t *testing.T) {
 	}
 }
 
-// Test_RetryMiddleware_TransportError_RequestAxis is IDE-2419-INT-004: the
-// request axis of the two-axis allow-list - safe methods are always
-// replayable, everything else only with an idempotency key.
 func Test_RetryMiddleware_TransportError_RequestAxis(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -1565,15 +1540,8 @@ func Test_RetryMiddleware_TransportError_RequestAxis(t *testing.T) {
 		headers map[string]string
 		retried bool
 	}{
-		{"GET retried", http.MethodGet, nil, true},
-		{"HEAD retried", http.MethodHead, nil, true},
-		{"OPTIONS retried", http.MethodOptions, nil, true},
-		{"TRACE retried", http.MethodTrace, nil, true},
 		{"POST not retried", http.MethodPost, nil, false},
-		{"PUT not retried", http.MethodPut, nil, false},
-		{"DELETE not retried", http.MethodDelete, nil, false},
 		{"POST with Idempotency-Key retried", http.MethodPost, map[string]string{"Idempotency-Key": "abc"}, true},
-		{"POST with X-Idempotency-Key retried", http.MethodPost, map[string]string{"X-Idempotency-Key": "abc"}, true},
 	}
 
 	for _, tt := range tests {
@@ -1615,57 +1583,6 @@ func Test_RetryMiddleware_TransportError_RequestAxis(t *testing.T) {
 	}
 }
 
-// Test_RetryMiddleware_TransportError_BodyReplayedOnEveryAttempt is
-// IDE-2419-INT-005: a replayable POST (carrying an Idempotency-Key) has its
-// full body available on every attempt, mirroring
-// TestRetryMiddleware_429_POST_BodyPreservedAcrossRetries for the transport
-// error path.
-func Test_RetryMiddleware_TransportError_BodyReplayedOnEveryAttempt(t *testing.T) {
-	expectedBody := []byte(`{"depGraph":{"pkgManager":{"name":"npm"},"nodes":[]}}`)
-	logger := zerolog.Nop()
-
-	var bodiesReceived [][]byte
-	attemptCount := 0
-
-	customRTFn := func(req *http.Request) (*http.Response, error) {
-		attemptCount++
-
-		body, err := io.ReadAll(req.Body)
-		require.NoError(t, err)
-		bodiesReceived = append(bodiesReceived, body)
-
-		if attemptCount < 3 {
-			return nil, connResetErr()
-		}
-		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Request: req}, nil
-	}
-
-	rt := &failRoundtripper{t: t, roundTripFn: &customRTFn}
-	config := configuration.NewWithOpts()
-	config.Set(configuration.NETWORK_REQUEST_RETRIES_ENABLED, true)
-	config.Set(ConfigurationKeyRequestAttempts, 3)
-	config.Set(configurationKeyRetryAfter, 1)
-
-	sut := NewRetryMiddleware(config, &logger, rt)
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/test", bytes.NewReader(expectedBody))
-	req.Header.Set("Idempotency-Key", "test-key")
-
-	resp, err := sut.RoundTrip(req)
-
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, 3, attemptCount)
-	require.Len(t, bodiesReceived, 3)
-	for i, body := range bodiesReceived {
-		assert.Equal(t, expectedBody, body, "attempt %d", i+1)
-	}
-}
-
-// Test_RetryMiddleware_TransportError_ExhaustsAtMaxAttempts is
-// IDE-2419-INT-006: an opted-in request that never recovers exhausts at the
-// configured attempt budget and returns the original transport error with a
-// nil response.
 func Test_RetryMiddleware_TransportError_ExhaustsAtMaxAttempts(t *testing.T) {
 	logger := zerolog.Nop()
 	attemptCount := 0
@@ -1691,9 +1608,6 @@ func Test_RetryMiddleware_TransportError_ExhaustsAtMaxAttempts(t *testing.T) {
 	assert.ErrorIs(t, err, syscall.ECONNRESET)
 }
 
-// Test_RetryMiddleware_TransportError_RetryCountHeaderSetOnRecovery is
-// IDE-2419-INT-007: the successful response after a transport-error retry
-// carries the attempt-count header.
 func Test_RetryMiddleware_TransportError_RetryCountHeaderSetOnRecovery(t *testing.T) {
 	logger := zerolog.Nop()
 	attemptCount := 0
@@ -1720,10 +1634,6 @@ func Test_RetryMiddleware_TransportError_RetryCountHeaderSetOnRecovery(t *testin
 	assert.Equal(t, "2", resp.Header.Get(retryCountHeaderKey))
 }
 
-// Test_RetryMiddleware_TransportError_SharesBudgetWith429Override is
-// IDE-2419-INT-008: a 429 override that bumps the retry budget to 3 is
-// shared with subsequent transport-error retries rather than each getting
-// its own independent budget.
 func Test_RetryMiddleware_TransportError_SharesBudgetWith429Override(t *testing.T) {
 	logger := zerolog.Nop()
 	attemptCount := 0
@@ -1749,10 +1659,6 @@ func Test_RetryMiddleware_TransportError_SharesBudgetWith429Override(t *testing.
 	assert.Equal(t, 3, attemptCount)
 }
 
-// Test_RetryMiddleware_TransportError_ContextCancelledMidFlightStopsImmediately
-// is IDE-2419-INT-009: when the request context is canceled concurrently
-// with a retryable transport error, the retry loop stops immediately rather
-// than attempting again.
 func Test_RetryMiddleware_TransportError_ContextCancelledMidFlightStopsImmediately(t *testing.T) {
 	logger := zerolog.Nop()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1781,14 +1687,6 @@ func Test_RetryMiddleware_TransportError_ContextCancelledMidFlightStopsImmediate
 	assert.Equal(t, 1, attemptCount)
 }
 
-// Test_RetryMiddleware_TransportError_PreviewFeaturesOnlyActivatesRetry pins
-// the approved deviation from the plan's Decision A1: PREVIEW_FEATURES_ENABLED
-// alone (without NETWORK_REQUEST_RETRIES_ENABLED) also activates
-// transport-error retry, mirroring the existing OR condition
-// defaultMaxNetworkRequestAttempts already uses for the attempt-count
-// default. This is the dedicated wiring test for that OR condition: it goes
-// RED if the gate inside RoundTrip is reverted to check
-// NETWORK_REQUEST_RETRIES_ENABLED only.
 func Test_RetryMiddleware_TransportError_PreviewFeaturesOnlyActivatesRetry(t *testing.T) {
 	logger := zerolog.Nop()
 	attemptCount := 0

--- a/pkg/networking/middleware/retry_transport_error.go
+++ b/pkg/networking/middleware/retry_transport_error.go
@@ -1,0 +1,60 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"syscall"
+)
+
+// errWSAEConnReset is the Windows WSAECONNRESET error code (10054). Go's
+// syscall package does not map it onto syscall.ECONNRESET the way POSIX
+// does, so it must be matched explicitly by numeric value.
+const errWSAEConnReset = syscall.Errno(10054)
+
+// isConnectionReset reports whether err is (or wraps) a TCP connection reset,
+// on POSIX (syscall.ECONNRESET) or Windows (WSAECONNRESET).
+func isConnectionReset(err error) bool {
+	return errors.Is(err, syscall.ECONNRESET) || errors.Is(err, errWSAEConnReset)
+}
+
+// isRetryableTransportError implements the error axis of the transport-error
+// retry allow-list: connection resets and network timeouts are retryable;
+// everything else (DNS NotFound, TLS failures, context cancellation/deadline,
+// EOF, connection refused) is not. context.DeadlineExceeded also satisfies
+// net.Error.Timeout(), so the cancellation/deadline deny-check must run
+// before the timeout allow-check.
+func isRetryableTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if isConnectionReset(err) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+// isReplayableRequest implements the request axis of the transport-error
+// retry allow-list, mirroring net/http.Transport's own isReplayable: safe
+// methods (or no method set) are always replayable; other methods are
+// replayable only when they carry an Idempotency-Key or X-Idempotency-Key
+// header (checked by presence, not value).
+func isReplayableRequest(req *http.Request) bool {
+	if req.Body != nil && req.Body != http.NoBody && req.GetBody == nil {
+		return false
+	}
+	switch req.Method {
+	case "", http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
+		return true
+	}
+	if _, ok := req.Header["Idempotency-Key"]; ok {
+		return true
+	}
+	_, ok := req.Header["X-Idempotency-Key"]
+	return ok
+}

--- a/pkg/networking/middleware/retry_transport_error.go
+++ b/pkg/networking/middleware/retry_transport_error.go
@@ -13,18 +13,12 @@ import (
 // does, so it must be matched explicitly by numeric value.
 const errWSAEConnReset = syscall.Errno(10054)
 
-// isConnectionReset reports whether err is (or wraps) a TCP connection reset,
-// on POSIX (syscall.ECONNRESET) or Windows (WSAECONNRESET).
 func isConnectionReset(err error) bool {
 	return errors.Is(err, syscall.ECONNRESET) || errors.Is(err, errWSAEConnReset)
 }
 
-// isRetryableTransportError implements the error axis of the transport-error
-// retry allow-list: connection resets and network timeouts are retryable;
-// everything else (DNS NotFound, TLS failures, context cancellation/deadline,
-// EOF, connection refused) is not. context.DeadlineExceeded also satisfies
-// net.Error.Timeout(), so the cancellation/deadline deny-check must run
-// before the timeout allow-check.
+// context.DeadlineExceeded also satisfies net.Error.Timeout(), so the
+// cancellation/deadline deny-check must run before the timeout allow-check.
 func isRetryableTransportError(err error) bool {
 	if err == nil {
 		return false
@@ -39,11 +33,7 @@ func isRetryableTransportError(err error) bool {
 	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
-// isReplayableRequest implements the request axis of the transport-error
-// retry allow-list, mirroring net/http.Transport's own isReplayable: safe
-// methods (or no method set) are always replayable; other methods are
-// replayable only when they carry an Idempotency-Key or X-Idempotency-Key
-// header (checked by presence, not value).
+// isReplayableRequest mirrors net/http.Transport's own isReplayable.
 func isReplayableRequest(req *http.Request) bool {
 	if req.Body != nil && req.Body != http.NoBody && req.GetBody == nil {
 		return false

--- a/pkg/networking/middleware/retry_transport_error_test.go
+++ b/pkg/networking/middleware/retry_transport_error_test.go
@@ -1,0 +1,131 @@
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_isRetryableTransportError is IDE-2419-UNIT-001: the error axis of the
+// two-axis allow-list in isolation.
+func Test_isRetryableTransportError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"bare ECONNRESET", syscall.ECONNRESET, true},
+		{
+			"wrapped in OpError and SyscallError",
+			&net.OpError{Op: "read", Net: "tcp", Err: &os.SyscallError{Syscall: "read", Err: syscall.ECONNRESET}},
+			true,
+		},
+		{
+			"wrapped in url.Error and OpError",
+			&url.Error{Op: "Get", URL: "http://example.com", Err: &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET}},
+			true,
+		},
+		{"Windows WSAECONNRESET", syscall.Errno(10054), true},
+		{"os.ErrDeadlineExceeded", os.ErrDeadlineExceeded, true},
+		{"DNS NotFound", &net.DNSError{IsNotFound: true}, false},
+		{"DNS timeout", &net.DNSError{IsTimeout: true}, true},
+		{"context canceled", context.Canceled, false},
+		{"context deadline exceeded", context.DeadlineExceeded, false},
+		{
+			"url error wrapping deadline exceeded",
+			&url.Error{Op: "Get", URL: "http://example.com", Err: context.DeadlineExceeded},
+			false,
+		},
+		{"tls certificate verification error", &tls.CertificateVerificationError{}, false},
+		{"ECONNREFUSED", syscall.ECONNREFUSED, false},
+		{"io.EOF", io.EOF, false},
+		{"io.ErrUnexpectedEOF", io.ErrUnexpectedEOF, false},
+		{"generic error", errors.New("boom"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isRetryableTransportError(tt.err))
+		})
+	}
+}
+
+// Test_isReplayableRequest is IDE-2419-UNIT-002: the request axis of the
+// two-axis allow-list in isolation, mirroring net/http.Transport's own
+// isReplayable.
+func Test_isReplayableRequest(t *testing.T) {
+	getBody := func() (io.ReadCloser, error) { return http.NoBody, nil }
+
+	newReq := func(method string, body io.Reader, hasGetBody bool, headers map[string]string) *http.Request {
+		req, err := http.NewRequest(method, "http://example.com", body)
+		require.NoError(t, err)
+		if hasGetBody {
+			req.GetBody = getBody
+		} else {
+			req.GetBody = nil
+		}
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+		return req
+	}
+
+	tests := []struct {
+		name string
+		req  *http.Request
+		want bool
+	}{
+		{"GET nil body", newReq(http.MethodGet, nil, false, nil), true},
+		{"empty method", newReq("", nil, false, nil), true},
+		{"HEAD", newReq(http.MethodHead, nil, false, nil), true},
+		{"OPTIONS", newReq(http.MethodOptions, nil, false, nil), true},
+		{"TRACE", newReq(http.MethodTrace, nil, false, nil), true},
+		{"POST no body", newReq(http.MethodPost, nil, false, nil), false},
+		{"PUT with body and GetBody", newReq(http.MethodPut, bytes.NewReader([]byte("x")), true, nil), false},
+		{"DELETE", newReq(http.MethodDelete, nil, false, nil), false},
+		{"lowercase get", newReq("get", nil, false, nil), false},
+		{
+			"POST with body, GetBody, Idempotency-Key",
+			newReq(http.MethodPost, bytes.NewReader([]byte("x")), true, map[string]string{"Idempotency-Key": "abc"}),
+			true,
+		},
+		{
+			"POST with X-Idempotency-Key",
+			newReq(http.MethodPost, bytes.NewReader([]byte("x")), true, map[string]string{"X-Idempotency-Key": "abc"}),
+			true,
+		},
+		{
+			"Idempotency-Key present but empty",
+			newReq(http.MethodPost, bytes.NewReader([]byte("x")), true, map[string]string{"Idempotency-Key": ""}),
+			true,
+		},
+		{"GET with body, GetBody nil", newReq(http.MethodGet, bytes.NewReader([]byte("x")), false, nil), false},
+		{
+			"GET with http.NoBody",
+			func() *http.Request {
+				req := newReq(http.MethodGet, nil, false, nil)
+				req.Body = http.NoBody
+				return req
+			}(),
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isReplayableRequest(tt.req))
+		})
+	}
+}

--- a/pkg/networking/middleware/retry_transport_error_test.go
+++ b/pkg/networking/middleware/retry_transport_error_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Test_isRetryableTransportError is IDE-2419-UNIT-001: the error axis of the
-// two-axis allow-list in isolation.
 func Test_isRetryableTransportError(t *testing.T) {
 	tests := []struct {
 		name string
@@ -62,9 +60,6 @@ func Test_isRetryableTransportError(t *testing.T) {
 	}
 }
 
-// Test_isReplayableRequest is IDE-2419-UNIT-002: the request axis of the
-// two-axis allow-list in isolation, mirroring net/http.Transport's own
-// isReplayable.
 func Test_isReplayableRequest(t *testing.T) {
 	getBody := func() (io.ReadCloser, error) { return http.NoBody, nil }
 


### PR DESCRIPTION
### Description

Extends the opt-in from #686 (`configuration.NETWORK_REQUEST_RETRIES_ENABLED`) to also retry transient **transport-level** connection errors (e.g. `ECONNRESET`), not just HTTP status codes. This closes a gap documented in [IDE-2050](https://snyksec.atlassian.net/wiki/spaces/IDE/pages/4888789043): today, every transport error is wrapped in `backoff.Permanent(rtErr)` and never retried, regardless of any retry configuration.

**Two-axis allow-list (both must hold to retry), per IDE-2050's resolved design:**
- **Error axis:** only `ECONNRESET` (including Windows' `WSAECONNRESET`/10054, which Go does not map onto the Unix errno) and `net.Error` timeouts (including DNS timeouts) — never DNS `NotFound`, context cancellation/deadline, or TLS/auth failures.
- **Request axis:** only idempotent/replayable requests (safe method or idempotency key) — mirroring Go's own `net/http.Transport.isReplayable`. A reset/timeout is ambiguous about whether the server already processed the request, so non-idempotent requests are never resent.

**Gating:** `PREVIEW_FEATURES_ENABLED || NETWORK_REQUEST_RETRIES_ENABLED` activates transport-level retry — mirroring the existing OR-condition already used for the attempt-count default in `defaultMaxNetworkRequestAttempts()`. Zero behavior change for anyone who doesn't set either flag.

On a transport-level retry, a warn-level log line is emitted (no separate user-facing notification, consistent with how 5xx/408/425 retries already behave silently today — only 429 has a notification).

**Correctness pitfalls specifically pinned by tests:**
- `context.DeadlineExceeded` also satisfies `net.Error.Timeout()` — the deny-list (context cancellation, DNS `NotFound`, TLS/auth) runs *before* the allow-list, so a caller-abandoned request is never retried just because it looks like a timeout.
- Windows' `WSAECONNRESET` (`syscall.Errno(10054)`) is checked explicitly alongside `syscall.ECONNRESET`, since `errors.Is` alone does not bridge them — CI runs on `win/server-2022` and this would otherwise pass on Linux while silently failing to retry on Windows.

Implements [IDE-2419](https://snyksec.atlassian.net/browse/IDE-2419), sub-task of [IDE-1890](https://snyksec.atlassian.net/browse/IDE-1890), sibling of [IDE-2412](https://snyksec.atlassian.net/browse/IDE-2412) (#686, base of this stacked PR) and [IDE-2415](https://snyksec.atlassian.net/browse/IDE-2415) (deferred CLI wiring). `ADR-1` amended to record this as an explicit decision-maker override of its original "real captured trace" gate on this change, based on documented customer demand rather than a satisfying trace.

**Note on size:** this diff is ~900 lines (82 production, ~820 test) against the repo's 700-line PR guideline. Deliberately shipped as one PR rather than split — the bulk is a genuine 3-layer TDD pyramid (acceptance against the real composition root with a real TCP server simulating RST, integration wiring tests, and a full two-axis classifier matrix including the deny-before-allow-list and Windows-errno edge cases) for a correctness-sensitive retry-safety feature. Splitting production code from the tests that pin it would leave an interim PR either under-tested or carrying dead code.

### Test plan

- [x] Acceptance: real composition root + real TCP server forcing `RST`, opted-in consumer recovers from a connection reset on an idempotent request
- [x] Acceptance regression guards: no-opt-in behavior, non-idempotent (POST) requests never retried on transport error, existing status-code-only retry paths unaffected
- [x] Acceptance: preview-features-only also activates transport retry (mirrors the attempt-count OR-condition) — `Test_TransportRetry_PreviewFeaturesOnly_ConnectionResetRecovers`
- [x] Integration: real `RetryMiddleware` wiring, including a dedicated test that goes RED if the `PREVIEW_FEATURES_ENABLED || NETWORK_REQUEST_RETRIES_ENABLED` OR-condition is reverted to flag-only
- [x] Unit: full two-axis classifier matrix (error type × request replayability), deny-before-allow ordering, Windows `WSAECONNRESET` handling

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.

[IDE-2050]: https://snyksec.atlassian.net/browse/IDE-2050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-2419]: https://snyksec.atlassian.net/browse/IDE-2419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core HTTP retry behavior for transport errors (duplicate-request and exhaustion semantics), but it is gated behind opt-in/preview flags and covered by extensive safety tests including non-replayable POST and attempt limits.
> 
> **Overview**
> Extends **network retry middleware** so opted-in apps (or preview features) can recover from **transient transport failures**—connection reset and network timeouts—not only retryable HTTP status codes.
> 
> **Gating** matches the existing resilient-retry opt-in: `PREVIEW_FEATURES_ENABLED` **or** `NETWORK_REQUEST_RETRIES_ENABLED`. No change for callers that set neither flag.
> 
> **Retry rules (both must pass):**
> - **Error:** `ECONNRESET` (including Windows WSA 10054), `net.Error` timeouts; **never** context cancel/deadline, DNS not found, TLS/auth, or generic errors. Deny-list runs before timeout allow-list so `DeadlineExceeded` is not retried.
> - **Request:** Replayable requests only (safe methods or idempotency headers, aligned with `net/http` replay rules); non-idempotent POSTs without a key stay single-attempt.
> 
> On transport retry, a **warn** log is emitted; attempt budget and `Snyk-Request-Attempt-Count` behave like status-code retries. New **`retry_transport_error`** helpers classify errors and replayability.
> 
> **Tests** add a raw TCP server that forces RST, composition-root acceptance cases, and middleware/unit matrices for the two-axis policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a883e7bfecd4004ca6cba318cee18ef89e97bbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->