### PR TITLE
fix!: allow-list env vars from workspace config files, read shell profile once [IDE-2136]

### DIFF
--- a/pkg/envvars/environment.go
+++ b/pkg/envvars/environment.go
@@ -26,8 +26,8 @@ const (
 var shellEnvOnce sync.Once
 
 // shellEnvLoader is the function invoked (at most once per process) by LoadConfiguredEnvironment to
-// read the user's shell environment. It is a variable, rather than a direct call, so tests can verify
-// it only ever runs once.
+// read the user's shell environment. It is a variable, rather than a direct call, so tests can
+// substitute a stub in place of spawning a real shell and verify call count/ordering.
 var shellEnvLoader = loadShellEnvironment
 
 // LoadConfiguredEnvironment updates the environment with user and local configuration.
@@ -87,22 +87,42 @@ func loadShellEnvironment() {
 // allowedEnvVarNames lists the exact environment variable names permitted to be set from a config file
 // loaded by loadFile. See isAllowedEnvVarName for the security rationale.
 var allowedEnvVarNames = map[string]bool{
-	PathEnvVarName:        true,
-	"JAVA_HOME":           true,
-	"HTTP_PROXY":          true,
-	"http_proxy":          true,
-	"HTTPS_PROXY":         true,
-	"https_proxy":         true,
-	"NO_PROXY":            true,
-	"no_proxy":            true,
-	"NODE_EXTRA_CA_CERTS": true,
-	"KRB5_CONFIG":         true,
-	"KRB5CCNAME":          true,
+	PathEnvVarName: true,
+	"Path":         true, // Windows conventionally spells this "Path" rather than "PATH"
+	"JAVA_HOME":    true,
+	"HTTP_PROXY":   true,
+	"http_proxy":   true,
+	"HTTPS_PROXY":  true,
+	"https_proxy":  true,
+	"ALL_PROXY":    true,
+	"all_proxy":    true,
+	"NO_PROXY":     true,
+	"no_proxy":     true,
 }
 
 // allowedEnvVarPrefixes lists environment variable name prefixes permitted to be set from a config
-// file loaded by loadFile, in addition to allowedEnvVarNames. See isAllowedEnvVarName.
+// file loaded by loadFile, in addition to allowedEnvVarNames, unless denied by
+// deniedSnykEnvVarNames/deniedSnykEnvVarPrefixes. See isAllowedEnvVarName.
 var allowedEnvVarPrefixes = []string{"SNYK_"}
+
+// deniedSnykEnvVarNames lists SNYK_-prefixed environment variable names that must never be set from a
+// workspace config file, even though the SNYK_ prefix is otherwise allowed. These directly control
+// authentication or API routing. See isAllowedEnvVarName for the full rationale.
+var deniedSnykEnvVarNames = map[string]bool{
+	"SNYK_TOKEN":             true,
+	"SNYK_OAUTH_TOKEN":       true,
+	"SNYK_DOCKER_TOKEN":      true,
+	"SNYK_API":               true,
+	"SNYK_REGISTRY_USERNAME": true,
+	"SNYK_REGISTRY_PASSWORD": true,
+}
+
+// deniedSnykEnvVarPrefixes lists SNYK_-prefixed environment variable name prefixes that must never be
+// set from a workspace config file. SNYK_CFG_<KEY> is bound by Configuration.AutomaticEnv to the
+// arbitrary config key <key> (lowercased), which includes (via alternative keys) authentication and
+// API routing - so unlike a fixed set of names, this whole family must be denied. See
+// isAllowedEnvVarName for the full rationale.
+var deniedSnykEnvVarPrefixes = []string{"SNYK_CFG_"}
 
 // isAllowedEnvVarName reports whether a variable read from a workspace config file (e.g. .snyk.env,
 // .envrc) may be applied to the process environment.
@@ -111,18 +131,38 @@ var allowedEnvVarPrefixes = []string{"SNYK_"}
 // variables. Previously any variable - including HOME - could be set this way; combined with
 // loadShellEnvironment spawning `bash --login` (which sources $HOME/.bash_profile), this allowed
 // arbitrary code execution (IDE-2136). Only variables genuinely needed by Snyk tooling (the SNYK_
-// prefix) or well-known variables required by common build/proxy tooling are allowed through. This is
-// a partial mitigation: some allowed variables (e.g. JAVA_HOME) could still be pointed at malicious
-// executables, but the direct HOME/shell-profile vector is closed.
+// prefix, minus the explicit exceptions below) or well-known variables required by common build/proxy
+// tooling are allowed through. This is a partial mitigation: some allowed variables (e.g. JAVA_HOME)
+// could still be pointed at malicious executables, but the direct HOME/shell-profile vector is closed.
+//
+// The SNYK_ prefix is not unconditionally safe: GAF's default Configuration binds any SNYK_-prefixed
+// environment variable directly to a config key of the same (lowercased) name (see
+// Configuration.AutomaticEnv), and SNYK_CFG_<KEY> is documented to override any config key, including
+// ones used for authentication (e.g. AUTHENTICATION_TOKEN) and API routing (e.g. API_URL). Allowing
+// those through would let a workspace config file substitute the user's credentials or redirect API
+// traffic to an attacker-controlled endpoint - a vulnerability of comparable severity to the one this
+// allow-list exists to close - so deniedSnykEnvVarNames/deniedSnykEnvVarPrefixes carve those back out.
 func isAllowedEnvVarName(name string) bool {
 	if allowedEnvVarNames[name] {
 		return true
 	}
 
 	for _, prefix := range allowedEnvVarPrefixes {
-		if strings.HasPrefix(name, prefix) {
-			return true
+		if !strings.HasPrefix(name, prefix) {
+			continue
 		}
+
+		if deniedSnykEnvVarNames[name] {
+			return false
+		}
+
+		for _, deniedPrefix := range deniedSnykEnvVarPrefixes {
+			if strings.HasPrefix(name, deniedPrefix) {
+				return false
+			}
+		}
+
+		return true
 	}
 
 	return false

--- a/pkg/envvars/environment.go
+++ b/pkg/envvars/environment.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/subosito/gotenv"
@@ -20,10 +21,46 @@ const (
 	ShellEnvVarName = "SHELL"
 )
 
+// shellEnvOnce guards loadShellEnvironment so the user's shell profile is only ever read once per
+// process. This is a deliberate security control, see loadShellEnvironment for details.
+var shellEnvOnce sync.Once
+
+// shellEnvLoader is the function invoked (at most once per process) by LoadConfiguredEnvironment to
+// read the user's shell environment. It is a variable, rather than a direct call, so tests can verify
+// it only ever runs once.
+var shellEnvLoader = loadShellEnvironment
+
 // LoadConfiguredEnvironment updates the environment with user and local configuration.
 // First Bash's env is read (as a fallback), then the user's preferred SHELL's env is read, then the configuration files.
 // The Bash env PATH is appended to the existing PATH (as a fallback), any other new PATH read is prepended (preferential).
+//
+// Security note: customConfigFiles are typically config files (e.g. .snyk.env, .envrc) found in a
+// (potentially untrusted) workspace. Only allow-listed variable names from those files are applied to
+// the process environment, see loadFile/isAllowedEnvVarName, and the shell profile is only ever read
+// once (before any config file is processed, and never again), see loadShellEnvironment. Both controls
+// exist to prevent a malicious config file from repointing HOME (or similar) to redirect a later shell
+// invocation into sourcing an attacker-controlled profile script.
 func LoadConfiguredEnvironment(customConfigFiles []string, workingDirectory string) {
+	shellEnvOnce.Do(shellEnvLoader)
+
+	// process config files
+	for _, file := range customConfigFiles {
+		if !filepath.IsAbs(file) {
+			file = filepath.Join(workingDirectory, file)
+		}
+		loadFile(file)
+	}
+}
+
+// loadShellEnvironment reads the user's shell environment (bash as a fallback, then their preferred
+// SHELL) via an interactive login shell, see getEnvFromShell, and applies it to the process environment.
+//
+// It must run before any (potentially untrusted) config file is loaded, and only once per process
+// (enforced by shellEnvOnce in LoadConfiguredEnvironment): once a config file has been loaded, HOME (or
+// other variables influencing shell startup) may have been changed by that file, and re-running this
+// would spawn `bash --login`, sourcing a profile from whatever HOME points to now instead of the real
+// user's profile - the root cause of the .snyk.env arbitrary code execution issue (IDE-2136).
+func loadShellEnvironment() {
 	bashOutput := getEnvFromShell("bash")
 
 	// this is applied at the end always, as it does not overwrite existing variables
@@ -45,24 +82,69 @@ func LoadConfiguredEnvironment(customConfigFiles []string, workingDirectory stri
 			UpdatePath(specificShellPATH, true)
 		}
 	}
-
-	// process config files
-	for _, file := range customConfigFiles {
-		if !filepath.IsAbs(file) {
-			file = filepath.Join(workingDirectory, file)
-		}
-		loadFile(file)
-	}
 }
 
+// allowedEnvVarNames lists the exact environment variable names permitted to be set from a config file
+// loaded by loadFile. See isAllowedEnvVarName for the security rationale.
+var allowedEnvVarNames = map[string]bool{
+	PathEnvVarName:        true,
+	"JAVA_HOME":           true,
+	"HTTP_PROXY":          true,
+	"http_proxy":          true,
+	"HTTPS_PROXY":         true,
+	"https_proxy":         true,
+	"NO_PROXY":            true,
+	"no_proxy":            true,
+	"NODE_EXTRA_CA_CERTS": true,
+	"KRB5_CONFIG":         true,
+	"KRB5CCNAME":          true,
+}
+
+// allowedEnvVarPrefixes lists environment variable name prefixes permitted to be set from a config
+// file loaded by loadFile, in addition to allowedEnvVarNames. See isAllowedEnvVarName.
+var allowedEnvVarPrefixes = []string{"SNYK_"}
+
+// isAllowedEnvVarName reports whether a variable read from a workspace config file (e.g. .snyk.env,
+// .envrc) may be applied to the process environment.
+//
+// Config files can live in an untrusted workspace directory, so they must not be able to set arbitrary
+// variables. Previously any variable - including HOME - could be set this way; combined with
+// loadShellEnvironment spawning `bash --login` (which sources $HOME/.bash_profile), this allowed
+// arbitrary code execution (IDE-2136). Only variables genuinely needed by Snyk tooling (the SNYK_
+// prefix) or well-known variables required by common build/proxy tooling are allowed through. This is
+// a partial mitigation: some allowed variables (e.g. JAVA_HOME) could still be pointed at malicious
+// executables, but the direct HOME/shell-profile vector is closed.
+func isAllowedEnvVarName(name string) bool {
+	if allowedEnvVarNames[name] {
+		return true
+	}
+
+	for _, prefix := range allowedEnvVarPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// loadFile applies allow-listed environment variables from a config file (e.g. .snyk.env, .envrc)
+// found in a (potentially untrusted) workspace directory. See isAllowedEnvVarName for which variables
+// are applied and why not all of them are.
 func loadFile(fileName string) {
 	// preserve path
 	previousPath := os.Getenv(PathEnvVarName)
 
-	// overwrite existing variables with file config
-	err := gotenv.OverLoad(fileName)
+	fileEnv, err := gotenv.Read(fileName)
 	if err != nil {
 		return
+	}
+
+	for key, value := range fileEnv {
+		if !isAllowedEnvVarName(key) {
+			continue
+		}
+		_ = os.Setenv(key, value)
 	}
 
 	// add previous path to the end of the new
@@ -86,6 +168,12 @@ var shellWhiteList = map[string]bool{
 	"/usr/bin/bash": true,
 }
 
+// getEnvFromShell spawns an interactive login shell to read the user's shell environment.
+//
+// Security note: `--login` causes the shell to source profile files (e.g. $HOME/.bash_profile) from
+// whatever HOME currently points to. Only call this before any untrusted config file has been loaded
+// into the process environment - see loadShellEnvironment - otherwise a poisoned HOME could redirect
+// this to an attacker-controlled profile script (IDE-2136).
 func getEnvFromShell(shell string) string {
 	// under windows, the shell environment is irrelevant
 	if runtime.GOOS == "windows" {

--- a/pkg/envvars/environment_test.go
+++ b/pkg/envvars/environment_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -125,6 +126,55 @@ func TestLoadFile(t *testing.T) {
 
 		require.Equal(t, uniqueEnvVar, os.Getenv(uniqueEnvVar))
 	})
+
+	t.Run("should not load HOME or other non-allow-listed variables from the config file", func(t *testing.T) {
+		dir := t.TempDir()
+		fileName := filepath.Join(dir, "env-file")
+
+		originalHome := os.Getenv("HOME")
+		t.Setenv("HOME", originalHome)
+
+		disallowedVar := "DISALLOWED_" + strconv.Itoa(rand.Int())
+		t.Setenv(disallowedVar, "")
+
+		contents := fmt.Sprintf("HOME=/tmp/evil-home\n%s=poisoned\n", disallowedVar)
+		require.NoError(t, os.WriteFile(fileName, []byte(contents), 0660))
+
+		loadFile(fileName)
+
+		require.Equal(t, originalHome, os.Getenv("HOME"), "HOME must not be overwritten by a config file")
+		require.Empty(t, os.Getenv(disallowedVar), "non-allow-listed variables must not be set from a config file")
+	})
+
+	t.Run("should load allow-listed variables other than SNYK_ prefixed ones", func(t *testing.T) {
+		dir := t.TempDir()
+		fileName := filepath.Join(dir, "env-file")
+
+		t.Setenv("JAVA_HOME", "")
+
+		contents := "JAVA_HOME=/opt/java\n"
+		require.NoError(t, os.WriteFile(fileName, []byte(contents), 0660))
+
+		loadFile(fileName)
+
+		require.Equal(t, "/opt/java", os.Getenv("JAVA_HOME"))
+	})
+}
+
+func TestIsAllowedEnvVarName(t *testing.T) {
+	allowed := []string{"PATH", "JAVA_HOME", "HTTP_PROXY", "https_proxy", "NO_PROXY", "SNYK_TOKEN", "SNYK_CFG_ORG"}
+	for _, name := range allowed {
+		t.Run(name+" is allowed", func(t *testing.T) {
+			require.True(t, isAllowedEnvVarName(name))
+		})
+	}
+
+	disallowed := []string{"HOME", "SHELL", "BASH_ENV", "ENV", "LD_PRELOAD", "RANDOM_VAR"}
+	for _, name := range disallowed {
+		t.Run(name+" is not allowed", func(t *testing.T) {
+			require.False(t, isAllowedEnvVarName(name))
+		})
+	}
 }
 
 func TestLoadConfiguredEnvironment(t *testing.T) {
@@ -149,11 +199,33 @@ func TestLoadConfiguredEnvironment(t *testing.T) {
 		err = os.Chdir(currentDir)
 		require.NoError(t, err)
 	})
+
+	t.Run("should only read the shell environment once, even across multiple calls", func(t *testing.T) {
+		originalLoader := shellEnvLoader
+		t.Cleanup(func() {
+			shellEnvOnce = sync.Once{}
+			shellEnvLoader = originalLoader
+		})
+		shellEnvOnce = sync.Once{}
+
+		var callCount int
+		shellEnvLoader = func() { callCount++ }
+
+		dir := t.TempDir()
+
+		LoadConfiguredEnvironment(nil, dir)
+		LoadConfiguredEnvironment(nil, dir)
+		LoadConfiguredEnvironment(nil, dir)
+
+		require.Equal(t, 1, callCount, "the shell environment must only be read once per process")
+	})
 }
 
+// setupTestFile writes a config file containing a single, uniquely-named, allow-listed (SNYK_-prefixed)
+// environment variable, and returns the variable name and the absolute path of the file written.
 func setupTestFile(t *testing.T, fileName string, dir string) (string, string) {
 	t.Helper()
-	uniqueEnvVar := strconv.Itoa(rand.Int())
+	uniqueEnvVar := "SNYK_TEST_" + strconv.Itoa(rand.Int())
 	t.Setenv(uniqueEnvVar, "")
 	absFileName := filepath.Join(dir, fileName)
 	varName := []byte(fmt.Sprintf("%s=%s\n", uniqueEnvVar, uniqueEnvVar))

--- a/pkg/envvars/environment_test.go
+++ b/pkg/envvars/environment_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"sync"
 	"testing"
@@ -146,7 +148,7 @@ func TestLoadFile(t *testing.T) {
 		require.Empty(t, os.Getenv(disallowedVar), "non-allow-listed variables must not be set from a config file")
 	})
 
-	t.Run("should load allow-listed variables other than SNYK_ prefixed ones", func(t *testing.T) {
+	t.Run("should load non-SNYK_-prefixed allow-listed variables (e.g. JAVA_HOME)", func(t *testing.T) {
 		dir := t.TempDir()
 		fileName := filepath.Join(dir, "env-file")
 
@@ -162,14 +164,19 @@ func TestLoadFile(t *testing.T) {
 }
 
 func TestIsAllowedEnvVarName(t *testing.T) {
-	allowed := []string{"PATH", "JAVA_HOME", "HTTP_PROXY", "https_proxy", "NO_PROXY", "SNYK_TOKEN", "SNYK_CFG_ORG"}
+	allowed := []string{"PATH", "Path", "JAVA_HOME", "HTTP_PROXY", "https_proxy", "ALL_PROXY", "NO_PROXY", "SNYK_LOG_LEVEL", "SNYK_INTEGRATION_NAME"}
 	for _, name := range allowed {
 		t.Run(name+" is allowed", func(t *testing.T) {
 			require.True(t, isAllowedEnvVarName(name))
 		})
 	}
 
-	disallowed := []string{"HOME", "SHELL", "BASH_ENV", "ENV", "LD_PRELOAD", "RANDOM_VAR"}
+	disallowed := []string{
+		"HOME", "SHELL", "BASH_ENV", "ENV", "LD_PRELOAD", "RANDOM_VAR",
+		// SNYK_-prefixed, but security-critical: must remain denied despite the SNYK_ prefix allow-list.
+		"SNYK_TOKEN", "SNYK_OAUTH_TOKEN", "SNYK_DOCKER_TOKEN", "SNYK_API",
+		"SNYK_REGISTRY_USERNAME", "SNYK_REGISTRY_PASSWORD", "SNYK_CFG_ORG", "SNYK_CFG_API",
+	}
 	for _, name := range disallowed {
 		t.Run(name+" is not allowed", func(t *testing.T) {
 			require.False(t, isAllowedEnvVarName(name))
@@ -203,7 +210,9 @@ func TestLoadConfiguredEnvironment(t *testing.T) {
 	t.Run("should only read the shell environment once, even across multiple calls", func(t *testing.T) {
 		originalLoader := shellEnvLoader
 		t.Cleanup(func() {
-			shellEnvOnce = sync.Once{}
+			// leave shellEnvOnce "consumed" (matching real single-process semantics), rather than reset
+			// to zero, so a later test in this package cannot unexpectedly spawn a real shell again.
+			shellEnvOnce.Do(func() {})
 			shellEnvLoader = originalLoader
 		})
 		shellEnvOnce = sync.Once{}
@@ -218,6 +227,41 @@ func TestLoadConfiguredEnvironment(t *testing.T) {
 		LoadConfiguredEnvironment(nil, dir)
 
 		require.Equal(t, 1, callCount, "the shell environment must only be read once per process")
+	})
+
+	t.Run("a HOME poisoned by a config file must not redirect a later shell invocation (regression, IDE-2136)", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("bash --login is not spawned on windows, see getEnvFromShell")
+		}
+		if _, err := exec.LookPath("bash"); err != nil {
+			t.Skip("bash is not available")
+		}
+
+		originalHome := os.Getenv("HOME")
+		t.Setenv("HOME", originalHome)
+		t.Cleanup(func() { shellEnvOnce.Do(func() {}) })
+		shellEnvOnce = sync.Once{}
+
+		// consume the shellEnvOnce guard with the real HOME, exactly like the first scan of a
+		// workspace, before any config file has been loaded.
+		LoadConfiguredEnvironment(nil, t.TempDir())
+
+		// an attacker-controlled workspace directory containing a malicious .bash_profile, matching
+		// the PoC attached to IDE-2136.
+		evilHome := t.TempDir()
+		sentinel := filepath.Join(evilHome, "PWNED")
+		bashProfile := fmt.Sprintf("#!/bin/sh\ntouch %s\n", sentinel)
+		require.NoError(t, os.WriteFile(filepath.Join(evilHome, ".bash_profile"), []byte(bashProfile), 0700))
+
+		configDir := t.TempDir()
+		snykEnvFile := filepath.Join(configDir, ".snyk.env")
+		require.NoError(t, os.WriteFile(snykEnvFile, []byte(fmt.Sprintf("HOME=%s\n", evilHome)), 0660))
+
+		// a subsequent scan: loads the malicious .snyk.env (poisoning HOME), then would - without the
+		// shellEnvOnce guard - spawn `bash --login`, sourcing the attacker's .bash_profile.
+		LoadConfiguredEnvironment([]string{snykEnvFile}, configDir)
+
+		require.NoFileExists(t, sentinel, "a config-file-poisoned HOME must never cause bash --login to source an attacker-controlled profile")
 	})
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Fixes [IDE-2136](https://snyksec.atlassian.net/browse/IDE-2136) — Arbitrary Code Execution via `.snyk.env`.

`LoadConfiguredEnvironment` auto-loads workspace-local config files (`.snyk.env`, `.envrc`, `.snyk.env.<os>`, `.envrc.<os>`, a user-supplied `configfile`, and `$HOME/.snyk.env`) via `gotenv.OverLoad()`, which `os.Setenv()`s **every** key/value pair with no filtering — including `HOME`. On a subsequent scan, the same function spawns `bash --login -i` to read the user's shell environment; `--login` sources `$HOME/.bash_profile`, so a workspace `.snyk.env` setting `HOME` redirects that shell invocation into sourcing an attacker-controlled profile script, achieving arbitrary code execution as the IDE user (requires the workspace to have been "trusted" first).

This implements the two engineering mitigations from the Jira triage:

1. **Allow-list environment variables loaded from config files.** `loadFile` now reads the file (`gotenv.Read`) and only applies variable names on an allow-list (`PATH`/`Path`, `JAVA_HOME`, the `*_PROXY` family, plus any `SNYK_`-prefixed variable) instead of setting everything via `gotenv.OverLoad`. This is a partial mitigation — some allowed variables (e.g. `JAVA_HOME`) could still be pointed at something malicious — but it removes the direct `HOME`/shell-profile vector.
2. **Read the shell profile once, before any config file, never again.** The `bash --login` / preferred-shell read (`getEnvFromShell`) is now wrapped in a `sync.Once` (`loadShellEnvironment`), so it only ever runs once per process, and always before any config file has had a chance to poison `HOME`. Verified with an end-to-end regression test that spawns a real `bash --login` against a malicious `.bash_profile` (mirroring the reported PoC) — and confirmed the test does fail without this guard.

A follow-up commit closes a gap found during self-review: blanket-allowing every `SNYK_`-prefixed variable would have let a workspace file set `SNYK_TOKEN`/`SNYK_API`/`SNYK_CFG_*`, which GAF's `Configuration.AutomaticEnv` binds straight to `AUTHENTICATION_TOKEN`/`API_URL`/arbitrary config keys — a credential-substitution vector of comparable severity. `deniedSnykEnvVarNames`/`deniedSnykEnvVarPrefixes` carve those back out. That commit also trims two speculative, unverified-risk entries (`NODE_EXTRA_CA_CERTS`, `KRB5_CONFIG`/`KRB5CCNAME`) from the default allow-list.

Doc comments were added throughout `pkg/envvars/environment.go` explaining the security rationale for future readers.

This is a **breaking change** in default behavior (not in the exported function signature): consumers relying on arbitrary variables being set from `.snyk.env`/`.envrc` will only see allow-listed ones applied going forward, and the shell profile is now read at most once per process (a long-running host needs a restart to pick up shell-profile changes made after its first scan). Shipped as `fix!` with `BREAKING CHANGE:` footers.

Out of scope for this repo (tracked on the Jira ticket, but living in other repos): trust-prompt wording updates (snyk-ls, IDE extensions, studio-mcp) and external docs updates (docs.snyk.io).

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`) — no drift
- [x] Linted (`make lint`)
- [ ] Test your changes work for the CLI

### Testing

- `pkg/envvars/environment_test.go` covers: disallowed variables (incl. `HOME`, `SNYK_TOKEN`, `SNYK_API`, `SNYK_CFG_*`) from a config file are not applied; allow-listed variables (incl. `JAVA_HOME`, safe `SNYK_`-prefixed ones) are applied; the shell profile is only read once across repeated `LoadConfiguredEnvironment` calls; an end-to-end regression reproducing the original PoC's exploit chain (poisoned `HOME` + malicious `.bash_profile` + a second scan) confirms no code execution.
- `go test ./... -race` and `golangci-lint run ./...` are clean.

Note: I was unable to run `snyk code test`/`snyk test` in this sandboxed environment (no `SNYK_TOKEN` credential available). `go.mod`/`go.sum` are untouched, so an SCA scan isn't required by the repo's contribution rules here, but a `snyk code test` pass by a reviewer with credentials would be good due diligence given the security nature of this change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33cf4357-d282-4afb-8edd-2c6b4851229d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33cf4357-d282-4afb-8edd-2c6b4851229d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[IDE-2136]: https://snyksec.atlassian.net/browse/IDE-2136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ