### PR TITLE
perf: optimize tracked-file exclusion predicate [CLI-1411]

### DIFF
--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -1,8 +1,11 @@
 package utils
 
 import (
+	"bufio"
 	"context"
+	"encoding/binary"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path"
@@ -14,7 +17,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/go-git/go-git/v5"
 	"github.com/rs/zerolog"
 	gitignore "github.com/sabhiram/go-gitignore"
 	"golang.org/x/sync/semaphore"
@@ -379,35 +381,22 @@ func (fw *FileFilter) trackedFileExclusionPredicate(globs []string, keptCount *a
 		return defaultPredicate
 	}
 
-	repo, err := git.PlainOpenWithOptions(fw.path, &git.PlainOpenOptions{
-		DetectDotGit: true,
-	})
+	dotGitDir, worktreeRoot, err := findDotGit(fw.path)
 	if err != nil {
-		fw.logger.Debug().Msgf("failed to open git repository: %v", err)
+		fw.logger.Debug().Msgf("failed to find .git directory: %v", err)
 		return defaultPredicate
 	}
 
-	worktree, err := repo.Worktree()
+	trackedFiles, err := readTrackedFileNames(dotGitDir)
 	if err != nil {
-		fw.logger.Debug().Msgf("failed to get worktree: %v", err)
+		fw.logger.Debug().Msgf("failed to read git index: %v", err)
 		return defaultPredicate
 	}
 
-	gitIndex, err := repo.Storer.Index()
-	if err != nil {
-		fw.logger.Debug().Msgf("failed to get git index: %v", err)
-		return defaultPredicate
-	}
-
-	repoRoot, err := matchingRepositoryRoot(fw.path, worktree.Filesystem.Root())
+	repoRoot, err := matchingRepositoryRoot(fw.path, worktreeRoot)
 	if err != nil {
 		fw.logger.Debug().Msgf("failed to resolve git repository root: %v", err)
 		return defaultPredicate
-	}
-
-	trackedFiles := make(map[string]struct{}, len(gitIndex.Entries))
-	for _, entry := range gitIndex.Entries {
-		trackedFiles[entry.Name] = struct{}{}
 	}
 
 	repoPrefix := filepath.ToSlash(repoRoot) + "/"
@@ -456,6 +445,186 @@ func matchingRepositoryRoot(scanRoot, worktreeRoot string) (string, error) {
 	}
 
 	return filepath.Clean(filepath.Join(scanRoot, relativeRoot)), nil
+}
+
+// findDotGit walks up from startPath looking for a .git directory, mirroring go-git's
+// DetectDotGit: true. It returns the .git path and the worktree root (its parent).
+func findDotGit(startPath string) (dotGitDir string, worktreeRoot string, err error) {
+	dir, err := filepath.Abs(startPath)
+	if err != nil {
+		return "", "", err
+	}
+
+	for {
+		candidate := filepath.Join(dir, ".git")
+		info, statErr := os.Stat(candidate)
+		if statErr == nil {
+			if info.IsDir() {
+				return candidate, dir, nil
+			}
+			resolved, resolveErr := resolveGitlink(candidate, dir)
+			if resolveErr != nil {
+				return "", "", resolveErr
+			}
+			return resolved, dir, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", "", fmt.Errorf("no .git directory found from %s", startPath)
+		}
+		dir = parent
+	}
+}
+
+// resolveGitlink reads a gitlink file (used for worktrees/submodules) and returns the .git
+// directory it points to.
+func resolveGitlink(gitlinkPath, baseDir string) (string, error) {
+	content, err := os.ReadFile(gitlinkPath)
+	if err != nil {
+		return "", err
+	}
+
+	const prefix = "gitdir:"
+	line := strings.TrimSpace(string(content))
+	if !strings.HasPrefix(line, prefix) {
+		return "", fmt.Errorf("malformed .git link file %s", gitlinkPath)
+	}
+
+	target := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(baseDir, target)
+	}
+	return filepath.Clean(target), nil
+}
+
+const (
+	gitIndexEntryHeaderLength = 62
+	gitIndexEntryExtendedFlag = 0x4000
+	gitIndexNameMask          = 0xfff
+)
+
+// readTrackedFileNames parses the git index binary format directly, reading only file names and
+// discarding every other entry field (hash, timestamps, mode, ...). This avoids go-git's full
+// Entry deserialization, which is significant overhead on repositories with many tracked files.
+func readTrackedFileNames(dotGitPath string) (map[string]struct{}, error) {
+	f, err := os.Open(filepath.Join(dotGitPath, "index"))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	r := bufio.NewReader(f)
+
+	var header [12]byte
+	if _, err := io.ReadFull(r, header[:]); err != nil {
+		return nil, err
+	}
+	if string(header[:4]) != "DIRC" {
+		return nil, fmt.Errorf("git index: missing DIRC signature")
+	}
+
+	version := binary.BigEndian.Uint32(header[4:8])
+	if version < 2 || version > 4 {
+		return nil, fmt.Errorf("git index: unsupported version %d", version)
+	}
+	entryCount := binary.BigEndian.Uint32(header[8:12])
+
+	names := make(map[string]struct{}, entryCount)
+	entryHeader := make([]byte, gitIndexEntryHeaderLength)
+	var lastName string
+
+	for i := uint32(0); i < entryCount; i++ {
+		if _, err := io.ReadFull(r, entryHeader); err != nil {
+			return nil, err
+		}
+		flags := binary.BigEndian.Uint16(entryHeader[60:62])
+		consumedHeader := gitIndexEntryHeaderLength
+
+		if version >= 3 && flags&gitIndexEntryExtendedFlag != 0 {
+			if _, err := r.Discard(2); err != nil {
+				return nil, err
+			}
+			consumedHeader += 2
+		}
+
+		name, nameConsumed, err := readGitIndexEntryName(r, version, flags, lastName)
+		if err != nil {
+			return nil, err
+		}
+
+		names[name] = struct{}{}
+		lastName = name
+
+		if version != 4 {
+			entrySize := consumedHeader + len(name)
+			padLen := 8 - entrySize%8
+			padLen -= nameConsumed - len(name)
+			if padLen > 0 {
+				if _, err := r.Discard(padLen); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	return names, nil
+}
+
+// readGitIndexEntryName reads a single entry's name, returning the name and the number of bytes
+// consumed from the stream for the name portion (used to compute v2/v3 padding).
+func readGitIndexEntryName(r *bufio.Reader, version uint32, flags uint16, lastName string) (name string, consumed int, err error) {
+	if version == 4 {
+		stripLen, err := readGitVarInt(r)
+		if err != nil {
+			return "", 0, err
+		}
+		if stripLen < 0 || int(stripLen) > len(lastName) {
+			return "", 0, fmt.Errorf("git index: invalid v4 name strip length %d", stripLen)
+		}
+		suffix, err := r.ReadString(0)
+		if err != nil {
+			return "", 0, err
+		}
+		name = lastName[:len(lastName)-int(stripLen)] + strings.TrimSuffix(suffix, "\x00")
+		return name, 0, nil
+	}
+
+	nameLen := int(flags & gitIndexNameMask)
+	if nameLen == gitIndexNameMask {
+		suffix, err := r.ReadString(0)
+		if err != nil {
+			return "", 0, err
+		}
+		name = strings.TrimSuffix(suffix, "\x00")
+		return name, len(name) + 1, nil
+	}
+
+	buf := make([]byte, nameLen)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return "", 0, err
+	}
+	return string(buf), nameLen, nil
+}
+
+// readGitVarInt reads a Git VLQ-encoded integer, used by the v4 index format for name-prefix
+// strip lengths.
+func readGitVarInt(r io.ByteReader) (int64, error) {
+	c, err := r.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+
+	v := int64(c & 0x7f)
+	for c&0x80 != 0 {
+		v++
+		c, err = r.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		v = (v << 7) + int64(c&0x7f)
+	}
+	return v, nil
 }
 
 // parseDotSnykFile builds a list of glob patterns from a given .snyk style file

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -356,27 +356,28 @@ func (fw *FileFilter) buildGlobs(ignoreFiles []string) ([]string, error) {
 // exempted from the .gitignore rule and not excluded by any other rule (e.g. a .snyk or
 // .dcignore rule).
 func (fw *FileFilter) trackedFileExclusionPredicate(globs []string, keptCount *atomic.Int64) func(string) bool {
-	gitignoreGlobs := make([]string, 0)
+	var nonGitignoreGlobs []string
 	allGlobs := make([]string, 0, len(globs))
+	hasGitignoreGlobs := false
 
 	for _, glob := range globs {
-		if gitignoreGlob, ok := strings.CutPrefix(glob, gitIgnoreGlobPrefix); ok {
-			gitignoreGlobs = append(gitignoreGlobs, gitignoreGlob)
-			allGlobs = append(allGlobs, gitignoreGlob)
-			continue
+		if stripped, ok := strings.CutPrefix(glob, gitIgnoreGlobPrefix); ok {
+			allGlobs = append(allGlobs, stripped)
+			hasGitignoreGlobs = true
+		} else {
+			nonGitignoreGlobs = append(nonGitignoreGlobs, glob)
+			allGlobs = append(allGlobs, glob)
 		}
-
-		allGlobs = append(allGlobs, glob)
 	}
-
-	otherMatcher := gitignore.CompileIgnoreLines(globs...)
 
 	allMatcher := gitignore.CompileIgnoreLines(allGlobs...)
 	defaultPredicate := func(file string) bool {
 		return allMatcher.MatchesPath(filepath.ToSlash(file))
 	}
 
-	gitignoreMatcher := gitignore.CompileIgnoreLines(gitignoreGlobs...)
+	if !hasGitignoreGlobs {
+		return defaultPredicate
+	}
 
 	repo, err := git.PlainOpenWithOptions(fw.path, &git.PlainOpenOptions{
 		DetectDotGit: true,
@@ -404,31 +405,32 @@ func (fw *FileFilter) trackedFileExclusionPredicate(globs []string, keptCount *a
 		return defaultPredicate
 	}
 
-	trackedFilesToPreserve := make(map[string]bool)
-
+	trackedFiles := make(map[string]struct{}, len(gitIndex.Entries))
 	for _, entry := range gitIndex.Entries {
-		relativePath := filepath.ToSlash(filepath.Join(repoRoot, filepath.FromSlash(entry.Name)))
-		if gitignoreMatcher.MatchesPath(relativePath) {
-			trackedFilesToPreserve[entry.Name] = true
-		}
+		trackedFiles[entry.Name] = struct{}{}
+	}
+
+	repoPrefix := filepath.ToSlash(repoRoot) + "/"
+
+	var nonGitignoreMatcher *gitignore.GitIgnore
+	if len(nonGitignoreGlobs) > 0 {
+		nonGitignoreMatcher = gitignore.CompileIgnoreLines(nonGitignoreGlobs...)
 	}
 
 	return func(file string) bool {
 		normalizedPath := filepath.ToSlash(file)
-		relativePath, err := filepath.Rel(repoRoot, file)
-		if err != nil {
-			return allMatcher.MatchesPath(normalizedPath)
+		if !allMatcher.MatchesPath(normalizedPath) {
+			return false
 		}
-
-		if trackedFilesToPreserve[filepath.ToSlash(relativePath)] {
-			excluded := otherMatcher.MatchesPath(normalizedPath)
-			if !excluded {
-				keptCount.Add(1)
+		relPath := strings.TrimPrefix(normalizedPath, repoPrefix)
+		if _, tracked := trackedFiles[relPath]; tracked {
+			if nonGitignoreMatcher != nil && nonGitignoreMatcher.MatchesPath(normalizedPath) {
+				return true
 			}
-			return excluded
+			keptCount.Add(1)
+			return false
 		}
-
-		return allMatcher.MatchesPath(normalizedPath)
+		return true
 	}
 }
 

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
 	"os"
 	"path"
@@ -2397,4 +2399,103 @@ func TestFileFilter_Metrics_TrackedFilesKeptCount(t *testing.T) {
 			assert.Equal(t, test.expectedCount, run.ints[metricFileFilterTrackedFilesKeptCount])
 		})
 	}
+}
+
+func gitIndexV2Entry(nameLen int, name string) []byte {
+	header := make([]byte, 62)
+	binary.BigEndian.PutUint16(header[60:62], uint16(nameLen))
+	entry := append(header, []byte(name)...)
+	padLen := 8 - len(entry)%8
+	return append(entry, make([]byte, padLen)...)
+}
+
+func gitIndexV4Entry(stripLen int, suffix string) []byte {
+	header := make([]byte, 62)
+	entry := append(header, byte(stripLen))
+	entry = append(entry, []byte(suffix)...)
+	return append(entry, 0)
+}
+
+func buildGitIndex(t *testing.T, version uint32, entries [][]byte) string {
+	t.Helper()
+	var buf bytes.Buffer
+	buf.WriteString("DIRC")
+	require.NoError(t, binary.Write(&buf, binary.BigEndian, version))
+	require.NoError(t, binary.Write(&buf, binary.BigEndian, uint32(len(entries))))
+	for _, entry := range entries {
+		buf.Write(entry)
+	}
+
+	dotGit := t.TempDir()
+	indexPath := filepath.Join(dotGit, "index")
+	require.NoError(t, os.WriteFile(indexPath, buf.Bytes(), 0o644))
+	return dotGit
+}
+
+func TestReadTrackedFileNames_v2(t *testing.T) {
+	dotGit := buildGitIndex(t, 2, [][]byte{
+		gitIndexV2Entry(len("a.txt"), "a.txt"),
+		gitIndexV2Entry(len("src/b.txt"), "src/b.txt"),
+	})
+
+	names, err := readTrackedFileNames(dotGit)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]struct{}{
+		"a.txt":     {},
+		"src/b.txt": {},
+	}, names)
+}
+
+func TestReadTrackedFileNames_v2LongNameUsesNameMask(t *testing.T) {
+	longName := "src/" + strings.Repeat("a", 4100) + "/file.txt"
+	dotGit := buildGitIndex(t, 2, [][]byte{
+		gitIndexV2Entry(0xfff, longName),
+	})
+
+	names, err := readTrackedFileNames(dotGit)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]struct{}{longName: {}}, names)
+}
+
+func TestReadTrackedFileNames_v4PrefixCompression(t *testing.T) {
+	dotGit := buildGitIndex(t, 4, [][]byte{
+		gitIndexV4Entry(0, "src/a.txt"),
+		gitIndexV4Entry(len("a.txt"), "b.txt"),
+	})
+
+	names, err := readTrackedFileNames(dotGit)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]struct{}{
+		"src/a.txt": {},
+		"src/b.txt": {},
+	}, names)
+}
+
+func TestFindDotGit(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, ".git"), 0o755))
+	nested := filepath.Join(root, "a", "b")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+
+	dotGitDir, worktreeRoot, err := findDotGit(nested)
+	require.NoError(t, err)
+
+	expectedRoot, err := filepath.EvalSymlinks(root)
+	require.NoError(t, err)
+	resolvedDotGit, err := filepath.EvalSymlinks(dotGitDir)
+	require.NoError(t, err)
+	resolvedWorktree, err := filepath.EvalSymlinks(worktreeRoot)
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(expectedRoot, ".git"), resolvedDotGit)
+	assert.Equal(t, expectedRoot, resolvedWorktree)
+}
+
+func TestFindDotGit_notFound(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+
+	_, _, err := findDotGit(sub)
+	require.Error(t, err)
 }


### PR DESCRIPTION
### **User description**
## Summary
- Replace eager O(entries × patterns) index scan with lazy map lookup + early-exit
- Parse `.git/index` binary directly instead of go-git's full `Entry` deserialization — reads only file names, skips hashes/timestamps/modes
- Eliminates ~20MB go-git overhead on large repos (100k+ files)

## Benchmark (median, flag=on vs flag=off overhead)

| Repo | Metric | Before optimization | After optimization |
|------|--------|--------------------|--------------------|
| DefinitelyTyped (63k files) | Wall | +60% | +4% |
| DefinitelyTyped (63k files) | Memory | +73% | ≤10% (expected) |
| cli (84k files) | Wall | +16% | -3% |
| cli (84k files) | Memory | +59% | +4% |
| juice-shop (129k files) | Wall | -13% | 0% |
| juice-shop (129k files) | Memory | +5% | -1% |

## Commits
1. **Lazy map + early exit** — build `map[string]struct{}` from index names, early-exit when `allMatcher` says not excluded, compile 2 matchers instead of 3
2. **Direct `.git/index` parsing** — replace `go-git` `PlainOpenWithOptions` + `Storer.Index()` with a lightweight binary parser that reads only file names; handles v2/v3/v4, gitlink files (submodules/worktrees)

## Test plan
- [ ] Existing `TestFileFilter_TrackedFiles*` tests pass (real git repos via `git.PlainInit`)
- [ ] New unit tests for `readTrackedFileNames` (v2, v2 long names, v4 prefix compression)
- [ ] New unit tests for `findDotGit` (found, not found)
- [ ] Benchmark on DefinitelyTyped to verify memory reduction
- [ ] `make lint && make test` green


___

### **PR Type**
Enhancement


___

### **Description**
- Replaced dependency on `go-git` for index parsing with custom logic.

- Optimized tracked file exclusion predicate for performance.

- Introduced utilities for finding the `.git` directory and parsing index files.

- Added comprehensive tests for new parsing and discovery utilities.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[FileFilter Context] --> B{Get Tracked Files};
  B -- Old way --> C[go-git Index Loader];
  B -- New way --> D[findDotGit + Custom Index Parser];
  C --> E[All Index Entries Loaded];
  D --> F[Only Tracked File Names Parsed];
  E --> G[Filter Logic (go-git-dependent)];
  F --> H[Filter Logic (custom, performant)];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement, dependencies, performance</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>file_filter.go</strong><dd><code>Custom Git index parsing and optimized exclusion predicate.</code></dd></summary>
<hr>

pkg/utils/file_filter.go

<ul><li>Removed the <code>go-git</code> dependency for index operations.<br> <li> Implemented custom binary parsing of <code>.git/index</code> files to read only <br>file names.<br> <li> Added <code>findDotGit</code> function to locate the <code>.git</code> directory and its parent <br>worktree root.<br> <li> Optimized the <code>trackedFileExclusionPredicate</code> to use the custom-parsed <br>tracked file names directly, improving performance.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/698/changes#diff-bf9226d9c8e73c07414a93ee5a315c13c9ad2be1c6ead9066e92b1adf6b296cd">+210/-39</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>file_filter_test.go</strong><dd><code>Tests for Git index parsing and .git discovery.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/utils/file_filter_test.go

<ul><li>Added helper functions (<code>gitIndexV2Entry</code>, <code>gitIndexV4Entry</code>, <br><code>buildGitIndex</code>) for constructing Git index files for testing.<br> <li> Introduced new unit tests for <code>readTrackedFileNames</code>, covering index <br>versions (v2, v4) and prefix compression.<br> <li> Added unit tests for the new <code>findDotGit</code> function, including scenarios <br>where the directory is not found.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/go-application-framework/pull/698/changes#diff-0525df151b63831e042ffd8a2c7cab466a29f8d6f710cb726c359b6becffa89c">+101/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

