### PR TITLE
chore: Add infrastructure for adding metrics in FileFilter [CLI-1749]

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,8 @@
+package metrics
+
+// Recorder is satisfied by analytics.Analytics.
+type Recorder interface {
+	AddExtensionIntegerValue(key string, value int)
+	AddExtensionStringValue(key string, value string)
+	AddExtensionBoolValue(key string, value bool)
+}

--- a/internal/metrics/recorder_fake.go
+++ b/internal/metrics/recorder_fake.go
@@ -1,0 +1,29 @@
+package metrics
+
+// RecorderFake is a simple in-memory Recorder for use in tests.
+type RecorderFake struct {
+	IntValues    map[string]int
+	StringValues map[string]string
+	BoolValues   map[string]bool
+}
+
+func (r *RecorderFake) AddExtensionIntegerValue(key string, value int) {
+	if r.IntValues == nil {
+		r.IntValues = make(map[string]int)
+	}
+	r.IntValues[key] = value
+}
+
+func (r *RecorderFake) AddExtensionStringValue(key string, value string) {
+	if r.StringValues == nil {
+		r.StringValues = make(map[string]string)
+	}
+	r.StringValues[key] = value
+}
+
+func (r *RecorderFake) AddExtensionBoolValue(key string, value bool) {
+	if r.BoolValues == nil {
+		r.BoolValues = make(map[string]bool)
+	}
+	r.BoolValues[key] = value
+}

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -2,6 +2,7 @@ package analytics
 
 import (
 	"bytes"
+
 	"github.com/snyk/go-application-framework/pkg/logging"
 
 	//nolint:gosec // insecure sha1 used for legacy identifier
@@ -21,6 +22,7 @@ import (
 	"github.com/hashicorp/go-uuid"
 
 	"github.com/snyk/go-application-framework/internal/api"
+	"github.com/snyk/go-application-framework/internal/metrics"
 	utils2 "github.com/snyk/go-application-framework/internal/utils"
 )
 
@@ -44,6 +46,9 @@ type Analytics interface {
 	AddExtensionStringValue(key string, value string)
 	AddExtensionBoolValue(key string, value bool)
 }
+
+// Compile-time check that Analytics satisfies metrics.Recorder.
+var _ metrics.Recorder = (Analytics)(nil)
 
 // AnalyticsImpl is the default implementation of the Analytics interface.
 type AnalyticsImpl struct {

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -40,7 +40,7 @@ type FileFilter struct {
 	max_threads     int64
 	dotSnykSections []DotSnykExcludeSectionName
 	config          configuration.Configuration
-	metrics         metrics.Recorder
+	metricsRecorder metrics.Recorder
 	metricScopeID   string
 }
 
@@ -79,7 +79,7 @@ const (
 	metricFileFilterPrefix           = "file-filter"
 	metricFileFilterDurationMs       = "durationMs"
 	metricFileFilterFileCount        = "fileCount"
-	metricFileFilterMetacharacterFix = "metacharacter-fix"
+	metricFileFilterMetacharacterFix = "metacharacterFix"
 )
 
 type FileFilterOption func(*FileFilter) error
@@ -124,22 +124,22 @@ func WithConfig(config configuration.Configuration) FileFilterOption {
 // Callers must pass a pkg/analytics.Analytics implementation here; it satisfies this interface.
 func WithMetrics(recorder metrics.Recorder) FileFilterOption {
 	return func(filter *FileFilter) error {
-		filter.metrics = recorder
+		filter.metricsRecorder = recorder
 		return nil
 	}
 }
 
 //nolint:unused // plumbing for a follow-up PR that adds the call sites [CLI-1740]
 func (fw *FileFilter) recordMetricLazy(key string, getMetric func() int) {
-	if fw.metrics != nil {
-		fw.metrics.AddExtensionIntegerValue(fw.metricKey(key), getMetric())
+	if fw.metricsRecorder != nil {
+		fw.metricsRecorder.AddExtensionIntegerValue(fw.metricKey(key), getMetric())
 	}
 }
 
 //nolint:unused // plumbing for a follow-up PR that adds the call sites [CLI-1740]
 func (fw *FileFilter) recordBoolMetricLazy(key string, getMetric func() bool) {
-	if fw.metrics != nil {
-		fw.metrics.AddExtensionBoolValue(fw.metricKey(key), getMetric())
+	if fw.metricsRecorder != nil {
+		fw.metricsRecorder.AddExtensionBoolValue(fw.metricKey(key), getMetric())
 	}
 }
 

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -18,6 +19,7 @@ import (
 	"golang.org/x/sync/semaphore"
 	"gopkg.in/yaml.v3"
 
+	"github.com/snyk/go-application-framework/internal/metrics"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 )
 
@@ -29,6 +31,8 @@ const (
 // by default, all rules are valid
 var defaultInvalidRules = []string{}
 
+var nextFileFilterMetricScopeID atomic.Uint64
+
 type FileFilter struct {
 	path            string
 	defaultRules    []string
@@ -36,6 +40,8 @@ type FileFilter struct {
 	max_threads     int64
 	dotSnykSections []DotSnykExcludeSectionName
 	config          configuration.Configuration
+	metrics         metrics.Recorder
+	metricScopeID   string
 }
 
 // DotSnykExcludeSectionName is the name of an `exclude` section in a .snyk
@@ -65,6 +71,16 @@ func (s DotSnykExcludeSectionName) String() string {
 type DotSnykRule struct {
 	Exclude map[DotSnykExcludeSectionName]yaml.Node `yaml:"exclude"`
 }
+
+// TODO: These metric keys are not read anywhere yet; actual recording is coming in a follow-up PR [CLI-1740].
+//
+//nolint:unused // plumbing for a follow-up PR that wires these into recordMetricLazy/recordBoolMetricLazy call sites [CLI-1740]
+const (
+	metricFileFilterPrefix           = "file-filter"
+	metricFileFilterDurationMs       = "durationMs"
+	metricFileFilterFileCount        = "fileCount"
+	metricFileFilterMetacharacterFix = "metacharacter-fix"
+)
 
 type FileFilterOption func(*FileFilter) error
 
@@ -104,6 +120,38 @@ func WithConfig(config configuration.Configuration) FileFilterOption {
 	}
 }
 
+// WithMetrics supplies a recorder for file-filter analytics values.
+// Callers must pass a pkg/analytics.Analytics implementation here; it satisfies this interface.
+func WithMetrics(recorder metrics.Recorder) FileFilterOption {
+	return func(filter *FileFilter) error {
+		filter.metrics = recorder
+		return nil
+	}
+}
+
+//nolint:unused // plumbing for a follow-up PR that adds the call sites [CLI-1740]
+func (fw *FileFilter) recordMetricLazy(key string, getMetric func() int) {
+	if fw.metrics != nil {
+		fw.metrics.AddExtensionIntegerValue(fw.metricKey(key), getMetric())
+	}
+}
+
+//nolint:unused // plumbing for a follow-up PR that adds the call sites [CLI-1740]
+func (fw *FileFilter) recordBoolMetricLazy(key string, getMetric func() bool) {
+	if fw.metrics != nil {
+		fw.metrics.AddExtensionBoolValue(fw.metricKey(key), getMetric())
+	}
+}
+
+//nolint:unused // plumbing for a follow-up PR that adds the call sites [CLI-1740]
+func (fw *FileFilter) metricKey(key string) string {
+	return fmt.Sprintf("%s.%s.%s", metricFileFilterPrefix, fw.metricScopeID, key)
+}
+
+func newFileFilterMetricScopeID() string {
+	return fmt.Sprintf("%d", nextFileFilterMetricScopeID.Add(1))
+}
+
 // NewFileFilter creates a FileFilter rooted at path. Without WithConfig, feature flags default to disabled (legacy).
 func NewFileFilter(path string, logger *zerolog.Logger, options ...FileFilterOption) *FileFilter {
 	filter := &FileFilter{
@@ -112,6 +160,7 @@ func NewFileFilter(path string, logger *zerolog.Logger, options ...FileFilterOpt
 		logger:          logger,
 		max_threads:     int64(runtime.NumCPU()),
 		dotSnykSections: []DotSnykExcludeSectionName{DotSnykExcludeCode, DotSnykExcludeGlobal}, // init default with DotSnykExcludeCode and DotSnykExcludeGlobal to keep it backwards compatible
+		metricScopeID:   newFileFilterMetricScopeID(),
 	}
 
 	options = append([]FileFilterOption{WithConfig(nil)}, options...)

--- a/pkg/workflow/invocationcontextimpl.go
+++ b/pkg/workflow/invocationcontextimpl.go
@@ -114,9 +114,11 @@ func (ici *invocationContextImpl) GetRuntimeInfo() runtimeinfo.RuntimeInfo {
 	return ici.WorkflowEngine.GetRuntimeInfo()
 }
 
-// GetFileFilter returns a utils.FileFilter rooted at path, wired to this invocation's configuration and logger.
+// GetFileFilter returns a utils.FileFilter rooted at path, wired to this invocation's configuration, analytics and logger.
 func (ici *invocationContextImpl) GetFileFilter(path string, options ...utils.FileFilterOption) *utils.FileFilter {
-	config := ici.Configuration
-	defaults := []utils.FileFilterOption{utils.WithConfig(config)}
+	defaults := []utils.FileFilterOption{
+		utils.WithConfig(ici.Configuration),
+		utils.WithMetrics(ici.GetAnalytics()),
+	}
 	return utils.NewFileFilter(path, ici.GetEnhancedLogger(), append(defaults, options...)...)
 }


### PR DESCRIPTION
### Description

_Provide description of this PR and changes._

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.

CLI PR: https://github.com/snyk/cli/pull/7084


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Infrastructure-only: no new metrics are emitted at runtime until CLI-1740 wires call sites; default FileFilter behavior is unchanged aside from optional recorder attachment.
> 
> **Overview**
> Introduces **`internal/metrics.Recorder`** (extension int/string/bool values) with a **`RecorderFake`** for tests, and a compile-time check that **`pkg/analytics.Analytics`** implements it.
> 
> **`FileFilter`** gains optional metrics wiring: **`WithMetrics`**, per-instance scoped keys (`file-filter.<scopeId>.<key>`), and **`recordMetricLazy` / `recordBoolMetricLazy`** helpers. Metric name constants (`durationMs`, `fileCount`, `metacharacterFix`) are defined but **not yet invoked** in filtering paths—that recording is deferred to follow-up **CLI-1740**.
> 
> **`invocationContextImpl.GetFileFilter`** now passes **`WithMetrics(ici.GetAnalytics())`** by default so workflow-created filters are ready for analytics without callers changing behavior today.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7de169a67bd222bf4e71b1c394c3abf3c592cd07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->