### PR TITLE
feat: Introduce Engine Invoke Post Hooks

### DIFF
--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	zlog "github.com/rs/zerolog/log"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/jws"
@@ -1119,4 +1121,29 @@ func Test_defaultMaxNetworkRequestAttempts(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func Test_WithPostInvokeHooks(t *testing.T) {
+	hookCalled := false
+	hook := func(ctx context.Context, eng workflow.Engine, hctx workflow.PostInvokeContext) {
+		hookCalled = true
+	}
+
+	engine := CreateAppEngineWithOptions(
+		WithConfiguration(configuration.NewInMemory()),
+		WithPostInvokeHooks(hook),
+	)
+
+	wfId := workflow.NewWorkflowIdentifier("hook-app-test")
+	_, err := engine.Register(wfId, workflow.ConfigurationOptionsFromFlagset(pflag.NewFlagSet("", pflag.ContinueOnError)), func(invocation workflow.InvocationContext, input []workflow.Data) ([]workflow.Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	_, err = engine.Invoke(wfId)
+	assert.NoError(t, err)
+	assert.True(t, hookCalled, "hook registered via WithPostInvokeHooks should fire")
 }

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -1125,7 +1125,7 @@ func Test_defaultMaxNetworkRequestAttempts(t *testing.T) {
 
 func Test_WithPostInvokeHooks(t *testing.T) {
 	hookCalled := false
-	hook := func(ctx context.Context, eng workflow.Engine, hctx workflow.PostInvokeContext) {
+	hook := func(ctx context.Context, eng workflow.Engine, output workflow.InvokeOutput) {
 		hookCalled = true
 	}
 

--- a/pkg/app/options.go
+++ b/pkg/app/options.go
@@ -53,7 +53,7 @@ func WithRuntimeInfo(ri runtimeinfo.RuntimeInfo) Opts {
 func WithPostInvokeHooks(hooks ...workflow.PostInvokeHook) Opts {
 	return func(engine workflow.Engine) {
 		for _, h := range hooks {
-			if err := engine.AddPostInvokeHook(h); err != nil {
+			if err := workflow.AddPostInvokeHook(engine, h); err != nil {
 				engine.GetLogger().Warn().Err(err).Msg("failed to add post-invoke hook")
 			}
 		}

--- a/pkg/app/options.go
+++ b/pkg/app/options.go
@@ -49,3 +49,13 @@ func WithRuntimeInfo(ri runtimeinfo.RuntimeInfo) Opts {
 		engine.SetRuntimeInfo(ri)
 	}
 }
+
+func WithPostInvokeHooks(hooks ...workflow.PostInvokeHook) Opts {
+	return func(engine workflow.Engine) {
+		for _, h := range hooks {
+			if err := engine.AddPostInvokeHook(h); err != nil {
+				engine.GetLogger().Warn().Err(err).Msg("failed to add post-invoke hook")
+			}
+		}
+	}
+}

--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -94,4 +94,10 @@ const (
 	FF_CODE_CONSISTENT_IGNORES string = "internal_snyk_code_ignores_enabled"
 	// Feature flag to enable native implementation for code, used in code-client-go's code workflow
 	FF_CODE_NATIVE_IMPLEMENTATION string = "internal_snyk_code_native_implementation"
+
+	// ---------
+	// workflow execution configuration
+	// ---------
+
+	POST_INVOKE_HOOK_TIMEOUT string = "internal_post_invoke_hook_timeout" // POST_INVOKE_HOOK_TIMEOUT (time.Duration) sets/returns the timeout for post-invoke hooks to complete
 )

--- a/pkg/local_workflows/connectivity_check_extension/connectivity/checker_test.go
+++ b/pkg/local_workflows/connectivity_check_extension/connectivity/checker_test.go
@@ -149,9 +149,16 @@ func TestDetectProxyConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Clear all proxy-related environment variables for test isolation
-			proxyEnvVars := []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "NO_PROXY", "no_proxy"}
-			for _, key := range proxyEnvVars {
+			// Clear all environment variables that DetectProxyConfig reads, matching envVarSpecs in constants.go
+			// These must be kept in sync with the variables enumerated there.
+			envVarsToClean := []string{
+				"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", // Proxy variables
+				"NO_PROXY", "no_proxy", // Proxy bypass variables
+				"NODE_EXTRA_CA_CERTS", // Node.js CA bundle
+				"KRB5_CONFIG",         // Kerberos config
+				"KRB5CCNAME",          // Kerberos credentials cache
+			}
+			for _, key := range envVarsToClean {
 				t.Setenv(key, "")
 			}
 

--- a/pkg/mocks/workflow.go
+++ b/pkg/mocks/workflow.go
@@ -21,6 +21,57 @@ import (
 	workflow "github.com/snyk/go-application-framework/pkg/workflow"
 )
 
+// MockPostInvokeContext is a mock of PostInvokeContext interface.
+type MockPostInvokeContext struct {
+	ctrl     *gomock.Controller
+	recorder *MockPostInvokeContextMockRecorder
+}
+
+// MockPostInvokeContextMockRecorder is the mock recorder for MockPostInvokeContext.
+type MockPostInvokeContextMockRecorder struct {
+	mock *MockPostInvokeContext
+}
+
+// NewMockPostInvokeContext creates a new mock instance.
+func NewMockPostInvokeContext(ctrl *gomock.Controller) *MockPostInvokeContext {
+	mock := &MockPostInvokeContext{ctrl: ctrl}
+	mock.recorder = &MockPostInvokeContextMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockPostInvokeContext) EXPECT() *MockPostInvokeContextMockRecorder {
+	return m.recorder
+}
+
+// GetError mocks base method.
+func (m *MockPostInvokeContext) GetError() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetError")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetError indicates an expected call of GetError.
+func (mr *MockPostInvokeContextMockRecorder) GetError() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetError", reflect.TypeOf((*MockPostInvokeContext)(nil).GetError))
+}
+
+// GetWorkflowIdentifier mocks base method.
+func (m *MockPostInvokeContext) GetWorkflowIdentifier() workflow.Identifier {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkflowIdentifier")
+	ret0, _ := ret[0].(workflow.Identifier)
+	return ret0
+}
+
+// GetWorkflowIdentifier indicates an expected call of GetWorkflowIdentifier.
+func (mr *MockPostInvokeContextMockRecorder) GetWorkflowIdentifier() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowIdentifier", reflect.TypeOf((*MockPostInvokeContext)(nil).GetWorkflowIdentifier))
+}
+
 // MockData is a mock of Data interface.
 type MockData struct {
 	ctrl     *gomock.Controller
@@ -659,6 +710,20 @@ func (m *MockEngine) AddExtensionInitializer(initializer workflow.ExtensionInit)
 func (mr *MockEngineMockRecorder) AddExtensionInitializer(initializer interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddExtensionInitializer", reflect.TypeOf((*MockEngine)(nil).AddExtensionInitializer), initializer)
+}
+
+// AddPostInvokeHook mocks base method.
+func (m *MockEngine) AddPostInvokeHook(hook workflow.PostInvokeHook) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddPostInvokeHook", hook)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddPostInvokeHook indicates an expected call of AddPostInvokeHook.
+func (mr *MockEngineMockRecorder) AddPostInvokeHook(hook interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPostInvokeHook", reflect.TypeOf((*MockEngine)(nil).AddPostInvokeHook), hook)
 }
 
 // GetAnalytics mocks base method.

--- a/pkg/mocks/workflow.go
+++ b/pkg/mocks/workflow.go
@@ -21,31 +21,31 @@ import (
 	workflow "github.com/snyk/go-application-framework/pkg/workflow"
 )
 
-// MockPostInvokeContext is a mock of PostInvokeContext interface.
-type MockPostInvokeContext struct {
+// MockInvokeOutput is a mock of InvokeOutput interface.
+type MockInvokeOutput struct {
 	ctrl     *gomock.Controller
-	recorder *MockPostInvokeContextMockRecorder
+	recorder *MockInvokeOutputMockRecorder
 }
 
-// MockPostInvokeContextMockRecorder is the mock recorder for MockPostInvokeContext.
-type MockPostInvokeContextMockRecorder struct {
-	mock *MockPostInvokeContext
+// MockInvokeOutputMockRecorder is the mock recorder for MockInvokeOutput.
+type MockInvokeOutputMockRecorder struct {
+	mock *MockInvokeOutput
 }
 
-// NewMockPostInvokeContext creates a new mock instance.
-func NewMockPostInvokeContext(ctrl *gomock.Controller) *MockPostInvokeContext {
-	mock := &MockPostInvokeContext{ctrl: ctrl}
-	mock.recorder = &MockPostInvokeContextMockRecorder{mock}
+// NewMockInvokeOutput creates a new mock instance.
+func NewMockInvokeOutput(ctrl *gomock.Controller) *MockInvokeOutput {
+	mock := &MockInvokeOutput{ctrl: ctrl}
+	mock.recorder = &MockInvokeOutputMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockPostInvokeContext) EXPECT() *MockPostInvokeContextMockRecorder {
+func (m *MockInvokeOutput) EXPECT() *MockInvokeOutputMockRecorder {
 	return m.recorder
 }
 
 // GetError mocks base method.
-func (m *MockPostInvokeContext) GetError() error {
+func (m *MockInvokeOutput) GetError() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetError")
 	ret0, _ := ret[0].(error)
@@ -53,13 +53,27 @@ func (m *MockPostInvokeContext) GetError() error {
 }
 
 // GetError indicates an expected call of GetError.
-func (mr *MockPostInvokeContextMockRecorder) GetError() *gomock.Call {
+func (mr *MockInvokeOutputMockRecorder) GetError() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetError", reflect.TypeOf((*MockPostInvokeContext)(nil).GetError))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetError", reflect.TypeOf((*MockInvokeOutput)(nil).GetError))
+}
+
+// GetOutput mocks base method.
+func (m *MockInvokeOutput) GetOutput() []workflow.Data {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOutput")
+	ret0, _ := ret[0].([]workflow.Data)
+	return ret0
+}
+
+// GetOutput indicates an expected call of GetOutput.
+func (mr *MockInvokeOutputMockRecorder) GetOutput() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOutput", reflect.TypeOf((*MockInvokeOutput)(nil).GetOutput))
 }
 
 // GetWorkflowIdentifier mocks base method.
-func (m *MockPostInvokeContext) GetWorkflowIdentifier() workflow.Identifier {
+func (m *MockInvokeOutput) GetWorkflowIdentifier() workflow.Identifier {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWorkflowIdentifier")
 	ret0, _ := ret[0].(workflow.Identifier)
@@ -67,9 +81,9 @@ func (m *MockPostInvokeContext) GetWorkflowIdentifier() workflow.Identifier {
 }
 
 // GetWorkflowIdentifier indicates an expected call of GetWorkflowIdentifier.
-func (mr *MockPostInvokeContextMockRecorder) GetWorkflowIdentifier() *gomock.Call {
+func (mr *MockInvokeOutputMockRecorder) GetWorkflowIdentifier() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowIdentifier", reflect.TypeOf((*MockPostInvokeContext)(nil).GetWorkflowIdentifier))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowIdentifier", reflect.TypeOf((*MockInvokeOutput)(nil).GetWorkflowIdentifier))
 }
 
 // MockData is a mock of Data interface.
@@ -965,4 +979,41 @@ func (m *MockEngine) SetUserInterface(ui ui.UserInterface) {
 func (mr *MockEngineMockRecorder) SetUserInterface(ui interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUserInterface", reflect.TypeOf((*MockEngine)(nil).SetUserInterface), ui)
+}
+
+// MockPostInvokeHookRegistrar is a mock of PostInvokeHookRegistrar interface.
+type MockPostInvokeHookRegistrar struct {
+	ctrl     *gomock.Controller
+	recorder *MockPostInvokeHookRegistrarMockRecorder
+}
+
+// MockPostInvokeHookRegistrarMockRecorder is the mock recorder for MockPostInvokeHookRegistrar.
+type MockPostInvokeHookRegistrarMockRecorder struct {
+	mock *MockPostInvokeHookRegistrar
+}
+
+// NewMockPostInvokeHookRegistrar creates a new mock instance.
+func NewMockPostInvokeHookRegistrar(ctrl *gomock.Controller) *MockPostInvokeHookRegistrar {
+	mock := &MockPostInvokeHookRegistrar{ctrl: ctrl}
+	mock.recorder = &MockPostInvokeHookRegistrarMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockPostInvokeHookRegistrar) EXPECT() *MockPostInvokeHookRegistrarMockRecorder {
+	return m.recorder
+}
+
+// AddPostInvokeHook mocks base method.
+func (m *MockPostInvokeHookRegistrar) AddPostInvokeHook(hook workflow.PostInvokeHook) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddPostInvokeHook", hook)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddPostInvokeHook indicates an expected call of AddPostInvokeHook.
+func (mr *MockPostInvokeHookRegistrarMockRecorder) AddPostInvokeHook(hook interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPostInvokeHook", reflect.TypeOf((*MockPostInvokeHookRegistrar)(nil).AddPostInvokeHook), hook)
 }

--- a/pkg/mocks/workflow.go
+++ b/pkg/mocks/workflow.go
@@ -712,20 +712,6 @@ func (mr *MockEngineMockRecorder) AddExtensionInitializer(initializer interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddExtensionInitializer", reflect.TypeOf((*MockEngine)(nil).AddExtensionInitializer), initializer)
 }
 
-// AddPostInvokeHook mocks base method.
-func (m *MockEngine) AddPostInvokeHook(hook workflow.PostInvokeHook) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddPostInvokeHook", hook)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AddPostInvokeHook indicates an expected call of AddPostInvokeHook.
-func (mr *MockEngineMockRecorder) AddPostInvokeHook(hook interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPostInvokeHook", reflect.TypeOf((*MockEngine)(nil).AddPostInvokeHook), hook)
-}
-
 // GetAnalytics mocks base method.
 func (m *MockEngine) GetAnalytics() analytics.Analytics {
 	m.ctrl.T.Helper()

--- a/pkg/workflow/engine_test.go
+++ b/pkg/workflow/engine_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/url"
@@ -886,11 +887,15 @@ func Test_PostInvokeHook_PanicNilObserved(t *testing.T) {
 }
 
 func Test_PostInvokeHook_Timeout(t *testing.T) {
-	original := postInvokeHookTimeout
-	postInvokeHookTimeout = 50 * time.Millisecond
-	defer func() { postInvokeHookTimeout = original }()
+	config := configuration.NewInMemory()
+	config.Set(configuration.POST_INVOKE_HOOK_TIMEOUT, 50*time.Millisecond)
+	engine := NewWorkFlowEngine(config)
 
-	engine, wfId := setupHookTestEngine(t, "timeout-test", nil)
+	wfId := NewWorkflowIdentifier("timeout-test")
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(pflag.NewFlagSet("", pflag.ContinueOnError)), func(InvocationContext, []Data) ([]Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
 
 	var secondHookDone sync.WaitGroup
 	secondHookDone.Add(1)
@@ -903,8 +908,124 @@ func Test_PostInvokeHook_Timeout(t *testing.T) {
 	assert.NoError(t, engine.Init())
 
 	start := time.Now()
-	_, err := engine.Invoke(wfId)
+	_, err = engine.Invoke(wfId)
 	secondHookDone.Wait()
 	assert.NoError(t, err)
 	assert.Less(t, time.Since(start), 2*time.Second, "invoke should not block on the hanging hook")
+}
+
+func Test_PostInvokeHook_ConcurrentAddAndInit(t *testing.T) {
+	const numAdders = 100
+	engine := NewWorkFlowEngine(configuration.NewInMemory())
+
+	wfId := NewWorkflowIdentifier("concurrent-test")
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(pflag.NewFlagSet("", pflag.ContinueOnError)), func(InvocationContext, []Data) ([]Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	var wg sync.WaitGroup
+	var barrier sync.WaitGroup
+	barrier.Add(numAdders + 1) // All adders plus Init
+
+	var countAfterInit int
+
+	// Goroutine that will call Init, snapshot hook count, then signal
+	wg.Add(1)
+	initDone := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		barrier.Wait() // Wait for all adders to be ready
+
+		assert.NoError(t, engine.Init())
+
+		// Snapshot the hook count immediately after Init returns
+		// Access the engine's internal postInvokeHooks slice under its mutex
+		engineImpl, ok := engine.(*EngineImpl)
+		assert.True(t, ok)
+		engineImpl.mu.RLock()
+		countAfterInit = len(engineImpl.postInvokeHooks)
+		engineImpl.mu.RUnlock()
+
+		close(initDone)
+	}()
+
+	// Multiple goroutines trying to add hooks concurrently with Init
+	for i := 0; i < numAdders; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			barrier.Done() // Signal ready
+			// Try to add a hook - this races with Init
+			//nolint:errcheck // expected: some will fail after Init, some will succeed
+			AddPostInvokeHook(engine, func(context.Context, Engine, InvokeOutput) {})
+		}()
+	}
+
+	barrier.Done() // Init goroutine is also ready
+	wg.Wait()
+
+	// Wait for Init to complete and countAfterInit to be set
+	<-initDone
+
+	// Now check the final hook count
+	engineImpl, ok := engine.(*EngineImpl)
+	assert.True(t, ok)
+	engineImpl.mu.RLock()
+	countFinal := len(engineImpl.postInvokeHooks)
+	engineImpl.mu.RUnlock()
+
+	// The critical invariant: once Init has returned, the hook slice must not grow
+	assert.Equal(t, countAfterInit, countFinal,
+		"hook slice must not grow after Init returns; snapshot=%d, final=%d", countAfterInit, countFinal)
+}
+
+func Test_PostInvokeHook_TimeoutObservability(t *testing.T) {
+	config := configuration.NewInMemory()
+	config.Set(configuration.POST_INVOKE_HOOK_TIMEOUT, 50*time.Millisecond)
+	engine := NewWorkFlowEngine(config)
+
+	wfId := NewWorkflowIdentifier("timeout-observability")
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(pflag.NewFlagSet("", pflag.ContinueOnError)), func(InvocationContext, []Data) ([]Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	// Create a buffer to capture log output
+	var logBuffer bytes.Buffer
+	logger := zerolog.New(&logBuffer).With().Timestamp().Logger()
+	engine.SetLogger(&logger)
+
+	// Register hooks: 2 that will hang past timeout, 1 that completes immediately
+	hangingCtx := make(chan struct{})
+	defer close(hangingCtx)
+
+	addPostInvokeHook(t, engine, func(ctx context.Context, _ Engine, _ InvokeOutput) {
+		<-ctx.Done()
+		<-hangingCtx // Wait for test cleanup
+	})
+
+	addPostInvokeHook(t, engine, func(ctx context.Context, _ Engine, _ InvokeOutput) {
+		<-ctx.Done()
+		<-hangingCtx // Wait for test cleanup
+	})
+
+	addPostInvokeHook(t, engine, func(context.Context, Engine, InvokeOutput) {
+		// This one returns immediately
+	})
+
+	assert.NoError(t, engine.Init())
+
+	start := time.Now()
+	_, err = engine.Invoke(wfId)
+	elapsed := time.Since(start)
+
+	assert.NoError(t, err)
+	// Should timeout and not block waiting for the hanging hooks
+	assert.Less(t, elapsed, 500*time.Millisecond, "invoke should not wait for all hooks to complete")
+
+	logOutput := logBuffer.String()
+	// Assert the log contains the warning about the timeout with the correct count of still-running hooks
+	assert.Contains(t, logOutput, "post-invoke hooks timed out", "log should contain timeout warning")
+	assert.Contains(t, logOutput, "(2 still running)", "log should contain the count of still-running hooks")
 }

--- a/pkg/workflow/engine_test.go
+++ b/pkg/workflow/engine_test.go
@@ -622,10 +622,10 @@ func Test_PostInvokeHook_FiresOnTopLevel(t *testing.T) {
 	engine, wfId := setupHookTestEngine(t, "hook-test", nil)
 
 	var hookCalled bool
-	var receivedHctx PostInvokeContext
-	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+	var receivedOutput InvokeOutput
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, output InvokeOutput) {
 		hookCalled = true
-		receivedHctx = hctx
+		receivedOutput = output
 	})
 
 	assert.NoError(t, engine.Init())
@@ -633,8 +633,8 @@ func Test_PostInvokeHook_FiresOnTopLevel(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.True(t, hookCalled)
-	assert.Equal(t, wfId.String(), receivedHctx.GetWorkflowIdentifier().String())
-	assert.NoError(t, receivedHctx.GetError())
+	assert.Equal(t, wfId.String(), receivedOutput.GetWorkflowIdentifier().String())
+	assert.NoError(t, receivedOutput.GetError())
 }
 
 func Test_PostInvokeHook_ReceivesError(t *testing.T) {
@@ -643,8 +643,8 @@ func Test_PostInvokeHook_ReceivesError(t *testing.T) {
 	})
 
 	var receivedErr error
-	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
-		receivedErr = hctx.GetError()
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, output InvokeOutput) {
+		receivedErr = output.GetError()
 	})
 
 	assert.NoError(t, engine.Init())
@@ -667,7 +667,7 @@ func Test_PostInvokeHook_SkippedForNestedInvocations(t *testing.T) {
 	assert.NoError(t, err)
 
 	hookCallCount := 0
-	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, output InvokeOutput) {
 		hookCallCount++
 	})
 
@@ -683,7 +683,7 @@ func Test_PostInvokeHook_MultipleHooksAllFire(t *testing.T) {
 	var mu sync.Mutex
 	var fired []int
 	for _, id := range []int{1, 2, 3} {
-		addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, output InvokeOutput) {
 			mu.Lock()
 			fired = append(fired, id)
 			mu.Unlock()
@@ -701,7 +701,7 @@ func Test_PostInvokeHook_ConcurrentTopLevelInvocations(t *testing.T) {
 
 	var mu sync.Mutex
 	hookCallCount := 0
-	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, output InvokeOutput) {
 		mu.Lock()
 		hookCallCount++
 		mu.Unlock()
@@ -733,16 +733,16 @@ func Test_PostInvokeHook_FiresForMissingWorkflow(t *testing.T) {
 	engine := NewWorkFlowEngine(configuration.NewInMemory())
 	missingWfId := NewWorkflowIdentifier("does-not-exist")
 
-	var receivedHctx PostInvokeContext
-	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
-		receivedHctx = hctx
+	var receivedOutput InvokeOutput
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, output InvokeOutput) {
+		receivedOutput = output
 	})
 
 	assert.NoError(t, engine.Init())
 	_, err := engine.Invoke(missingWfId)
 	assert.Error(t, err)
-	assert.Equal(t, missingWfId.String(), receivedHctx.GetWorkflowIdentifier().String())
-	assert.Error(t, receivedHctx.GetError())
+	assert.Equal(t, missingWfId.String(), receivedOutput.GetWorkflowIdentifier().String())
+	assert.Error(t, receivedOutput.GetError())
 }
 
 func Test_PostInvokeHook_IgnoredAfterInit(t *testing.T) {
@@ -750,7 +750,7 @@ func Test_PostInvokeHook_IgnoredAfterInit(t *testing.T) {
 	assert.NoError(t, engine.Init())
 
 	hookCalled := false
-	assert.Error(t, AddPostInvokeHook(engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+	assert.Error(t, AddPostInvokeHook(engine, func(ctx context.Context, eng Engine, output InvokeOutput) {
 		hookCalled = true
 	}))
 
@@ -775,13 +775,13 @@ func Test_PostInvokeHook_PanicRecovery(t *testing.T) {
 
 	var mu sync.Mutex
 	var fired []int
-	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, output InvokeOutput) {
 		mu.Lock()
 		fired = append(fired, 1)
 		mu.Unlock()
 	})
-	addPostInvokeHook(t, engine, func(context.Context, Engine, PostInvokeContext) { panic("hook blew up") })
-	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+	addPostInvokeHook(t, engine, func(context.Context, Engine, InvokeOutput) { panic("hook blew up") })
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, output InvokeOutput) {
 		mu.Lock()
 		fired = append(fired, 3)
 		mu.Unlock()
@@ -799,7 +799,7 @@ func Test_PostInvokeHook_FiresPerInvocation(t *testing.T) {
 	engine, wfId := setupHookTestEngine(t, "per-invoke", nil)
 
 	hookCallCount := 0
-	addPostInvokeHook(t, engine, func(context.Context, Engine, PostInvokeContext) { hookCallCount++ })
+	addPostInvokeHook(t, engine, func(context.Context, Engine, InvokeOutput) { hookCallCount++ })
 
 	assert.NoError(t, engine.Init())
 	for range 3 {
@@ -816,7 +816,7 @@ func Test_PostInvokeHook_ReceivesContextValues(t *testing.T) {
 	testKey := ctxKey("hook-test-key")
 
 	var receivedCtx context.Context
-	addPostInvokeHook(t, engine, func(ctx context.Context, _ Engine, _ PostInvokeContext) { receivedCtx = ctx })
+	addPostInvokeHook(t, engine, func(ctx context.Context, _ Engine, _ InvokeOutput) { receivedCtx = ctx })
 
 	assert.NoError(t, engine.Init())
 
@@ -840,7 +840,7 @@ func Test_PostInvokeHook_NestedInvokeOfMissingWorkflow(t *testing.T) {
 	})
 
 	hookCallCount := 0
-	addPostInvokeHook(t, engine, func(context.Context, Engine, PostInvokeContext) { hookCallCount++ })
+	addPostInvokeHook(t, engine, func(context.Context, Engine, InvokeOutput) { hookCallCount++ })
 
 	assert.NoError(t, engine.Init())
 	_, err := engine.Invoke(outerWfId)
@@ -855,9 +855,9 @@ func Test_PostInvokeHook_FiresOnCallbackPanic(t *testing.T) {
 
 	var hookErr error
 	hookCalled := false
-	addPostInvokeHook(t, engine, func(_ context.Context, _ Engine, hctx PostInvokeContext) {
+	addPostInvokeHook(t, engine, func(_ context.Context, _ Engine, output InvokeOutput) {
 		hookCalled = true
-		hookErr = hctx.GetError()
+		hookErr = output.GetError()
 	})
 
 	assert.NoError(t, engine.Init())
@@ -874,8 +874,8 @@ func Test_PostInvokeHook_PanicNilObserved(t *testing.T) {
 	})
 
 	var hookErr error
-	addPostInvokeHook(t, engine, func(_ context.Context, _ Engine, hctx PostInvokeContext) {
-		hookErr = hctx.GetError()
+	addPostInvokeHook(t, engine, func(_ context.Context, _ Engine, output InvokeOutput) {
+		hookErr = output.GetError()
 	})
 
 	assert.NoError(t, engine.Init())
@@ -894,11 +894,11 @@ func Test_PostInvokeHook_Timeout(t *testing.T) {
 
 	var secondHookDone sync.WaitGroup
 	secondHookDone.Add(1)
-	addPostInvokeHook(t, engine, func(ctx context.Context, _ Engine, _ PostInvokeContext) {
+	addPostInvokeHook(t, engine, func(ctx context.Context, _ Engine, _ InvokeOutput) {
 		<-ctx.Done()
 		time.Sleep(time.Second)
 	})
-	addPostInvokeHook(t, engine, func(context.Context, Engine, PostInvokeContext) { secondHookDone.Done() })
+	addPostInvokeHook(t, engine, func(context.Context, Engine, InvokeOutput) { secondHookDone.Done() })
 
 	assert.NoError(t, engine.Init())
 

--- a/pkg/workflow/engine_test.go
+++ b/pkg/workflow/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,6 +18,12 @@ import (
 )
 
 var expectedDataIdentifier []Identifier
+
+func addPostInvokeHook(t *testing.T, e Engine, hook PostInvokeHook) {
+	t.Helper()
+	err := e.AddPostInvokeHook(hook)
+	assert.NoError(t, err)
+}
 
 func callback1(invocation InvocationContext, input []Data) ([]Data, error) {
 	if len(input) <= 0 {
@@ -597,4 +604,378 @@ func Test_EngineImpl_InvokeWithContext_DefaultContext(t *testing.T) {
 	_, err = engine.Invoke(wfId)
 	assert.NoError(t, err)
 	assert.NotNil(t, receivedCtx)
+}
+
+func Test_PostInvokeHook_FiresOnTopLevel(t *testing.T) {
+	engine := NewWorkFlowEngine(configuration.NewInMemory())
+	wfId := NewWorkflowIdentifier("hook-test")
+	flagset := pflag.NewFlagSet("h", pflag.ContinueOnError)
+
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		return []Data{NewData(NewTypeIdentifier(wfId, "out"), "text/plain", nil)}, nil
+	})
+	assert.NoError(t, err)
+
+	var hookCalled bool
+	var receivedHctx PostInvokeContext
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		hookCalled = true
+		receivedHctx = hctx
+	})
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	_, err = engine.Invoke(wfId)
+	assert.NoError(t, err)
+
+	assert.True(t, hookCalled)
+	assert.Equal(t, wfId.String(), receivedHctx.GetWorkflowIdentifier().String())
+	assert.NoError(t, receivedHctx.GetError())
+}
+
+func Test_PostInvokeHook_ReceivesError(t *testing.T) {
+	engine := NewWorkFlowEngine(configuration.NewInMemory())
+	wfId := NewWorkflowIdentifier("hook-err")
+	flagset := pflag.NewFlagSet("he", pflag.ContinueOnError)
+
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		return nil, fmt.Errorf("workflow failed")
+	})
+	assert.NoError(t, err)
+
+	var receivedErr error
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		receivedErr = hctx.GetError()
+	})
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	_, err = engine.Invoke(wfId)
+	assert.Error(t, err)
+	assert.EqualError(t, receivedErr, "workflow failed")
+}
+
+func Test_PostInvokeHook_SkippedForNestedInvocations(t *testing.T) {
+	engine := NewWorkFlowEngine(configuration.NewInMemory())
+	outerWfId := NewWorkflowIdentifier("outer")
+	innerWfId := NewWorkflowIdentifier("inner")
+	flagset := pflag.NewFlagSet("n", pflag.ContinueOnError)
+
+	_, err := engine.Register(innerWfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	_, err = engine.Register(outerWfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		return invocation.GetEngine().Invoke(innerWfId)
+	})
+	assert.NoError(t, err)
+
+	hookCallCount := 0
+	var hookedWorkflowIDs []string
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		hookCallCount++
+		hookedWorkflowIDs = append(hookedWorkflowIDs, hctx.GetWorkflowIdentifier().String())
+	})
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	_, err = engine.Invoke(outerWfId)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, hookCallCount, "hook should fire exactly once for the top-level invocation")
+	assert.Equal(t, outerWfId.String(), hookedWorkflowIDs[0])
+}
+
+func Test_PostInvokeHook_MultipleHooksFireInOrder(t *testing.T) {
+	engine := NewWorkFlowEngine(configuration.NewInMemory())
+	wfId := NewWorkflowIdentifier("multi-hook")
+	flagset := pflag.NewFlagSet("mh", pflag.ContinueOnError)
+
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	var order []int
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		order = append(order, 1)
+	})
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		order = append(order, 2)
+	})
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		order = append(order, 3)
+	})
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	_, err = engine.Invoke(wfId)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []int{1, 2, 3}, order)
+}
+
+func Test_PostInvokeHook_ConcurrentTopLevelInvocations(t *testing.T) {
+	engine := NewWorkFlowEngine(configuration.NewInMemory())
+	wfId := NewWorkflowIdentifier("concurrent-hook")
+	flagset := pflag.NewFlagSet("ch", pflag.ContinueOnError)
+
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	var mu sync.Mutex
+	hookCallCount := 0
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		mu.Lock()
+		hookCallCount++
+		mu.Unlock()
+	})
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	N := 10
+	done := make(chan struct{}, N)
+	for range N {
+		go func() {
+			_, invokeErr := engine.Invoke(wfId)
+			assert.NoError(t, invokeErr)
+			done <- struct{}{}
+		}()
+	}
+
+	for range N {
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			assert.FailNow(t, "timeout")
+			return
+		}
+	}
+
+	assert.Equal(t, N, hookCallCount)
+}
+
+func Test_PostInvokeHook_FiresForMissingWorkflow(t *testing.T) {
+	engine := NewWorkFlowEngine(configuration.NewInMemory())
+
+	var receivedHctx PostInvokeContext
+	hookCalled := false
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		hookCalled = true
+		receivedHctx = hctx
+	})
+
+	err := engine.Init()
+	assert.NoError(t, err)
+
+	missingWfId := NewWorkflowIdentifier("does-not-exist")
+	_, err = engine.Invoke(missingWfId)
+	assert.Error(t, err)
+
+	assert.True(t, hookCalled, "hook should fire even when the workflow is not found")
+	assert.Equal(t, missingWfId.String(), receivedHctx.GetWorkflowIdentifier().String())
+	assert.Error(t, receivedHctx.GetError())
+}
+
+func Test_PostInvokeHook_IgnoredAfterInit(t *testing.T) {
+	engine := NewWorkFlowEngine(configuration.NewInMemory())
+	wfId := NewWorkflowIdentifier("late-hook")
+	flagset := pflag.NewFlagSet("lh", pflag.ContinueOnError)
+
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	hookCalled := false
+	hookErr := engine.AddPostInvokeHook(func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		hookCalled = true
+	})
+	assert.Error(t, hookErr)
+
+	_, err = engine.Invoke(wfId)
+	assert.NoError(t, err)
+	assert.False(t, hookCalled, "hook registered after Init should be ignored")
+}
+
+func Test_PostInvokeHook_NilHookIgnored(t *testing.T) {
+	engine := NewWorkFlowEngine(configuration.NewInMemory())
+	wfId := NewWorkflowIdentifier("nil-hook")
+	flagset := pflag.NewFlagSet("nh", pflag.ContinueOnError)
+
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	addPostInvokeHook(t, engine, nil)
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	assert.NotPanics(t, func() {
+		_, invokeErr := engine.Invoke(wfId)
+		assert.NoError(t, invokeErr)
+	})
+}
+
+func Test_PostInvokeHook_PanicRecovery(t *testing.T) {
+	engine := NewWorkFlowEngine(configuration.NewInMemory())
+	wfId := NewWorkflowIdentifier("panic-hook")
+	flagset := pflag.NewFlagSet("ph", pflag.ContinueOnError)
+
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	var order []int
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		order = append(order, 1)
+	})
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		panic("hook blew up")
+	})
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		order = append(order, 3)
+	})
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	assert.NotPanics(t, func() {
+		_, invokeErr := engine.Invoke(wfId)
+		assert.NoError(t, invokeErr)
+	})
+	assert.Equal(t, []int{1, 3}, order, "hooks before and after the panicking hook should still fire")
+}
+
+func Test_PostInvokeHook_FiresPerInvocation(t *testing.T) {
+	engine := NewWorkFlowEngine(configuration.NewInMemory())
+	wfId := NewWorkflowIdentifier("per-invoke")
+	flagset := pflag.NewFlagSet("pi", pflag.ContinueOnError)
+
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	hookCallCount := 0
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		hookCallCount++
+	})
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	for range 3 {
+		_, err = engine.Invoke(wfId)
+		assert.NoError(t, err)
+	}
+
+	assert.Equal(t, 3, hookCallCount)
+}
+
+func Test_PostInvokeHook_ReceivesContextValues(t *testing.T) {
+	engine := NewWorkFlowEngine(configuration.NewInMemory())
+	wfId := NewWorkflowIdentifier("ctx-hook")
+	flagset := pflag.NewFlagSet("ctxh", pflag.ContinueOnError)
+
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	type ctxKey string
+	testKey := ctxKey("hook-test-key")
+	testValue := "hook-test-value"
+
+	var receivedCtx context.Context
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		receivedCtx = ctx
+	})
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = context.WithValue(ctx, testKey, testValue)
+
+	_, err = engine.Invoke(wfId, WithContext(ctx))
+	assert.NoError(t, err)
+
+	assert.NotNil(t, receivedCtx)
+	assert.Equal(t, testValue, receivedCtx.Value(testKey))
+
+	deadline, hasDeadline := receivedCtx.Deadline()
+	assert.True(t, hasDeadline)
+	assert.False(t, deadline.IsZero())
+}
+
+func Test_PostInvokeHook_NestedInvokeOfMissingWorkflow(t *testing.T) {
+	engine := NewWorkFlowEngine(configuration.NewInMemory())
+	outerWfId := NewWorkflowIdentifier("outer-missing-inner")
+	flagset := pflag.NewFlagSet("omi", pflag.ContinueOnError)
+
+	_, err := engine.Register(outerWfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		_, invokeErr := invocation.GetEngine().Invoke(NewWorkflowIdentifier("nonexistent"))
+		return nil, invokeErr
+	})
+	assert.NoError(t, err)
+
+	hookCallCount := 0
+	var hookedIDs []string
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		hookCallCount++
+		hookedIDs = append(hookedIDs, hctx.GetWorkflowIdentifier().String())
+	})
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	_, err = engine.Invoke(outerWfId)
+	assert.Error(t, err)
+
+	assert.Equal(t, 1, hookCallCount, "hook fires once for the top-level invocation only")
+	assert.Equal(t, outerWfId.String(), hookedIDs[0])
+}
+
+func Test_PostInvokeHook_FiresOnCallbackPanic(t *testing.T) {
+	engine := NewWorkFlowEngine(configuration.NewInMemory())
+	wfId := NewWorkflowIdentifier("panic-callback")
+	flagset := pflag.NewFlagSet("pc", pflag.ContinueOnError)
+
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		panic("callback blew up")
+	})
+	assert.NoError(t, err)
+
+	var hookErr error
+	hookCalled := false
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		hookCalled = true
+		hookErr = hctx.GetError()
+	})
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	assert.Panics(t, func() {
+		//nolint:errcheck // panic prevents return
+		engine.Invoke(wfId)
+	}, "original panic must re-propagate after hooks fire")
+	assert.True(t, hookCalled, "hook must fire even when the callback panics")
+	assert.ErrorContains(t, hookErr, "callback blew up")
 }

--- a/pkg/workflow/engine_test.go
+++ b/pkg/workflow/engine_test.go
@@ -1192,3 +1192,56 @@ func Test_PostInvokeHook_InitRetryPreservesPreInitHooks(t *testing.T) {
 
 	assert.True(t, preInitHookCalled, "hook registered before Init should still fire after failed and retried Init")
 }
+
+func Test_PostInvokeHook_NestedInvokeContextBoundByHookTimeout(t *testing.T) {
+	// Verify that nested invocations made through the engine given to a hook
+	// are bound by the same timeout the hook is bound by.
+	config := configuration.NewInMemory()
+	config.Set(configuration.POST_INVOKE_HOOK_TIMEOUT, 50*time.Millisecond)
+	engine := NewWorkFlowEngine(config)
+
+	outerWfId := NewWorkflowIdentifier("outer-timeout-test")
+	innerWfId := NewWorkflowIdentifier("inner-timeout-test")
+	opts := ConfigurationOptionsFromFlagset(pflag.NewFlagSet("", pflag.ContinueOnError))
+
+	_, err := engine.Register(outerWfId, opts, func(InvocationContext, []Data) ([]Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	ctxCanceledDuringInvoke := make(chan bool, 1)
+	_, err = engine.Register(innerWfId, opts, func(inv InvocationContext, _ []Data) ([]Data, error) {
+		// Wait up to 200ms and check if context gets canceled.
+		// With the bug: context won't be canceled (unbounded)
+		// With the fix: context will be canceled (bounded by 50ms hook timeout)
+		wasCanceled := false
+		select {
+		case <-inv.Context().Done():
+			wasCanceled = true
+		case <-time.After(200 * time.Millisecond):
+		}
+		ctxCanceledDuringInvoke <- wasCanceled
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, _ InvokeOutput) {
+		// Invoke inner workflow WITHOUT passing WithContext.
+		// It should inherit the hook's timeout-bounded context, not the unbounded parent.
+		_, invokeErr := eng.Invoke(innerWfId)
+		assert.NoError(t, invokeErr)
+	})
+
+	assert.NoError(t, engine.Init())
+
+	_, err = engine.Invoke(outerWfId)
+	assert.NoError(t, err)
+
+	// Wait for inner workflow callback to report whether its context was canceled
+	select {
+	case canceled := <-ctxCanceledDuringInvoke:
+		assert.True(t, canceled, "nested invoke context should be canceled by hook timeout")
+	case <-time.After(1 * time.Second):
+		assert.FailNow(t, "timeout waiting for inner workflow callback")
+	}
+}

--- a/pkg/workflow/engine_test.go
+++ b/pkg/workflow/engine_test.go
@@ -21,8 +21,20 @@ var expectedDataIdentifier []Identifier
 
 func addPostInvokeHook(t *testing.T, e Engine, hook PostInvokeHook) {
 	t.Helper()
-	err := e.AddPostInvokeHook(hook)
+	err := AddPostInvokeHook(e, hook)
 	assert.NoError(t, err)
+}
+
+func setupHookTestEngine(t *testing.T, name string, callback Callback) (Engine, Identifier) {
+	t.Helper()
+	engine := NewWorkFlowEngine(configuration.NewInMemory())
+	wfId := NewWorkflowIdentifier(name)
+	if callback == nil {
+		callback = func(InvocationContext, []Data) ([]Data, error) { return nil, nil }
+	}
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(pflag.NewFlagSet("", pflag.ContinueOnError)), callback)
+	assert.NoError(t, err)
+	return engine, wfId
 }
 
 func callback1(invocation InvocationContext, input []Data) ([]Data, error) {
@@ -607,14 +619,7 @@ func Test_EngineImpl_InvokeWithContext_DefaultContext(t *testing.T) {
 }
 
 func Test_PostInvokeHook_FiresOnTopLevel(t *testing.T) {
-	engine := NewWorkFlowEngine(configuration.NewInMemory())
-	wfId := NewWorkflowIdentifier("hook-test")
-	flagset := pflag.NewFlagSet("h", pflag.ContinueOnError)
-
-	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
-		return []Data{NewData(NewTypeIdentifier(wfId, "out"), "text/plain", nil)}, nil
-	})
-	assert.NoError(t, err)
+	engine, wfId := setupHookTestEngine(t, "hook-test", nil)
 
 	var hookCalled bool
 	var receivedHctx PostInvokeContext
@@ -623,10 +628,8 @@ func Test_PostInvokeHook_FiresOnTopLevel(t *testing.T) {
 		receivedHctx = hctx
 	})
 
-	err = engine.Init()
-	assert.NoError(t, err)
-
-	_, err = engine.Invoke(wfId)
+	assert.NoError(t, engine.Init())
+	_, err := engine.Invoke(wfId)
 	assert.NoError(t, err)
 
 	assert.True(t, hookCalled)
@@ -635,107 +638,66 @@ func Test_PostInvokeHook_FiresOnTopLevel(t *testing.T) {
 }
 
 func Test_PostInvokeHook_ReceivesError(t *testing.T) {
-	engine := NewWorkFlowEngine(configuration.NewInMemory())
-	wfId := NewWorkflowIdentifier("hook-err")
-	flagset := pflag.NewFlagSet("he", pflag.ContinueOnError)
-
-	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+	engine, wfId := setupHookTestEngine(t, "hook-err", func(InvocationContext, []Data) ([]Data, error) {
 		return nil, fmt.Errorf("workflow failed")
 	})
-	assert.NoError(t, err)
 
 	var receivedErr error
 	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
 		receivedErr = hctx.GetError()
 	})
 
-	err = engine.Init()
-	assert.NoError(t, err)
-
-	_, err = engine.Invoke(wfId)
+	assert.NoError(t, engine.Init())
+	_, err := engine.Invoke(wfId)
 	assert.Error(t, err)
 	assert.EqualError(t, receivedErr, "workflow failed")
 }
 
 func Test_PostInvokeHook_SkippedForNestedInvocations(t *testing.T) {
 	engine := NewWorkFlowEngine(configuration.NewInMemory())
-	outerWfId := NewWorkflowIdentifier("outer")
 	innerWfId := NewWorkflowIdentifier("inner")
-	flagset := pflag.NewFlagSet("n", pflag.ContinueOnError)
+	outerWfId := NewWorkflowIdentifier("outer")
+	opts := ConfigurationOptionsFromFlagset(pflag.NewFlagSet("", pflag.ContinueOnError))
 
-	_, err := engine.Register(innerWfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
-		return nil, nil
-	})
+	_, err := engine.Register(innerWfId, opts, func(InvocationContext, []Data) ([]Data, error) { return nil, nil })
 	assert.NoError(t, err)
-
-	_, err = engine.Register(outerWfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
-		return invocation.GetEngine().Invoke(innerWfId)
+	_, err = engine.Register(outerWfId, opts, func(inv InvocationContext, _ []Data) ([]Data, error) {
+		return inv.GetEngine().Invoke(innerWfId)
 	})
 	assert.NoError(t, err)
 
 	hookCallCount := 0
-	var hookedWorkflowIDs []string
 	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
 		hookCallCount++
-		hookedWorkflowIDs = append(hookedWorkflowIDs, hctx.GetWorkflowIdentifier().String())
 	})
 
-	err = engine.Init()
-	assert.NoError(t, err)
-
+	assert.NoError(t, engine.Init())
 	_, err = engine.Invoke(outerWfId)
 	assert.NoError(t, err)
-
 	assert.Equal(t, 1, hookCallCount, "hook should fire exactly once for the top-level invocation")
-	assert.Equal(t, outerWfId.String(), hookedWorkflowIDs[0])
 }
 
 func Test_PostInvokeHook_MultipleHooksAllFire(t *testing.T) {
-	engine := NewWorkFlowEngine(configuration.NewInMemory())
-	wfId := NewWorkflowIdentifier("multi-hook")
-	flagset := pflag.NewFlagSet("mh", pflag.ContinueOnError)
-
-	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
-		return nil, nil
-	})
-	assert.NoError(t, err)
+	engine, wfId := setupHookTestEngine(t, "multi-hook", nil)
 
 	var mu sync.Mutex
 	var fired []int
-	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
-		mu.Lock()
-		fired = append(fired, 1)
-		mu.Unlock()
-	})
-	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
-		mu.Lock()
-		fired = append(fired, 2)
-		mu.Unlock()
-	})
-	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
-		mu.Lock()
-		fired = append(fired, 3)
-		mu.Unlock()
-	})
+	for _, id := range []int{1, 2, 3} {
+		addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+			mu.Lock()
+			fired = append(fired, id)
+			mu.Unlock()
+		})
+	}
 
-	err = engine.Init()
+	assert.NoError(t, engine.Init())
+	_, err := engine.Invoke(wfId)
 	assert.NoError(t, err)
-
-	_, err = engine.Invoke(wfId)
-	assert.NoError(t, err)
-
 	assert.ElementsMatch(t, []int{1, 2, 3}, fired)
 }
 
 func Test_PostInvokeHook_ConcurrentTopLevelInvocations(t *testing.T) {
-	engine := NewWorkFlowEngine(configuration.NewInMemory())
-	wfId := NewWorkflowIdentifier("concurrent-hook")
-	flagset := pflag.NewFlagSet("ch", pflag.ContinueOnError)
-
-	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
-		return nil, nil
-	})
-	assert.NoError(t, err)
+	engine, wfId := setupHookTestEngine(t, "concurrent-hook", nil)
 
 	var mu sync.Mutex
 	hookCallCount := 0
@@ -745,8 +707,7 @@ func Test_PostInvokeHook_ConcurrentTopLevelInvocations(t *testing.T) {
 		mu.Unlock()
 	})
 
-	err = engine.Init()
-	assert.NoError(t, err)
+	assert.NoError(t, engine.Init())
 
 	N := 10
 	done := make(chan struct{}, N)
@@ -757,7 +718,6 @@ func Test_PostInvokeHook_ConcurrentTopLevelInvocations(t *testing.T) {
 			done <- struct{}{}
 		}()
 	}
-
 	for range N {
 		select {
 		case <-done:
@@ -766,86 +726,52 @@ func Test_PostInvokeHook_ConcurrentTopLevelInvocations(t *testing.T) {
 			return
 		}
 	}
-
 	assert.Equal(t, N, hookCallCount)
 }
 
 func Test_PostInvokeHook_FiresForMissingWorkflow(t *testing.T) {
 	engine := NewWorkFlowEngine(configuration.NewInMemory())
+	missingWfId := NewWorkflowIdentifier("does-not-exist")
 
 	var receivedHctx PostInvokeContext
-	hookCalled := false
 	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
-		hookCalled = true
 		receivedHctx = hctx
 	})
 
-	err := engine.Init()
-	assert.NoError(t, err)
-
-	missingWfId := NewWorkflowIdentifier("does-not-exist")
-	_, err = engine.Invoke(missingWfId)
+	assert.NoError(t, engine.Init())
+	_, err := engine.Invoke(missingWfId)
 	assert.Error(t, err)
-
-	assert.True(t, hookCalled, "hook should fire even when the workflow is not found")
 	assert.Equal(t, missingWfId.String(), receivedHctx.GetWorkflowIdentifier().String())
 	assert.Error(t, receivedHctx.GetError())
 }
 
 func Test_PostInvokeHook_IgnoredAfterInit(t *testing.T) {
-	engine := NewWorkFlowEngine(configuration.NewInMemory())
-	wfId := NewWorkflowIdentifier("late-hook")
-	flagset := pflag.NewFlagSet("lh", pflag.ContinueOnError)
-
-	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
-		return nil, nil
-	})
-	assert.NoError(t, err)
-
-	err = engine.Init()
-	assert.NoError(t, err)
+	engine, wfId := setupHookTestEngine(t, "late-hook", nil)
+	assert.NoError(t, engine.Init())
 
 	hookCalled := false
-	hookErr := engine.AddPostInvokeHook(func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+	assert.Error(t, AddPostInvokeHook(engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
 		hookCalled = true
-	})
-	assert.Error(t, hookErr)
+	}))
 
-	_, err = engine.Invoke(wfId)
+	_, err := engine.Invoke(wfId)
 	assert.NoError(t, err)
-	assert.False(t, hookCalled, "hook registered after Init should be ignored")
+	assert.False(t, hookCalled)
 }
 
 func Test_PostInvokeHook_NilHookIgnored(t *testing.T) {
-	engine := NewWorkFlowEngine(configuration.NewInMemory())
-	wfId := NewWorkflowIdentifier("nil-hook")
-	flagset := pflag.NewFlagSet("nh", pflag.ContinueOnError)
-
-	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
-		return nil, nil
-	})
-	assert.NoError(t, err)
-
+	engine, wfId := setupHookTestEngine(t, "nil-hook", nil)
 	addPostInvokeHook(t, engine, nil)
-
-	err = engine.Init()
-	assert.NoError(t, err)
+	assert.NoError(t, engine.Init())
 
 	assert.NotPanics(t, func() {
-		_, invokeErr := engine.Invoke(wfId)
-		assert.NoError(t, invokeErr)
+		_, err := engine.Invoke(wfId)
+		assert.NoError(t, err)
 	})
 }
 
 func Test_PostInvokeHook_PanicRecovery(t *testing.T) {
-	engine := NewWorkFlowEngine(configuration.NewInMemory())
-	wfId := NewWorkflowIdentifier("panic-hook")
-	flagset := pflag.NewFlagSet("ph", pflag.ContinueOnError)
-
-	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
-		return nil, nil
-	})
-	assert.NoError(t, err)
+	engine, wfId := setupHookTestEngine(t, "panic-hook", nil)
 
 	var mu sync.Mutex
 	var fired []int
@@ -854,82 +780,53 @@ func Test_PostInvokeHook_PanicRecovery(t *testing.T) {
 		fired = append(fired, 1)
 		mu.Unlock()
 	})
-	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
-		panic("hook blew up")
-	})
+	addPostInvokeHook(t, engine, func(context.Context, Engine, PostInvokeContext) { panic("hook blew up") })
 	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
 		mu.Lock()
 		fired = append(fired, 3)
 		mu.Unlock()
 	})
 
-	err = engine.Init()
-	assert.NoError(t, err)
-
+	assert.NoError(t, engine.Init())
 	assert.NotPanics(t, func() {
-		_, invokeErr := engine.Invoke(wfId)
-		assert.NoError(t, invokeErr)
+		_, err := engine.Invoke(wfId)
+		assert.NoError(t, err)
 	})
 	assert.ElementsMatch(t, []int{1, 3}, fired, "hooks before and after the panicking hook should still fire")
 }
 
 func Test_PostInvokeHook_FiresPerInvocation(t *testing.T) {
-	engine := NewWorkFlowEngine(configuration.NewInMemory())
-	wfId := NewWorkflowIdentifier("per-invoke")
-	flagset := pflag.NewFlagSet("pi", pflag.ContinueOnError)
-
-	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
-		return nil, nil
-	})
-	assert.NoError(t, err)
+	engine, wfId := setupHookTestEngine(t, "per-invoke", nil)
 
 	hookCallCount := 0
-	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
-		hookCallCount++
-	})
+	addPostInvokeHook(t, engine, func(context.Context, Engine, PostInvokeContext) { hookCallCount++ })
 
-	err = engine.Init()
-	assert.NoError(t, err)
-
+	assert.NoError(t, engine.Init())
 	for range 3 {
-		_, err = engine.Invoke(wfId)
+		_, err := engine.Invoke(wfId)
 		assert.NoError(t, err)
 	}
-
 	assert.Equal(t, 3, hookCallCount)
 }
 
 func Test_PostInvokeHook_ReceivesContextValues(t *testing.T) {
-	engine := NewWorkFlowEngine(configuration.NewInMemory())
-	wfId := NewWorkflowIdentifier("ctx-hook")
-	flagset := pflag.NewFlagSet("ctxh", pflag.ContinueOnError)
-
-	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
-		return nil, nil
-	})
-	assert.NoError(t, err)
+	engine, wfId := setupHookTestEngine(t, "ctx-hook", nil)
 
 	type ctxKey string
 	testKey := ctxKey("hook-test-key")
-	testValue := "hook-test-value"
 
 	var receivedCtx context.Context
-	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
-		receivedCtx = ctx
-	})
+	addPostInvokeHook(t, engine, func(ctx context.Context, _ Engine, _ PostInvokeContext) { receivedCtx = ctx })
 
-	err = engine.Init()
-	assert.NoError(t, err)
+	assert.NoError(t, engine.Init())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	ctx = context.WithValue(ctx, testKey, testValue)
+	ctx = context.WithValue(ctx, testKey, "hook-test-value")
 
-	_, err = engine.Invoke(wfId, WithContext(ctx))
+	_, err := engine.Invoke(wfId, WithContext(ctx))
 	assert.NoError(t, err)
-
-	assert.NotNil(t, receivedCtx)
-	assert.Equal(t, testValue, receivedCtx.Value(testKey))
+	assert.Equal(t, "hook-test-value", receivedCtx.Value(testKey))
 
 	deadline, hasDeadline := receivedCtx.Deadline()
 	assert.True(t, hasDeadline)
@@ -937,86 +834,54 @@ func Test_PostInvokeHook_ReceivesContextValues(t *testing.T) {
 }
 
 func Test_PostInvokeHook_NestedInvokeOfMissingWorkflow(t *testing.T) {
-	engine := NewWorkFlowEngine(configuration.NewInMemory())
-	outerWfId := NewWorkflowIdentifier("outer-missing-inner")
-	flagset := pflag.NewFlagSet("omi", pflag.ContinueOnError)
-
-	_, err := engine.Register(outerWfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
-		_, invokeErr := invocation.GetEngine().Invoke(NewWorkflowIdentifier("nonexistent"))
-		return nil, invokeErr
+	engine, outerWfId := setupHookTestEngine(t, "outer-missing-inner", func(inv InvocationContext, _ []Data) ([]Data, error) {
+		_, err := inv.GetEngine().Invoke(NewWorkflowIdentifier("nonexistent"))
+		return nil, err
 	})
-	assert.NoError(t, err)
 
 	hookCallCount := 0
-	var hookedIDs []string
-	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
-		hookCallCount++
-		hookedIDs = append(hookedIDs, hctx.GetWorkflowIdentifier().String())
-	})
+	addPostInvokeHook(t, engine, func(context.Context, Engine, PostInvokeContext) { hookCallCount++ })
 
-	err = engine.Init()
-	assert.NoError(t, err)
-
-	_, err = engine.Invoke(outerWfId)
+	assert.NoError(t, engine.Init())
+	_, err := engine.Invoke(outerWfId)
 	assert.Error(t, err)
-
 	assert.Equal(t, 1, hookCallCount, "hook fires once for the top-level invocation only")
-	assert.Equal(t, outerWfId.String(), hookedIDs[0])
 }
 
 func Test_PostInvokeHook_FiresOnCallbackPanic(t *testing.T) {
-	engine := NewWorkFlowEngine(configuration.NewInMemory())
-	wfId := NewWorkflowIdentifier("panic-callback")
-	flagset := pflag.NewFlagSet("pc", pflag.ContinueOnError)
-
-	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+	engine, wfId := setupHookTestEngine(t, "panic-callback", func(InvocationContext, []Data) ([]Data, error) {
 		panic("callback blew up")
 	})
-	assert.NoError(t, err)
 
 	var hookErr error
 	hookCalled := false
-	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+	addPostInvokeHook(t, engine, func(_ context.Context, _ Engine, hctx PostInvokeContext) {
 		hookCalled = true
 		hookErr = hctx.GetError()
 	})
 
-	err = engine.Init()
-	assert.NoError(t, err)
-
+	assert.NoError(t, engine.Init())
 	assert.Panics(t, func() {
-		//nolint:errcheck // panic prevents return
-		engine.Invoke(wfId)
-	}, "original panic must re-propagate after hooks fire")
+		engine.Invoke(wfId) //nolint:errcheck // panic prevents return
+	})
 	assert.True(t, hookCalled, "hook must fire even when the callback panics")
 	assert.ErrorContains(t, hookErr, "callback blew up")
 }
 
 func Test_PostInvokeHook_PanicNilObserved(t *testing.T) {
-	engine := NewWorkFlowEngine(configuration.NewInMemory())
-	wfId := NewWorkflowIdentifier("panic-nil")
-	flagset := pflag.NewFlagSet("pn", pflag.ContinueOnError)
-
-	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+	engine, wfId := setupHookTestEngine(t, "panic-nil", func(InvocationContext, []Data) ([]Data, error) {
 		panic(any(nil)) //nolint:govet // intentional: verifying Go 1.21+ PanicNilError is observed by hooks
 	})
-	assert.NoError(t, err)
 
 	var hookErr error
-	hookCalled := false
-	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
-		hookCalled = true
+	addPostInvokeHook(t, engine, func(_ context.Context, _ Engine, hctx PostInvokeContext) {
 		hookErr = hctx.GetError()
 	})
 
-	err = engine.Init()
-	assert.NoError(t, err)
-
+	assert.NoError(t, engine.Init())
 	assert.Panics(t, func() {
-		//nolint:errcheck // panic prevents return
-		engine.Invoke(wfId)
-	}, "panic(nil) must still propagate on Go 1.21+")
-	assert.True(t, hookCalled, "hook must fire for panic(nil)")
+		engine.Invoke(wfId) //nolint:errcheck // panic prevents return
+	})
 	assert.NotNil(t, hookErr, "hook should observe error from panic(nil) via Go 1.21+ PanicNilError")
 }
 
@@ -1025,33 +890,21 @@ func Test_PostInvokeHook_Timeout(t *testing.T) {
 	postInvokeHookTimeout = 50 * time.Millisecond
 	defer func() { postInvokeHookTimeout = original }()
 
-	engine := NewWorkFlowEngine(configuration.NewInMemory())
-	wfId := NewWorkflowIdentifier("timeout-test")
-	flagset := pflag.NewFlagSet("to", pflag.ContinueOnError)
-
-	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
-		return nil, nil
-	})
-	assert.NoError(t, err)
+	engine, wfId := setupHookTestEngine(t, "timeout-test", nil)
 
 	var secondHookDone sync.WaitGroup
 	secondHookDone.Add(1)
-	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+	addPostInvokeHook(t, engine, func(ctx context.Context, _ Engine, _ PostInvokeContext) {
 		<-ctx.Done()
 		time.Sleep(time.Second)
 	})
-	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
-		secondHookDone.Done()
-	})
+	addPostInvokeHook(t, engine, func(context.Context, Engine, PostInvokeContext) { secondHookDone.Done() })
 
-	err = engine.Init()
-	assert.NoError(t, err)
+	assert.NoError(t, engine.Init())
 
 	start := time.Now()
-	_, err = engine.Invoke(wfId)
-	elapsed := time.Since(start)
-
+	_, err := engine.Invoke(wfId)
 	secondHookDone.Wait()
 	assert.NoError(t, err)
-	assert.Less(t, elapsed, 2*time.Second, "invoke should not block on the hanging hook")
+	assert.Less(t, time.Since(start), 2*time.Second, "invoke should not block on the hanging hook")
 }

--- a/pkg/workflow/engine_test.go
+++ b/pkg/workflow/engine_test.go
@@ -1117,3 +1117,78 @@ func Test_PostInvokeHook_EngineWideTimeoutWhenNoOverride(t *testing.T) {
 	assert.Less(t, hookCtxCanceledAfter, 200*time.Millisecond, "hook context should be canceled with engine-wide timeout")
 	assert.Less(t, totalElapsed, 500*time.Millisecond, "total invocation should complete quickly")
 }
+
+func Test_PostInvokeHook_InitRetryDeduplication(t *testing.T) {
+	engine := NewWorkFlowEngine(configuration.NewInMemory())
+	wfId := NewWorkflowIdentifier("test-retry-hook")
+
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(pflag.NewFlagSet("", pflag.ContinueOnError)), func(InvocationContext, []Data) ([]Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	hookCallCount := 0
+	engine.AddExtensionInitializer(func(e Engine) error {
+		return AddPostInvokeHook(e, func(ctx context.Context, eng Engine, output InvokeOutput) {
+			hookCallCount++
+		})
+	})
+
+	initCallCount := 0
+	engine.AddExtensionInitializer(func(e Engine) error {
+		initCallCount++
+		if initCallCount == 1 {
+			return fmt.Errorf("init failed on first attempt")
+		}
+		return nil
+	})
+
+	err = engine.Init()
+	assert.Error(t, err)
+	assert.Equal(t, 1, initCallCount)
+
+	err = engine.Init()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, initCallCount)
+
+	_, err = engine.Invoke(wfId)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, hookCallCount, "hook should fire exactly once despite Init being retried")
+}
+
+func Test_PostInvokeHook_InitRetryPreservesPreInitHooks(t *testing.T) {
+	engine := NewWorkFlowEngine(configuration.NewInMemory())
+	wfId := NewWorkflowIdentifier("test-pre-init-hook")
+
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(pflag.NewFlagSet("", pflag.ContinueOnError)), func(InvocationContext, []Data) ([]Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	preInitHookCalled := false
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, output InvokeOutput) {
+		preInitHookCalled = true
+	})
+
+	initCallCount := 0
+	engine.AddExtensionInitializer(func(e Engine) error {
+		initCallCount++
+		if initCallCount == 1 {
+			return fmt.Errorf("init failed on first attempt")
+		}
+		return nil
+	})
+
+	err = engine.Init()
+	assert.Error(t, err)
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	preInitHookCalled = false
+	_, err = engine.Invoke(wfId)
+	assert.NoError(t, err)
+
+	assert.True(t, preInitHookCalled, "hook registered before Init should still fire after failed and retried Init")
+}

--- a/pkg/workflow/engine_test.go
+++ b/pkg/workflow/engine_test.go
@@ -1029,3 +1029,91 @@ func Test_PostInvokeHook_TimeoutObservability(t *testing.T) {
 	assert.Contains(t, logOutput, "post-invoke hooks timed out", "log should contain timeout warning")
 	assert.Contains(t, logOutput, "(2 still running)", "log should contain the count of still-running hooks")
 }
+
+func Test_PostInvokeHook_PerInvocationTimeoutOverride(t *testing.T) {
+	// Create engine with a LONG timeout in engine-wide config
+	engineConfig := configuration.NewInMemory()
+	engineConfig.Set(configuration.POST_INVOKE_HOOK_TIMEOUT, 10*time.Second) // Very long
+	engine := NewWorkFlowEngine(engineConfig)
+
+	wfId := NewWorkflowIdentifier("per-invocation-timeout")
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(pflag.NewFlagSet("", pflag.ContinueOnError)), func(InvocationContext, []Data) ([]Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	// Track how long it takes for hook context to be canceled
+	hookDone := make(chan time.Duration, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	addPostInvokeHook(t, engine, func(ctx context.Context, _ Engine, _ InvokeOutput) {
+		start := time.Now()
+		<-ctx.Done()
+		canceled := time.Since(start)
+		hookDone <- canceled
+		wg.Done()
+	})
+
+	assert.NoError(t, engine.Init())
+
+	// Invoke with a SHORT timeout override via WithConfig
+	invokeConfig := configuration.NewInMemory()
+	invokeConfig.Set(configuration.POST_INVOKE_HOOK_TIMEOUT, 50*time.Millisecond) // Very short override
+
+	start := time.Now()
+	_, err = engine.Invoke(wfId, WithConfig(invokeConfig))
+	totalElapsed := time.Since(start)
+	assert.NoError(t, err)
+
+	// Wait for hook to complete
+	wg.Wait()
+	hookCtxCanceledAfter := <-hookDone
+
+	// Verify the hook saw its context canceled quickly (respecting the short timeout)
+	// not after the long engine-wide timeout
+	assert.Greater(t, hookCtxCanceledAfter, 30*time.Millisecond, "hook context should be canceled")
+	assert.Less(t, hookCtxCanceledAfter, 200*time.Millisecond, "hook context should be canceled quickly, not wait for 10s engine-wide timeout")
+	assert.Less(t, totalElapsed, 1*time.Second, "total invocation should complete quickly, not wait for 10s timeout")
+}
+
+func Test_PostInvokeHook_EngineWideTimeoutWhenNoOverride(t *testing.T) {
+	// Create engine with a short timeout in engine-wide config
+	engineConfig := configuration.NewInMemory()
+	engineConfig.Set(configuration.POST_INVOKE_HOOK_TIMEOUT, 50*time.Millisecond)
+	engine := NewWorkFlowEngine(engineConfig)
+
+	wfId := NewWorkflowIdentifier("engine-wide-timeout")
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(pflag.NewFlagSet("", pflag.ContinueOnError)), func(InvocationContext, []Data) ([]Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	// Track how long it takes for hook context to be canceled
+	hookDone := make(chan time.Duration, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	addPostInvokeHook(t, engine, func(ctx context.Context, _ Engine, _ InvokeOutput) {
+		start := time.Now()
+		<-ctx.Done()
+		canceled := time.Since(start)
+		hookDone <- canceled
+		wg.Done()
+	})
+
+	assert.NoError(t, engine.Init())
+
+	// Invoke WITHOUT WithConfig - should use engine-wide timeout
+	start := time.Now()
+	_, err = engine.Invoke(wfId)
+	totalElapsed := time.Since(start)
+	assert.NoError(t, err)
+
+	// Wait for hook to complete
+	wg.Wait()
+	hookCtxCanceledAfter := <-hookDone
+
+	// Verify the hook saw its context canceled with the engine-wide timeout
+	assert.Greater(t, hookCtxCanceledAfter, 30*time.Millisecond, "hook context should be canceled")
+	assert.Less(t, hookCtxCanceledAfter, 200*time.Millisecond, "hook context should be canceled with engine-wide timeout")
+	assert.Less(t, totalElapsed, 500*time.Millisecond, "total invocation should complete quickly")
+}

--- a/pkg/workflow/engine_test.go
+++ b/pkg/workflow/engine_test.go
@@ -690,7 +690,7 @@ func Test_PostInvokeHook_SkippedForNestedInvocations(t *testing.T) {
 	assert.Equal(t, outerWfId.String(), hookedWorkflowIDs[0])
 }
 
-func Test_PostInvokeHook_MultipleHooksFireInOrder(t *testing.T) {
+func Test_PostInvokeHook_MultipleHooksAllFire(t *testing.T) {
 	engine := NewWorkFlowEngine(configuration.NewInMemory())
 	wfId := NewWorkflowIdentifier("multi-hook")
 	flagset := pflag.NewFlagSet("mh", pflag.ContinueOnError)
@@ -700,15 +700,22 @@ func Test_PostInvokeHook_MultipleHooksFireInOrder(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	var order []int
+	var mu sync.Mutex
+	var fired []int
 	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
-		order = append(order, 1)
+		mu.Lock()
+		fired = append(fired, 1)
+		mu.Unlock()
 	})
 	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
-		order = append(order, 2)
+		mu.Lock()
+		fired = append(fired, 2)
+		mu.Unlock()
 	})
 	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
-		order = append(order, 3)
+		mu.Lock()
+		fired = append(fired, 3)
+		mu.Unlock()
 	})
 
 	err = engine.Init()
@@ -717,7 +724,7 @@ func Test_PostInvokeHook_MultipleHooksFireInOrder(t *testing.T) {
 	_, err = engine.Invoke(wfId)
 	assert.NoError(t, err)
 
-	assert.Equal(t, []int{1, 2, 3}, order)
+	assert.ElementsMatch(t, []int{1, 2, 3}, fired)
 }
 
 func Test_PostInvokeHook_ConcurrentTopLevelInvocations(t *testing.T) {
@@ -840,15 +847,20 @@ func Test_PostInvokeHook_PanicRecovery(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	var order []int
+	var mu sync.Mutex
+	var fired []int
 	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
-		order = append(order, 1)
+		mu.Lock()
+		fired = append(fired, 1)
+		mu.Unlock()
 	})
 	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
 		panic("hook blew up")
 	})
 	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
-		order = append(order, 3)
+		mu.Lock()
+		fired = append(fired, 3)
+		mu.Unlock()
 	})
 
 	err = engine.Init()
@@ -858,7 +870,7 @@ func Test_PostInvokeHook_PanicRecovery(t *testing.T) {
 		_, invokeErr := engine.Invoke(wfId)
 		assert.NoError(t, invokeErr)
 	})
-	assert.Equal(t, []int{1, 3}, order, "hooks before and after the panicking hook should still fire")
+	assert.ElementsMatch(t, []int{1, 3}, fired, "hooks before and after the panicking hook should still fire")
 }
 
 func Test_PostInvokeHook_FiresPerInvocation(t *testing.T) {
@@ -978,4 +990,68 @@ func Test_PostInvokeHook_FiresOnCallbackPanic(t *testing.T) {
 	}, "original panic must re-propagate after hooks fire")
 	assert.True(t, hookCalled, "hook must fire even when the callback panics")
 	assert.ErrorContains(t, hookErr, "callback blew up")
+}
+
+func Test_PostInvokeHook_PanicNilObserved(t *testing.T) {
+	engine := NewWorkFlowEngine(configuration.NewInMemory())
+	wfId := NewWorkflowIdentifier("panic-nil")
+	flagset := pflag.NewFlagSet("pn", pflag.ContinueOnError)
+
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		panic(any(nil)) //nolint:govet // intentional: verifying Go 1.21+ PanicNilError is observed by hooks
+	})
+	assert.NoError(t, err)
+
+	var hookErr error
+	hookCalled := false
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		hookCalled = true
+		hookErr = hctx.GetError()
+	})
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	assert.Panics(t, func() {
+		//nolint:errcheck // panic prevents return
+		engine.Invoke(wfId)
+	}, "panic(nil) must still propagate on Go 1.21+")
+	assert.True(t, hookCalled, "hook must fire for panic(nil)")
+	assert.NotNil(t, hookErr, "hook should observe error from panic(nil) via Go 1.21+ PanicNilError")
+}
+
+func Test_PostInvokeHook_Timeout(t *testing.T) {
+	original := postInvokeHookTimeout
+	postInvokeHookTimeout = 50 * time.Millisecond
+	defer func() { postInvokeHookTimeout = original }()
+
+	engine := NewWorkFlowEngine(configuration.NewInMemory())
+	wfId := NewWorkflowIdentifier("timeout-test")
+	flagset := pflag.NewFlagSet("to", pflag.ContinueOnError)
+
+	_, err := engine.Register(wfId, ConfigurationOptionsFromFlagset(flagset), func(invocation InvocationContext, input []Data) ([]Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	var secondHookDone sync.WaitGroup
+	secondHookDone.Add(1)
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		<-ctx.Done()
+		time.Sleep(time.Second)
+	})
+	addPostInvokeHook(t, engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		secondHookDone.Done()
+	})
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	start := time.Now()
+	_, err = engine.Invoke(wfId)
+	elapsed := time.Since(start)
+
+	secondHookDone.Wait()
+	assert.NoError(t, err)
+	assert.Less(t, elapsed, 2*time.Second, "invoke should not block on the hanging hook")
 }

--- a/pkg/workflow/engineimpl.go
+++ b/pkg/workflow/engineimpl.go
@@ -194,6 +194,7 @@ func (e *EngineImpl) Init() error {
 
 	e.mu.Lock()
 	e.invocationCounter = 0
+	preInitHookCount := len(e.postInvokeHooks)
 	e.mu.Unlock()
 
 	_ = e.GetNetworkAccess()
@@ -201,6 +202,9 @@ func (e *EngineImpl) Init() error {
 	for i := range e.extensionInitializer {
 		err = e.extensionInitializer[i](e)
 		if err != nil {
+			e.mu.Lock()
+			e.postInvokeHooks = e.postInvokeHooks[:preInitHookCount]
+			e.mu.Unlock()
 			return err
 		}
 	}

--- a/pkg/workflow/engineimpl.go
+++ b/pkg/workflow/engineimpl.go
@@ -409,7 +409,7 @@ func (e *EngineImpl) Invoke(
 	}
 
 	if !options.nested {
-		e.firePostInvokeHooks(hookCtx, id, output, err, options.ic)
+		e.firePostInvokeHooks(hookCtx, id, output, err, options.ic, options.config)
 	}
 
 	if callbackPanic != nil {
@@ -419,7 +419,7 @@ func (e *EngineImpl) Invoke(
 	return output, err
 }
 
-func (e *EngineImpl) firePostInvokeHooks(ctx context.Context, id Identifier, invokeOutput []Data, invokeErr error, ic analytics.InstrumentationCollector) {
+func (e *EngineImpl) firePostInvokeHooks(ctx context.Context, id Identifier, invokeOutput []Data, invokeErr error, ic analytics.InstrumentationCollector, cfg configuration.Configuration) {
 	e.mu.RLock()
 	if len(e.postInvokeHooks) == 0 {
 		e.mu.RUnlock()
@@ -436,7 +436,13 @@ func (e *EngineImpl) firePostInvokeHooks(ctx context.Context, id Identifier, inv
 	}
 	hookEngine := &engineWrapper{WrappedEngine: e, defaultCtxFunc: func() context.Context { return ctx }, defaultInstrumentationCollector: ic}
 
-	hookTimeout := e.config.GetDuration(configuration.POST_INVOKE_HOOK_TIMEOUT)
+	// Use per-invocation config if provided, otherwise fall back to engine-wide config
+	resolvedCfg := cfg
+	if resolvedCfg == nil {
+		resolvedCfg = e.config
+	}
+
+	hookTimeout := resolvedCfg.GetDuration(configuration.POST_INVOKE_HOOK_TIMEOUT)
 	if hookTimeout <= 0 {
 		hookTimeout = 5 * time.Second
 	}

--- a/pkg/workflow/engineimpl.go
+++ b/pkg/workflow/engineimpl.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"runtime/debug"
 	"strings"
 	"sync"
 
@@ -33,6 +34,7 @@ type EngineImpl struct {
 
 	mu                sync.RWMutex
 	invocationCounter int
+	postInvokeHooks   []PostInvokeHook
 }
 
 var _ Engine = (*EngineImpl)(nil)
@@ -42,6 +44,7 @@ type engineRuntimeConfig struct {
 	input   []Data
 	ic      analytics.InstrumentationCollector
 	ctxFunc func() context.Context
+	nested  bool
 }
 
 type EngineInvokeOption func(*engineRuntimeConfig)
@@ -70,6 +73,25 @@ func WithContext(ctx context.Context) EngineInvokeOption {
 			e.ctxFunc = func() context.Context { return ctx }
 		}
 	}
+}
+
+func withNested() EngineInvokeOption {
+	return func(e *engineRuntimeConfig) {
+		e.nested = true
+	}
+}
+
+type postInvokeContextImpl struct {
+	workflowID Identifier
+	err        error
+}
+
+func (p *postInvokeContextImpl) GetWorkflowIdentifier() Identifier {
+	return p.workflowID
+}
+
+func (p *postInvokeContextImpl) GetError() error {
+	return p.err
 }
 
 func (e *EngineImpl) GetLogger() *zerolog.Logger {
@@ -174,7 +196,9 @@ func (e *EngineImpl) Init() error {
 	}
 
 	if err == nil {
+		e.mu.Lock()
 		e.initialized = true
+		e.mu.Unlock()
 	}
 
 	return err
@@ -283,10 +307,25 @@ func (e *EngineImpl) Invoke(
 ) ([]Data, error) {
 	var output []Data
 	var err error
+	var callbackPanic any
 
-	if !e.initialized {
+	e.mu.RLock()
+	initialized := e.initialized
+	e.mu.RUnlock()
+	if !initialized {
 		return output, fmt.Errorf("workflow must be initialized with init() before it can be invoked")
 	}
+
+	// Parse options once upfront.
+	options := engineRuntimeConfig{
+		ctxFunc: context.Background,
+		input:   []Data{},
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	hookCtx := options.ctxFunc()
 
 	workflow, ok := e.GetWorkflow(id)
 	if ok {
@@ -295,15 +334,9 @@ func (e *EngineImpl) Invoke(
 			e.mu.Lock()
 			e.invocationCounter++
 
-			// create default options
-			options := engineRuntimeConfig{
-				config: e.config.Clone(),
-				input:  []Data{},
-			}
-
-			// override default options based on optional parameters
-			for _, opt := range opts {
-				opt(&options)
+			// Apply defaults for options the caller didn't set.
+			if options.config == nil {
+				options.config = e.config.Clone()
 			}
 
 			// prepare logger
@@ -335,16 +368,60 @@ func (e *EngineImpl) Invoke(
 			// create a context object for the invocation
 			invocationCtx := newInvocationContext(options.ctxFunc, id, options.config, localEngine, localNetworkAccess, localLogger, localAnalytics, localUi)
 
-			// invoke workflow through its callback
+			// invoke workflow through its callback, recovering panics so hooks can observe them
 			localLogger.Printf("Workflow Start")
-			output, err = callback(invocationCtx, options.input)
+			func() {
+				defer func() {
+					callbackPanic = recover()
+				}()
+				output, err = callback(invocationCtx, options.input)
+			}()
 			localLogger.Printf("Workflow End")
+
+			if callbackPanic != nil {
+				err = fmt.Errorf("workflow callback panicked: %v", callbackPanic)
+			}
 		}
 	} else {
 		err = fmt.Errorf("workflow '%v' not found", id)
 	}
 
+	if !options.nested {
+		e.firePostInvokeHooks(hookCtx, id, err)
+	}
+
+	if callbackPanic != nil {
+		panic(callbackPanic)
+	}
+
 	return output, err
+}
+
+func (e *EngineImpl) firePostInvokeHooks(ctx context.Context, id Identifier, invokeErr error) {
+	e.mu.RLock()
+	if len(e.postInvokeHooks) == 0 {
+		e.mu.RUnlock()
+		return
+	}
+	hooks := make([]PostInvokeHook, len(e.postInvokeHooks))
+	copy(hooks, e.postInvokeHooks)
+	e.mu.RUnlock()
+
+	hctx := &postInvokeContextImpl{
+		workflowID: id,
+		err:        invokeErr,
+	}
+	hookEngine := &engineWrapper{WrappedEngine: e, defaultCtxFunc: func() context.Context { return ctx }}
+	for _, hook := range hooks {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					e.GetLogger().Error().Msgf("post-invoke hook panicked: %v\n%s", r, debug.Stack())
+				}
+			}()
+			hook(ctx, hookEngine, hctx)
+		}()
+	}
 }
 
 // GetAnalytics returns the analytics object.
@@ -365,6 +442,22 @@ func (e *EngineImpl) GetNetworkAccess() networking.NetworkAccess {
 // AddExtensionInitializer adds an extension initializer to the engine.
 func (e *EngineImpl) AddExtensionInitializer(initializer ExtensionInit) {
 	e.extensionInitializer = append(e.extensionInitializer, initializer)
+}
+
+// AddPostInvokeHook registers a hook that fires after each top-level Invoke completes.
+// Hooks fire in registration order and are skipped for nested (sub-workflow) invocations.
+// Hooks must be registered before or during Init; calls after Init return an error.
+func (e *EngineImpl) AddPostInvokeHook(hook PostInvokeHook) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.initialized {
+		return fmt.Errorf("AddPostInvokeHook called after Init")
+	}
+	if hook == nil {
+		return nil
+	}
+	e.postInvokeHooks = append(e.postInvokeHooks, hook)
+	return nil
 }
 
 // GetConfiguration returns the configuration object.

--- a/pkg/workflow/engineimpl.go
+++ b/pkg/workflow/engineimpl.go
@@ -8,6 +8,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -28,7 +29,7 @@ type EngineImpl struct {
 	config               configuration.Configuration
 	analytics            analytics.Analytics
 	networkAccess        networking.NetworkAccess
-	initialized          bool
+	initialized          atomic.Bool
 	logger               *zerolog.Logger
 	ui                   ui.UserInterface
 	runtimeInfo          runtimeinfo.RuntimeInfo
@@ -92,16 +93,21 @@ func withNested() EngineInvokeOption {
 	}
 }
 
-type postInvokeContextImpl struct {
+type invokeOutputImpl struct {
 	workflowID Identifier
+	output     []Data
 	err        error
 }
 
-func (p *postInvokeContextImpl) GetWorkflowIdentifier() Identifier {
+func (p *invokeOutputImpl) GetWorkflowIdentifier() Identifier {
 	return p.workflowID
 }
 
-func (p *postInvokeContextImpl) GetError() error {
+func (p *invokeOutputImpl) GetOutput() []Data {
+	return p.output
+}
+
+func (p *invokeOutputImpl) GetError() error {
 	return p.err
 }
 
@@ -173,7 +179,6 @@ func NewWorkFlowEngine(configuration configuration.Configuration) Engine {
 func NewDefaultWorkFlowEngine() Engine {
 	engine := &EngineImpl{
 		workflows:            make(map[string]Entry),
-		initialized:          false,
 		extensionInitializer: make([]ExtensionInit, 0),
 		invocationCounter:    0,
 		logger:               &zlog.Logger,
@@ -207,9 +212,7 @@ func (e *EngineImpl) Init() error {
 	}
 
 	if err == nil {
-		e.mu.Lock()
-		e.initialized = true
-		e.mu.Unlock()
+		e.initialized.Store(true)
 	}
 
 	return err
@@ -321,10 +324,7 @@ func (e *EngineImpl) Invoke(
 	var callbackPanic any
 	var callbackPanicStack []byte
 
-	e.mu.RLock()
-	initialized := e.initialized
-	e.mu.RUnlock()
-	if !initialized {
+	if !e.initialized.Load() {
 		return output, fmt.Errorf("workflow must be initialized with init() before it can be invoked")
 	}
 
@@ -407,7 +407,7 @@ func (e *EngineImpl) Invoke(
 	}
 
 	if !options.nested {
-		e.firePostInvokeHooks(hookCtx, id, err, options.ic)
+		e.firePostInvokeHooks(hookCtx, id, output, err, options.ic)
 	}
 
 	if callbackPanic != nil {
@@ -419,7 +419,7 @@ func (e *EngineImpl) Invoke(
 
 var postInvokeHookTimeout = 5 * time.Second
 
-func (e *EngineImpl) firePostInvokeHooks(ctx context.Context, id Identifier, invokeErr error, ic analytics.InstrumentationCollector) {
+func (e *EngineImpl) firePostInvokeHooks(ctx context.Context, id Identifier, invokeOutput []Data, invokeErr error, ic analytics.InstrumentationCollector) {
 	e.mu.RLock()
 	if len(e.postInvokeHooks) == 0 {
 		e.mu.RUnlock()
@@ -429,8 +429,9 @@ func (e *EngineImpl) firePostInvokeHooks(ctx context.Context, id Identifier, inv
 	copy(hooks, e.postInvokeHooks)
 	e.mu.RUnlock()
 
-	hctx := &postInvokeContextImpl{
+	result := &invokeOutputImpl{
 		workflowID: id,
+		output:     invokeOutput,
 		err:        invokeErr,
 	}
 	hookEngine := &engineWrapper{WrappedEngine: e, defaultCtxFunc: func() context.Context { return ctx }, defaultInstrumentationCollector: ic}
@@ -448,7 +449,7 @@ func (e *EngineImpl) firePostInvokeHooks(ctx context.Context, id Identifier, inv
 					e.GetLogger().Error().Msgf("post-invoke hook panicked: %v\n%s", r, debug.Stack())
 				}
 			}()
-			hook(hookCtx, hookEngine, hctx)
+			hook(hookCtx, hookEngine, result)
 		}()
 	}
 
@@ -489,14 +490,14 @@ func (e *EngineImpl) AddExtensionInitializer(initializer ExtensionInit) {
 // Hooks fire in registration order and are skipped for nested (sub-workflow) invocations.
 // Hooks must be registered before or during Init; calls after Init return an error.
 func (e *EngineImpl) AddPostInvokeHook(hook PostInvokeHook) error {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	if e.initialized {
+	if e.initialized.Load() {
 		return fmt.Errorf("AddPostInvokeHook called after Init")
 	}
 	if hook == nil {
 		return nil
 	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	e.postInvokeHooks = append(e.postInvokeHooks, hook)
 	return nil
 }

--- a/pkg/workflow/engineimpl.go
+++ b/pkg/workflow/engineimpl.go
@@ -212,7 +212,9 @@ func (e *EngineImpl) Init() error {
 	}
 
 	if err == nil {
+		e.mu.Lock()
 		e.initialized.Store(true)
+		e.mu.Unlock()
 	}
 
 	return err
@@ -417,8 +419,6 @@ func (e *EngineImpl) Invoke(
 	return output, err
 }
 
-var postInvokeHookTimeout = 5 * time.Second
-
 func (e *EngineImpl) firePostInvokeHooks(ctx context.Context, id Identifier, invokeOutput []Data, invokeErr error, ic analytics.InstrumentationCollector) {
 	e.mu.RLock()
 	if len(e.postInvokeHooks) == 0 {
@@ -436,14 +436,23 @@ func (e *EngineImpl) firePostInvokeHooks(ctx context.Context, id Identifier, inv
 	}
 	hookEngine := &engineWrapper{WrappedEngine: e, defaultCtxFunc: func() context.Context { return ctx }, defaultInstrumentationCollector: ic}
 
-	hookCtx, cancel := context.WithTimeout(ctx, postInvokeHookTimeout)
+	hookTimeout := e.config.GetDuration(configuration.POST_INVOKE_HOOK_TIMEOUT)
+	if hookTimeout <= 0 {
+		hookTimeout = 5 * time.Second
+	}
+
+	hookCtx, cancel := context.WithTimeout(ctx, hookTimeout)
 	defer cancel()
 
 	var wg sync.WaitGroup
+	var completedCount atomic.Int32
 	for _, hook := range hooks {
 		wg.Add(1)
 		go func() {
-			defer wg.Done()
+			defer func() {
+				completedCount.Add(1)
+				wg.Done()
+			}()
 			defer func() {
 				if r := recover(); r != nil {
 					e.GetLogger().Error().Msgf("post-invoke hook panicked: %v\n%s", r, debug.Stack())
@@ -462,7 +471,8 @@ func (e *EngineImpl) firePostInvokeHooks(ctx context.Context, id Identifier, inv
 	select {
 	case <-done:
 	case <-hookCtx.Done():
-		e.GetLogger().Warn().Msgf("post-invoke hooks timed out after %s", postInvokeHookTimeout)
+		stillRunning := len(hooks) - int(completedCount.Load())
+		e.GetLogger().Warn().Msgf("post-invoke hooks timed out after %s (%d still running)", hookTimeout, stillRunning)
 	}
 }
 
@@ -490,14 +500,14 @@ func (e *EngineImpl) AddExtensionInitializer(initializer ExtensionInit) {
 // Hooks fire in registration order and are skipped for nested (sub-workflow) invocations.
 // Hooks must be registered before or during Init; calls after Init return an error.
 func (e *EngineImpl) AddPostInvokeHook(hook PostInvokeHook) error {
-	if e.initialized.Load() {
-		return fmt.Errorf("AddPostInvokeHook called after Init")
-	}
 	if hook == nil {
 		return nil
 	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	if e.initialized.Load() {
+		return fmt.Errorf("AddPostInvokeHook called after Init")
+	}
 	e.postInvokeHooks = append(e.postInvokeHooks, hook)
 	return nil
 }

--- a/pkg/workflow/engineimpl.go
+++ b/pkg/workflow/engineimpl.go
@@ -39,6 +39,16 @@ type EngineImpl struct {
 }
 
 var _ Engine = (*EngineImpl)(nil)
+var _ PostInvokeHookRegistrar = (*EngineImpl)(nil)
+
+// AddPostInvokeHook registers a hook on the given engine if it supports post-invoke hooks.
+// This is the preferred way to register hooks — it handles the type assertion internally.
+func AddPostInvokeHook(engine Engine, hook PostInvokeHook) error {
+	if registrar, ok := engine.(PostInvokeHookRegistrar); ok {
+		return registrar.AddPostInvokeHook(hook)
+	}
+	return fmt.Errorf("engine does not support post-invoke hooks")
+}
 
 type engineRuntimeConfig struct {
 	config  configuration.Configuration

--- a/pkg/workflow/engineimpl.go
+++ b/pkg/workflow/engineimpl.go
@@ -438,7 +438,6 @@ func (e *EngineImpl) firePostInvokeHooks(ctx context.Context, id Identifier, inv
 		output:     invokeOutput,
 		err:        invokeErr,
 	}
-	hookEngine := &engineWrapper{WrappedEngine: e, defaultCtxFunc: func() context.Context { return ctx }, defaultInstrumentationCollector: ic}
 
 	// Use per-invocation config if provided, otherwise fall back to engine-wide config
 	resolvedCfg := cfg
@@ -451,8 +450,11 @@ func (e *EngineImpl) firePostInvokeHooks(ctx context.Context, id Identifier, inv
 		hookTimeout = 5 * time.Second
 	}
 
-	hookCtx, cancel := context.WithTimeout(ctx, hookTimeout)
+	boundedHookCtx, cancel := context.WithTimeout(ctx, hookTimeout)
 	defer cancel()
+
+	// Nested invocations made through hookEngine must be bound by the same timeout.
+	hookEngine := &engineWrapper{WrappedEngine: e, defaultCtxFunc: func() context.Context { return boundedHookCtx }, defaultInstrumentationCollector: ic}
 
 	var wg sync.WaitGroup
 	var completedCount atomic.Int32
@@ -468,7 +470,7 @@ func (e *EngineImpl) firePostInvokeHooks(ctx context.Context, id Identifier, inv
 					e.GetLogger().Error().Msgf("post-invoke hook panicked: %v\n%s", r, debug.Stack())
 				}
 			}()
-			hook(hookCtx, hookEngine, result)
+			hook(boundedHookCtx, hookEngine, result)
 		}()
 	}
 
@@ -480,7 +482,7 @@ func (e *EngineImpl) firePostInvokeHooks(ctx context.Context, id Identifier, inv
 
 	select {
 	case <-done:
-	case <-hookCtx.Done():
+	case <-boundedHookCtx.Done():
 		stillRunning := len(hooks) - int(completedCount.Load())
 		e.GetLogger().Warn().Msgf("post-invoke hooks timed out after %s (%d still running)", hookTimeout, stillRunning)
 	}

--- a/pkg/workflow/engineimpl.go
+++ b/pkg/workflow/engineimpl.go
@@ -8,6 +8,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/rs/zerolog"
 	zlog "github.com/rs/zerolog/log"
@@ -308,6 +309,7 @@ func (e *EngineImpl) Invoke(
 	var output []Data
 	var err error
 	var callbackPanic any
+	var callbackPanicStack []byte
 
 	e.mu.RLock()
 	initialized := e.initialized
@@ -372,14 +374,22 @@ func (e *EngineImpl) Invoke(
 			localLogger.Printf("Workflow Start")
 			func() {
 				defer func() {
-					callbackPanic = recover()
+					if r := recover(); r != nil {
+						callbackPanic = r
+						callbackPanicStack = debug.Stack()
+					}
 				}()
 				output, err = callback(invocationCtx, options.input)
 			}()
 			localLogger.Printf("Workflow End")
 
 			if callbackPanic != nil {
-				err = fmt.Errorf("workflow callback panicked: %v", callbackPanic)
+				localLogger.Printf("Workflow callback panicked: %v\n%s", callbackPanic, callbackPanicStack)
+				if panicErr, ok := callbackPanic.(error); ok {
+					err = fmt.Errorf("workflow callback panicked: %w", panicErr)
+				} else {
+					err = fmt.Errorf("workflow callback panicked: %v", callbackPanic)
+				}
 			}
 		}
 	} else {
@@ -387,7 +397,7 @@ func (e *EngineImpl) Invoke(
 	}
 
 	if !options.nested {
-		e.firePostInvokeHooks(hookCtx, id, err)
+		e.firePostInvokeHooks(hookCtx, id, err, options.ic)
 	}
 
 	if callbackPanic != nil {
@@ -397,7 +407,9 @@ func (e *EngineImpl) Invoke(
 	return output, err
 }
 
-func (e *EngineImpl) firePostInvokeHooks(ctx context.Context, id Identifier, invokeErr error) {
+var postInvokeHookTimeout = 5 * time.Second
+
+func (e *EngineImpl) firePostInvokeHooks(ctx context.Context, id Identifier, invokeErr error, ic analytics.InstrumentationCollector) {
 	e.mu.RLock()
 	if len(e.postInvokeHooks) == 0 {
 		e.mu.RUnlock()
@@ -411,16 +423,35 @@ func (e *EngineImpl) firePostInvokeHooks(ctx context.Context, id Identifier, inv
 		workflowID: id,
 		err:        invokeErr,
 	}
-	hookEngine := &engineWrapper{WrappedEngine: e, defaultCtxFunc: func() context.Context { return ctx }}
+	hookEngine := &engineWrapper{WrappedEngine: e, defaultCtxFunc: func() context.Context { return ctx }, defaultInstrumentationCollector: ic}
+
+	hookCtx, cancel := context.WithTimeout(ctx, postInvokeHookTimeout)
+	defer cancel()
+
+	var wg sync.WaitGroup
 	for _, hook := range hooks {
-		func() {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
 			defer func() {
 				if r := recover(); r != nil {
 					e.GetLogger().Error().Msgf("post-invoke hook panicked: %v\n%s", r, debug.Stack())
 				}
 			}()
-			hook(ctx, hookEngine, hctx)
+			hook(hookCtx, hookEngine, hctx)
 		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-hookCtx.Done():
+		e.GetLogger().Warn().Msgf("post-invoke hooks timed out after %s", postInvokeHookTimeout)
 	}
 }
 

--- a/pkg/workflow/enginewrapper.go
+++ b/pkg/workflow/enginewrapper.go
@@ -125,4 +125,3 @@ func (e *engineWrapper) GetRuntimeInfo() runtimeinfo.RuntimeInfo {
 func (e *engineWrapper) SetRuntimeInfo(ri runtimeinfo.RuntimeInfo) {
 	e.WrappedEngine.SetRuntimeInfo(ri)
 }
-

--- a/pkg/workflow/enginewrapper.go
+++ b/pkg/workflow/enginewrapper.go
@@ -43,7 +43,10 @@ func (e *engineWrapper) GetWorkflow(id Identifier) (Entry, bool) {
 }
 
 // Invoke invokes the workflow with the given identifier.
+// Calls through the wrapper are marked as nested so post-invoke hooks are skipped.
 func (e *engineWrapper) Invoke(id Identifier, opts ...EngineInvokeOption) ([]Data, error) {
+	opts = append([]EngineInvokeOption{withNested()}, opts...)
+
 	options := &engineRuntimeConfig{}
 	for _, opt := range opts {
 		opt(options)
@@ -121,4 +124,11 @@ func (e *engineWrapper) GetRuntimeInfo() runtimeinfo.RuntimeInfo {
 
 func (e *engineWrapper) SetRuntimeInfo(ri runtimeinfo.RuntimeInfo) {
 	e.WrappedEngine.SetRuntimeInfo(ri)
+}
+
+// AddPostInvokeHook delegates to the wrapped engine. Because wrappers are only created after
+// Init, this will always return an error — hooks must be registered before Init via the
+// concrete engine or the WithPostInvokeHooks app option.
+func (e *engineWrapper) AddPostInvokeHook(hook PostInvokeHook) error {
+	return e.WrappedEngine.AddPostInvokeHook(hook)
 }

--- a/pkg/workflow/enginewrapper.go
+++ b/pkg/workflow/enginewrapper.go
@@ -126,9 +126,3 @@ func (e *engineWrapper) SetRuntimeInfo(ri runtimeinfo.RuntimeInfo) {
 	e.WrappedEngine.SetRuntimeInfo(ri)
 }
 
-// AddPostInvokeHook delegates to the wrapped engine. Because wrappers are only created after
-// Init, this will always return an error — hooks must be registered before Init via the
-// concrete engine or the WithPostInvokeHooks app option.
-func (e *engineWrapper) AddPostInvokeHook(hook PostInvokeHook) error {
-	return e.WrappedEngine.AddPostInvokeHook(hook)
-}

--- a/pkg/workflow/enginewrapper_test.go
+++ b/pkg/workflow/enginewrapper_test.go
@@ -85,7 +85,7 @@ func Test_EngineWrapper_HookRecursionGuard(t *testing.T) {
 	assert.NoError(t, err)
 
 	hookCallCount := 0
-	err = AddPostInvokeHook(engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+	err = AddPostInvokeHook(engine, func(ctx context.Context, eng Engine, output InvokeOutput) {
 		hookCallCount++
 		_, invokeErr := eng.Invoke(reportWfId)
 		assert.NoError(t, invokeErr)

--- a/pkg/workflow/enginewrapper_test.go
+++ b/pkg/workflow/enginewrapper_test.go
@@ -85,7 +85,7 @@ func Test_EngineWrapper_HookRecursionGuard(t *testing.T) {
 	assert.NoError(t, err)
 
 	hookCallCount := 0
-	err = engine.AddPostInvokeHook(func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+	err = AddPostInvokeHook(engine, func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
 		hookCallCount++
 		_, invokeErr := eng.Invoke(reportWfId)
 		assert.NoError(t, invokeErr)
@@ -100,40 +100,6 @@ func Test_EngineWrapper_HookRecursionGuard(t *testing.T) {
 
 	assert.Equal(t, 1, hookCallCount, "hook should fire exactly once, not recursively")
 	assert.Equal(t, 1, reportCallCount, "report workflow should be invoked once from the hook")
-}
-
-func Test_EngineWrapper_NestedInvocationsSkipHooks(t *testing.T) {
-	engine := NewWorkFlowEngine(configuration.NewWithOpts())
-
-	outerWfId := NewWorkflowIdentifier("wrapper-outer")
-	innerWfId := NewWorkflowIdentifier("wrapper-inner")
-	noOpWorkflowOptions := ConfigurationOptionsFromFlagset(pflag.NewFlagSet("", pflag.ContinueOnError))
-
-	_, err := engine.Register(innerWfId, noOpWorkflowOptions, func(invocation InvocationContext, input []Data) ([]Data, error) {
-		return nil, nil
-	})
-	assert.NoError(t, err)
-
-	_, err = engine.Register(outerWfId, noOpWorkflowOptions, func(invocation InvocationContext, input []Data) ([]Data, error) {
-		// This goes through the engineWrapper, which prepends withNested()
-		return invocation.GetEngine().Invoke(innerWfId)
-	})
-	assert.NoError(t, err)
-
-	var hookedIDs []string
-	err = engine.AddPostInvokeHook(func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
-		hookedIDs = append(hookedIDs, hctx.GetWorkflowIdentifier().String())
-	})
-	assert.NoError(t, err)
-
-	err = engine.Init()
-	assert.NoError(t, err)
-
-	_, err = engine.Invoke(outerWfId)
-	assert.NoError(t, err)
-
-	assert.Equal(t, 1, len(hookedIDs), "only the top-level invocation should trigger the hook")
-	assert.Equal(t, outerWfId.String(), hookedIDs[0])
 }
 
 func Test_EngineWrapper_Accessors(t *testing.T) {

--- a/pkg/workflow/enginewrapper_test.go
+++ b/pkg/workflow/enginewrapper_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -62,6 +63,77 @@ func Test_EngineWrapper_Invoke(t *testing.T) {
 	for i := range counter {
 		assert.Equal(t, float64(i), extension[fmt.Sprintf("test1::%d", i)])
 	}
+}
+
+func Test_EngineWrapper_HookRecursionGuard(t *testing.T) {
+	engine := NewWorkFlowEngine(configuration.NewWithOpts())
+
+	reportWfId := NewWorkflowIdentifier("report")
+	outerWfId := NewWorkflowIdentifier("outer")
+	noOpWorkflowOptions := ConfigurationOptionsFromFlagset(pflag.NewFlagSet("", pflag.ContinueOnError))
+
+	reportCallCount := 0
+	_, err := engine.Register(reportWfId, noOpWorkflowOptions, func(invocation InvocationContext, input []Data) ([]Data, error) {
+		reportCallCount++
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	_, err = engine.Register(outerWfId, noOpWorkflowOptions, func(invocation InvocationContext, input []Data) ([]Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	hookCallCount := 0
+	err = engine.AddPostInvokeHook(func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		hookCallCount++
+		_, invokeErr := eng.Invoke(reportWfId)
+		assert.NoError(t, invokeErr)
+	})
+	assert.NoError(t, err)
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	_, err = engine.Invoke(outerWfId)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, hookCallCount, "hook should fire exactly once, not recursively")
+	assert.Equal(t, 1, reportCallCount, "report workflow should be invoked once from the hook")
+}
+
+func Test_EngineWrapper_NestedInvocationsSkipHooks(t *testing.T) {
+	engine := NewWorkFlowEngine(configuration.NewWithOpts())
+
+	outerWfId := NewWorkflowIdentifier("wrapper-outer")
+	innerWfId := NewWorkflowIdentifier("wrapper-inner")
+	noOpWorkflowOptions := ConfigurationOptionsFromFlagset(pflag.NewFlagSet("", pflag.ContinueOnError))
+
+	_, err := engine.Register(innerWfId, noOpWorkflowOptions, func(invocation InvocationContext, input []Data) ([]Data, error) {
+		return nil, nil
+	})
+	assert.NoError(t, err)
+
+	_, err = engine.Register(outerWfId, noOpWorkflowOptions, func(invocation InvocationContext, input []Data) ([]Data, error) {
+		// This goes through the engineWrapper, which prepends withNested()
+		return invocation.GetEngine().Invoke(innerWfId)
+	})
+	assert.NoError(t, err)
+
+	var hookedIDs []string
+	err = engine.AddPostInvokeHook(func(ctx context.Context, eng Engine, hctx PostInvokeContext) {
+		hookedIDs = append(hookedIDs, hctx.GetWorkflowIdentifier().String())
+	})
+	assert.NoError(t, err)
+
+	err = engine.Init()
+	assert.NoError(t, err)
+
+	_, err = engine.Invoke(outerWfId)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(hookedIDs), "only the top-level invocation should trigger the hook")
+	assert.Equal(t, outerWfId.String(), hookedIDs[0])
 }
 
 func Test_EngineWrapper_Accessors(t *testing.T) {

--- a/pkg/workflow/types.go
+++ b/pkg/workflow/types.go
@@ -135,6 +135,10 @@ type Engine interface {
 	SetUserInterface(ui ui.UserInterface)
 	GetRuntimeInfo() runtimeinfo.RuntimeInfo
 	SetRuntimeInfo(ri runtimeinfo.RuntimeInfo)
+}
 
+// PostInvokeHookRegistrar is implemented by engines that support post-invoke hooks.
+// Use the package-level AddPostInvokeHook helper instead of type-asserting manually.
+type PostInvokeHookRegistrar interface {
 	AddPostInvokeHook(hook PostInvokeHook) error
 }

--- a/pkg/workflow/types.go
+++ b/pkg/workflow/types.go
@@ -24,21 +24,25 @@ type Callback func(invocation InvocationContext, input []Data) ([]Data, error)
 type ExtensionInit func(engine Engine) error
 
 // PostInvokeContext provides read access to the result of a top-level Invoke call.
+// Hooks fire globally for every top-level Invoke, so GetError may return an error originating
+// from any registered workflow — not necessarily one the hook "owns."
 type PostInvokeContext interface {
 	GetWorkflowIdentifier() Identifier
 	GetError() error
 }
 
 // PostInvokeHook is called once per top-level Invoke call, after the workflow callback returns
-// (including when the workflow is not found). Hooks fire in registration order. Nested invocations
-// (sub-workflow calls within an invocation chain) do not trigger hooks.
+// (including when the workflow is not found). Nested invocations (sub-workflow calls within an
+// invocation chain) do not trigger hooks.
+//
+// All registered hooks run concurrently in separate goroutines with a shared timeout-bounded
+// context. Invoke returns once every hook completes or the timeout expires; timed-out hooks are
+// logged and their goroutines are left to drain.
 //
 // The engine parameter passed to the hook is scoped so that any Invoke calls from within the hook
 // are treated as nested and will not re-trigger hooks. WARNING: this recursion guard is
 // convention-based — hooks must use the provided engine parameter for invocations. A hook that
 // captures and calls the original *EngineImpl directly will bypass the guard.
-//
-// Hooks run synchronously and inline — implementations should avoid blocking or expensive work.
 type PostInvokeHook func(ctx context.Context, engine Engine, hctx PostInvokeContext)
 
 // interfaces

--- a/pkg/workflow/types.go
+++ b/pkg/workflow/types.go
@@ -47,9 +47,11 @@ type InvokeOutput interface {
 // caller after Invoke has returned (a real hazard, verified with the Go race detector).
 //
 // The engine parameter passed to the hook is scoped so that any Invoke calls from within the hook
-// are treated as nested and will not re-trigger hooks. WARNING: this recursion guard is
-// convention-based — hooks must use the provided engine parameter for invocations. A hook that
-// captures and calls the original *EngineImpl directly will bypass the guard.
+// are treated as nested and will not re-trigger hooks. Nested invocations are also bound by the
+// hook's timeout: if a nested Invoke is in progress when the timeout fires, its context will be
+// canceled. WARNING: this recursion guard is convention-based — hooks must use the provided
+// engine parameter for invocations. A hook that captures and calls the original *EngineImpl directly
+// will bypass the guard.
 type PostInvokeHook func(ctx context.Context, engine Engine, output InvokeOutput)
 
 // interfaces

--- a/pkg/workflow/types.go
+++ b/pkg/workflow/types.go
@@ -23,11 +23,12 @@ type Identifier = *url.URL
 type Callback func(invocation InvocationContext, input []Data) ([]Data, error)
 type ExtensionInit func(engine Engine) error
 
-// PostInvokeContext provides read access to the result of a top-level Invoke call.
+// InvokeOutput provides read access to the result of a top-level Invoke call.
 // Hooks fire globally for every top-level Invoke, so GetError may return an error originating
 // from any registered workflow — not necessarily one the hook "owns."
-type PostInvokeContext interface {
+type InvokeOutput interface {
 	GetWorkflowIdentifier() Identifier
+	GetOutput() []Data
 	GetError() error
 }
 
@@ -43,7 +44,7 @@ type PostInvokeContext interface {
 // are treated as nested and will not re-trigger hooks. WARNING: this recursion guard is
 // convention-based — hooks must use the provided engine parameter for invocations. A hook that
 // captures and calls the original *EngineImpl directly will bypass the guard.
-type PostInvokeHook func(ctx context.Context, engine Engine, hctx PostInvokeContext)
+type PostInvokeHook func(ctx context.Context, engine Engine, output InvokeOutput)
 
 // interfaces
 

--- a/pkg/workflow/types.go
+++ b/pkg/workflow/types.go
@@ -23,6 +23,24 @@ type Identifier = *url.URL
 type Callback func(invocation InvocationContext, input []Data) ([]Data, error)
 type ExtensionInit func(engine Engine) error
 
+// PostInvokeContext provides read access to the result of a top-level Invoke call.
+type PostInvokeContext interface {
+	GetWorkflowIdentifier() Identifier
+	GetError() error
+}
+
+// PostInvokeHook is called once per top-level Invoke call, after the workflow callback returns
+// (including when the workflow is not found). Hooks fire in registration order. Nested invocations
+// (sub-workflow calls within an invocation chain) do not trigger hooks.
+//
+// The engine parameter passed to the hook is scoped so that any Invoke calls from within the hook
+// are treated as nested and will not re-trigger hooks. WARNING: this recursion guard is
+// convention-based — hooks must use the provided engine parameter for invocations. A hook that
+// captures and calls the original *EngineImpl directly will bypass the guard.
+//
+// Hooks run synchronously and inline — implementations should avoid blocking or expensive work.
+type PostInvokeHook func(ctx context.Context, engine Engine, hctx PostInvokeContext)
+
 // interfaces
 
 // Data is an interface that wraps the methods that are used to manage data that is passed between workflows.
@@ -113,4 +131,6 @@ type Engine interface {
 	SetUserInterface(ui ui.UserInterface)
 	GetRuntimeInfo() runtimeinfo.RuntimeInfo
 	SetRuntimeInfo(ri runtimeinfo.RuntimeInfo)
+
+	AddPostInvokeHook(hook PostInvokeHook) error
 }

--- a/pkg/workflow/types.go
+++ b/pkg/workflow/types.go
@@ -36,9 +36,15 @@ type InvokeOutput interface {
 // (including when the workflow is not found). Nested invocations (sub-workflow calls within an
 // invocation chain) do not trigger hooks.
 //
-// All registered hooks run concurrently in separate goroutines with a shared timeout-bounded
-// context. Invoke returns once every hook completes or the timeout expires; timed-out hooks are
-// logged and their goroutines are left to drain.
+// All hooks run concurrently in separate goroutines under a shared timeout-bounded context.
+// Invoke returns once every hook completes or the timeout expires. If a hook exceeds the timeout
+// it is ABANDONED: Invoke returns and the hook keeps running in the background. The timeout
+// warning reports how many hooks were still running when it fired.
+//
+// The timeout is configurable via configuration.POST_INVOKE_HOOK_TIMEOUT and defaults to 5 seconds.
+// Hooks MUST honor ctx.Done() and return promptly when it fires. A hook MUST NOT write to
+// caller-owned state without its own synchronization, because a timed-out hook can race with the
+// caller after Invoke has returned (a real hazard, verified with the Go race detector).
 //
 // The engine parameter passed to the hook is scoped so that any Invoke calls from within the hook
 // are treated as nested and will not re-trigger hooks. WARNING: this recursion guard is


### PR DESCRIPTION
### **User description**
### Description

This PR introduces a capability to register and run post invoke hooks.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the central `Invoke` path (panic recovery, hook goroutines, timeout) so regressions could affect every workflow run; behavior is heavily tested and hooks are opt-in registration.
> 
> **Overview**
> Adds **post-invoke hooks** that run after each **top-level** `Engine.Invoke` completes, including when the workflow is missing or the callback returns an error.
> 
> Hooks receive an `InvokeOutput` (workflow id, data, error) and a scoped `Engine`. Registration is via `AddPostInvokeHook` / `PostInvokeHookRegistrar`, with `workflow.AddPostInvokeHook` and app `WithPostInvokeHooks`. Hooks must be registered before `Init`; late registration errors.
> 
> **Nested invokes** (sub-workflows via `engineWrapper` / `invocation.GetEngine()`) do not fire hooks; the wrapper injects `withNested()`. Hooks that invoke workflows through the **engine argument** stay nested and avoid recursion.
> 
> Hooks run **concurrently** with a shared **5s timeout** context; slow hooks are logged and `Invoke` does not wait indefinitely. Hook and callback **panics** are recovered so other hooks still run and panics surface as errors to hooks before the original panic is re-raised.
> 
> `initialized` on `EngineImpl` is now `atomic.Bool`. Mocks add `InvokeOutput` and `PostInvokeHookRegistrar`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c1f800b1923a2bc5bb67229b1e8046e4bcf3117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Implement post-invoke hooks for engine invocations.

- Support configurable timeouts for hook execution.

- Hooks observe workflow errors and panics.

- Prevent hook recursion on nested invocations.

- Add comprehensive test coverage for hook scenarios.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Engine -- Invoke --> InvokeFlow
  InvokeFlow -- Execute Workflow --> WorkflowCallback
  InvokeFlow -- Execute Hooks --> PostInvokeHooks
  PostInvokeHooks -- Run concurrently --> HookGoroutine
  HookGoroutine -- Use bounded context --> Timeout
  InvokeFlow -- Nested Invoke --> WorkflowCallback
  WorkflowCallback -- Marked as nested --> InvokeFlow
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>app_test.go</strong><dd><code>Add test for WithPostInvokeHooks option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/692/changes#diff-c7d8cc80ef42a7d06d8053179322063692c2714db211e9393be0114fd9744c7a">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>checker_test.go</strong><dd><code>Improve test isolation for proxy config detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/692/changes#diff-ad86dcc31ffc9bbd88cc245176bc772da6b990d43ca499b1791867df5699b989">+10/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>workflow.go</strong><dd><code>Add mocks for new hook interfaces and types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/692/changes#diff-6e0af9ea3e73b4c570fc2c77f02712aff0b2e6938a17ce7b30f304e74a28e9c5">+102/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>engine_test.go</strong><dd><code>Add extensive tests for post-invoke hook scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/692/changes#diff-95bcd88858f99e1bfecd015f2c3490e3072dbcb550ac8f7cb385b7462ae929cc">+647/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>enginewrapper_test.go</strong><dd><code>Test recursion guard for wrapper invokes and hooks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/692/changes#diff-b4c62ac50b5403409b842caee0e6aafaa7209fd8fdcd26e3d5d3b90f6ea9f690">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>options.go</strong><dd><code>Add option to register post-invoke hooks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/692/changes#diff-c14a7f72f3d031fc850d2f8152277d34d15799b85f62e6c3f373c414ee2f9570">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>constants.go</strong><dd><code>Add constant for post-invoke hook timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/692/changes#diff-b346bdeac320c8fe8bc31a635e59da3e8bf59c7c00ed11bf8cd6a17dccda15b7">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>engineimpl.go</strong><dd><code>Implement core post-invoke hook execution logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/692/changes#diff-672848374dc64d0b5059745d90ef50be714f0f3d9791ef4f6db7174eff68c460">+172/-15</a></td>

</tr>

<tr>
  <td><strong>enginewrapper.go</strong><dd><code>Mark wrapper invocations as nested to skip hooks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/692/changes#diff-257a344848a05745f3a436530bd590518d6d152863482bd00fbbda2cb85ecca0">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.go</strong><dd><code>Define types for post-invoke hooks and output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/692/changes#diff-b8e1f959a9e8f88281411ee05110927f078f04053a361262445df8b34865ad09">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

