### PR TITLE
fix: remove gitignore prepass from tracked file filtering

### DIFF
--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -77,12 +77,11 @@ type DotSnykRule struct {
 const (
 	metricFileFilterPrefix = "file-filter" // prefix for all file-filter analytics keys
 
-	metricFileFilterDurationMs            = "durationMs"            // elapsed time for GetFilteredFiles: exclusion-predicate build (incl. git index read) and filtering, including caller drain of the result channel
-	metricFileFilterSurvivingFileCount    = "survivingFileCount"    // number of files that passed exclusion in this filter run
-	metricFileFilterRulesBuildDurationMs  = "rulesBuildDurationMs"  // elapsed time for GetRules: directory walk, ignore discovery, and buildGlobs
-	metricFileFilterMetacharacterFix      = "metacharacterFix"      // whether FF_FILE_FILTER_METACHARACTER_FIX was enabled for this run
-	metricFileFilterRespectTrackedFiles   = "respectTrackedFiles"   // whether FF_GITIGNORE_RESPECT_TRACKED_FILES was enabled for this run
-	metricFileFilterTrackedFilesKeptCount = "trackedFilesKeptCount" // tracked files kept despite a matching .gitignore rule
+	metricFileFilterDurationMs           = "durationMs"           // elapsed time for GetFilteredFiles: exclusion-predicate build (incl. git index read) and filtering, including caller drain of the result channel
+	metricFileFilterSurvivingFileCount   = "survivingFileCount"   // number of files that passed exclusion in this filter run
+	metricFileFilterRulesBuildDurationMs = "rulesBuildDurationMs" // elapsed time for GetRules: directory walk, ignore discovery, and buildGlobs
+	metricFileFilterMetacharacterFix     = "metacharacterFix"     // whether FF_FILE_FILTER_METACHARACTER_FIX was enabled for this run
+	metricFileFilterRespectTrackedFiles  = "respectTrackedFiles"  // whether FF_GITIGNORE_RESPECT_TRACKED_FILES was enabled for this run
 )
 
 type FileFilterOption func(*FileFilter) error
@@ -264,9 +263,8 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 		// Building the predicate is part of the run: with FF_GITIGNORE_RESPECT_TRACKED_FILES it
 		// opens the repository and reads the git index, so it is timed alongside the filtering.
 		var isFileExcluded func(string) bool
-		var trackedFilesKeptCount atomic.Int64
 		if fw.config.GetBool(FF_GITIGNORE_RESPECT_TRACKED_FILES) {
-			isFileExcluded = fw.trackedFileExclusionPredicate(globs, &trackedFilesKeptCount)
+			isFileExcluded = fw.trackedFileExclusionPredicate(globs)
 		} else {
 			globPatternMatcher := gitignore.CompileIgnoreLines(globs...)
 			isFileExcluded = func(filePath string) bool {
@@ -307,9 +305,6 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 		})
 		fw.recordMetricLazy(runScopeID, metricFileFilterSurvivingFileCount, func() int {
 			return int(resolvedFileCount.Load())
-		})
-		fw.recordMetricLazy(runScopeID, metricFileFilterTrackedFilesKeptCount, func() int {
-			return int(trackedFilesKeptCount.Load())
 		})
 	}()
 
@@ -355,13 +350,11 @@ func (fw *FileFilter) buildGlobs(ignoreFiles []string) ([]string, error) {
 // .gitignore rule would have excluded but that is kept because git tracks it, i.e. it is
 // exempted from the .gitignore rule and not excluded by any other rule (e.g. a .snyk or
 // .dcignore rule).
-func (fw *FileFilter) trackedFileExclusionPredicate(globs []string, keptCount *atomic.Int64) func(string) bool {
-	gitignoreGlobs := make([]string, 0)
+func (fw *FileFilter) trackedFileExclusionPredicate(globs []string) func(string) bool {
 	allGlobs := make([]string, 0, len(globs))
 
 	for _, glob := range globs {
 		if gitignoreGlob, ok := strings.CutPrefix(glob, gitIgnoreGlobPrefix); ok {
-			gitignoreGlobs = append(gitignoreGlobs, gitignoreGlob)
 			allGlobs = append(allGlobs, gitignoreGlob)
 			continue
 		}
@@ -375,8 +368,6 @@ func (fw *FileFilter) trackedFileExclusionPredicate(globs []string, keptCount *a
 	defaultPredicate := func(file string) bool {
 		return allMatcher.MatchesPath(filepath.ToSlash(file))
 	}
-
-	gitignoreMatcher := gitignore.CompileIgnoreLines(gitignoreGlobs...)
 
 	repo, err := git.PlainOpenWithOptions(fw.path, &git.PlainOpenOptions{
 		DetectDotGit: true,
@@ -404,13 +395,9 @@ func (fw *FileFilter) trackedFileExclusionPredicate(globs []string, keptCount *a
 		return defaultPredicate
 	}
 
-	trackedFilesToPreserve := make(map[string]bool)
-
+	trackedFiles := make(map[string]bool, len(gitIndex.Entries))
 	for _, entry := range gitIndex.Entries {
-		relativePath := filepath.ToSlash(filepath.Join(repoRoot, filepath.FromSlash(entry.Name)))
-		if gitignoreMatcher.MatchesPath(relativePath) {
-			trackedFilesToPreserve[entry.Name] = true
-		}
+		trackedFiles[entry.Name] = true
 	}
 
 	return func(file string) bool {
@@ -420,12 +407,8 @@ func (fw *FileFilter) trackedFileExclusionPredicate(globs []string, keptCount *a
 			return allMatcher.MatchesPath(normalizedPath)
 		}
 
-		if trackedFilesToPreserve[filepath.ToSlash(relativePath)] {
-			excluded := otherMatcher.MatchesPath(normalizedPath)
-			if !excluded {
-				keptCount.Add(1)
-			}
-			return excluded
+		if trackedFiles[filepath.ToSlash(relativePath)] {
+			return otherMatcher.MatchesPath(normalizedPath)
 		}
 
 		return allMatcher.MatchesPath(normalizedPath)

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -2233,9 +2233,7 @@ func TestFileFilter_Metrics(t *testing.T) {
 			// .gitignore and file.txt pass the filter, ignored.txt does not
 			assert.Equal(t, 2, run.ints[metricFileFilterSurvivingFileCount])
 			assert.Contains(t, run.ints, metricFileFilterDurationMs)
-			// newRepo isn't a git repository, so no tracked file is ever exempted from a gitignore rule
-			assert.Equal(t, 0, run.ints[metricFileFilterTrackedFilesKeptCount])
-			assert.Len(t, run.ints, 3)
+			assert.Len(t, run.ints, 2)
 
 			// Building the rules reports its duration and the flags it built them with, under a scope of its own.
 			rulesRun := singleRun(t, recorder, metricFileFilterRulesBuildDurationMs)
@@ -2329,72 +2327,4 @@ func TestFileFilter_Metrics(t *testing.T) {
 			assert.Contains(t, run.ints, metricFileFilterDurationMs, "scope %s", scopeID)
 		}
 	})
-}
-
-func TestFileFilter_Metrics_TrackedFilesKeptCount(t *testing.T) {
-	tests := []struct {
-		name           string
-		testCase       gitTrackedFilesTestCase
-		ruleFiles      []string
-		featureEnabled bool
-		expectedCount  int
-	}{
-		{
-			// regular.txt is tracked but no gitignore rule matches it, so it is not a kept file
-			name: "counts every tracked file a gitignore rule would have excluded",
-			testCase: gitTrackedFilesTestCase{
-				files: map[string]string{
-					"tracked.log":      "tracked but ignored",
-					"also-tracked.log": "tracked but ignored",
-					"untracked.log":    "untracked and ignored",
-					"regular.txt":      "regular file",
-				},
-				trackedFiles: []string{"tracked.log", "also-tracked.log", "regular.txt"},
-				ruleFiles:    map[string]string{".gitignore": "*.log\n"},
-			},
-			ruleFiles:      []string{".gitignore"},
-			featureEnabled: true,
-			expectedCount:  2,
-		},
-		{
-			// vendored.log is exempted from .gitignore, but the .dcignore rule still excludes it
-			name: "does not count a tracked file another rule still excludes",
-			testCase: gitTrackedFilesTestCase{
-				files:        map[string]string{"vendored.log": "vendored", "regular.txt": "regular"},
-				trackedFiles: []string{"vendored.log"},
-				ruleFiles: map[string]string{
-					".gitignore": "vendored.log\n",
-					".dcignore":  "vendored.log\n",
-				},
-			},
-			ruleFiles:      []string{".gitignore", ".dcignore"},
-			featureEnabled: true,
-			expectedCount:  0,
-		},
-		{
-			name: "does not count tracked files while the feature is disabled",
-			testCase: gitTrackedFilesTestCase{
-				files:        map[string]string{"tracked.log": "tracked but ignored"},
-				trackedFiles: []string{"tracked.log"},
-				ruleFiles:    map[string]string{".gitignore": "*.log\n"},
-			},
-			ruleFiles:      []string{".gitignore"},
-			featureEnabled: false,
-			expectedCount:  0,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			root, _ := setupGitTrackedFilesTestCase(t, test.testCase)
-			recorder := &metrics.RecorderFake{}
-			config := newTestConfig(map[string]bool{FF_GITIGNORE_RESPECT_TRACKED_FILES: test.featureEnabled})
-			fileFilter := NewFileFilter(root, &log.Logger, WithConfig(config), WithMetrics(recorder))
-
-			runFileFilter(t, fileFilter, test.ruleFiles...)
-
-			run := singleRun(t, recorder, metricFileFilterDurationMs)
-			assert.Equal(t, test.expectedCount, run.ints[metricFileFilterTrackedFilesKeptCount])
-		})
-	}
 }

--- a/pkg/workflow/invocationcontextimpl_test.go
+++ b/pkg/workflow/invocationcontextimpl_test.go
@@ -122,7 +122,6 @@ func TestInvocationContextImpl_GetFileFilter(t *testing.T) {
 		assert.ElementsMatch(t, []string{
 			"durationMs",
 			"survivingFileCount",
-			"trackedFilesKeptCount",
 			"metacharacterFix",
 			"respectTrackedFiles",
 		}, filterScope)


### PR DESCRIPTION
### Description

Removes the gitignore prepass step from `trackedFileExclusionPredicate`. Previously, the predicate iterated every git index entry and checked it against a compiled gitignore matcher to build a filtered `trackedFilesToPreserve` map. Now all tracked files go directly into the map, and the gitignore exemption is handled solely by the `otherMatcher` at query time.

Profiling with a memory sampler across the CLI repo and a large JDK repo showed that the prepass adds CPU time to the filter phase without reducing peak heap.

This also removes `metricFileFilterTrackedFilesKeptCount` since without the prepass there is no meaningful distinction between "rescued" tracked files and ordinary tracked files.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI (https://github.com/snyk/cli/pull/7119)
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core file-filter behavior for git-tracked repos under `FF_GITIGNORE_RESPECT_TRACKED_FILES`, though existing git-tracked tests remain. Low risk for callers that only relied on the removed analytics key.
> 
> **Overview**
> **Removes the gitignore prepass** in `trackedFileExclusionPredicate` when `FF_GITIGNORE_RESPECT_TRACKED_FILES` is on. The index is no longer scanned with a separate gitignore matcher to build a subset of “preserved” paths; every indexed path is marked tracked, and tracked paths are still evaluated with `otherMatcher` (non–gitignore rules) instead of `allMatcher`.
> 
> **Drops `metricFileFilterTrackedFilesKeptCount`** and the `keptCount` plumbing in `GetFilteredFiles`, since the prepass was what defined “rescued” tracked files. Filter-scope analytics and tests are updated accordingly (e.g. invocation context filter metrics no longer expect `trackedFilesKeptCount`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc2f98623f3c81c096f89616312e6a14dedf5bc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->