### PR TITLE
chore(ci): do not tag on release branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'release/**'
 
 permissions: {}
 


### PR DESCRIPTION
### Description

There is an issue when tags are created on release branches, where the latest tag from main will be used to determine the next version number. This creates a bigger version jump as expected and creates a semver that not correctly expresses the version. As a stop gap, we disable this automation for release/* branches

### Checklist

- [ ] Tests added and all succeed (`make test`)
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger-only change; release tagging on `main` is unchanged.
> 
> **Overview**
> **Release automation now runs only on pushes to `main`**, not on `release/**` branches.
> 
> This avoids incorrect semver bumps when tags are created on release branches (the workflow was using the latest tag from `main` to compute the next version, causing oversized jumps and misleading version numbers). Tagging on release branches is disabled until that versioning behavior is fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60485aef287dcafde61701251aeb77d6e5797c7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->