### PR TITLE
fix: improve FileFilter metrics

### DIFF
--- a/internal/metrics/accumulator.go
+++ b/internal/metrics/accumulator.go
@@ -2,28 +2,32 @@ package metrics
 
 import "sync"
 
-// Accumulator aggregates the metrics of repeated operations into one value per key, so that callers
-// report under a fixed set of keys instead of namespacing every operation with a run identifier.
-// A key must use the same aggregation throughout.
-//
-// A Recorder keeps only the last value per key, so every update writes the running aggregate
-// through and there is nothing to flush. Two Accumulators sharing a key on one Recorder overwrite
-// each other rather than aggregating, so operations reporting under one key must share one.
-//
-// An Accumulator is safe for concurrent use.
+// accumulated is shared by every Accumulator, so two of them reporting under one key add up
+// instead of overwriting each other in a Recorder, which keeps only the last value per key.
+var (
+	accumulatedMu sync.Mutex
+	accumulated   = map[string]int{}
+)
+
+// Accumulator aggregates repeated operations into one running value per key, so callers report
+// under a fixed set of keys instead of namespacing every operation. Safe for concurrent use.
 type Accumulator struct {
-	mu       sync.Mutex
 	recorder Recorder
-	ints     map[string]int
 }
 
-// NewAccumulator returns an Accumulator writing through to recorder. A nil recorder discards
-// everything; use Recording to skip obtaining values that are expensive to compute.
+// NewAccumulator returns an Accumulator writing through to recorder; a nil recorder discards
+// everything. It continues the shared aggregate rather than starting one of its own.
 func NewAccumulator(recorder Recorder) *Accumulator {
-	return &Accumulator{
-		recorder: recorder,
-		ints:     make(map[string]int),
-	}
+	return &Accumulator{recorder: recorder}
+}
+
+// ResetAccumulated discards every accumulated value. It exists for tests, which assert the values a
+// single Recorder saw and would otherwise observe the aggregate of preceding tests.
+func ResetAccumulated() {
+	accumulatedMu.Lock()
+	defer accumulatedMu.Unlock()
+
+	accumulated = map[string]int{}
 }
 
 // Recording reports whether values written to this Accumulator reach a Recorder.
@@ -37,11 +41,11 @@ func (a *Accumulator) AddToSum(key string, delta int) {
 		return
 	}
 
-	a.mu.Lock()
-	defer a.mu.Unlock()
+	accumulatedMu.Lock()
+	defer accumulatedMu.Unlock()
 
-	a.ints[key] += delta
-	a.recorder.AddExtensionIntegerValue(key, a.ints[key])
+	accumulated[key] += delta
+	a.recorder.AddExtensionIntegerValue(key, accumulated[key])
 }
 
 // RecordBool records value under key, overwriting whatever was recorded for it before. Unlike
@@ -62,13 +66,13 @@ func (a *Accumulator) KeepMaximum(key string, value int) {
 		return
 	}
 
-	a.mu.Lock()
-	defer a.mu.Unlock()
+	accumulatedMu.Lock()
+	defer accumulatedMu.Unlock()
 
-	if current, recorded := a.ints[key]; recorded && current >= value {
+	if current, recorded := accumulated[key]; recorded && current >= value {
 		return
 	}
 
-	a.ints[key] = value
+	accumulated[key] = value
 	a.recorder.AddExtensionIntegerValue(key, value)
 }

--- a/internal/metrics/accumulator.go
+++ b/internal/metrics/accumulator.go
@@ -1,0 +1,74 @@
+package metrics
+
+import "sync"
+
+// Accumulator aggregates the metrics of repeated operations into one value per key, so that callers
+// report under a fixed set of keys instead of namespacing every operation with a run identifier.
+// A key must use the same aggregation throughout.
+//
+// A Recorder keeps only the last value per key, so every update writes the running aggregate
+// through and there is nothing to flush. Two Accumulators sharing a key on one Recorder overwrite
+// each other rather than aggregating, so operations reporting under one key must share one.
+//
+// An Accumulator is safe for concurrent use.
+type Accumulator struct {
+	mu       sync.Mutex
+	recorder Recorder
+	ints     map[string]int
+}
+
+// NewAccumulator returns an Accumulator writing through to recorder. A nil recorder discards
+// everything; use Recording to skip obtaining values that are expensive to compute.
+func NewAccumulator(recorder Recorder) *Accumulator {
+	return &Accumulator{
+		recorder: recorder,
+		ints:     make(map[string]int),
+	}
+}
+
+// Recording reports whether values written to this Accumulator reach a Recorder.
+func (a *Accumulator) Recording() bool {
+	return a != nil && a.recorder != nil
+}
+
+// AddToSum adds delta to the running sum recorded under key.
+func (a *Accumulator) AddToSum(key string, delta int) {
+	if !a.Recording() {
+		return
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.ints[key] += delta
+	a.recorder.AddExtensionIntegerValue(key, a.ints[key])
+}
+
+// RecordBool records value under key, overwriting whatever was recorded for it before. Unlike
+// AddToSum or KeepMaximum, a bool is not aggregated: callers reporting a fact that does not change
+// between calls (e.g. whether a feature flag applied to the run) simply see it written through.
+func (a *Accumulator) RecordBool(key string, value bool) {
+	if !a.Recording() {
+		return
+	}
+
+	a.recorder.AddExtensionBoolValue(key, value)
+}
+
+// KeepMaximum records value under key unless a larger value was recorded for it before. It keeps an
+// outlier visible where a sum would hide it, e.g. the slowest of many operations.
+func (a *Accumulator) KeepMaximum(key string, value int) {
+	if !a.Recording() {
+		return
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if current, recorded := a.ints[key]; recorded && current >= value {
+		return
+	}
+
+	a.ints[key] = value
+	a.recorder.AddExtensionIntegerValue(key, value)
+}

--- a/internal/metrics/accumulator.go
+++ b/internal/metrics/accumulator.go
@@ -2,27 +2,23 @@ package metrics
 
 import "sync"
 
-// accumulated is shared by every Accumulator, so two of them reporting under one key add up
-// instead of overwriting each other in a Recorder, which keeps only the last value per key.
+// accumulated is shared by all Accumulators.
 var (
 	accumulatedMu sync.Mutex
 	accumulated   = map[string]int{}
 )
 
-// Accumulator aggregates repeated operations into one running value per key, so callers report
-// under a fixed set of keys instead of namespacing every operation. Safe for concurrent use.
+// Accumulator safely aggregates repeated operations by key.
 type Accumulator struct {
 	recorder Recorder
 }
 
-// NewAccumulator returns an Accumulator writing through to recorder; a nil recorder discards
-// everything. It continues the shared aggregate rather than starting one of its own.
+// NewAccumulator writes shared aggregates to recorder; a nil recorder discards values.
 func NewAccumulator(recorder Recorder) *Accumulator {
 	return &Accumulator{recorder: recorder}
 }
 
-// ResetAccumulated discards every accumulated value. It exists for tests, which assert the values a
-// single Recorder saw and would otherwise observe the aggregate of preceding tests.
+// ResetAccumulated clears shared values between tests.
 func ResetAccumulated() {
 	accumulatedMu.Lock()
 	defer accumulatedMu.Unlock()
@@ -30,14 +26,14 @@ func ResetAccumulated() {
 	accumulated = map[string]int{}
 }
 
-// Recording reports whether values written to this Accumulator reach a Recorder.
-func (a *Accumulator) Recording() bool {
+// IsRecording reports whether values written to this Accumulator reach a Recorder.
+func (a *Accumulator) IsRecording() bool {
 	return a != nil && a.recorder != nil
 }
 
 // AddToSum adds delta to the running sum recorded under key.
 func (a *Accumulator) AddToSum(key string, delta int) {
-	if !a.Recording() {
+	if !a.IsRecording() {
 		return
 	}
 
@@ -48,21 +44,18 @@ func (a *Accumulator) AddToSum(key string, delta int) {
 	a.recorder.AddExtensionIntegerValue(key, accumulated[key])
 }
 
-// RecordBool records value under key, overwriting whatever was recorded for it before. Unlike
-// AddToSum or KeepMaximum, a bool is not aggregated: callers reporting a fact that does not change
-// between calls (e.g. whether a feature flag applied to the run) simply see it written through.
+// RecordBool writes value without aggregation.
 func (a *Accumulator) RecordBool(key string, value bool) {
-	if !a.Recording() {
+	if !a.IsRecording() {
 		return
 	}
 
 	a.recorder.AddExtensionBoolValue(key, value)
 }
 
-// KeepMaximum records value under key unless a larger value was recorded for it before. It keeps an
-// outlier visible where a sum would hide it, e.g. the slowest of many operations.
+// KeepMaximum records the largest value seen under key.
 func (a *Accumulator) KeepMaximum(key string, value int) {
-	if !a.Recording() {
+	if !a.IsRecording() {
 		return
 	}
 

--- a/internal/metrics/accumulator_test.go
+++ b/internal/metrics/accumulator_test.go
@@ -9,8 +9,7 @@ import (
 	"github.com/snyk/go-application-framework/internal/metrics"
 )
 
-// newRecorder returns a Recorder for a test that asserts the values it saw. The accumulated values
-// are package state, so a test may not inherit those of a preceding one.
+// newRecorder prevents shared values leaking between tests.
 func newRecorder(t *testing.T) *metrics.RecorderFake {
 	t.Helper()
 	metrics.ResetAccumulated()
@@ -78,7 +77,6 @@ func TestAccumulator_KeepMaximum(t *testing.T) {
 		{name: "keeps a later larger value", values: []int{3, 9}, expected: 9},
 		{name: "keeps an earlier larger value", values: []int{9, 3}, expected: 9},
 		{name: "keeps the largest of many", values: []int{3, 9, 4, 1}, expected: 9},
-		// a first report of 0 must still land, otherwise the key is missing entirely
 		{name: "records a single zero", values: []int{0}, expected: 0},
 		{name: "prefers any value over zero", values: []int{0, 2}, expected: 2},
 	}
@@ -97,8 +95,6 @@ func TestAccumulator_KeepMaximum(t *testing.T) {
 	}
 }
 
-// The aggregate is shared by every Accumulator, so operations reporting under one key add up no
-// matter how many Accumulators they are spread over, rather than the Recorder keeping only the last.
 func TestAccumulator_SharedAggregate(t *testing.T) {
 	t.Run("aggregates over several Accumulators on one Recorder", func(t *testing.T) {
 		recorder := newRecorder(t)
@@ -111,8 +107,7 @@ func TestAccumulator_SharedAggregate(t *testing.T) {
 		assert.Equal(t, map[string]int{"files": 5, "durationMs": 7}, recorder.IntValues)
 	})
 
-	// The trade-off of a shared aggregate: a key holds the same value wherever it is read, at the
-	// price of no longer being attributable to the Accumulator that reported it.
+	// Different recorders still share the same aggregate.
 	t.Run("reports the shared aggregate to every Recorder", func(t *testing.T) {
 		first := newRecorder(t)
 		second := metrics.NewRecorderFake()
@@ -137,13 +132,12 @@ func TestAccumulator_SharedAggregate(t *testing.T) {
 }
 
 func TestAccumulator_WithoutRecorder(t *testing.T) {
-	// Callers hold an Accumulator unconditionally, so one without a recorder has to stay usable.
 	for name, accumulator := range map[string]*metrics.Accumulator{
 		"nil recorder":    metrics.NewAccumulator(nil),
 		"nil accumulator": nil,
 	} {
 		t.Run(name+" discards every value", func(t *testing.T) {
-			assert.False(t, accumulator.Recording())
+			assert.False(t, accumulator.IsRecording())
 
 			assert.NotPanics(t, func() {
 				accumulator.AddToSum("files", 2)
@@ -154,12 +148,11 @@ func TestAccumulator_WithoutRecorder(t *testing.T) {
 	}
 
 	t.Run("reports recording with a recorder", func(t *testing.T) {
-		assert.True(t, metrics.NewAccumulator(metrics.NewRecorderFake()).Recording())
+		assert.True(t, metrics.NewAccumulator(metrics.NewRecorderFake()).IsRecording())
 	})
 }
 
-// Several operations of one invocation may report concurrently, each through an Accumulator of its
-// own, so no update may be lost. Run under -race to also cover the accumulated state.
+// Run under -race to cover concurrent access to accumulated state.
 func TestAccumulator_ConcurrentUpdates(t *testing.T) {
 	const (
 		writers            = 8

--- a/internal/metrics/accumulator_test.go
+++ b/internal/metrics/accumulator_test.go
@@ -1,0 +1,141 @@
+package metrics_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/go-application-framework/internal/metrics"
+)
+
+func TestAccumulator_AddToSum(t *testing.T) {
+	t.Run("writes the running sum through on every update", func(t *testing.T) {
+		recorder := &metrics.RecorderFake{}
+		accumulator := metrics.NewAccumulator(recorder)
+
+		accumulator.AddToSum("files", 2)
+		assert.Equal(t, 2, recorder.IntValues["files"])
+
+		accumulator.AddToSum("files", 3)
+		assert.Equal(t, 5, recorder.IntValues["files"], "the recorder must hold the aggregate, not the last delta")
+	})
+
+	t.Run("keeps sums of different keys apart", func(t *testing.T) {
+		recorder := &metrics.RecorderFake{}
+		accumulator := metrics.NewAccumulator(recorder)
+
+		accumulator.AddToSum("files", 2)
+		accumulator.AddToSum("rules", 7)
+		accumulator.AddToSum("files", 1)
+
+		assert.Equal(t, map[string]int{"files": 3, "rules": 7}, recorder.IntValues)
+	})
+
+	t.Run("records a zero delta so the key is present", func(t *testing.T) {
+		recorder := &metrics.RecorderFake{}
+
+		metrics.NewAccumulator(recorder).AddToSum("files", 0)
+
+		assert.Equal(t, map[string]int{"files": 0}, recorder.IntValues)
+	})
+}
+
+func TestAccumulator_RecordBool(t *testing.T) {
+	t.Run("writes the value through", func(t *testing.T) {
+		recorder := &metrics.RecorderFake{}
+
+		metrics.NewAccumulator(recorder).RecordBool("featureEnabled", true)
+
+		assert.Equal(t, map[string]bool{"featureEnabled": true}, recorder.BoolValues)
+	})
+
+	t.Run("overwrites rather than aggregating repeated calls", func(t *testing.T) {
+		recorder := &metrics.RecorderFake{}
+		accumulator := metrics.NewAccumulator(recorder)
+
+		accumulator.RecordBool("featureEnabled", true)
+		accumulator.RecordBool("featureEnabled", false)
+
+		assert.Equal(t, map[string]bool{"featureEnabled": false}, recorder.BoolValues)
+	})
+}
+
+func TestAccumulator_KeepMaximum(t *testing.T) {
+	tests := []struct {
+		name     string
+		values   []int
+		expected int
+	}{
+		{name: "keeps a later larger value", values: []int{3, 9}, expected: 9},
+		{name: "keeps an earlier larger value", values: []int{9, 3}, expected: 9},
+		{name: "keeps the largest of many", values: []int{3, 9, 4, 1}, expected: 9},
+		// a first report of 0 must still land, otherwise the key is missing entirely
+		{name: "records a single zero", values: []int{0}, expected: 0},
+		{name: "prefers any value over zero", values: []int{0, 2}, expected: 2},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := &metrics.RecorderFake{}
+			accumulator := metrics.NewAccumulator(recorder)
+
+			for _, value := range test.values {
+				accumulator.KeepMaximum("durationMs", value)
+			}
+
+			assert.Equal(t, map[string]int{"durationMs": test.expected}, recorder.IntValues)
+		})
+	}
+}
+
+func TestAccumulator_WithoutRecorder(t *testing.T) {
+	// Callers hold an Accumulator unconditionally, so one without a recorder has to stay usable.
+	for name, accumulator := range map[string]*metrics.Accumulator{
+		"nil recorder":    metrics.NewAccumulator(nil),
+		"nil accumulator": nil,
+	} {
+		t.Run(name+" discards every value", func(t *testing.T) {
+			assert.False(t, accumulator.Recording())
+
+			assert.NotPanics(t, func() {
+				accumulator.AddToSum("files", 2)
+				accumulator.KeepMaximum("durationMs", 5)
+				accumulator.RecordBool("featureEnabled", true)
+			})
+		})
+	}
+
+	t.Run("reports recording with a recorder", func(t *testing.T) {
+		assert.True(t, metrics.NewAccumulator(&metrics.RecorderFake{}).Recording())
+	})
+}
+
+// Several operations of one invocation may report concurrently, so no update may be lost.
+// Run under -race to also cover the accumulator's own state.
+func TestAccumulator_ConcurrentUpdates(t *testing.T) {
+	const (
+		writers            = 8
+		updatesPerWriter   = 50
+		expectedTotalFiles = writers * updatesPerWriter
+	)
+
+	recorder := &metrics.RecorderFake{}
+	accumulator := metrics.NewAccumulator(recorder)
+
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for writer := range writers {
+		go func() {
+			defer wg.Done()
+			for range updatesPerWriter {
+				accumulator.AddToSum("files", 1)
+				accumulator.KeepMaximum("durationMs", writer)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, expectedTotalFiles, recorder.IntValues["files"])
+	assert.Equal(t, writers-1, recorder.IntValues["durationMs"])
+}

--- a/internal/metrics/accumulator_test.go
+++ b/internal/metrics/accumulator_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccumulator_AddToSum(t *testing.T) {
 	t.Run("writes the running sum through on every update", func(t *testing.T) {
-		recorder := &metrics.RecorderFake{}
+		recorder := metrics.NewRecorderFake()
 		accumulator := metrics.NewAccumulator(recorder)
 
 		accumulator.AddToSum("files", 2)
@@ -22,7 +22,7 @@ func TestAccumulator_AddToSum(t *testing.T) {
 	})
 
 	t.Run("keeps sums of different keys apart", func(t *testing.T) {
-		recorder := &metrics.RecorderFake{}
+		recorder := metrics.NewRecorderFake()
 		accumulator := metrics.NewAccumulator(recorder)
 
 		accumulator.AddToSum("files", 2)
@@ -33,7 +33,7 @@ func TestAccumulator_AddToSum(t *testing.T) {
 	})
 
 	t.Run("records a zero delta so the key is present", func(t *testing.T) {
-		recorder := &metrics.RecorderFake{}
+		recorder := metrics.NewRecorderFake()
 
 		metrics.NewAccumulator(recorder).AddToSum("files", 0)
 
@@ -77,7 +77,7 @@ func TestAccumulator_KeepMaximum(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			recorder := &metrics.RecorderFake{}
+			recorder := metrics.NewRecorderFake()
 			accumulator := metrics.NewAccumulator(recorder)
 
 			for _, value := range test.values {
@@ -107,7 +107,7 @@ func TestAccumulator_WithoutRecorder(t *testing.T) {
 	}
 
 	t.Run("reports recording with a recorder", func(t *testing.T) {
-		assert.True(t, metrics.NewAccumulator(&metrics.RecorderFake{}).Recording())
+		assert.True(t, metrics.NewAccumulator(metrics.NewRecorderFake()).Recording())
 	})
 }
 
@@ -120,7 +120,7 @@ func TestAccumulator_ConcurrentUpdates(t *testing.T) {
 		expectedTotalFiles = writers * updatesPerWriter
 	)
 
-	recorder := &metrics.RecorderFake{}
+	recorder := metrics.NewRecorderFake()
 	accumulator := metrics.NewAccumulator(recorder)
 
 	var wg sync.WaitGroup

--- a/internal/metrics/accumulator_test.go
+++ b/internal/metrics/accumulator_test.go
@@ -9,9 +9,17 @@ import (
 	"github.com/snyk/go-application-framework/internal/metrics"
 )
 
+// newRecorder returns a Recorder for a test that asserts the values it saw. The accumulated values
+// are package state, so a test may not inherit those of a preceding one.
+func newRecorder(t *testing.T) *metrics.RecorderFake {
+	t.Helper()
+	metrics.ResetAccumulated()
+	return metrics.NewRecorderFake()
+}
+
 func TestAccumulator_AddToSum(t *testing.T) {
 	t.Run("writes the running sum through on every update", func(t *testing.T) {
-		recorder := metrics.NewRecorderFake()
+		recorder := newRecorder(t)
 		accumulator := metrics.NewAccumulator(recorder)
 
 		accumulator.AddToSum("files", 2)
@@ -22,7 +30,7 @@ func TestAccumulator_AddToSum(t *testing.T) {
 	})
 
 	t.Run("keeps sums of different keys apart", func(t *testing.T) {
-		recorder := metrics.NewRecorderFake()
+		recorder := newRecorder(t)
 		accumulator := metrics.NewAccumulator(recorder)
 
 		accumulator.AddToSum("files", 2)
@@ -33,7 +41,7 @@ func TestAccumulator_AddToSum(t *testing.T) {
 	})
 
 	t.Run("records a zero delta so the key is present", func(t *testing.T) {
-		recorder := metrics.NewRecorderFake()
+		recorder := newRecorder(t)
 
 		metrics.NewAccumulator(recorder).AddToSum("files", 0)
 
@@ -43,7 +51,7 @@ func TestAccumulator_AddToSum(t *testing.T) {
 
 func TestAccumulator_RecordBool(t *testing.T) {
 	t.Run("writes the value through", func(t *testing.T) {
-		recorder := &metrics.RecorderFake{}
+		recorder := newRecorder(t)
 
 		metrics.NewAccumulator(recorder).RecordBool("featureEnabled", true)
 
@@ -51,7 +59,7 @@ func TestAccumulator_RecordBool(t *testing.T) {
 	})
 
 	t.Run("overwrites rather than aggregating repeated calls", func(t *testing.T) {
-		recorder := &metrics.RecorderFake{}
+		recorder := newRecorder(t)
 		accumulator := metrics.NewAccumulator(recorder)
 
 		accumulator.RecordBool("featureEnabled", true)
@@ -77,7 +85,7 @@ func TestAccumulator_KeepMaximum(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			recorder := metrics.NewRecorderFake()
+			recorder := newRecorder(t)
 			accumulator := metrics.NewAccumulator(recorder)
 
 			for _, value := range test.values {
@@ -87,6 +95,45 @@ func TestAccumulator_KeepMaximum(t *testing.T) {
 			assert.Equal(t, map[string]int{"durationMs": test.expected}, recorder.IntValues)
 		})
 	}
+}
+
+// The aggregate is shared by every Accumulator, so operations reporting under one key add up no
+// matter how many Accumulators they are spread over, rather than the Recorder keeping only the last.
+func TestAccumulator_SharedAggregate(t *testing.T) {
+	t.Run("aggregates over several Accumulators on one Recorder", func(t *testing.T) {
+		recorder := newRecorder(t)
+
+		metrics.NewAccumulator(recorder).AddToSum("files", 2)
+		metrics.NewAccumulator(recorder).AddToSum("files", 3)
+		metrics.NewAccumulator(recorder).KeepMaximum("durationMs", 7)
+		metrics.NewAccumulator(recorder).KeepMaximum("durationMs", 4)
+
+		assert.Equal(t, map[string]int{"files": 5, "durationMs": 7}, recorder.IntValues)
+	})
+
+	// The trade-off of a shared aggregate: a key holds the same value wherever it is read, at the
+	// price of no longer being attributable to the Accumulator that reported it.
+	t.Run("reports the shared aggregate to every Recorder", func(t *testing.T) {
+		first := newRecorder(t)
+		second := metrics.NewRecorderFake()
+
+		metrics.NewAccumulator(first).AddToSum("files", 2)
+		metrics.NewAccumulator(second).AddToSum("files", 3)
+
+		assert.Equal(t, map[string]int{"files": 2}, first.IntValues, "the value it saw last")
+		assert.Equal(t, map[string]int{"files": 5}, second.IntValues, "the aggregate of both")
+	})
+
+	t.Run("starts from no accumulated value after a reset", func(t *testing.T) {
+		recorder := newRecorder(t)
+		metrics.NewAccumulator(recorder).AddToSum("files", 2)
+
+		metrics.ResetAccumulated()
+		next := metrics.NewRecorderFake()
+		metrics.NewAccumulator(next).AddToSum("files", 3)
+
+		assert.Equal(t, map[string]int{"files": 3}, next.IntValues)
+	})
 }
 
 func TestAccumulator_WithoutRecorder(t *testing.T) {
@@ -111,8 +158,8 @@ func TestAccumulator_WithoutRecorder(t *testing.T) {
 	})
 }
 
-// Several operations of one invocation may report concurrently, so no update may be lost.
-// Run under -race to also cover the accumulator's own state.
+// Several operations of one invocation may report concurrently, each through an Accumulator of its
+// own, so no update may be lost. Run under -race to also cover the accumulated state.
 func TestAccumulator_ConcurrentUpdates(t *testing.T) {
 	const (
 		writers            = 8
@@ -120,14 +167,14 @@ func TestAccumulator_ConcurrentUpdates(t *testing.T) {
 		expectedTotalFiles = writers * updatesPerWriter
 	)
 
-	recorder := metrics.NewRecorderFake()
-	accumulator := metrics.NewAccumulator(recorder)
+	recorder := newRecorder(t)
 
 	var wg sync.WaitGroup
 	wg.Add(writers)
 	for writer := range writers {
 		go func() {
 			defer wg.Done()
+			accumulator := metrics.NewAccumulator(recorder)
 			for range updatesPerWriter {
 				accumulator.AddToSum("files", 1)
 				accumulator.KeepMaximum("durationMs", writer)

--- a/internal/metrics/recorder_fake.go
+++ b/internal/metrics/recorder_fake.go
@@ -4,6 +4,7 @@ import "sync"
 
 // RecorderFake is a simple in-memory Recorder for use in tests.
 // Like the production recorder it may be written to concurrently, so its values are mutex guarded.
+// Construct it with NewRecorderFake rather than a bare struct literal, so its maps are never nil.
 type RecorderFake struct {
 	mu           sync.Mutex
 	IntValues    map[string]int
@@ -11,13 +12,19 @@ type RecorderFake struct {
 	BoolValues   map[string]bool
 }
 
+// NewRecorderFake returns a RecorderFake with its value maps ready to write to.
+func NewRecorderFake() *RecorderFake {
+	return &RecorderFake{
+		IntValues:    make(map[string]int),
+		StringValues: make(map[string]string),
+		BoolValues:   make(map[string]bool),
+	}
+}
+
 func (r *RecorderFake) AddExtensionIntegerValue(key string, value int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.IntValues == nil {
-		r.IntValues = make(map[string]int)
-	}
 	r.IntValues[key] = value
 }
 
@@ -25,9 +32,6 @@ func (r *RecorderFake) AddExtensionStringValue(key string, value string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.StringValues == nil {
-		r.StringValues = make(map[string]string)
-	}
 	r.StringValues[key] = value
 }
 
@@ -35,8 +39,5 @@ func (r *RecorderFake) AddExtensionBoolValue(key string, value bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.BoolValues == nil {
-		r.BoolValues = make(map[string]bool)
-	}
 	r.BoolValues[key] = value
 }

--- a/internal/metrics/recorder_fake.go
+++ b/internal/metrics/recorder_fake.go
@@ -4,7 +4,6 @@ import "sync"
 
 // RecorderFake is a simple in-memory Recorder for use in tests.
 // Like the production recorder it may be written to concurrently, so its values are mutex guarded.
-// Construct it with NewRecorderFake rather than a bare struct literal, so its maps are never nil.
 type RecorderFake struct {
 	mu           sync.Mutex
 	IntValues    map[string]int
@@ -12,7 +11,7 @@ type RecorderFake struct {
 	BoolValues   map[string]bool
 }
 
-// NewRecorderFake returns a RecorderFake with its value maps ready to write to.
+// NewRecorderFake returns an initialized recorder.
 func NewRecorderFake() *RecorderFake {
 	return &RecorderFake{
 		IntValues:    make(map[string]int),

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -72,12 +72,10 @@ type DotSnykRule struct {
 	Exclude map[DotSnykExcludeSectionName]yaml.Node `yaml:"exclude"`
 }
 
-// File-filter metric keys, of the shape "file-filter.<variant>.<metric>". Both parts come from a
-// fixed set, so that an analytics backend can derive facets from them; see metrics.Accumulator.
+// File-filter metric keys have the shape "file-filter.<variant>.<metric>".
 const (
 	metricFileFilterPrefix = "file-filter" // prefix for all file-filter analytics keys
 
-	// The variant names the behavior a run applied, keeping values attributable to it.
 	metricFileFilterVariantLegacy       = "var0" // neither feature flag enabled
 	metricFileFilterVariantMetacharFix  = "var1" // FF_FILE_FILTER_METACHARACTER_FIX only
 	metricFileFilterVariantTrackedFiles = "var2" // FF_GITIGNORE_RESPECT_TRACKED_FILES only
@@ -86,8 +84,7 @@ const (
 	metricFileFilterInputFileCount = "filter.inputFileCount" // files offered to GetFilteredFiles, before exclusion
 	metricFileFilterRuleCount      = "filter.ruleCount"      // glob patterns GetRules produced
 
-	// Recorded alongside the variant so a consumer can read a run's behavior directly off its
-	// metrics, without having to know which variant name maps to which feature flag combination.
+	// Record feature flags alongside the variant so consumers need not decode its name.
 	metricFileFilterFeatureMetacharFix  = "feature.metaCharFix"    // whether FF_FILE_FILTER_METACHARACTER_FIX applied to the run
 	metricFileFilterFeatureTrackedFiles = "feature.includeTracked" // whether FF_GITIGNORE_RESPECT_TRACKED_FILES applied to the run
 
@@ -134,8 +131,7 @@ func WithConfig(config configuration.Configuration) FileFilterOption {
 	}
 }
 
-// WithMetrics supplies a recorder (e.g. pkg/analytics.Analytics) for file-filter analytics values.
-// Every FileFilter reports under the same keys, so values aggregate instead of overwriting each other.
+// WithMetrics supplies a recorder for aggregated file-filter analytics.
 func WithMetrics(recorder metrics.Recorder) FileFilterOption {
 	return func(filter *FileFilter) error {
 		filter.metrics = metrics.NewAccumulator(recorder)
@@ -143,18 +139,16 @@ func WithMetrics(recorder metrics.Recorder) FileFilterOption {
 	}
 }
 
-// The record*Lazy helpers obtain a metric only once it is known to be recorded, so that a FileFilter
-// without a recorder pays for none of them.
+// Avoid computing metrics when no recorder is configured.
 func (fw *FileFilter) recordSumLazy(variant, key string, getMetric func() int) {
-	if fw.metrics.Recording() {
+	if fw.metrics.IsRecording() {
 		fw.metrics.AddToSum(metricKey(variant, key), getMetric())
 	}
 }
 
-// metricVariant names the behavior the calling run applies. It returns an empty variant while nothing
-// is recorded, so that the flags — whose lookup may reach the network — are not resolved for metrics alone.
+// Avoid resolving flags, which may require network access, when metrics are disabled.
 func (fw *FileFilter) metricVariant() string {
-	if !fw.metrics.Recording() {
+	if !fw.metrics.IsRecording() {
 		return ""
 	}
 
@@ -179,7 +173,6 @@ func (fw *FileFilter) metricVariant() string {
 	return variant
 }
 
-// metricKey namespaces a metric under the file-filter prefix and the variant that produced it.
 func metricKey(variant, key string) string {
 	return fmt.Sprintf("%s.%s.%s", metricFileFilterPrefix, variant, key)
 }
@@ -192,7 +185,7 @@ func NewFileFilter(path string, logger *zerolog.Logger, options ...FileFilterOpt
 		logger:          logger,
 		max_threads:     int64(runtime.NumCPU()),
 		dotSnykSections: []DotSnykExcludeSectionName{DotSnykExcludeCode, DotSnykExcludeGlobal}, // init default with DotSnykExcludeCode and DotSnykExcludeGlobal to keep it backwards compatible
-		metrics:         metrics.NewAccumulator(nil),                                           // discards until WithMetrics supplies a recorder
+		metrics:         metrics.NewAccumulator(nil),
 	}
 
 	options = append([]FileFilterOption{WithConfig(nil)}, options...)
@@ -239,7 +232,7 @@ func (fw *FileFilter) GetAllFiles() chan string {
 
 // GetRules builds a list of glob patterns that can be used to filter filesToFilter
 func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
-	// Reports under its own variant: a GetFilteredFiles run may never happen, or may resolve the flags differently.
+	// Rule building and filtering may resolve feature flags at different times.
 	variant := fw.metricVariant()
 	start := time.Now()
 	defer fw.recordSumLazy(variant, metricFileFilterRulesBuildDurationMs, func() int {
@@ -265,7 +258,9 @@ func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
 	}
 
 	rules := append(fw.defaultRules, globs...)
-	fw.recordSumLazy(variant, metricFileFilterRuleCount, func() int { return len(rules) })
+
+	recordRulesCount := func() int { return len(rules) }
+	fw.recordSumLazy(variant, metricFileFilterRuleCount, recordRulesCount)
 
 	return rules, nil
 }

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -83,10 +83,9 @@ const (
 	metricVariantTrackedFiles = "var2" // FF_GITIGNORE_RESPECT_TRACKED_FILES only
 	metricVariantBothFixes    = ""     // both feature flags enabled; the variant segment is omitted
 
-	metricFilterRuleCount          = "filter.ruleCount"       // glob patterns GetRules produced
-	metricFilterInputFileCount     = "filter.inputFileCount"  // files offered to GetFilteredFiles, before exclusion
-	metricFilterSurvivingFileCount = "filter.outputFileCount" // number of files that passed exclusion
-	metricFilterDurationMs         = "filter.durationMs"      // elapsed time for GetFilteredFiles, including the caller's drain of the result channel
+	metricFilterInputFileCount  = "filter.inputFileCount"  // files offered to GetFilteredFiles, before exclusion
+	metricFilterOutputFileCount = "filter.outputFileCount" // number of files that passed exclusion
+	metricFilterDurationMs      = "filter.durationMs"      // elapsed time for GetFilteredFiles, including the caller's drain of the result channel
 
 	metricRulesBuildDurationMs = "rules.durationMs" // elapsed time for GetRules: directory walk, ignore discovery, and buildGlobs
 
@@ -141,13 +140,6 @@ func WithMetrics(recorder metrics.Recorder) FileFilterOption {
 	}
 }
 
-// Avoid computing metrics when no recorder is configured.
-func (fw *FileFilter) recordSumLazy(variant, key string, getMetric func() int) {
-	if fw.metrics.IsRecording() {
-		fw.metrics.AddToSum(metricKey(variant, key), getMetric())
-	}
-}
-
 // Avoid resolving flags, which may require network access, when metrics are disabled.
 func (fw *FileFilter) metricVariant() string {
 	if !fw.metrics.IsRecording() {
@@ -169,13 +161,26 @@ func (fw *FileFilter) metricVariant() string {
 		variant = metricVariantLegacy
 	}
 
-	fw.metrics.RecordBool(metricKey(variant, metricFeatureMetacharFix), metacharacterFix)
-	fw.metrics.RecordBool(metricKey(variant, metricFeatureTrackedFiles), respectTrackedFiles)
+	fw.recordBool(variant, metricFeatureMetacharFix, func() bool { return metacharacterFix })
+	fw.recordBool(variant, metricFeatureTrackedFiles, func() bool { return respectTrackedFiles })
 
 	return variant
 }
 
-func metricKey(variant, key string) string {
+// Avoid computing metrics when no recorder is configured.
+func (fw *FileFilter) recordBool(variant, key string, getMetric func() bool) {
+	if fw.metrics.IsRecording() {
+		fw.metrics.RecordBool(buildMetricKey(variant, key), getMetric())
+	}
+}
+
+func (fw *FileFilter) recordSumLazy(variant, key string, getMetric func() int) {
+	if fw.metrics.IsRecording() {
+		fw.metrics.AddToSum(buildMetricKey(variant, key), getMetric())
+	}
+}
+
+func buildMetricKey(variant, key string) string {
 	if variant == metricVariantBothFixes {
 		return fmt.Sprintf("%s.%s", metricPrefix, key)
 	}
@@ -237,12 +242,12 @@ func (fw *FileFilter) GetAllFiles() chan string {
 
 // GetRules builds a list of glob patterns that can be used to filter filesToFilter
 func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
-	// Rule building and filtering may resolve feature flags at different times.
 	variant := fw.metricVariant()
 	start := time.Now()
 	defer fw.recordSumLazy(variant, metricRulesBuildDurationMs, func() int {
 		return int(time.Since(start).Milliseconds())
 	})
+
 	files := fw.GetAllFiles()
 
 	// iterate filesToFilter channel and find ignore filesToFilter
@@ -263,9 +268,6 @@ func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
 	}
 
 	rules := append(fw.defaultRules, globs...)
-
-	recordRulesCount := func() int { return len(rules) }
-	fw.recordSumLazy(variant, metricFilterRuleCount, recordRulesCount)
 
 	return rules, nil
 }
@@ -319,13 +321,13 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 			fw.logger.Err(err).Msg("failed to wait for all threads")
 		}
 
+		// Record metrics
 		fw.recordSumLazy(variant, metricFilterInputFileCount, func() int {
 			return candidateFileCount
 		})
-		fw.recordSumLazy(variant, metricFilterSurvivingFileCount, func() int {
+		fw.recordSumLazy(variant, metricFilterOutputFileCount, func() int {
 			return int(resolvedFileCount.Load())
 		})
-
 		fw.recordSumLazy(variant, metricFilterDurationMs, func() int { return int(time.Since(start).Milliseconds()) })
 	}()
 

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -72,14 +72,16 @@ type DotSnykRule struct {
 	Exclude map[DotSnykExcludeSectionName]yaml.Node `yaml:"exclude"`
 }
 
-// File-filter metric keys have the shape "file-filter.<variant>.<metric>".
+// File-filter metric keys have the shape "file-filter.<variant>.<metric>", except for
+// metricFileFilterVariantBothFixes, the target end state once both feature flags are always on,
+// whose keys drop the variant segment: "file-filter.<metric>".
 const (
 	metricFileFilterPrefix = "file-filter" // prefix for all file-filter analytics keys
 
 	metricFileFilterVariantLegacy       = "var0" // neither feature flag enabled
 	metricFileFilterVariantMetacharFix  = "var1" // FF_FILE_FILTER_METACHARACTER_FIX only
 	metricFileFilterVariantTrackedFiles = "var2" // FF_GITIGNORE_RESPECT_TRACKED_FILES only
-	metricFileFilterVariantBothFixes    = "var3" // both feature flags enabled
+	metricFileFilterVariantBothFixes    = ""     // both feature flags enabled; the variant segment is omitted
 
 	metricFileFilterInputFileCount = "filter.inputFileCount" // files offered to GetFilteredFiles, before exclusion
 	metricFileFilterRuleCount      = "filter.ruleCount"      // glob patterns GetRules produced
@@ -174,6 +176,9 @@ func (fw *FileFilter) metricVariant() string {
 }
 
 func metricKey(variant, key string) string {
+	if variant == metricFileFilterVariantBothFixes {
+		return fmt.Sprintf("%s.%s", metricFileFilterPrefix, key)
+	}
 	return fmt.Sprintf("%s.%s.%s", metricFileFilterPrefix, variant, key)
 }
 

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -73,26 +73,26 @@ type DotSnykRule struct {
 }
 
 // File-filter metric keys have the shape "file-filter.<variant>.<metric>", except for
-// metricFileFilterVariantBothFixes, the target end state once both feature flags are always on,
+// metricVariantBothFixes, the target end state once both feature flags are always on,
 // whose keys drop the variant segment: "file-filter.<metric>".
 const (
-	metricFileFilterPrefix = "file-filter" // prefix for all file-filter analytics keys
+	metricPrefix = "file-filter" // prefix for all file-filter analytics keys
 
-	metricFileFilterVariantLegacy       = "var0" // neither feature flag enabled
-	metricFileFilterVariantMetacharFix  = "var1" // FF_FILE_FILTER_METACHARACTER_FIX only
-	metricFileFilterVariantTrackedFiles = "var2" // FF_GITIGNORE_RESPECT_TRACKED_FILES only
-	metricFileFilterVariantBothFixes    = ""     // both feature flags enabled; the variant segment is omitted
+	metricVariantLegacy       = "var0" // neither feature flag enabled
+	metriVariantMetacharFix   = "var1" // FF_FILE_FILTER_METACHARACTER_FIX only
+	metricVariantTrackedFiles = "var2" // FF_GITIGNORE_RESPECT_TRACKED_FILES only
+	metricVariantBothFixes    = ""     // both feature flags enabled; the variant segment is omitted
 
-	metricFileFilterInputFileCount = "filter.inputFileCount" // files offered to GetFilteredFiles, before exclusion
-	metricFileFilterRuleCount      = "filter.ruleCount"      // glob patterns GetRules produced
+	metricFilterRuleCount          = "filter.ruleCount"       // glob patterns GetRules produced
+	metricFilterInputFileCount     = "filter.inputFileCount"  // files offered to GetFilteredFiles, before exclusion
+	metricFilterSurvivingFileCount = "filter.outputFileCount" // number of files that passed exclusion
+	metricFilterDurationMs         = "filter.durationMs"      // elapsed time for GetFilteredFiles, including the caller's drain of the result channel
+
+	metricRulesBuildDurationMs = "rules.durationMs" // elapsed time for GetRules: directory walk, ignore discovery, and buildGlobs
 
 	// Record feature flags alongside the variant so consumers need not decode its name.
-	metricFileFilterFeatureMetacharFix  = "feature.metaCharFix"    // whether FF_FILE_FILTER_METACHARACTER_FIX applied to the run
-	metricFileFilterFeatureTrackedFiles = "feature.includeTracked" // whether FF_GITIGNORE_RESPECT_TRACKED_FILES applied to the run
-
-	metricFileFilterDurationMs           = "filter.durationMs"      // elapsed time for GetFilteredFiles, including the caller's drain of the result channel
-	metricFileFilterRulesBuildDurationMs = "rules.durationMs"       // elapsed time for GetRules: directory walk, ignore discovery, and buildGlobs
-	metricFileFilterSurvivingFileCount   = "filter.outputFileCount" // number of files that passed exclusion
+	metricFeatureMetacharFix  = "feature.metaCharFix"    // whether FF_FILE_FILTER_METACHARACTER_FIX applied to the run
+	metricFeatureTrackedFiles = "feature.includeTracked" // whether FF_GITIGNORE_RESPECT_TRACKED_FILES applied to the run
 )
 
 type FileFilterOption func(*FileFilter) error
@@ -160,26 +160,26 @@ func (fw *FileFilter) metricVariant() string {
 	var variant string
 	switch {
 	case metacharacterFix && respectTrackedFiles:
-		variant = metricFileFilterVariantBothFixes
+		variant = metricVariantBothFixes
 	case metacharacterFix:
-		variant = metricFileFilterVariantMetacharFix
+		variant = metriVariantMetacharFix
 	case respectTrackedFiles:
-		variant = metricFileFilterVariantTrackedFiles
+		variant = metricVariantTrackedFiles
 	default:
-		variant = metricFileFilterVariantLegacy
+		variant = metricVariantLegacy
 	}
 
-	fw.metrics.RecordBool(metricKey(variant, metricFileFilterFeatureMetacharFix), metacharacterFix)
-	fw.metrics.RecordBool(metricKey(variant, metricFileFilterFeatureTrackedFiles), respectTrackedFiles)
+	fw.metrics.RecordBool(metricKey(variant, metricFeatureMetacharFix), metacharacterFix)
+	fw.metrics.RecordBool(metricKey(variant, metricFeatureTrackedFiles), respectTrackedFiles)
 
 	return variant
 }
 
 func metricKey(variant, key string) string {
-	if variant == metricFileFilterVariantBothFixes {
-		return fmt.Sprintf("%s.%s", metricFileFilterPrefix, key)
+	if variant == metricVariantBothFixes {
+		return fmt.Sprintf("%s.%s", metricPrefix, key)
 	}
-	return fmt.Sprintf("%s.%s.%s", metricFileFilterPrefix, variant, key)
+	return fmt.Sprintf("%s.%s.%s", metricPrefix, variant, key)
 }
 
 // NewFileFilter creates a FileFilter rooted at path. Without WithConfig, feature flags default to disabled (legacy).
@@ -240,7 +240,7 @@ func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
 	// Rule building and filtering may resolve feature flags at different times.
 	variant := fw.metricVariant()
 	start := time.Now()
-	defer fw.recordSumLazy(variant, metricFileFilterRulesBuildDurationMs, func() int {
+	defer fw.recordSumLazy(variant, metricRulesBuildDurationMs, func() int {
 		return int(time.Since(start).Milliseconds())
 	})
 	files := fw.GetAllFiles()
@@ -265,7 +265,7 @@ func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
 	rules := append(fw.defaultRules, globs...)
 
 	recordRulesCount := func() int { return len(rules) }
-	fw.recordSumLazy(variant, metricFileFilterRuleCount, recordRulesCount)
+	fw.recordSumLazy(variant, metricFilterRuleCount, recordRulesCount)
 
 	return rules, nil
 }
@@ -319,14 +319,14 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 			fw.logger.Err(err).Msg("failed to wait for all threads")
 		}
 
-		fw.recordSumLazy(variant, metricFileFilterInputFileCount, func() int {
+		fw.recordSumLazy(variant, metricFilterInputFileCount, func() int {
 			return candidateFileCount
 		})
-		fw.recordSumLazy(variant, metricFileFilterSurvivingFileCount, func() int {
+		fw.recordSumLazy(variant, metricFilterSurvivingFileCount, func() int {
 			return int(resolvedFileCount.Load())
 		})
 
-		fw.recordSumLazy(variant, metricFileFilterDurationMs, func() int { return int(time.Since(start).Milliseconds()) })
+		fw.recordSumLazy(variant, metricFilterDurationMs, func() int { return int(time.Since(start).Milliseconds()) })
 	}()
 
 	return filteredFilesCh

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -32,8 +32,6 @@ const (
 // by default, all rules are valid
 var defaultInvalidRules = []string{}
 
-var nextFileFilterMetricScopeID atomic.Uint64
-
 const gitIgnoreGlobPrefix = "#gitignore:"
 
 type FileFilter struct {
@@ -43,7 +41,7 @@ type FileFilter struct {
 	max_threads     int64
 	dotSnykSections []DotSnykExcludeSectionName
 	config          configuration.Configuration
-	metricsRecorder metrics.Recorder
+	metrics         *metrics.Accumulator
 }
 
 // DotSnykExcludeSectionName is the name of an `exclude` section in a .snyk
@@ -74,14 +72,28 @@ type DotSnykRule struct {
 	Exclude map[DotSnykExcludeSectionName]yaml.Node `yaml:"exclude"`
 }
 
+// File-filter metric keys, of the shape "file-filter.<variant>.<metric>". Both parts come from a
+// fixed set, so that an analytics backend can derive facets from them; see metrics.Accumulator.
 const (
 	metricFileFilterPrefix = "file-filter" // prefix for all file-filter analytics keys
 
-	metricFileFilterDurationMs           = "durationMs"           // elapsed time for GetFilteredFiles: exclusion-predicate build (incl. git index read) and filtering, including caller drain of the result channel
-	metricFileFilterSurvivingFileCount   = "survivingFileCount"   // number of files that passed exclusion in this filter run
-	metricFileFilterRulesBuildDurationMs = "rulesBuildDurationMs" // elapsed time for GetRules: directory walk, ignore discovery, and buildGlobs
-	metricFileFilterMetacharacterFix     = "metacharacterFix"     // whether FF_FILE_FILTER_METACHARACTER_FIX was enabled for this run
-	metricFileFilterRespectTrackedFiles  = "respectTrackedFiles"  // whether FF_GITIGNORE_RESPECT_TRACKED_FILES was enabled for this run
+	// The variant names the behavior a run applied, keeping values attributable to it.
+	metricFileFilterVariantLegacy       = "var0" // neither feature flag enabled
+	metricFileFilterVariantMetacharFix  = "var1" // FF_FILE_FILTER_METACHARACTER_FIX only
+	metricFileFilterVariantTrackedFiles = "var2" // FF_GITIGNORE_RESPECT_TRACKED_FILES only
+	metricFileFilterVariantBothFixes    = "var3" // both feature flags enabled
+
+	metricFileFilterInputFileCount = "filter.inputFileCount" // files offered to GetFilteredFiles, before exclusion
+	metricFileFilterRuleCount      = "filter.ruleCount"      // glob patterns GetRules produced
+
+	// Recorded alongside the variant so a consumer can read a run's behavior directly off its
+	// metrics, without having to know which variant name maps to which feature flag combination.
+	metricFileFilterFeatureMetacharFix  = "feature.metaCharFix"    // whether FF_FILE_FILTER_METACHARACTER_FIX applied to the run
+	metricFileFilterFeatureTrackedFiles = "feature.includeTracked" // whether FF_GITIGNORE_RESPECT_TRACKED_FILES applied to the run
+
+	metricFileFilterDurationMs           = "filter.durationMs"      // elapsed time for GetFilteredFiles, including the caller's drain of the result channel
+	metricFileFilterRulesBuildDurationMs = "rules.durationMs"       // elapsed time for GetRules: directory walk, ignore discovery, and buildGlobs
+	metricFileFilterSurvivingFileCount   = "filter.outputFileCount" // number of files that passed exclusion
 )
 
 type FileFilterOption func(*FileFilter) error
@@ -126,31 +138,50 @@ func WithConfig(config configuration.Configuration) FileFilterOption {
 // Callers must pass a pkg/analytics.Analytics implementation here; it satisfies this interface.
 func WithMetrics(recorder metrics.Recorder) FileFilterOption {
 	return func(filter *FileFilter) error {
-		filter.metricsRecorder = recorder
+		filter.metrics = metrics.NewAccumulator(recorder)
 		return nil
 	}
 }
 
-func (fw *FileFilter) recordMetricLazy(scopeID, key string, getMetric func() int) {
-	if fw.metricsRecorder != nil {
-		fw.metricsRecorder.AddExtensionIntegerValue(metricKey(scopeID, key), getMetric())
+// The record*Lazy helpers obtain a metric only once it is known to be recorded, so that a FileFilter
+// without a recorder pays for none of them.
+func (fw *FileFilter) recordSumLazy(variant, key string, getMetric func() int) {
+	if fw.metrics.Recording() {
+		fw.metrics.AddToSum(metricKey(variant, key), getMetric())
 	}
 }
 
-func (fw *FileFilter) recordBoolMetricLazy(scopeID, key string, getMetric func() bool) {
-	if fw.metricsRecorder != nil {
-		fw.metricsRecorder.AddExtensionBoolValue(metricKey(scopeID, key), getMetric())
+// metricVariant names the behavior the calling run applies. It returns an empty variant while nothing
+// is recorded, so that the flags — whose lookup may reach the network — are not resolved for metrics alone.
+func (fw *FileFilter) metricVariant() string {
+	if !fw.metrics.Recording() {
+		return ""
 	}
+
+	metacharacterFix := fw.config.GetBool(FF_FILE_FILTER_METACHARACTER_FIX)
+	respectTrackedFiles := fw.config.GetBool(FF_GITIGNORE_RESPECT_TRACKED_FILES)
+
+	var variant string
+	switch {
+	case metacharacterFix && respectTrackedFiles:
+		variant = metricFileFilterVariantBothFixes
+	case metacharacterFix:
+		variant = metricFileFilterVariantMetacharFix
+	case respectTrackedFiles:
+		variant = metricFileFilterVariantTrackedFiles
+	default:
+		variant = metricFileFilterVariantLegacy
+	}
+
+	fw.metrics.RecordBool(metricKey(variant, metricFileFilterFeatureMetacharFix), metacharacterFix)
+	fw.metrics.RecordBool(metricKey(variant, metricFileFilterFeatureTrackedFiles), respectTrackedFiles)
+
+	return variant
 }
 
-// metricKey namespaces a metric under the scope of the filter run that recorded it, so that
-// repeated runs do not overwrite each other in a recorder that keeps only the last value per key.
-func metricKey(scopeID, key string) string {
-	return fmt.Sprintf("%s.%s.%s", metricFileFilterPrefix, scopeID, key)
-}
-
-func newFileFilterMetricScopeID() string {
-	return fmt.Sprintf("%d", nextFileFilterMetricScopeID.Add(1))
+// metricKey namespaces a metric under the file-filter prefix and the variant that produced it.
+func metricKey(variant, key string) string {
+	return fmt.Sprintf("%s.%s.%s", metricFileFilterPrefix, variant, key)
 }
 
 // NewFileFilter creates a FileFilter rooted at path. Without WithConfig, feature flags default to disabled (legacy).
@@ -161,6 +192,7 @@ func NewFileFilter(path string, logger *zerolog.Logger, options ...FileFilterOpt
 		logger:          logger,
 		max_threads:     int64(runtime.NumCPU()),
 		dotSnykSections: []DotSnykExcludeSectionName{DotSnykExcludeCode, DotSnykExcludeGlobal}, // init default with DotSnykExcludeCode and DotSnykExcludeGlobal to keep it backwards compatible
+		metrics:         metrics.NewAccumulator(nil),                                           // discards until WithMetrics supplies a recorder
 	}
 
 	options = append([]FileFilterOption{WithConfig(nil)}, options...)
@@ -207,21 +239,12 @@ func (fw *FileFilter) GetAllFiles() chan string {
 
 // GetRules builds a list of glob patterns that can be used to filter filesToFilter
 func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
-	// Both feature flags change how rules are built (see buildGlobs), so the rules scope reports
-	// them alongside the build duration rather than relying on a GetFilteredFiles run that may
-	// never happen or may read a different flag value.
-	scopeID := newFileFilterMetricScopeID()
+	// Reports under its own variant: a GetFilteredFiles run may never happen, or may resolve the flags differently.
+	variant := fw.metricVariant()
 	start := time.Now()
-	defer fw.recordMetricLazy(scopeID, metricFileFilterRulesBuildDurationMs, func() int {
+	defer fw.recordSumLazy(variant, metricFileFilterRulesBuildDurationMs, func() int {
 		return int(time.Since(start).Milliseconds())
 	})
-	fw.recordBoolMetricLazy(scopeID, metricFileFilterMetacharacterFix, func() bool {
-		return fw.config.GetBool(FF_FILE_FILTER_METACHARACTER_FIX)
-	})
-	fw.recordBoolMetricLazy(scopeID, metricFileFilterRespectTrackedFiles, func() bool {
-		return fw.config.GetBool(FF_GITIGNORE_RESPECT_TRACKED_FILES)
-	})
-
 	files := fw.GetAllFiles()
 
 	// iterate filesToFilter channel and find ignore filesToFilter
@@ -241,22 +264,23 @@ func (fw *FileFilter) GetRules(ruleFiles []string) ([]string, error) {
 		return nil, err
 	}
 
-	return append(fw.defaultRules, globs...), nil
+	rules := append(fw.defaultRules, globs...)
+	fw.recordSumLazy(variant, metricFileFilterRuleCount, func() int { return len(rules) })
+
+	return rules, nil
 }
 
 // GetFilteredFiles returns a filtered channel of filepaths from a given channel of filespaths and glob patterns to filter on
 func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan string {
-	// Each run reports under its own scope, so that concurrent or repeated runs of this FileFilter
-	// neither race on shared state nor overwrite each other's values in the recorder.
-	runScopeID := newFileFilterMetricScopeID()
-
 	var filteredFilesCh = make(chan string)
 
 	go func() {
 		ctx := context.Background()
 		availableThreads := semaphore.NewWeighted(fw.max_threads)
+		variant := fw.metricVariant()
 		start := time.Now()
 		var resolvedFileCount atomic.Int64
+		candidateFileCount := 0
 
 		defer close(filteredFilesCh)
 
@@ -274,6 +298,7 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 
 		// iterate the filesToFilter channel
 		for file := range filesCh {
+			candidateFileCount++
 			err := availableThreads.Acquire(ctx, 1)
 			if err != nil {
 				fw.logger.Err(err).Msg("failed to limit threads")
@@ -294,18 +319,14 @@ func (fw *FileFilter) GetFilteredFiles(filesCh chan string, globs []string) chan
 			fw.logger.Err(err).Msg("failed to wait for all threads")
 		}
 
-		fw.recordBoolMetricLazy(runScopeID, metricFileFilterMetacharacterFix, func() bool {
-			return fw.config.GetBool(FF_FILE_FILTER_METACHARACTER_FIX)
+		fw.recordSumLazy(variant, metricFileFilterInputFileCount, func() int {
+			return candidateFileCount
 		})
-		fw.recordBoolMetricLazy(runScopeID, metricFileFilterRespectTrackedFiles, func() bool {
-			return fw.config.GetBool(FF_GITIGNORE_RESPECT_TRACKED_FILES)
-		})
-		fw.recordMetricLazy(runScopeID, metricFileFilterDurationMs, func() int {
-			return int(time.Since(start).Milliseconds())
-		})
-		fw.recordMetricLazy(runScopeID, metricFileFilterSurvivingFileCount, func() int {
+		fw.recordSumLazy(variant, metricFileFilterSurvivingFileCount, func() int {
 			return int(resolvedFileCount.Load())
 		})
+
+		fw.recordSumLazy(variant, metricFileFilterDurationMs, func() int { return int(time.Since(start).Milliseconds()) })
 	}()
 
 	return filteredFilesCh

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -83,11 +83,11 @@ const (
 	metricVariantTrackedFiles = "var2" // FF_GITIGNORE_RESPECT_TRACKED_FILES only
 	metricVariantBothFixes    = ""     // both feature flags enabled; the variant segment is omitted
 
-	metricFilterInputFileCount  = "filter.inputFileCount"  // files offered to GetFilteredFiles, before exclusion
-	metricFilterOutputFileCount = "filter.outputFileCount" // number of files that passed exclusion
-	metricFilterDurationMs      = "filter.durationMs"      // elapsed time for GetFilteredFiles, including the caller's drain of the result channel
+	metricFilterInputFileCount  = "filter.inputFileCount"  // sum, across all GetFilteredFiles calls for the variant, of files offered before exclusion
+	metricFilterOutputFileCount = "filter.outputFileCount" // sum, across all GetFilteredFiles calls for the variant, of files that passed exclusion
+	metricFilterDurationMs      = "filter.durationMs"      // sum, across all GetFilteredFiles calls for the variant, of elapsed time including the caller's drain of the result channel
 
-	metricRulesBuildDurationMs = "rules.durationMs" // elapsed time for GetRules: directory walk, ignore discovery, and buildGlobs
+	metricRulesBuildDurationMs = "rules.durationMs" // sum, across all GetRules calls for the variant, of elapsed time for directory walk, ignore discovery, and buildGlobs
 
 	// Record feature flags alongside the variant so consumers need not decode its name.
 	metricFeatureMetacharFix  = "feature.metaCharFix"    // whether FF_FILE_FILTER_METACHARACTER_FIX applied to the run

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -134,8 +134,8 @@ func WithConfig(config configuration.Configuration) FileFilterOption {
 	}
 }
 
-// WithMetrics supplies a recorder for file-filter analytics values.
-// Callers must pass a pkg/analytics.Analytics implementation here; it satisfies this interface.
+// WithMetrics supplies a recorder (e.g. pkg/analytics.Analytics) for file-filter analytics values.
+// Every FileFilter reports under the same keys, so values aggregate instead of overwriting each other.
 func WithMetrics(recorder metrics.Recorder) FileFilterOption {
 	return func(filter *FileFilter) error {
 		filter.metrics = metrics.NewAccumulator(recorder)

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -2,10 +2,12 @@ package utils
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -2140,59 +2142,53 @@ func drainFilteredFiles(t *testing.T, filesCh <-chan string) []string {
 	return filteredFiles
 }
 
-// filterRunMetrics holds what a single FileFilter run recorded, keyed by metric name.
-type filterRunMetrics struct {
+// filterMetrics holds everything a recorder saw, keyed by metric name.
+type filterMetrics struct {
 	ints  map[string]int
 	bools map[string]bool
 }
 
-// metricsByScope groups everything a recorder saw by run scope, asserting the
-// "file-filter.<scopeID>.<metric>" shape of every key on the way. Scope IDs are allocated
-// inside a run and never exposed, so tests discover them here rather than predicting them.
-func metricsByScope(t *testing.T, recorder *metrics.RecorderFake) map[string]filterRunMetrics {
+// recordedMetrics groups what a recorder saw by variant, asserting the fixed
+// "file-filter.<variant>.<metric>" shape of every key on the way. Both parts come from a closed set,
+// so a run may not introduce a key of its own; its values are aggregated into its variant instead.
+func recordedMetrics(t *testing.T, recorder *metrics.RecorderFake) map[string]filterMetrics {
 	t.Helper()
 
-	runs := make(map[string]filterRunMetrics)
-	runFor := func(key string) (filterRunMetrics, string) {
-		parts := strings.Split(key, ".")
-		require.Len(t, parts, 3, "metric key %q must be %s.<scopeID>.<metric>", key, metricFileFilterPrefix)
-		require.Equal(t, metricFileFilterPrefix, parts[0])
+	knownVariants := []string{
+		metricFileFilterVariantLegacy,
+		metricFileFilterVariantMetacharFix,
+		metricFileFilterVariantTrackedFiles,
+		metricFileFilterVariantBothFixes,
+	}
 
-		run, ok := runs[parts[1]]
+	recorded := map[string]filterMetrics{}
+	variantFor := func(key string) (filterMetrics, string) {
+		// the metric names a group of its own (e.g. "filter.durationMs"), so only the prefix and the
+		// variant are split off
+		parts := strings.SplitN(key, ".", 3)
+		require.Len(t, parts, 3, "metric key %q must be %s.<variant>.<metric>", key, metricFileFilterPrefix)
+		require.Equal(t, metricFileFilterPrefix, parts[0])
+		require.Contains(t, knownVariants, parts[1], "metric key %q must name a known variant", key)
+
+		variant, ok := recorded[parts[1]]
 		if !ok {
-			run = filterRunMetrics{ints: map[string]int{}, bools: map[string]bool{}}
-			runs[parts[1]] = run
+			variant = filterMetrics{ints: map[string]int{}, bools: map[string]bool{}}
+			recorded[parts[1]] = variant
 		}
-		return run, parts[2]
+		return variant, parts[2]
 	}
 
 	for key, value := range recorder.IntValues {
-		run, metric := runFor(key)
-		run.ints[metric] = value
+		variant, metric := variantFor(key)
+		variant.ints[metric] = value
 	}
+
 	for key, value := range recorder.BoolValues {
-		run, metric := runFor(key)
-		run.bools[metric] = value
+		variant, metric := variantFor(key)
+		variant.bools[metric] = value
 	}
 
-	return runs
-}
-
-// singleRun returns the metrics of the one run a recorder is expected to have seen that recorded
-// the given metric. The metric picks the kind of run: metricFileFilterDurationMs is recorded by
-// GetFilteredFiles, metricFileFilterRulesBuildDurationMs by GetRules.
-func singleRun(t *testing.T, recorder *metrics.RecorderFake, metric string) filterRunMetrics {
-	t.Helper()
-
-	var matched []filterRunMetrics
-	for _, run := range metricsByScope(t, recorder) {
-		if _, ok := run.ints[metric]; ok {
-			matched = append(matched, run)
-		}
-	}
-	require.Len(t, matched, 1, "expected exactly one run recording %q", metric)
-
-	return matched[0]
+	return recorded
 }
 
 func TestFileFilter_Metrics(t *testing.T) {
@@ -2206,16 +2202,20 @@ func TestFileFilter_Metrics(t *testing.T) {
 		return root
 	}
 
-	// The two feature flags carry opposite values so that a mix-up between their metric keys cannot pass.
+	// Each combination of the feature flags names a variant of its own, so that the values of a run
+	// are never read as those of a run applying different behavior.
 	for _, test := range []struct {
 		name                string
 		metacharacterFix    bool
 		respectTrackedFiles bool
+		expectedVariant     string
 	}{
-		{name: "metacharacter fix only", metacharacterFix: true},
-		{name: "respect tracked files only", respectTrackedFiles: true},
+		{name: "neither fix", expectedVariant: metricFileFilterVariantLegacy},
+		{name: "metacharacter fix only", metacharacterFix: true, expectedVariant: metricFileFilterVariantMetacharFix},
+		{name: "respect tracked files only", respectTrackedFiles: true, expectedVariant: metricFileFilterVariantTrackedFiles},
+		{name: "both fixes", metacharacterFix: true, respectTrackedFiles: true, expectedVariant: metricFileFilterVariantBothFixes},
 	} {
-		t.Run("records every metric under run-scoped keys, "+test.name, func(t *testing.T) {
+		t.Run("records every metric under the variant of the run, "+test.name, func(t *testing.T) {
 			recorder := &metrics.RecorderFake{}
 			config := newTestConfig(map[string]bool{
 				FF_FILE_FILTER_METACHARACTER_FIX:   test.metacharacterFix,
@@ -2225,54 +2225,52 @@ func TestFileFilter_Metrics(t *testing.T) {
 
 			runFileFilter(t, fileFilter, ".gitignore")
 
-			run := singleRun(t, recorder, metricFileFilterDurationMs)
-			assert.Equal(t, map[string]bool{
-				metricFileFilterMetacharacterFix:    test.metacharacterFix,
-				metricFileFilterRespectTrackedFiles: test.respectTrackedFiles,
-			}, run.bools)
-			// .gitignore and file.txt pass the filter, ignored.txt does not
-			assert.Equal(t, 2, run.ints[metricFileFilterSurvivingFileCount])
-			assert.Contains(t, run.ints, metricFileFilterDurationMs)
-			assert.Len(t, run.ints, 2)
+			recorded := recordedMetrics(t, recorder)
+			require.Equal(t, []string{test.expectedVariant}, slices.Collect(maps.Keys(recorded)),
+				"a run reports under its variant and no other")
 
-			// Building the rules reports its duration and the flags it built them with, under a scope of its own.
-			rulesRun := singleRun(t, recorder, metricFileFilterRulesBuildDurationMs)
+			variant := recorded[test.expectedVariant]
+
+			// The durations depend on timing, so assert that they are reported and compare the rest exactly.
+			for _, duration := range []string{metricFileFilterDurationMs, metricFileFilterRulesBuildDurationMs} {
+				assert.Contains(t, variant.ints, duration)
+				delete(variant.ints, duration)
+			}
+
+			assert.Equal(t, map[string]int{
+				// .gitignore, ignored.txt and file.txt are walked
+				metricFileFilterInputFileCount: 3,
+				// .gitignore and file.txt pass the filter, ignored.txt does not
+				metricFileFilterSurvivingFileCount: 2,
+				// **/.git/** plus the two globs the ignored.txt rule expands into
+				metricFileFilterRuleCount: 3,
+			}, variant.ints)
+
+			// The variant is named after the flag combination, but a consumer should not have to
+			// decode that name: the flags a run applied are also recorded directly.
 			assert.Equal(t, map[string]bool{
-				metricFileFilterMetacharacterFix:    test.metacharacterFix,
-				metricFileFilterRespectTrackedFiles: test.respectTrackedFiles,
-			}, rulesRun.bools)
-			assert.Len(t, rulesRun.ints, 1)
+				metricFileFilterFeatureMetacharFix:  test.metacharacterFix,
+				metricFileFilterFeatureTrackedFiles: test.respectTrackedFiles,
+			}, variant.bools)
 		})
 	}
 
-	// Neither several FileFilter instances nor repeated runs of one instance may overwrite each other's values.
-	// The rules are built once and reused, so every run has to report on its own rather than relying on GetRules.
-	t.Run("every run reports under its own scope", func(t *testing.T) {
+	// Every run of a FileFilter reports under the same keys, so their values add up rather than
+	// overwriting each other.
+	t.Run("aggregates repeated runs into one value per key", func(t *testing.T) {
 		recorder := &metrics.RecorderFake{}
 		config := newTestConfig(map[string]bool{FF_FILE_FILTER_METACHARACTER_FIX: true})
 		fileFilter := NewFileFilter(newRepo(t), &log.Logger, WithConfig(config), WithMetrics(recorder))
 
+		// the rules are built once and reused, so the filter runs may not rely on GetRules reporting
 		rules, err := fileFilter.GetRules([]string{".gitignore"})
 		require.NoError(t, err)
-
 		drainFilteredFiles(t, fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), rules))
 		drainFilteredFiles(t, fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), rules))
-		runFileFilter(t, NewFileFilter(newRepo(t), &log.Logger, WithConfig(config), WithMetrics(recorder)), ".gitignore")
 
-		// two GetFilteredFiles runs of one FileFilter, one GetRules, and one full runFileFilter
-		// (GetRules + GetFilteredFiles), each under its own scope
-		runs := metricsByScope(t, recorder)
-		assert.Len(t, runs, 5)
-
-		filterRuns := 0
-		for scopeID, run := range runs {
-			if count, ok := run.ints[metricFileFilterSurvivingFileCount]; ok {
-				filterRuns++
-				assert.Equal(t, 2, count, "scope %s", scopeID)
-				assert.True(t, run.bools[metricFileFilterMetacharacterFix], "scope %s", scopeID)
-			}
-		}
-		assert.Equal(t, 3, filterRuns)
+		variant := recordedMetrics(t, recorder)[metricFileFilterVariantMetacharFix]
+		assert.Equal(t, 2*3, variant.ints[metricFileFilterInputFileCount])
+		assert.Equal(t, 2*2, variant.ints[metricFileFilterSurvivingFileCount])
 	})
 
 	t.Run("without a recorder filtering is unaffected", func(t *testing.T) {
@@ -2289,24 +2287,23 @@ func TestFileFilter_Metrics(t *testing.T) {
 		}
 	})
 
-	t.Run("records bool metrics when no ignore files produce globs", func(t *testing.T) {
+	t.Run("records metrics when no ignore file produces globs", func(t *testing.T) {
 		recorder := &metrics.RecorderFake{}
 		config := newTestConfig(map[string]bool{FF_FILE_FILTER_METACHARACTER_FIX: true})
 		root := t.TempDir()
 		createFileInPath(t, filepath.Join(root, "file.txt"), []byte("x"))
 		fileFilter := NewFileFilter(root, &log.Logger, WithConfig(config), WithMetrics(recorder))
 
-		drainFilteredFiles(t, fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), nil))
+		runFileFilter(t, fileFilter, ".gitignore")
 
-		assert.Equal(t, map[string]bool{
-			metricFileFilterMetacharacterFix:    true,
-			metricFileFilterRespectTrackedFiles: false,
-		}, singleRun(t, recorder, metricFileFilterDurationMs).bools)
+		variant := recordedMetrics(t, recorder)[metricFileFilterVariantMetacharFix]
+		assert.Equal(t, 1, variant.ints[metricFileFilterRuleCount], "only the default **/.git/** rule remains")
+		assert.Equal(t, 1, variant.ints[metricFileFilterSurvivingFileCount])
 	})
 
-	// One FileFilter may be started from several goroutines at once: no run may race on shared
-	// state or land in the scope of another. Run under -race to cover the former.
-	t.Run("concurrent filter runs use distinct metric scopes", func(t *testing.T) {
+	// One FileFilter may be started from several goroutines at once: no run may race on shared state
+	// or lose its values to another. Run under -race to cover the former.
+	t.Run("concurrent filter runs aggregate without loss", func(t *testing.T) {
 		const concurrentRuns = 4
 		recorder := &metrics.RecorderFake{}
 		fileFilter := NewFileFilter(newRepo(t), &log.Logger, WithMetrics(recorder))
@@ -2321,10 +2318,35 @@ func TestFileFilter_Metrics(t *testing.T) {
 		}
 		wg.Wait()
 
-		runs := metricsByScope(t, recorder)
-		assert.Len(t, runs, concurrentRuns)
-		for scopeID, run := range runs {
-			assert.Contains(t, run.ints, metricFileFilterDurationMs, "scope %s", scopeID)
-		}
+		variant := recordedMetrics(t, recorder)[metricFileFilterVariantLegacy]
+		// **/.git/** excludes none of newRepo's three files
+		assert.Equal(t, concurrentRuns*3, variant.ints[metricFileFilterInputFileCount])
+		assert.Equal(t, concurrentRuns*3, variant.ints[metricFileFilterSurvivingFileCount])
+	})
+
+	// A feature flag may resolve differently between the runs of one FileFilter. Each run then reports
+	// under the variant of the behavior it applied, leaving neither variant holding values of the other.
+	t.Run("keeps runs applying differing behavior apart", func(t *testing.T) {
+		recorder := &metrics.RecorderFake{}
+		config := newTestConfig(map[string]bool{FF_FILE_FILTER_METACHARACTER_FIX: false})
+		fileFilter := NewFileFilter(newRepo(t), &log.Logger, WithConfig(config), WithMetrics(recorder))
+
+		rules, err := fileFilter.GetRules([]string{".gitignore"})
+		require.NoError(t, err)
+		config.Set(FF_FILE_FILTER_METACHARACTER_FIX, true)
+		drainFilteredFiles(t, fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), rules))
+
+		recorded := recordedMetrics(t, recorder)
+		assert.ElementsMatch(t, []string{metricFileFilterVariantLegacy, metricFileFilterVariantMetacharFix},
+			slices.Collect(maps.Keys(recorded)))
+
+		// the rules were built on the legacy behavior, the filtering applied the fix
+		legacy := recorded[metricFileFilterVariantLegacy]
+		assert.Contains(t, legacy.ints, metricFileFilterRuleCount)
+		assert.NotContains(t, legacy.ints, metricFileFilterInputFileCount)
+
+		metacharFix := recorded[metricFileFilterVariantMetacharFix]
+		assert.Contains(t, metacharFix.ints, metricFileFilterInputFileCount)
+		assert.NotContains(t, metacharFix.ints, metricFileFilterRuleCount)
 	})
 }

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -2155,7 +2155,8 @@ type filterMetrics struct {
 }
 
 // recordedMetrics groups what a recorder saw by variant, asserting the fixed
-// "file-filter.<variant>.<metric>" shape of every key on the way.
+// "file-filter.<variant>.<metric>" shape of every key on the way, except for
+// metricFileFilterVariantBothFixes, whose keys drop the variant segment: "file-filter.<metric>".
 func recordedMetrics(t *testing.T, recorder *metrics.RecorderFake) map[string]filterMetrics {
 	t.Helper()
 
@@ -2163,23 +2164,28 @@ func recordedMetrics(t *testing.T, recorder *metrics.RecorderFake) map[string]fi
 		metricFileFilterVariantLegacy,
 		metricFileFilterVariantMetacharFix,
 		metricFileFilterVariantTrackedFiles,
-		metricFileFilterVariantBothFixes,
 	}
 
 	recorded := map[string]filterMetrics{}
 	variantFor := func(key string) (filterMetrics, string) {
-		// Preserve dots within the metric name, such as "filter.durationMs".
-		parts := strings.SplitN(key, ".", 3)
-		require.Len(t, parts, 3, "metric key %q must be %s.<variant>.<metric>", key, metricFileFilterPrefix)
-		require.Equal(t, metricFileFilterPrefix, parts[0])
-		require.Contains(t, knownVariants, parts[1], "metric key %q must name a known variant", key)
+		rest, ok := strings.CutPrefix(key, metricFileFilterPrefix+".")
+		require.True(t, ok, "metric key %q must start with %q", key, metricFileFilterPrefix+".")
 
-		variant, ok := recorded[parts[1]]
-		if !ok {
-			variant = filterMetrics{ints: map[string]int{}, bools: map[string]bool{}}
-			recorded[parts[1]] = variant
+		// Preserve dots within the metric name, such as "filter.durationMs".
+		variant, metric := metricFileFilterVariantBothFixes, rest
+		for _, known := range knownVariants {
+			if m, hasVariant := strings.CutPrefix(rest, known+"."); hasVariant {
+				variant, metric = known, m
+				break
+			}
 		}
-		return variant, parts[2]
+
+		group, ok := recorded[variant]
+		if !ok {
+			group = filterMetrics{ints: map[string]int{}, bools: map[string]bool{}}
+			recorded[variant] = group
+		}
+		return group, metric
 	}
 
 	for key, value := range recorder.IntValues {

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -2142,15 +2142,13 @@ func drainFilteredFiles(t *testing.T, filesCh <-chan string) []string {
 	return filteredFiles
 }
 
-// newMetricsRecorder returns a recorder for a test that asserts the values it saw; a test may not
-// inherit the accumulated values of a preceding one, see metrics.ResetAccumulated.
+// newMetricsRecorder prevents shared values leaking between tests.
 func newMetricsRecorder(t *testing.T) *metrics.RecorderFake {
 	t.Helper()
 	metrics.ResetAccumulated()
 	return metrics.NewRecorderFake()
 }
 
-// filterMetrics holds everything a recorder saw, keyed by metric name.
 type filterMetrics struct {
 	ints  map[string]int
 	bools map[string]bool
@@ -2170,8 +2168,7 @@ func recordedMetrics(t *testing.T, recorder *metrics.RecorderFake) map[string]fi
 
 	recorded := map[string]filterMetrics{}
 	variantFor := func(key string) (filterMetrics, string) {
-		// the metric names a group of its own (e.g. "filter.durationMs"), so only the prefix and the
-		// variant are split off
+		// Preserve dots within the metric name, such as "filter.durationMs".
 		parts := strings.SplitN(key, ".", 3)
 		require.Len(t, parts, 3, "metric key %q must be %s.<variant>.<metric>", key, metricFileFilterPrefix)
 		require.Equal(t, metricFileFilterPrefix, parts[0])
@@ -2209,8 +2206,6 @@ func TestFileFilter_Metrics(t *testing.T) {
 		return root
 	}
 
-	// Each combination of the feature flags names a variant of its own, so that the values of a run
-	// are never read as those of a run applying different behavior.
 	for _, test := range []struct {
 		name                string
 		metacharacterFix    bool
@@ -2238,7 +2233,7 @@ func TestFileFilter_Metrics(t *testing.T) {
 
 			variant := recorded[test.expectedVariant]
 
-			// The durations depend on timing, so assert that they are reported and compare the rest exactly.
+			// Durations vary, so compare only their presence.
 			for _, duration := range []string{metricFileFilterDurationMs, metricFileFilterRulesBuildDurationMs} {
 				assert.Contains(t, variant.ints, duration)
 				delete(variant.ints, duration)
@@ -2253,8 +2248,6 @@ func TestFileFilter_Metrics(t *testing.T) {
 				metricFileFilterRuleCount: 3,
 			}, variant.ints)
 
-			// The variant is named after the flag combination, but a consumer should not have to
-			// decode that name: the flags a run applied are also recorded directly.
 			assert.Equal(t, map[string]bool{
 				metricFileFilterFeatureMetacharFix:  test.metacharacterFix,
 				metricFileFilterFeatureTrackedFiles: test.respectTrackedFiles,
@@ -2262,8 +2255,6 @@ func TestFileFilter_Metrics(t *testing.T) {
 		})
 	}
 
-	// Every run of a FileFilter reports under the same keys, so the runs of one FileFilter, or the
-	// runs of several, add up rather than overwriting each other.
 	t.Run("aggregates runs into one value per key", func(t *testing.T) {
 		for _, test := range []struct {
 			name     string
@@ -2281,7 +2272,6 @@ func TestFileFilter_Metrics(t *testing.T) {
 				for range test.filters {
 					fileFilter := NewFileFilter(newRepo(t), &log.Logger, WithConfig(config), WithMetrics(recorder))
 
-					// the rules are built once and reused, so repeated runs may not rely on GetRules reporting
 					rules, err := fileFilter.GetRules([]string{".gitignore"})
 					require.NoError(t, err)
 					for range test.runsEach {
@@ -2296,8 +2286,7 @@ func TestFileFilter_Metrics(t *testing.T) {
 		}
 	})
 
-	// Several FileFilters, or several goroutines sharing one, may run concurrently: neither races on
-	// the accumulated values nor loses them to one another. Run under -race to cover the former.
+	// Run under -race to cover concurrent access to accumulated values.
 	t.Run("concurrent runs aggregate without loss", func(t *testing.T) {
 		for _, test := range []struct {
 			name          string
@@ -2310,7 +2299,6 @@ func TestFileFilter_Metrics(t *testing.T) {
 				const concurrentRuns = 4
 				recorder := newMetricsRecorder(t)
 
-				// the filters are created up front, so that the goroutines only run them
 				filters := make([]*FileFilter, concurrentRuns)
 				if test.oneFilterEach {
 					for i := range filters {
@@ -2369,8 +2357,6 @@ func TestFileFilter_Metrics(t *testing.T) {
 		assert.Equal(t, 1, variant.ints[metricFileFilterSurvivingFileCount])
 	})
 
-	// A feature flag may resolve differently between the runs of one FileFilter. Each run then reports
-	// under the variant of the behavior it applied, leaving neither variant holding values of the other.
 	t.Run("keeps runs applying differing behavior apart", func(t *testing.T) {
 		recorder := newMetricsRecorder(t)
 		config := newTestConfig(map[string]bool{FF_FILE_FILTER_METACHARACTER_FIX: false})
@@ -2385,7 +2371,6 @@ func TestFileFilter_Metrics(t *testing.T) {
 		assert.ElementsMatch(t, []string{metricFileFilterVariantLegacy, metricFileFilterVariantMetacharFix},
 			slices.Collect(maps.Keys(recorded)))
 
-		// the rules were built on the legacy behavior, the filtering applied the fix
 		legacy := recorded[metricFileFilterVariantLegacy]
 		assert.Contains(t, legacy.ints, metricFileFilterRuleCount)
 		assert.NotContains(t, legacy.ints, metricFileFilterInputFileCount)

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -2142,6 +2142,14 @@ func drainFilteredFiles(t *testing.T, filesCh <-chan string) []string {
 	return filteredFiles
 }
 
+// newMetricsRecorder returns a recorder for a test that asserts the values it saw; a test may not
+// inherit the accumulated values of a preceding one, see metrics.ResetAccumulated.
+func newMetricsRecorder(t *testing.T) *metrics.RecorderFake {
+	t.Helper()
+	metrics.ResetAccumulated()
+	return metrics.NewRecorderFake()
+}
+
 // filterMetrics holds everything a recorder saw, keyed by metric name.
 type filterMetrics struct {
 	ints  map[string]int
@@ -2149,8 +2157,7 @@ type filterMetrics struct {
 }
 
 // recordedMetrics groups what a recorder saw by variant, asserting the fixed
-// "file-filter.<variant>.<metric>" shape of every key on the way. Both parts come from a closed set,
-// so a run may not introduce a key of its own; its values are aggregated into its variant instead.
+// "file-filter.<variant>.<metric>" shape of every key on the way.
 func recordedMetrics(t *testing.T, recorder *metrics.RecorderFake) map[string]filterMetrics {
 	t.Helper()
 
@@ -2216,7 +2223,7 @@ func TestFileFilter_Metrics(t *testing.T) {
 		{name: "both fixes", metacharacterFix: true, respectTrackedFiles: true, expectedVariant: metricFileFilterVariantBothFixes},
 	} {
 		t.Run("records every metric under the variant of the run, "+test.name, func(t *testing.T) {
-			recorder := metrics.NewRecorderFake()
+			recorder := newMetricsRecorder(t)
 			config := newTestConfig(map[string]bool{
 				FF_FILE_FILTER_METACHARACTER_FIX:   test.metacharacterFix,
 				FF_GITIGNORE_RESPECT_TRACKED_FILES: test.respectTrackedFiles,
@@ -2255,22 +2262,83 @@ func TestFileFilter_Metrics(t *testing.T) {
 		})
 	}
 
-	// Every run of a FileFilter reports under the same keys, so their values add up rather than
-	// overwriting each other.
-	t.Run("aggregates repeated runs into one value per key", func(t *testing.T) {
-		recorder := metrics.NewRecorderFake()
-		config := newTestConfig(map[string]bool{FF_FILE_FILTER_METACHARACTER_FIX: true})
-		fileFilter := NewFileFilter(newRepo(t), &log.Logger, WithConfig(config), WithMetrics(recorder))
+	// Every run of a FileFilter reports under the same keys, so the runs of one FileFilter, or the
+	// runs of several, add up rather than overwriting each other.
+	t.Run("aggregates runs into one value per key", func(t *testing.T) {
+		for _, test := range []struct {
+			name     string
+			filters  int
+			runsEach int
+		}{
+			{name: "repeated runs of one FileFilter", filters: 1, runsEach: 2},
+			{name: "one run each of several FileFilters", filters: 3, runsEach: 1},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				recorder := newMetricsRecorder(t)
+				config := newTestConfig(map[string]bool{FF_FILE_FILTER_METACHARACTER_FIX: true})
+				totalRuns := test.filters * test.runsEach
 
-		// the rules are built once and reused, so the filter runs may not rely on GetRules reporting
-		rules, err := fileFilter.GetRules([]string{".gitignore"})
-		require.NoError(t, err)
-		drainFilteredFiles(t, fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), rules))
-		drainFilteredFiles(t, fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), rules))
+				for range test.filters {
+					fileFilter := NewFileFilter(newRepo(t), &log.Logger, WithConfig(config), WithMetrics(recorder))
 
-		variant := recordedMetrics(t, recorder)[metricFileFilterVariantMetacharFix]
-		assert.Equal(t, 2*3, variant.ints[metricFileFilterInputFileCount])
-		assert.Equal(t, 2*2, variant.ints[metricFileFilterSurvivingFileCount])
+					// the rules are built once and reused, so repeated runs may not rely on GetRules reporting
+					rules, err := fileFilter.GetRules([]string{".gitignore"})
+					require.NoError(t, err)
+					for range test.runsEach {
+						drainFilteredFiles(t, fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), rules))
+					}
+				}
+
+				variant := recordedMetrics(t, recorder)[metricFileFilterVariantMetacharFix]
+				assert.Equal(t, totalRuns*3, variant.ints[metricFileFilterInputFileCount])
+				assert.Equal(t, totalRuns*2, variant.ints[metricFileFilterSurvivingFileCount])
+			})
+		}
+	})
+
+	// Several FileFilters, or several goroutines sharing one, may run concurrently: neither races on
+	// the accumulated values nor loses them to one another. Run under -race to cover the former.
+	t.Run("concurrent runs aggregate without loss", func(t *testing.T) {
+		for _, test := range []struct {
+			name          string
+			oneFilterEach bool
+		}{
+			{name: "several FileFilters", oneFilterEach: true},
+			{name: "one FileFilter from several goroutines", oneFilterEach: false},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				const concurrentRuns = 4
+				recorder := newMetricsRecorder(t)
+
+				// the filters are created up front, so that the goroutines only run them
+				filters := make([]*FileFilter, concurrentRuns)
+				if test.oneFilterEach {
+					for i := range filters {
+						filters[i] = NewFileFilter(newRepo(t), &log.Logger, WithMetrics(recorder))
+					}
+				} else {
+					shared := NewFileFilter(newRepo(t), &log.Logger, WithMetrics(recorder))
+					for i := range filters {
+						filters[i] = shared
+					}
+				}
+
+				var wg sync.WaitGroup
+				wg.Add(concurrentRuns)
+				for _, fileFilter := range filters {
+					go func() {
+						defer wg.Done()
+						drainFilteredFiles(t, fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), []string{"**/.git/**"}))
+					}()
+				}
+				wg.Wait()
+
+				variant := recordedMetrics(t, recorder)[metricFileFilterVariantLegacy]
+				// **/.git/** excludes none of newRepo's three files
+				assert.Equal(t, concurrentRuns*3, variant.ints[metricFileFilterInputFileCount])
+				assert.Equal(t, concurrentRuns*3, variant.ints[metricFileFilterSurvivingFileCount])
+			})
+		}
 	})
 
 	t.Run("without a recorder filtering is unaffected", func(t *testing.T) {
@@ -2288,7 +2356,7 @@ func TestFileFilter_Metrics(t *testing.T) {
 	})
 
 	t.Run("records metrics when no ignore file produces globs", func(t *testing.T) {
-		recorder := metrics.NewRecorderFake()
+		recorder := newMetricsRecorder(t)
 		config := newTestConfig(map[string]bool{FF_FILE_FILTER_METACHARACTER_FIX: true})
 		root := t.TempDir()
 		createFileInPath(t, filepath.Join(root, "file.txt"), []byte("x"))
@@ -2301,33 +2369,10 @@ func TestFileFilter_Metrics(t *testing.T) {
 		assert.Equal(t, 1, variant.ints[metricFileFilterSurvivingFileCount])
 	})
 
-	// One FileFilter may be started from several goroutines at once: no run may race on shared state
-	// or lose its values to another. Run under -race to cover the former.
-	t.Run("concurrent filter runs aggregate without loss", func(t *testing.T) {
-		const concurrentRuns = 4
-		recorder := metrics.NewRecorderFake()
-		fileFilter := NewFileFilter(newRepo(t), &log.Logger, WithMetrics(recorder))
-
-		var wg sync.WaitGroup
-		wg.Add(concurrentRuns)
-		for range concurrentRuns {
-			go func() {
-				defer wg.Done()
-				drainFilteredFiles(t, fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), []string{"**/.git/**"}))
-			}()
-		}
-		wg.Wait()
-
-		variant := recordedMetrics(t, recorder)[metricFileFilterVariantLegacy]
-		// **/.git/** excludes none of newRepo's three files
-		assert.Equal(t, concurrentRuns*3, variant.ints[metricFileFilterInputFileCount])
-		assert.Equal(t, concurrentRuns*3, variant.ints[metricFileFilterSurvivingFileCount])
-	})
-
 	// A feature flag may resolve differently between the runs of one FileFilter. Each run then reports
 	// under the variant of the behavior it applied, leaving neither variant holding values of the other.
 	t.Run("keeps runs applying differing behavior apart", func(t *testing.T) {
-		recorder := metrics.NewRecorderFake()
+		recorder := newMetricsRecorder(t)
 		config := newTestConfig(map[string]bool{FF_FILE_FILTER_METACHARACTER_FIX: false})
 		fileFilter := NewFileFilter(newRepo(t), &log.Logger, WithConfig(config), WithMetrics(recorder))
 

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -2216,7 +2216,7 @@ func TestFileFilter_Metrics(t *testing.T) {
 		{name: "both fixes", metacharacterFix: true, respectTrackedFiles: true, expectedVariant: metricFileFilterVariantBothFixes},
 	} {
 		t.Run("records every metric under the variant of the run, "+test.name, func(t *testing.T) {
-			recorder := &metrics.RecorderFake{}
+			recorder := metrics.NewRecorderFake()
 			config := newTestConfig(map[string]bool{
 				FF_FILE_FILTER_METACHARACTER_FIX:   test.metacharacterFix,
 				FF_GITIGNORE_RESPECT_TRACKED_FILES: test.respectTrackedFiles,
@@ -2258,7 +2258,7 @@ func TestFileFilter_Metrics(t *testing.T) {
 	// Every run of a FileFilter reports under the same keys, so their values add up rather than
 	// overwriting each other.
 	t.Run("aggregates repeated runs into one value per key", func(t *testing.T) {
-		recorder := &metrics.RecorderFake{}
+		recorder := metrics.NewRecorderFake()
 		config := newTestConfig(map[string]bool{FF_FILE_FILTER_METACHARACTER_FIX: true})
 		fileFilter := NewFileFilter(newRepo(t), &log.Logger, WithConfig(config), WithMetrics(recorder))
 
@@ -2288,7 +2288,7 @@ func TestFileFilter_Metrics(t *testing.T) {
 	})
 
 	t.Run("records metrics when no ignore file produces globs", func(t *testing.T) {
-		recorder := &metrics.RecorderFake{}
+		recorder := metrics.NewRecorderFake()
 		config := newTestConfig(map[string]bool{FF_FILE_FILTER_METACHARACTER_FIX: true})
 		root := t.TempDir()
 		createFileInPath(t, filepath.Join(root, "file.txt"), []byte("x"))
@@ -2305,7 +2305,7 @@ func TestFileFilter_Metrics(t *testing.T) {
 	// or lose its values to another. Run under -race to cover the former.
 	t.Run("concurrent filter runs aggregate without loss", func(t *testing.T) {
 		const concurrentRuns = 4
-		recorder := &metrics.RecorderFake{}
+		recorder := metrics.NewRecorderFake()
 		fileFilter := NewFileFilter(newRepo(t), &log.Logger, WithMetrics(recorder))
 
 		var wg sync.WaitGroup
@@ -2327,7 +2327,7 @@ func TestFileFilter_Metrics(t *testing.T) {
 	// A feature flag may resolve differently between the runs of one FileFilter. Each run then reports
 	// under the variant of the behavior it applied, leaving neither variant holding values of the other.
 	t.Run("keeps runs applying differing behavior apart", func(t *testing.T) {
-		recorder := &metrics.RecorderFake{}
+		recorder := metrics.NewRecorderFake()
 		config := newTestConfig(map[string]bool{FF_FILE_FILTER_METACHARACTER_FIX: false})
 		fileFilter := NewFileFilter(newRepo(t), &log.Logger, WithConfig(config), WithMetrics(recorder))
 

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -2249,9 +2249,7 @@ func TestFileFilter_Metrics(t *testing.T) {
 				// .gitignore, ignored.txt and file.txt are walked
 				metricFilterInputFileCount: 3,
 				// .gitignore and file.txt pass the filter, ignored.txt does not
-				metricFilterSurvivingFileCount: 2,
-				// **/.git/** plus the two globs the ignored.txt rule expands into
-				metricFilterRuleCount: 3,
+				metricFilterOutputFileCount: 2,
 			}, variant.ints)
 
 			assert.Equal(t, map[string]bool{
@@ -2287,7 +2285,7 @@ func TestFileFilter_Metrics(t *testing.T) {
 
 				variant := recordedMetrics(t, recorder)[metriVariantMetacharFix]
 				assert.Equal(t, totalRuns*3, variant.ints[metricFilterInputFileCount])
-				assert.Equal(t, totalRuns*2, variant.ints[metricFilterSurvivingFileCount])
+				assert.Equal(t, totalRuns*2, variant.ints[metricFilterOutputFileCount])
 			})
 		}
 	})
@@ -2330,7 +2328,7 @@ func TestFileFilter_Metrics(t *testing.T) {
 				variant := recordedMetrics(t, recorder)[metricVariantLegacy]
 				// **/.git/** excludes none of newRepo's three files
 				assert.Equal(t, concurrentRuns*3, variant.ints[metricFilterInputFileCount])
-				assert.Equal(t, concurrentRuns*3, variant.ints[metricFilterSurvivingFileCount])
+				assert.Equal(t, concurrentRuns*3, variant.ints[metricFilterOutputFileCount])
 			})
 		}
 	})
@@ -2359,8 +2357,7 @@ func TestFileFilter_Metrics(t *testing.T) {
 		runFileFilter(t, fileFilter, ".gitignore")
 
 		variant := recordedMetrics(t, recorder)[metriVariantMetacharFix]
-		assert.Equal(t, 1, variant.ints[metricFilterRuleCount], "only the default **/.git/** rule remains")
-		assert.Equal(t, 1, variant.ints[metricFilterSurvivingFileCount])
+		assert.Equal(t, 1, variant.ints[metricFilterOutputFileCount])
 	})
 
 	t.Run("keeps runs applying differing behavior apart", func(t *testing.T) {
@@ -2378,11 +2375,11 @@ func TestFileFilter_Metrics(t *testing.T) {
 			slices.Collect(maps.Keys(recorded)))
 
 		legacy := recorded[metricVariantLegacy]
-		assert.Contains(t, legacy.ints, metricFilterRuleCount)
+		assert.Contains(t, legacy.ints, metricRulesBuildDurationMs)
 		assert.NotContains(t, legacy.ints, metricFilterInputFileCount)
 
 		metacharFix := recorded[metriVariantMetacharFix]
 		assert.Contains(t, metacharFix.ints, metricFilterInputFileCount)
-		assert.NotContains(t, metacharFix.ints, metricFilterRuleCount)
+		assert.NotContains(t, metacharFix.ints, metricRulesBuildDurationMs)
 	})
 }

--- a/pkg/utils/file_filter_test.go
+++ b/pkg/utils/file_filter_test.go
@@ -2161,18 +2161,18 @@ func recordedMetrics(t *testing.T, recorder *metrics.RecorderFake) map[string]fi
 	t.Helper()
 
 	knownVariants := []string{
-		metricFileFilterVariantLegacy,
-		metricFileFilterVariantMetacharFix,
-		metricFileFilterVariantTrackedFiles,
+		metricVariantLegacy,
+		metriVariantMetacharFix,
+		metricVariantTrackedFiles,
 	}
 
 	recorded := map[string]filterMetrics{}
 	variantFor := func(key string) (filterMetrics, string) {
-		rest, ok := strings.CutPrefix(key, metricFileFilterPrefix+".")
-		require.True(t, ok, "metric key %q must start with %q", key, metricFileFilterPrefix+".")
+		rest, ok := strings.CutPrefix(key, metricPrefix+".")
+		require.True(t, ok, "metric key %q must start with %q", key, metricPrefix+".")
 
 		// Preserve dots within the metric name, such as "filter.durationMs".
-		variant, metric := metricFileFilterVariantBothFixes, rest
+		variant, metric := metricVariantBothFixes, rest
 		for _, known := range knownVariants {
 			if m, hasVariant := strings.CutPrefix(rest, known+"."); hasVariant {
 				variant, metric = known, m
@@ -2218,10 +2218,10 @@ func TestFileFilter_Metrics(t *testing.T) {
 		respectTrackedFiles bool
 		expectedVariant     string
 	}{
-		{name: "neither fix", expectedVariant: metricFileFilterVariantLegacy},
-		{name: "metacharacter fix only", metacharacterFix: true, expectedVariant: metricFileFilterVariantMetacharFix},
-		{name: "respect tracked files only", respectTrackedFiles: true, expectedVariant: metricFileFilterVariantTrackedFiles},
-		{name: "both fixes", metacharacterFix: true, respectTrackedFiles: true, expectedVariant: metricFileFilterVariantBothFixes},
+		{name: "neither fix", expectedVariant: metricVariantLegacy},
+		{name: "metacharacter fix only", metacharacterFix: true, expectedVariant: metriVariantMetacharFix},
+		{name: "respect tracked files only", respectTrackedFiles: true, expectedVariant: metricVariantTrackedFiles},
+		{name: "both fixes", metacharacterFix: true, respectTrackedFiles: true, expectedVariant: metricVariantBothFixes},
 	} {
 		t.Run("records every metric under the variant of the run, "+test.name, func(t *testing.T) {
 			recorder := newMetricsRecorder(t)
@@ -2240,23 +2240,23 @@ func TestFileFilter_Metrics(t *testing.T) {
 			variant := recorded[test.expectedVariant]
 
 			// Durations vary, so compare only their presence.
-			for _, duration := range []string{metricFileFilterDurationMs, metricFileFilterRulesBuildDurationMs} {
+			for _, duration := range []string{metricFilterDurationMs, metricRulesBuildDurationMs} {
 				assert.Contains(t, variant.ints, duration)
 				delete(variant.ints, duration)
 			}
 
 			assert.Equal(t, map[string]int{
 				// .gitignore, ignored.txt and file.txt are walked
-				metricFileFilterInputFileCount: 3,
+				metricFilterInputFileCount: 3,
 				// .gitignore and file.txt pass the filter, ignored.txt does not
-				metricFileFilterSurvivingFileCount: 2,
+				metricFilterSurvivingFileCount: 2,
 				// **/.git/** plus the two globs the ignored.txt rule expands into
-				metricFileFilterRuleCount: 3,
+				metricFilterRuleCount: 3,
 			}, variant.ints)
 
 			assert.Equal(t, map[string]bool{
-				metricFileFilterFeatureMetacharFix:  test.metacharacterFix,
-				metricFileFilterFeatureTrackedFiles: test.respectTrackedFiles,
+				metricFeatureMetacharFix:  test.metacharacterFix,
+				metricFeatureTrackedFiles: test.respectTrackedFiles,
 			}, variant.bools)
 		})
 	}
@@ -2285,9 +2285,9 @@ func TestFileFilter_Metrics(t *testing.T) {
 					}
 				}
 
-				variant := recordedMetrics(t, recorder)[metricFileFilterVariantMetacharFix]
-				assert.Equal(t, totalRuns*3, variant.ints[metricFileFilterInputFileCount])
-				assert.Equal(t, totalRuns*2, variant.ints[metricFileFilterSurvivingFileCount])
+				variant := recordedMetrics(t, recorder)[metriVariantMetacharFix]
+				assert.Equal(t, totalRuns*3, variant.ints[metricFilterInputFileCount])
+				assert.Equal(t, totalRuns*2, variant.ints[metricFilterSurvivingFileCount])
 			})
 		}
 	})
@@ -2327,10 +2327,10 @@ func TestFileFilter_Metrics(t *testing.T) {
 				}
 				wg.Wait()
 
-				variant := recordedMetrics(t, recorder)[metricFileFilterVariantLegacy]
+				variant := recordedMetrics(t, recorder)[metricVariantLegacy]
 				// **/.git/** excludes none of newRepo's three files
-				assert.Equal(t, concurrentRuns*3, variant.ints[metricFileFilterInputFileCount])
-				assert.Equal(t, concurrentRuns*3, variant.ints[metricFileFilterSurvivingFileCount])
+				assert.Equal(t, concurrentRuns*3, variant.ints[metricFilterInputFileCount])
+				assert.Equal(t, concurrentRuns*3, variant.ints[metricFilterSurvivingFileCount])
 			})
 		}
 	})
@@ -2358,9 +2358,9 @@ func TestFileFilter_Metrics(t *testing.T) {
 
 		runFileFilter(t, fileFilter, ".gitignore")
 
-		variant := recordedMetrics(t, recorder)[metricFileFilterVariantMetacharFix]
-		assert.Equal(t, 1, variant.ints[metricFileFilterRuleCount], "only the default **/.git/** rule remains")
-		assert.Equal(t, 1, variant.ints[metricFileFilterSurvivingFileCount])
+		variant := recordedMetrics(t, recorder)[metriVariantMetacharFix]
+		assert.Equal(t, 1, variant.ints[metricFilterRuleCount], "only the default **/.git/** rule remains")
+		assert.Equal(t, 1, variant.ints[metricFilterSurvivingFileCount])
 	})
 
 	t.Run("keeps runs applying differing behavior apart", func(t *testing.T) {
@@ -2374,15 +2374,15 @@ func TestFileFilter_Metrics(t *testing.T) {
 		drainFilteredFiles(t, fileFilter.GetFilteredFiles(fileFilter.GetAllFiles(), rules))
 
 		recorded := recordedMetrics(t, recorder)
-		assert.ElementsMatch(t, []string{metricFileFilterVariantLegacy, metricFileFilterVariantMetacharFix},
+		assert.ElementsMatch(t, []string{metricVariantLegacy, metriVariantMetacharFix},
 			slices.Collect(maps.Keys(recorded)))
 
-		legacy := recorded[metricFileFilterVariantLegacy]
-		assert.Contains(t, legacy.ints, metricFileFilterRuleCount)
-		assert.NotContains(t, legacy.ints, metricFileFilterInputFileCount)
+		legacy := recorded[metricVariantLegacy]
+		assert.Contains(t, legacy.ints, metricFilterRuleCount)
+		assert.NotContains(t, legacy.ints, metricFilterInputFileCount)
 
-		metacharFix := recorded[metricFileFilterVariantMetacharFix]
-		assert.Contains(t, metacharFix.ints, metricFileFilterInputFileCount)
-		assert.NotContains(t, metacharFix.ints, metricFileFilterRuleCount)
+		metacharFix := recorded[metriVariantMetacharFix]
+		assert.Contains(t, metacharFix.ints, metricFilterInputFileCount)
+		assert.NotContains(t, metacharFix.ints, metricFilterRuleCount)
 	})
 }

--- a/pkg/workflow/invocationcontextimpl_test.go
+++ b/pkg/workflow/invocationcontextimpl_test.go
@@ -106,7 +106,6 @@ func TestInvocationContextImpl_GetFileFilter(t *testing.T) {
 
 		assert.ElementsMatch(t, []string{
 			"file-filter.var0.filter.inputFileCount",
-			"file-filter.var0.filter.ruleCount",
 			"file-filter.var0.filter.durationMs",
 			"file-filter.var0.rules.durationMs",
 			"file-filter.var0.filter.outputFileCount",

--- a/pkg/workflow/invocationcontextimpl_test.go
+++ b/pkg/workflow/invocationcontextimpl_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -77,7 +78,24 @@ func TestInvocationContextImpl_GetFileFilter(t *testing.T) {
 			"the option passed by the caller must win over the invocation's configuration")
 	})
 
-	// The FileFilter records into the invocation's Analytics, so the metrics have to show up in its instrumentation.
+	// fileFilterMetrics returns the file-filter entries of an invocation's instrumentation extension.
+	fileFilterMetrics := func(t *testing.T, invocationAnalytics analytics.Analytics) map[string]any {
+		t.Helper()
+
+		obj, err := analytics.GetV2InstrumentationObject(invocationAnalytics.GetInstrumentation())
+		require.NoError(t, err)
+
+		recorded := map[string]any{}
+		for key, value := range *obj.Data.Attributes.Interaction.Extension {
+			if strings.HasPrefix(key, "file-filter.") {
+				recorded[key] = value
+			}
+		}
+		return recorded
+	}
+
+	// The FileFilter records into the invocation's Analytics, so the metrics have to show up in its
+	// instrumentation, under keys carrying no run-specific segment.
 	t.Run("reports filter metrics through the analytics of the invocation", func(t *testing.T) {
 		base, _ := setup(t)
 		invocationAnalytics := analytics.New()
@@ -87,43 +105,17 @@ func TestInvocationContextImpl_GetFileFilter(t *testing.T) {
 			Analytics:     invocationAnalytics,
 		}
 
-		fileFilter := ictx.GetFileFilter(base)
-		filteredFiles(t, fileFilter)
+		filteredFiles(t, ictx.GetFileFilter(base))
 
-		obj, err := analytics.GetV2InstrumentationObject(invocationAnalytics.GetInstrumentation())
-		require.NoError(t, err)
-
-		recorded := map[string][]string{}
-		for key := range *obj.Data.Attributes.Interaction.Extension {
-			// keys are scoped per filter run: file-filter.<scopeID>.<metric>
-			parts := strings.Split(key, ".")
-			if len(parts) == 3 && parts[0] == "file-filter" {
-				recorded[parts[1]] = append(recorded[parts[1]], parts[2])
-			}
-		}
-
-		// GetRules and GetFilteredFiles each report under a scope of their own; scope IDs are
-		// allocated inside the run, so the scopes are told apart by their duration metric.
-		require.Len(t, recorded, 2)
-		var rulesScope, filterScope []string
-		for _, metricNames := range recorded {
-			if slices.Contains(metricNames, "rulesBuildDurationMs") {
-				rulesScope = metricNames
-			} else {
-				filterScope = metricNames
-			}
-		}
-
+		// no feature flag is set on this invocation, so its runs report as legacy
 		assert.ElementsMatch(t, []string{
-			"rulesBuildDurationMs",
-			"metacharacterFix",
-			"respectTrackedFiles",
-		}, rulesScope)
-		assert.ElementsMatch(t, []string{
-			"durationMs",
-			"survivingFileCount",
-			"metacharacterFix",
-			"respectTrackedFiles",
-		}, filterScope)
+			"file-filter.var0.filter.inputFileCount",
+			"file-filter.var0.filter.ruleCount",
+			"file-filter.var0.filter.durationMs",
+			"file-filter.var0.rules.durationMs",
+			"file-filter.var0.filter.outputFileCount",
+			"file-filter.var0.feature.metaCharFix",
+			"file-filter.var0.feature.includeTracked",
+		}, slices.Collect(maps.Keys(fileFilterMetrics(t, invocationAnalytics))))
 	})
 }

--- a/pkg/workflow/invocationcontextimpl_test.go
+++ b/pkg/workflow/invocationcontextimpl_test.go
@@ -78,7 +78,6 @@ func TestInvocationContextImpl_GetFileFilter(t *testing.T) {
 			"the option passed by the caller must win over the invocation's configuration")
 	})
 
-	// fileFilterMetrics returns the file-filter entries of an invocation's instrumentation extension.
 	fileFilterMetrics := func(t *testing.T, invocationAnalytics analytics.Analytics) map[string]any {
 		t.Helper()
 
@@ -94,8 +93,6 @@ func TestInvocationContextImpl_GetFileFilter(t *testing.T) {
 		return recorded
 	}
 
-	// The FileFilter records into the invocation's Analytics, so the metrics have to show up in its
-	// instrumentation, under keys carrying no run-specific segment.
 	t.Run("reports filter metrics through the analytics of the invocation", func(t *testing.T) {
 		base, _ := setup(t)
 		invocationAnalytics := analytics.New()
@@ -107,7 +104,6 @@ func TestInvocationContextImpl_GetFileFilter(t *testing.T) {
 
 		filteredFiles(t, ictx.GetFileFilter(base))
 
-		// no feature flag is set on this invocation, so its runs report as legacy
 		assert.ElementsMatch(t, []string{
 			"file-filter.var0.filter.inputFileCount",
 			"file-filter.var0.filter.ruleCount",


### PR DESCRIPTION
### Description

This PR improves FileFilter analytics by replacing per-run metric scopes with stable keys that aggregate repeated runs. Runs are grouped by the feature-flag combination they use, allowing input/output file counts, rule counts, and durations, to be compared across variants. Temporary legacy variants: var0 (no feature flags), var1 (metaCharFix), var2 (gitIgnoreRespectTrackedFiles).

This PR also introduces a concurrency-safe metrics accumulator.

Tests cover every feature-flag variant, repeated and concurrent runs, nil recorders, aggregation behavior, and FileFilter metrics reaching invocation analytics.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Analytics key schema and aggregation semantics change for FileFilter metrics consumed via invocation analytics; filtering behavior is unchanged when metrics are disabled.
> 
> **Overview**
> **FileFilter analytics** no longer use per-run scope IDs (`file-filter.<scopeID>.<metric>`). Metrics are written under stable keys grouped by feature-flag combination (`var0` / `var1` / `var2`, or `file-filter.<metric>` when both flags are on), and repeated runs **aggregate** into the same keys instead of overwriting each other.
> 
> A new **`metrics.Accumulator`** backs this: it sums integer metrics (input/output counts, durations), keeps per-key maximums, and records bools without aggregation, with mutex-protected global state shared across accumulators on different recorders. **`ResetAccumulated`** clears that state for tests. **`FileFilter`** wires `WithMetrics` through an accumulator and skips flag reads when nothing is recording.
> 
> Metric names and semantics shift: e.g. `survivingFileCount` → `filter.outputFileCount`, `rulesBuildDurationMs` → `rules.durationMs`, plus `filter.inputFileCount`; duration fields are **summed** across calls for a variant. Feature flags are recorded as `feature.metaCharFix` and `feature.includeTracked`. **`RecorderFake`** gains **`NewRecorderFake()`** so maps are always initialized.
> 
> Tests cover aggregation, concurrency, variants, and invocation analytics extension keys; workflow tests expect the new `file-filter.var0.*` shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b8d12259f3ebdb1bb020b9e7a0b52baa17c5a89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->