### PR TITLE
chore: use hotfix code-client-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/go-application-framework
 
-go 1.26.2
+go 1.26.5
 
 retract v1.0.0 // Accidental release: GAF intentionally stays on major version 0
 
@@ -15,7 +15,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.34.0
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
-	github.com/snyk/code-client-go v1.31.1
+	github.com/snyk/code-client-go v1.27.6-0.20260812155622-7574c749c95e
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
-github.com/snyk/code-client-go v1.31.1 h1:fJHx9kZwcYikKGvIIXDxMxpSNbj5gxChEsV8xrYDRnw=
-github.com/snyk/code-client-go v1.31.1/go.mod h1:sAl5uS+Bc+3Owy1HS0UjrFihuWdq5CkIF4jzEZT2meY=
+github.com/snyk/code-client-go v1.27.6-0.20260812155622-7574c749c95e h1:KJ7OxdpZTYYOFRfNsVyTQt98XGn4ZYwK5C6Nib7pXCI=
+github.com/snyk/code-client-go v1.27.6-0.20260812155622-7574c749c95e/go.mod h1:zC3NwvjY89RkDQrcNtYGlzLGiTWSnVE4tt0N74tCTPE=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=


### PR DESCRIPTION
### Description

_Provide description of this PR and changes._

### Checklist

- [ ] Tests added and all succeed (`make test`)
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swapping the code scanning client to an older-line hotfix commit can change Snyk Code behavior for all GAF/CLI consumers without any in-repo code review of the diff itself.
> 
> **Overview**
> Updates **only** module metadata: bumps the toolchain to **Go 1.26.5** and swaps **`github.com/snyk/code-client-go`** from **v1.31.1** to a **pre-release hotfix** pseudo-version **`v1.27.6-0.20260812155622-7574c749c95e`**, with matching **`go.sum`** checksums.
> 
> There are **no** changes to application source in this PR—consumers (e.g. the CLI via `go get` on GAF) pick up whatever behavior fixes ship in that **`code-client-go`** commit for code/SARIF integration paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f971352d03966b4912acfe3830eb3001c8976d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->