### PR TITLE
Wire secret-shape scrubbing into the analytics extension chokepoint

### DIFF
--- a/pkg/analytics/instrumentation_collector.go
+++ b/pkg/analytics/instrumentation_collector.go
@@ -7,6 +7,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/logging"
 	"maps"
 	"os/user"
+	"reflect"
 	"sync"
 	"time"
 
@@ -238,23 +239,46 @@ func (ic *instrumentationCollectorImpl) sanitizeExtensionData(options *serialize
 // AddExtension payload without ever serializing it to JSON bytes first, so a redaction
 // can't run past the field it matched in and corrupt or bleed into a sibling field.
 func scrubExtensionMap(m map[string]interface{}, dict logging.ScrubbingDict) map[string]interface{} {
+	return scrubExtensionMapSeen(m, dict, map[uintptr]bool{})
+}
+
+// seen tracks map/slice pointers on the current recursion path, guarding against
+// cycles a caller of AddExtension could construct (e.g. a map containing itself).
+// It is deleted on the way back up so a value referenced from two non-cyclic
+// branches (a diamond, not a cycle) is still scrubbed both times.
+func scrubExtensionMapSeen(m map[string]interface{}, dict logging.ScrubbingDict, seen map[uintptr]bool) map[string]interface{} {
+	ptr := reflect.ValueOf(m).Pointer()
+	if seen[ptr] {
+		return nil
+	}
+	seen[ptr] = true
+	defer delete(seen, ptr)
+
 	scrubbed := make(map[string]interface{}, len(m))
 	for k, v := range m {
-		scrubbed[k] = scrubExtensionValue(v, dict)
+		scrubbed[k] = scrubExtensionValueSeen(v, dict, seen)
 	}
 	return scrubbed
 }
 
-func scrubExtensionValue(v interface{}, dict logging.ScrubbingDict) interface{} {
+func scrubExtensionValueSeen(v interface{}, dict logging.ScrubbingDict, seen map[uintptr]bool) interface{} {
 	switch val := v.(type) {
 	case string:
 		return string(logging.Scrub([]byte(val), dict))
 	case map[string]interface{}:
-		return scrubExtensionMap(val, dict)
+		return scrubExtensionMapSeen(val, dict, seen)
 	case []interface{}:
+		ptr := reflect.ValueOf(val).Pointer()
+		if ptr != 0 && seen[ptr] {
+			return nil
+		}
+		if ptr != 0 {
+			seen[ptr] = true
+			defer delete(seen, ptr)
+		}
 		scrubbed := make([]interface{}, len(val))
 		for i, item := range val {
-			scrubbed[i] = scrubExtensionValue(item, dict)
+			scrubbed[i] = scrubExtensionValueSeen(item, dict, seen)
 		}
 		return scrubbed
 	default:

--- a/pkg/analytics/instrumentation_collector.go
+++ b/pkg/analytics/instrumentation_collector.go
@@ -15,6 +15,7 @@ import (
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 
 	api "github.com/snyk/go-application-framework/internal/api/analytics/2024-03-07"
+	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
 	"github.com/snyk/go-application-framework/pkg/networking"
 )
@@ -71,6 +72,7 @@ type instrumentationCollectorImpl struct {
 
 type serializeOptions struct {
 	logger *zerolog.Logger
+	cfg    configuration.Configuration
 }
 
 type serializeOptionFunc func(*serializeOptions)
@@ -78,6 +80,15 @@ type serializeOptionFunc func(*serializeOptions)
 func WithLogger(logger *zerolog.Logger) serializeOptionFunc {
 	return func(o *serializeOptions) {
 		o.logger = logger
+	}
+}
+
+// WithConfiguration opts sanitizeExtensionData into shape-based secret redaction,
+// using the same scrub dictionary GAF's debug-log redaction already trusts.
+// Omitted, sanitizeExtensionData's behavior is unchanged from before this option existed.
+func WithConfiguration(cfg configuration.Configuration) serializeOptionFunc {
+	return func(o *serializeOptions) {
+		o.cfg = cfg
 	}
 }
 
@@ -156,10 +167,10 @@ func GetV2InstrumentationObject(collector InstrumentationCollector, opt ...seria
 		o(&options)
 	}
 
-	return t.getV2InstrumentationObject(options.logger), nil
+	return t.getV2InstrumentationObject(&options), nil
 }
 
-func (ic *instrumentationCollectorImpl) getV2InstrumentationObject(logger *zerolog.Logger) *api.AnalyticsRequestBody {
+func (ic *instrumentationCollectorImpl) getV2InstrumentationObject(options *serializeOptions) *api.AnalyticsRequestBody {
 	a := ic.getV2Attributes()
 
 	d := api.AnalyticsData{
@@ -167,13 +178,14 @@ func (ic *instrumentationCollectorImpl) getV2InstrumentationObject(logger *zerol
 		Attributes: a,
 	}
 
-	return ic.sanitizeExtensionData(logger, d)
+	return ic.sanitizeExtensionData(options, d)
 }
 
 // Since the `extension` attribute in the analytics payload is a value any
 // product line potentially can contribute to, we utilize the same sanitation logic
 // already in place for the legacy v1 analytics, to ensure the same level of PII protection.
-func (ic *instrumentationCollectorImpl) sanitizeExtensionData(logger *zerolog.Logger, d api.AnalyticsData) *api.AnalyticsRequestBody {
+func (ic *instrumentationCollectorImpl) sanitizeExtensionData(options *serializeOptions, d api.AnalyticsData) *api.AnalyticsRequestBody {
+	logger := options.logger
 	extension, err := json.Marshal(d.Attributes.Interaction.Extension)
 	result := &api.AnalyticsRequestBody{
 		Data: d,
@@ -183,6 +195,10 @@ func (ic *instrumentationCollectorImpl) sanitizeExtensionData(logger *zerolog.Lo
 	if err != nil {
 		logger.Printf("failed to marshal extension, removing extension object from analytics payload: %v", err)
 		return result
+	}
+
+	if options.cfg != nil {
+		extension = logging.Scrub(extension, logging.GetScrubDictFromConfig(options.cfg))
 	}
 
 	var sanitized []byte

--- a/pkg/analytics/instrumentation_collector.go
+++ b/pkg/analytics/instrumentation_collector.go
@@ -186,6 +186,15 @@ func (ic *instrumentationCollectorImpl) getV2InstrumentationObject(options *seri
 // already in place for the legacy v1 analytics, to ensure the same level of PII protection.
 func (ic *instrumentationCollectorImpl) sanitizeExtensionData(options *serializeOptions, d api.AnalyticsData) *api.AnalyticsRequestBody {
 	logger := options.logger
+
+	// Scrub string leaf values before marshaling, never the marshaled JSON bytes: logging.Scrub
+	// does whole-string literal replacement, so running it over raw JSON would let a redacted
+	// value collide with an unrelated field that happens to contain the same substring.
+	if options.cfg != nil && d.Attributes.Interaction.Extension != nil {
+		scrubbed := scrubExtensionMap(*d.Attributes.Interaction.Extension, logging.GetScrubDictFromConfig(options.cfg))
+		d.Attributes.Interaction.Extension = &scrubbed
+	}
+
 	extension, err := json.Marshal(d.Attributes.Interaction.Extension)
 	result := &api.AnalyticsRequestBody{
 		Data: d,
@@ -195,10 +204,6 @@ func (ic *instrumentationCollectorImpl) sanitizeExtensionData(options *serialize
 	if err != nil {
 		logger.Printf("failed to marshal extension, removing extension object from analytics payload: %v", err)
 		return result
-	}
-
-	if options.cfg != nil {
-		extension = logging.Scrub(extension, logging.GetScrubDictFromConfig(options.cfg))
 	}
 
 	var sanitized []byte
@@ -227,6 +232,34 @@ func (ic *instrumentationCollectorImpl) sanitizeExtensionData(options *serialize
 	}
 
 	return result
+}
+
+// scrubExtensionMap and scrubExtensionValue redact string leaves of an arbitrary
+// AddExtension payload without ever serializing it to JSON bytes first, so a redaction
+// can't run past the field it matched in and corrupt or bleed into a sibling field.
+func scrubExtensionMap(m map[string]interface{}, dict logging.ScrubbingDict) map[string]interface{} {
+	scrubbed := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		scrubbed[k] = scrubExtensionValue(v, dict)
+	}
+	return scrubbed
+}
+
+func scrubExtensionValue(v interface{}, dict logging.ScrubbingDict) interface{} {
+	switch val := v.(type) {
+	case string:
+		return string(logging.Scrub([]byte(val), dict))
+	case map[string]interface{}:
+		return scrubExtensionMap(val, dict)
+	case []interface{}:
+		scrubbed := make([]interface{}, len(val))
+		for i, item := range val {
+			scrubbed[i] = scrubExtensionValue(item, dict)
+		}
+		return scrubbed
+	default:
+		return v
+	}
 }
 
 func (ic *instrumentationCollectorImpl) getV2Attributes() api.AnalyticsAttributes {

--- a/pkg/analytics/instrumentation_collector_test.go
+++ b/pkg/analytics/instrumentation_collector_test.go
@@ -254,6 +254,23 @@ func Test_InstrumentationCollector(t *testing.T) {
 		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
 	})
 
+	t.Run("it should not stack-overflow when a shape-scrubbed extension value contains a cycle", func(t *testing.T) {
+		ic := setupBaseCollector(t)
+
+		cyclic := map[string]interface{}{"note": "Bearer abcdef123456"}
+		cyclic["self"] = cyclic
+		ic.AddExtension("cyclic", cyclic)
+
+		actualV2InstrumentationObject, err := GetV2InstrumentationObject(ic, WithLogger(&logger), WithConfiguration(configuration.NewInMemory()))
+		assert.NoError(t, err)
+
+		extension := *actualV2InstrumentationObject.Data.Attributes.Interaction.Extension
+		cyclicResult, ok := extension["cyclic"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, "Bearer ***", cyclicResult["note"])
+		assert.Nil(t, cyclicResult["self"])
+	})
+
 	t.Run("it should not redact unrelated extension values that merely share a substring with a scrubbed secret", func(t *testing.T) {
 		ic := setupBaseCollector(t)
 		expectedV2InstrumentationObject := buildExpectedBaseObject(t)

--- a/pkg/analytics/instrumentation_collector_test.go
+++ b/pkg/analytics/instrumentation_collector_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	api "github.com/snyk/go-application-framework/internal/api/analytics/2024-03-07"
+	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
 	"github.com/snyk/go-application-framework/pkg/networking"
 )
@@ -216,6 +217,52 @@ func Test_InstrumentationCollector(t *testing.T) {
 		mockExtension := map[string]interface{}{
 			"strings":  "hello world",
 			"password": "***",
+		}
+
+		expectedV2InstrumentationObject.Data.Attributes.Interaction.Extension = &mockExtension
+
+		actualV2InstrumentationObject, err := GetV2InstrumentationObject(ic, WithLogger(&logger))
+		assert.NoError(t, err)
+		expectedV2InstrumentationJson, err := json.Marshal(expectedV2InstrumentationObject)
+		assert.NoError(t, err)
+		actualV2InstrumentationJson, err := json.Marshal(actualV2InstrumentationObject)
+		assert.NoError(t, err)
+
+		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
+	})
+
+	t.Run("it should shape-scrub secret-shaped extension values when WithConfiguration is supplied", func(t *testing.T) {
+		ic := setupBaseCollector(t)
+		expectedV2InstrumentationObject := buildExpectedBaseObject(t)
+
+		ic.AddExtension("note", "Bearer abcdef123456")
+
+		mockExtension := map[string]interface{}{
+			"strings": "hello world",
+			"note":    "Bearer ***",
+		}
+
+		expectedV2InstrumentationObject.Data.Attributes.Interaction.Extension = &mockExtension
+
+		actualV2InstrumentationObject, err := GetV2InstrumentationObject(ic, WithLogger(&logger), WithConfiguration(configuration.NewInMemory()))
+		assert.NoError(t, err)
+		expectedV2InstrumentationJson, err := json.Marshal(expectedV2InstrumentationObject)
+		assert.NoError(t, err)
+		actualV2InstrumentationJson, err := json.Marshal(actualV2InstrumentationObject)
+		assert.NoError(t, err)
+
+		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
+	})
+
+	t.Run("it should leave secret-shaped extension values untouched when WithConfiguration is omitted", func(t *testing.T) {
+		ic := setupBaseCollector(t)
+		expectedV2InstrumentationObject := buildExpectedBaseObject(t)
+
+		ic.AddExtension("note", "Bearer abcdef123456")
+
+		mockExtension := map[string]interface{}{
+			"strings": "hello world",
+			"note":    "Bearer abcdef123456",
 		}
 
 		expectedV2InstrumentationObject.Data.Attributes.Interaction.Extension = &mockExtension

--- a/pkg/analytics/instrumentation_collector_test.go
+++ b/pkg/analytics/instrumentation_collector_test.go
@@ -254,6 +254,56 @@ func Test_InstrumentationCollector(t *testing.T) {
 		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
 	})
 
+	t.Run("it should not redact unrelated extension values that merely share a substring with a scrubbed secret", func(t *testing.T) {
+		ic := setupBaseCollector(t)
+		expectedV2InstrumentationObject := buildExpectedBaseObject(t)
+
+		ic.AddExtension("detail", "Bearer abcdef123456")
+		ic.AddExtension("note", "unrelated log message mentioning abcdef123456 in passing")
+
+		mockExtension := map[string]interface{}{
+			"strings": "hello world",
+			"detail":  "Bearer ***",
+			"note":    "unrelated log message mentioning abcdef123456 in passing",
+		}
+
+		expectedV2InstrumentationObject.Data.Attributes.Interaction.Extension = &mockExtension
+
+		actualV2InstrumentationObject, err := GetV2InstrumentationObject(ic, WithLogger(&logger), WithConfiguration(configuration.NewInMemory()))
+		assert.NoError(t, err)
+		expectedV2InstrumentationJson, err := json.Marshal(expectedV2InstrumentationObject)
+		assert.NoError(t, err)
+		actualV2InstrumentationJson, err := json.Marshal(actualV2InstrumentationObject)
+		assert.NoError(t, err)
+
+		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
+	})
+
+	t.Run("it should not corrupt sibling fields when a short-form-keyed extension value is a nested object", func(t *testing.T) {
+		ic := setupBaseCollector(t)
+		expectedV2InstrumentationObject := buildExpectedBaseObject(t)
+
+		ic.AddExtension("p", map[string]interface{}{"nested": "obj"})
+		ic.AddExtension("tail", "keep")
+
+		mockExtension := map[string]interface{}{
+			"strings": "hello world",
+			"p":       map[string]interface{}{"nested": "obj"},
+			"tail":    "keep",
+		}
+
+		expectedV2InstrumentationObject.Data.Attributes.Interaction.Extension = &mockExtension
+
+		actualV2InstrumentationObject, err := GetV2InstrumentationObject(ic, WithLogger(&logger), WithConfiguration(configuration.NewInMemory()))
+		assert.NoError(t, err)
+		expectedV2InstrumentationJson, err := json.Marshal(expectedV2InstrumentationObject)
+		assert.NoError(t, err)
+		actualV2InstrumentationJson, err := json.Marshal(actualV2InstrumentationObject)
+		assert.NoError(t, err)
+
+		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
+	})
+
 	t.Run("it should leave secret-shaped extension values untouched when WithConfiguration is omitted", func(t *testing.T) {
 		ic := setupBaseCollector(t)
 		expectedV2InstrumentationObject := buildExpectedBaseObject(t)

--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -53,12 +53,6 @@ const (
 	AUTHENTICATION_ADDITIONAL_URLS string = "internal_additional_auth_urls" // AUTHENTICATION_ADDITIONAL_URLS ([]string) array of additional urls to add authentication for
 
 	// ---------
-	// redaction related configuration
-	// ---------
-
-	REDACTION_TERMS string = "internal_redaction_terms" // REDACTION_TERMS ([]string) arbitrary literal terms to redact from analytics/log output, in addition to the token/OAuth-derived terms GetScrubDictFromConfig already adds
-
-	// ---------
 	// general application configuration
 	// ---------
 

--- a/pkg/configuration/constants.go
+++ b/pkg/configuration/constants.go
@@ -53,6 +53,12 @@ const (
 	AUTHENTICATION_ADDITIONAL_URLS string = "internal_additional_auth_urls" // AUTHENTICATION_ADDITIONAL_URLS ([]string) array of additional urls to add authentication for
 
 	// ---------
+	// redaction related configuration
+	// ---------
+
+	REDACTION_TERMS string = "internal_redaction_terms" // REDACTION_TERMS ([]string) arbitrary literal terms to redact from analytics/log output, in addition to the token/OAuth-derived terms GetScrubDictFromConfig already adds
+
+	// ---------
 	// general application configuration
 	// ---------
 

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -316,6 +316,11 @@ func (w *scrubbingLevelWriter) Write(p []byte) (int, error) {
 	return internalWrite(w.scrubDict, p, w.writer.Write)
 }
 
+// Scrub applies scrubDict's redaction rules to data, the same logic used internally by ScrubbingLogWriter.
+func Scrub(data []byte, scrubDict ScrubbingDict) []byte {
+	return scrub(data, scrubDict)
+}
+
 func scrub(p []byte, scrubDict ScrubbingDict) []byte {
 	s := string(p)
 	// The dictionary order is important here, as we want potentially overlapping regexes to be applied

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -127,13 +127,19 @@ func (w *scrubbingIoWriter) RemoveTerm(term string) {
 	delete(w.scrubDict, term)
 }
 
+// REDACTION_TERMS ([]string) arbitrary literal terms to redact from analytics/log
+// output, in addition to the token/OAuth-derived terms GetScrubDictFromConfig
+// already adds. Lives here rather than pkg/configuration since this package is
+// its only reader, matching the precedent of local_workflows.ConfigurationNewAuthenticationToken.
+const REDACTION_TERMS string = "internal_redaction_terms"
+
 func GetScrubDictFromConfig(config configuration.Configuration) ScrubbingDict {
 	dict := getDefaultDict()
 	addStaticTermToDict(config.GetString(configuration.AUTHENTICATION_TOKEN), dict)
 	addStaticTermToDict(config.GetString(configuration.AUTHENTICATION_BEARER_TOKEN), dict)
 	addStaticTermToDict(config.GetString(auth.PARAMETER_CLIENT_SECRET), dict)
 	addStaticTermToDict(config.GetString(auth.PARAMETER_CLIENT_ID), dict)
-	for _, term := range config.GetStringSlice(configuration.REDACTION_TERMS) {
+	for _, term := range config.GetStringSlice(REDACTION_TERMS) {
 		addStaticTermToDict(term, dict)
 	}
 	token, err := auth.GetOAuthToken(config)

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -133,6 +133,9 @@ func GetScrubDictFromConfig(config configuration.Configuration) ScrubbingDict {
 	addStaticTermToDict(config.GetString(configuration.AUTHENTICATION_BEARER_TOKEN), dict)
 	addStaticTermToDict(config.GetString(auth.PARAMETER_CLIENT_SECRET), dict)
 	addStaticTermToDict(config.GetString(auth.PARAMETER_CLIENT_ID), dict)
+	for _, term := range config.GetStringSlice(configuration.REDACTION_TERMS) {
+		addStaticTermToDict(term, dict)
+	}
 	token, err := auth.GetOAuthToken(config)
 	if err != nil || token == nil {
 		return dict

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -92,7 +92,7 @@ func TestScrubbingWriter_WriteLevel(t *testing.T) {
 
 func TestScrubbingWriter_GetScrubDictFromConfig_RedactionTerms(t *testing.T) {
 	config := configuration.NewInMemory()
-	config.Set(configuration.REDACTION_TERMS, []string{"my-literal-secret"})
+	config.Set(REDACTION_TERMS, []string{"my-literal-secret"})
 
 	mockWriter := &mockWriter{}
 	writer := NewScrubbingWriter(mockWriter, GetScrubDictFromConfig(config))

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -196,6 +196,17 @@ func TestScrubFunction(t *testing.T) {
 	})
 }
 
+func TestScrub_MatchesPrivateScrubPath(t *testing.T) {
+	dict := addMandatoryMasking(ScrubbingDict{})
+	input := []byte("Authorization: Bearer sometoken123456")
+
+	expected := scrub(input, dict)
+	actual := Scrub(input, dict)
+
+	assert.Equal(t, string(expected), string(actual))
+	assert.Equal(t, "Authorization: Bearer ***", string(actual), "Scrub should redact the token, not just mirror the input")
+}
+
 func TestAddDefaults(t *testing.T) {
 	dict := addMandatoryMasking(ScrubbingDict{})
 	u, uErr := user.Current()

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -90,6 +90,20 @@ func TestScrubbingWriter_WriteLevel(t *testing.T) {
 	require.Equal(t, expected, string(mockWriter.written), "password should be scrubbed")
 }
 
+func TestScrubbingWriter_GetScrubDictFromConfig_RedactionTerms(t *testing.T) {
+	config := configuration.NewInMemory()
+	config.Set(configuration.REDACTION_TERMS, []string{"my-literal-secret"})
+
+	mockWriter := &mockWriter{}
+	writer := NewScrubbingWriter(mockWriter, GetScrubDictFromConfig(config))
+
+	n, err := writer.Write([]byte("my-literal-secret"))
+
+	assert.Nil(t, err)
+	assert.Equal(t, len("my-literal-secret"), n)
+	require.Equal(t, "***", string(mockWriter.written), "configured redaction term should be scrubbed")
+}
+
 func TestScrubbingIoWriter(t *testing.T) {
 	scrubDict := map[string]scrubStruct{
 		"token":  {0, regexp.MustCompile("token"), ""},


### PR DESCRIPTION
## Summary
- Exports `logging.Scrub` so it's reusable outside `pkg/logging` — a thin wrapper around the existing private `scrub`, no new patterns.
- Adds `analytics.WithConfiguration(cfg)`, matching the shape of the existing `WithLogger` option.
- When supplied, `sanitizeExtensionData` shape-scrubs the extension payload via `logging.GetScrubDictFromConfig(cfg)` before the existing key-name sanitization runs. Omitted, behavior is unchanged.

This closes the gap where every product line's `AddExtension*` analytics data went out with only key-name-based filtering — none of GAF's mature debug-log secret-shape patterns (Bearer tokens, PATs, basic auth, etc.) were applied to analytics. One fix at this shared chokepoint protects every current and future extension caller, including `cli-extension-axi`'s `agent feedback` command, without any of them needing their own redaction code.

Implements ticket 01 of the `agent-feedback-secret-redaction` spec tracked in `cli-extension-axi`'s `.scratch/`. Follow-on tickets (wiring `cli`'s `sendInstrumentation` call site with `WithConfiguration`, then bumping this dependency in `cli-extension-axi`) are separate, sequenced after this merges and releases.

## Test plan
- [x] `go test ./pkg/logging/... ./pkg/analytics/...`
- [x] `go test -cover ./... -race` (full suite, green)
- [x] `go vet ./pkg/analytics/... ./pkg/logging/...`
- [x] New test proves `Scrub` matches the private `scrub` path and actually redacts (not just an identity check)
- [x] Extended `instrumentation_collector_test.go`: secret-shaped extension value (no sensitive key name nearby) is redacted with `WithConfiguration`, left untouched without it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how sensitive data may appear in outbound analytics when enabled; behavior is opt-in but touches PII/secret handling on a shared path used by many product lines.
> 
> **Overview**
> Adds **opt-in secret-shape redaction** for V2 analytics `extension` data at the shared `sanitizeExtensionData` chokepoint, so callers that pass `WithConfiguration` get the same scrub dictionary GAF already uses for debug logs (tokens, Bearer patterns, config-derived terms).
> 
> **`WithConfiguration(cfg)`** runs **before** JSON marshal: it walks extension maps/slices and applies `logging.Scrub` only on **string leaves**, avoiding whole-JSON scrubbing that could redact unrelated fields that share a substring with a secret. Recursive scrubbing includes **cycle guards** for self-referential extension values.
> 
> **`logging.Scrub`** is exported (wrapper around existing private scrub). **`REDACTION_TERMS`** config adds extra literal terms to `GetScrubDictFromConfig`. Without `WithConfiguration`, extension handling stays as before (key-name sanitization only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ea4a4f24d1e69c9835e9be544d4e256f2c873db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->