### PR TITLE
fix: render the asset link once below the overall test summary

### DIFF
--- a/internal/presenters/funcs.go
+++ b/internal/presenters/funcs.go
@@ -357,6 +357,7 @@ func getDefaultTemplateFuncMap(config configuration.Configuration, ri runtimeinf
 	}
 	defaultMap["getFindingTypesFromTestResult"] = getFindingTypesFromTestResult
 	defaultMap["getFindingTypesFromMultipleTestResults"] = getFindingTypesFromMultipleTestResults
+	defaultMap["assetLink"] = assetLink
 	defaultMap["getIssuesFromTestResult"] = func(testResults testapi.TestResult, findingType ...testapi.FindingType) []testapi.Issue {
 		return utils.ValueOf(testapi.GetIssuesFromTestResult(testResults, findingType))
 	}
@@ -602,6 +603,19 @@ func getFindingTypesFromMultipleTestResults(testResults []testapi.TestResult) []
 	slices.Sort(findingTypesList)
 	slices.Reverse(findingTypesList)
 	return findingTypesList
+}
+
+func assetLink(testResults []testapi.TestResult) string {
+	for _, result := range testResults {
+		if result == nil {
+			continue
+		}
+		if link, ok := result.GetMetadataValue(testapi.TestResultMetadataKeyAsset).(string); ok && link != "" {
+			return link
+		}
+	}
+
+	return ""
 }
 
 func getDefaultFindingTypesFromConfig(testResults testapi.TestResult) []testapi.FindingType {

--- a/internal/presenters/presenter_ufm_test.go
+++ b/internal/presenters/presenter_ufm_test.go
@@ -1264,6 +1264,13 @@ func Test_UfmPresenter_HumanReadable(t *testing.T) {
 			severityThreshold: "",
 		},
 		{
+			name:              "multi_project_with_asset",
+			expectedPath:      "testdata/ufm/multi_project.with-asset.human.readable",
+			testResultPath:    "testdata/ufm/multi_project.with-asset.testresult.json",
+			includeIgnores:    false,
+			severityThreshold: "",
+		},
+		{
 			name:              "secrets_duplicated_rules",
 			expectedPath:      "testdata/ufm/secrets.duplicated-sarif-rules.human.readable",
 			testResultPath:    "testdata/ufm/secrets.duplicated-sarif-rules.testresult.json",

--- a/internal/presenters/templates/ufm.human.tmpl
+++ b/internal/presenters/templates/ufm.human.tmpl
@@ -305,12 +305,6 @@ Tested {{ int $dependencyCount }} dependencies for known issues, found {{ len $o
         {{- printf "  %s" ( . | bold ) }}
     {{- end -}}
 
-    {{- /* Render asset inventory link when available (sbom test --report) */ -}}
-    {{- with $.GetMetadataValue "asset" }}
-        {{- "\n\n" }}
-        {{- printf "View your asset(s) at: %s" ( . | bold ) }}
-    {{- end -}}
-
     {{- "\n" }}
     {{- with $.GetMetadataValue "target-directory" }}
 	    {{- $targetId := getTargetId . }}
@@ -352,6 +346,13 @@ Tested {{ int $dependencyCount }} dependencies for known issues, found {{ len $o
     {{- if gt $totalResults 1 }}
         {{- "\n" }}{{- divider }}{{- "\n" }}
         {{- box (renderToString "overallTestSummary" $) }}
+    {{- end }}
+
+    {{- /* Render asset inventory link when available (sbom test --report) */ -}}
+    {{- with assetLink $.TestResults }}
+        {{- if gt $totalResults 1 }}{{- "\n" }}{{- end }}
+        {{- "\n" }}
+        {{- printf "View your asset(s) at: %s" ( . | bold ) }}
     {{- end }}
 
     {{- /* Show hint if results are filtered */}}

--- a/internal/presenters/testdata/ufm/multi_project.with-asset.human.readable
+++ b/internal/presenters/testdata/ufm/multi_project.with-asset.human.readable
@@ -1,0 +1,772 @@
+[1mTesting  (dotnet/obj/project.assets.json) ...[0m
+
+Tested 84 dependencies for known issues, found 6 issues, 9 vulnerable paths.
+
+[1mOpen Security issues: 6[0m
+
+ ✗ [33m[MEDIUM][0m [1mAuthentication Bypass[0m
+   Finding ID: SNYK-DOTNET-SYSTEMNETHTTP-60048
+   Info: https://snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-60048
+   Introduced by: System.Net.Http
+   Introduced through: tpwe@1.0.0 > NSubstitute@4.3.0 > Castle.Core@4.4.1 > NETStandard.Library@1.6.1 > System.Net.Http@4.3.0
+   Risk Score: 48
+
+ ✗ [31m[HIGH][0m [1mDenial of Service (DoS)[0m
+   Finding ID: SNYK-DOTNET-SYSTEMNETHTTP-60045
+   Info: https://snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-60045
+   Introduced by: System.Net.Http
+   Introduced through: tpwe@1.0.0 > NSubstitute@4.3.0 > Castle.Core@4.4.1 > NETStandard.Library@1.6.1 > System.Net.Http@4.3.0
+   Risk Score: 130
+
+ ✗ [31m[HIGH][0m [1mImproper Certificate Validation[0m
+   Finding ID: SNYK-DOTNET-SYSTEMNETHTTP-60046
+   Info: https://snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-60046
+   Introduced by: System.Net.Http
+   Introduced through: tpwe@1.0.0 > NSubstitute@4.3.0 > Castle.Core@4.4.1 > NETStandard.Library@1.6.1 > System.Net.Http@4.3.0
+   Risk Score: 115
+
+ ✗ [31m[HIGH][0m [1mPrivilege Escalation[0m
+   Finding ID: SNYK-DOTNET-SYSTEMNETHTTP-60047
+   Info: https://snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-60047
+   Introduced by: System.Net.Http
+   Introduced through: tpwe@1.0.0 > NSubstitute@4.3.0 > Castle.Core@4.4.1 > NETStandard.Library@1.6.1 > System.Net.Http@4.3.0
+   Risk Score: 115
+
+ ✗ [31m[HIGH][0m [1mInformation Exposure[0m
+   Finding ID: SNYK-DOTNET-SYSTEMNETHTTP-72439
+   Info: https://snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-72439
+   Introduced by: System.Net.Http
+   Introduced through: tpwe@1.0.0 > NSubstitute@4.3.0 > Castle.Core@4.4.1 > NETStandard.Library@1.6.1 > System.Net.Http@4.3.0
+   Risk Score: 123
+
+ ✗ [31m[HIGH][0m [1mRegular Expression Denial of Service (ReDoS)[0m
+   Finding ID: SNYK-DOTNET-SYSTEMTEXTREGULAREXPRESSIONS-174708
+   Info: https://snyk.io/vuln/SNYK-DOTNET-SYSTEMTEXTREGULAREXPRESSIONS-174708
+   Introduced by: System.Text.RegularExpressions
+   Introduced through: tpwe@1.0.0 > NSubstitute@4.3.0 > Castle.Core@4.4.1 > NETStandard.Library@1.6.1 > System.Text.RegularExpressions@4.3.0
+   Risk Score: 119
+
+╭─────────────────────────────────────────────────────────╮
+│ [1mTest Summary[0m                                            │
+│                                                         │
+│   Organization:      My Org                             │
+│   Test type:         Software Composition Analysis      │
+│   Project path:      multi-project                      │
+│   Target file:       dotnet/obj/project.assets.json     │
+│                                                         │
+│   Total security issues: 6                              │
+│   Ignored: [1m0[0m [[35m 0 CRITICAL [0m[31m 0 HIGH [0m[33m 0 MEDIUM [0m 0 LOW ]    │
+│   Open   : [1m6[0m [[35m 0 CRITICAL [0m[31m 5 HIGH [0m[33m 1 MEDIUM [0m 0 LOW ]    │
+╰─────────────────────────────────────────────────────────╯
+
+─────────────────────────────────────────────────────
+
+[1mTesting  (ghost/package.json) ...[0m
+
+Tested 23 dependencies for known issues, found 19 issues, 27 vulnerable paths.
+
+[1mOpen Security issues: 19[0m
+
+ ✗ [LOW] [1mCross-site Scripting[0m
+   Finding ID: SNYK-JS-SEND-7926862
+   Info: https://snyk.io/vuln/SNYK-JS-SEND-7926862
+   Introduced by: send
+   Introduced through: package.json@ > express@4.0.0 > send@0.2.0
+   Risk Score: 57
+
+ ✗ [LOW] [1mCross-site Scripting[0m
+   Finding ID: SNYK-JS-SERVESTATIC-7926865
+   Info: https://snyk.io/vuln/SNYK-JS-SERVESTATIC-7926865
+   Introduced by: serve-static
+   Introduced through: package.json@ > express@4.0.0 > serve-static@1.0.1
+   Risk Score: 57
+
+ ✗ [LOW] [1mRegular Expression Denial of Service (ReDoS)[0m
+   Finding ID: npm:mime:20170907
+   Info: https://snyk.io/vuln/npm:mime:20170907
+   Introduced by: mime
+   Introduced through: package.json@ > express@4.0.0 > accepts@1.0.0 > mime@1.2.11
+   Risk Score: 35
+
+ ✗ [LOW] [1mOpen Redirect[0m
+   Finding ID: npm:serve-static:20150113
+   Info: https://snyk.io/vuln/npm:serve-static:20150113
+   Introduced by: serve-static
+   Introduced through: package.json@ > express@4.0.0 > serve-static@1.0.1
+   Risk Score: 24
+
+ ✗ [33m[MEDIUM][0m [1mCross-site Scripting (XSS)[0m
+   Finding ID: SNYK-JS-COOKIE-8163060
+   Info: https://snyk.io/vuln/SNYK-JS-COOKIE-8163060
+   Introduced by: cookie
+   Introduced through: package.json@ > express@4.0.0 > cookie@0.1.0
+   Risk Score: 34
+
+ ✗ [33m[MEDIUM][0m [1mOpen Redirect[0m
+   Finding ID: SNYK-JS-EXPRESS-6474509
+   Info: https://snyk.io/vuln/SNYK-JS-EXPRESS-6474509
+   Introduced by: express
+   Introduced through: package.json@ > express@4.0.0
+   Risk Score: 74
+
+ ✗ [33m[MEDIUM][0m [1mCross-site Scripting[0m
+   Finding ID: SNYK-JS-EXPRESS-7926867
+   Info: https://snyk.io/vuln/SNYK-JS-EXPRESS-7926867
+   Introduced by: express
+   Introduced through: package.json@ > express@4.0.0
+   Risk Score: 75
+
+ ✗ [33m[MEDIUM][0m [1mRegular Expression Denial of Service (ReDoS)[0m
+   Finding ID: SNYK-JS-PATHTOREGEXP-7925106
+   Info: https://snyk.io/vuln/SNYK-JS-PATHTOREGEXP-7925106
+   Introduced by: path-to-regexp
+   Introduced through: package.json@ > express@4.0.0 > path-to-regexp@0.1.2
+   Risk Score: 57
+
+ ✗ [33m[MEDIUM][0m [1mRegular Expression Denial of Service (ReDoS)[0m
+   Finding ID: SNYK-JS-PATHTOREGEXP-8482416
+   Info: https://snyk.io/vuln/SNYK-JS-PATHTOREGEXP-8482416
+   Introduced by: path-to-regexp
+   Introduced through: package.json@ > express@4.0.0 > path-to-regexp@0.1.2
+   Risk Score: 61
+
+ ✗ [33m[MEDIUM][0m [1mNon-Constant Time String Comparison[0m
+   Finding ID: npm:cookie-signature:20160804
+   Info: https://snyk.io/vuln/npm:cookie-signature:20160804
+   Introduced by: cookie-signature
+   Introduced through: package.json@ > express@4.0.0 > cookie-signature@1.0.3
+   Risk Score: 86
+
+ ✗ [33m[MEDIUM][0m [1mCross-site Scripting (XSS)[0m
+   Finding ID: npm:express:20140912
+   Info: https://snyk.io/vuln/npm:express:20140912
+   Introduced by: express
+   Introduced through: package.json@ > express@4.0.0
+   Risk Score: 69
+
+ ✗ [33m[MEDIUM][0m [1mDenial of Service (DoS)[0m
+   Finding ID: npm:qs:20140806-1
+   Info: https://snyk.io/vuln/npm:qs:20140806-1
+   Introduced by: qs
+   Introduced through: package.json@ > express@4.0.0 > qs@0.6.6
+   Risk Score: 74
+
+ ✗ [33m[MEDIUM][0m [1mDirectory Traversal[0m
+   Finding ID: npm:send:20140912
+   Info: https://snyk.io/vuln/npm:send:20140912
+   Introduced by: send
+   Introduced through: package.json@ > express@4.0.0 > send@0.2.0
+   Risk Score: 39
+
+ ✗ [33m[MEDIUM][0m [1mRoot Path Disclosure[0m
+   Finding ID: npm:send:20151103
+   Info: https://snyk.io/vuln/npm:send:20151103
+   Introduced by: send
+   Introduced through: package.json@ > express@4.0.0 > send@0.2.0
+   Risk Score: 40
+
+ ✗ [31m[HIGH][0m [1mPrototype Poisoning[0m
+   Finding ID: SNYK-JS-QS-3153490
+   Info: https://snyk.io/vuln/SNYK-JS-QS-3153490
+   Introduced by: qs
+   Introduced through: package.json@ > express@4.0.0 > qs@0.6.6
+   Risk Score: 150
+
+ ✗ [31m[HIGH][0m [1mRegular Expression Denial of Service (ReDoS)[0m
+   Finding ID: npm:fresh:20170908
+   Info: https://snyk.io/vuln/npm:fresh:20170908
+   Introduced by: fresh
+   Introduced through: package.json@ > express@4.0.0 > fresh@0.2.2
+   Risk Score: 101
+
+ ✗ [31m[HIGH][0m [1mRegular Expression Denial of Service (ReDoS)[0m
+   Finding ID: npm:negotiator:20160616
+   Info: https://snyk.io/vuln/npm:negotiator:20160616
+   Introduced by: negotiator
+   Introduced through: package.json@ > express@4.0.0 > accepts@1.0.0 > negotiator@0.3.0
+   Risk Score: 101
+
+ ✗ [31m[HIGH][0m [1mDenial of Service (DoS)[0m
+   Finding ID: npm:qs:20140806
+   Info: https://snyk.io/vuln/npm:qs:20140806
+   Introduced by: qs
+   Introduced through: package.json@ > express@4.0.0 > qs@0.6.6
+   Risk Score: 105
+
+ ✗ [31m[HIGH][0m [1mPrototype Override Protection Bypass[0m
+   Finding ID: npm:qs:20170213
+   Info: https://snyk.io/vuln/npm:qs:20170213
+   Introduced by: qs
+   Introduced through: package.json@ > express@4.0.0 > qs@0.6.6
+   Risk Score: 101
+
+[32m[1mIssues to fix by upgrading:[0m[0m
+
+  Upgrade [1mexpress@4.0.0[0m to [1mexpress@4.21.2[0m to fix
+  ✗ [1mCross-site Scripting[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-SEND-7926862] in [1msend@0.2.0[0m
+    introduced by package.json@ > express@4.0.0 > send@0.2.0 and [36m1[0m other path
+  ✗ [1mCross-site Scripting[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-SERVESTATIC-7926865] in [1mserve-static@1.0.1[0m
+    introduced by package.json@ > express@4.0.0 > serve-static@1.0.1
+  ✗ [1mRegular Expression Denial of Service (ReDoS)[0m [LOW] [https://security.snyk.io/vuln/npm:mime:20170907] in [1mmime@1.2.11[0m
+    introduced by package.json@ > express@4.0.0 > accepts@1.0.0 > mime@1.2.11 and [36m3[0m other paths
+  ✗ [1mOpen Redirect[0m [LOW] [https://security.snyk.io/vuln/npm:serve-static:20150113] in [1mserve-static@1.0.1[0m
+    introduced by package.json@ > express@4.0.0 > serve-static@1.0.1
+  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-COOKIE-8163060] in [1mcookie@0.1.0[0m
+    introduced by package.json@ > express@4.0.0 > cookie@0.1.0
+  ✗ [33m[1mOpen Redirect[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-EXPRESS-6474509] in [1mexpress@4.0.0[0m
+    introduced by package.json@ > express@4.0.0
+  ✗ [33m[1mCross-site Scripting[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-EXPRESS-7926867] in [1mexpress@4.0.0[0m
+    introduced by package.json@ > express@4.0.0
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-PATHTOREGEXP-7925106] in [1mpath-to-regexp@0.1.2[0m
+    introduced by package.json@ > express@4.0.0 > path-to-regexp@0.1.2
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-PATHTOREGEXP-8482416] in [1mpath-to-regexp@0.1.2[0m
+    introduced by package.json@ > express@4.0.0 > path-to-regexp@0.1.2
+  ✗ [33m[1mNon-Constant Time String Comparison[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:cookie-signature:20160804] in [1mcookie-signature@1.0.3[0m
+    introduced by package.json@ > express@4.0.0 > cookie-signature@1.0.3
+  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:express:20140912] in [1mexpress@4.0.0[0m
+    introduced by package.json@ > express@4.0.0
+  ✗ [33m[1mDenial of Service (DoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:qs:20140806-1] in [1mqs@0.6.6[0m
+    introduced by package.json@ > express@4.0.0 > qs@0.6.6
+  ✗ [33m[1mDirectory Traversal[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:send:20140912] in [1msend@0.2.0[0m
+    introduced by package.json@ > express@4.0.0 > send@0.2.0 and [36m1[0m other path
+  ✗ [33m[1mRoot Path Disclosure[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:send:20151103] in [1msend@0.2.0[0m
+    introduced by package.json@ > express@4.0.0 > send@0.2.0 and [36m1[0m other path
+  ✗ [31m[1mPrototype Poisoning[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JS-QS-3153490] in [1mqs@0.6.6[0m
+    introduced by package.json@ > express@4.0.0 > qs@0.6.6
+  ✗ [31m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:fresh:20170908] in [1mfresh@0.2.2[0m
+    introduced by package.json@ > express@4.0.0 > fresh@0.2.2 and [36m2[0m other paths
+  ✗ [31m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:negotiator:20160616] in [1mnegotiator@0.3.0[0m
+    introduced by package.json@ > express@4.0.0 > accepts@1.0.0 > negotiator@0.3.0
+  ✗ [31m[1mDenial of Service (DoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:qs:20140806] in [1mqs@0.6.6[0m
+    introduced by package.json@ > express@4.0.0 > qs@0.6.6
+  ✗ [31m[1mPrototype Override Protection Bypass[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:qs:20170213] in [1mqs@0.6.6[0m
+    introduced by package.json@ > express@4.0.0 > qs@0.6.6
+
+╭───────────────────────────────────────────────────────────╮
+│ [1mTest Summary[0m                                              │
+│                                                           │
+│   Organization:      My Org                               │
+│   Test type:         Software Composition Analysis        │
+│   Project path:      multi-project                        │
+│   Target file:       ghost/package.json                   │
+│                                                           │
+│   Total security issues: 19                               │
+│   Ignored: [1m0[0m [[35m 0 CRITICAL [0m[31m 0 HIGH [0m[33m 0 MEDIUM [0m 0 LOW ]      │
+│   Open   : [1m19[0m [[35m 0 CRITICAL [0m[31m 5 HIGH [0m[33m 10 MEDIUM [0m 4 LOW ]    │
+╰───────────────────────────────────────────────────────────╯
+
+─────────────────────────────────────────────────────
+
+[1mTesting  (golang/go.mod) ...[0m
+
+Tested 29 dependencies for known issues, found 1 issues, 1 vulnerable paths.
+
+[1mOpen Security issues: 1[0m
+
+ ✗ [33m[MEDIUM][0m [1mOpen Redirect[0m
+   Finding ID: SNYK-GOLANG-GITHUBCOMVALYALAFASTHTTP-6815320
+   Info: https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMVALYALAFASTHTTP-6815320
+   Introduced by: github.com/valyala/fasthttp
+   Introduced through: golangproject@0.0.0 > github.com/gofiber/fiber/v2@2.52.9 > github.com/valyala/fasthttp@1.51.0
+   Risk Score: 84
+
+╭─────────────────────────────────────────────────────────╮
+│ [1mTest Summary[0m                                            │
+│                                                         │
+│   Organization:      My Org                             │
+│   Test type:         Software Composition Analysis      │
+│   Project path:      multi-project                      │
+│   Target file:       golang/go.mod                      │
+│                                                         │
+│   Total security issues: 1                              │
+│   Ignored: [1m0[0m [[35m 0 CRITICAL [0m[31m 0 HIGH [0m[33m 0 MEDIUM [0m 0 LOW ]    │
+│   Open   : [1m1[0m [[35m 0 CRITICAL [0m[31m 0 HIGH [0m[33m 1 MEDIUM [0m 0 LOW ]    │
+╰─────────────────────────────────────────────────────────╯
+
+─────────────────────────────────────────────────────
+
+[1mTesting  (maven/pom.xml) ...[0m
+
+Tested 4 dependencies for known issues, found 0 issues, 0 vulnerable paths.
+
+[1mOpen no findings type found issues: 0[0m
+
+╭─────────────────────────────────────────────╮
+│ [1mTest Summary[0m                                │
+│                                             │
+│   Organization:      My Org                 │
+│   Test type:         Other                  │
+│   Project path:      multi-project          │
+│   Target file:       maven/pom.xml          │
+│                                             │
+│   Total no findings type found issues: 0    │
+╰─────────────────────────────────────────────╯
+
+─────────────────────────────────────────────────────
+
+[1mTesting  (not-python/requirements.txt) ...[0m
+
+Tested 7 dependencies for known issues, found 11 issues, 22 vulnerable paths.
+
+[1mOpen Security issues: 11[0m
+
+ ✗ [33m[MEDIUM][0m [1mRegular Expression Denial of Service (ReDoS)[0m
+   Finding ID: SNYK-PYTHON-JINJA2-1012994
+   Info: https://snyk.io/vuln/SNYK-PYTHON-JINJA2-1012994
+   Introduced by: jinja2
+   Introduced through: not-python@0.0.0 > jinja2@2.7.2
+   Risk Score: 84
+
+ ✗ [33m[MEDIUM][0m [1mSandbox Escape[0m
+   Finding ID: SNYK-PYTHON-JINJA2-174126
+   Info: https://snyk.io/vuln/SNYK-PYTHON-JINJA2-174126
+   Introduced by: jinja2
+   Introduced through: not-python@0.0.0 > jinja2@2.7.2
+   Risk Score: 154
+
+ ✗ [33m[MEDIUM][0m [1mCross-site Scripting (XSS)[0m
+   Finding ID: SNYK-PYTHON-JINJA2-6150717
+   Info: https://snyk.io/vuln/SNYK-PYTHON-JINJA2-6150717
+   Introduced by: jinja2
+   Introduced through: not-python@0.0.0 > jinja2@2.7.2
+   Risk Score: 81
+
+ ✗ [33m[MEDIUM][0m [1mCross-site Scripting (XSS)[0m
+   Finding ID: SNYK-PYTHON-JINJA2-6809379
+   Info: https://snyk.io/vuln/SNYK-PYTHON-JINJA2-6809379
+   Introduced by: jinja2
+   Introduced through: not-python@0.0.0 > jinja2@2.7.2
+   Risk Score: 82
+
+ ✗ [33m[MEDIUM][0m [1mTemplate Injection[0m
+   Finding ID: SNYK-PYTHON-JINJA2-8548181
+   Info: https://snyk.io/vuln/SNYK-PYTHON-JINJA2-8548181
+   Introduced by: jinja2
+   Introduced through: not-python@0.0.0 > jinja2@2.7.2
+   Risk Score: 98
+
+ ✗ [33m[MEDIUM][0m [1mImproper Neutralization[0m
+   Finding ID: SNYK-PYTHON-JINJA2-8548987
+   Info: https://snyk.io/vuln/SNYK-PYTHON-JINJA2-8548987
+   Introduced by: jinja2
+   Introduced through: not-python@0.0.0 > jinja2@2.7.2
+   Risk Score: 190
+
+ ✗ [33m[MEDIUM][0m [1mTemplate Injection[0m
+   Finding ID: SNYK-PYTHON-JINJA2-9292516
+   Info: https://snyk.io/vuln/SNYK-PYTHON-JINJA2-9292516
+   Introduced by: jinja2
+   Introduced through: not-python@0.0.0 > jinja2@2.7.2
+   Risk Score: 190
+
+ ✗ [33m[MEDIUM][0m [1mDirectory Traversal[0m
+   Finding ID: SNYK-PYTHON-WERKZEUG-8309091
+   Info: https://snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309091
+   Introduced by: werkzeug
+   Introduced through: not-python@0.0.0 > werkzeug@3.0.1
+   Risk Score: 53
+
+ ✗ [33m[MEDIUM][0m [1mAllocation of Resources Without Limits or Throttling[0m
+   Finding ID: SNYK-PYTHON-WERKZEUG-8309092
+   Info: https://snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309092
+   Introduced by: werkzeug
+   Introduced through: not-python@0.0.0 > werkzeug@3.0.1
+   Risk Score: 61
+
+ ✗ [31m[HIGH][0m [1mSandbox Bypass[0m
+   Finding ID: SNYK-PYTHON-JINJA2-455616
+   Info: https://snyk.io/vuln/SNYK-PYTHON-JINJA2-455616
+   Introduced by: jinja2
+   Introduced through: not-python@0.0.0 > jinja2@2.7.2
+   Risk Score: 171
+
+ ✗ [31m[HIGH][0m [1mRemote Code Execution (RCE)[0m
+   Finding ID: SNYK-PYTHON-WERKZEUG-6808933
+   Info: https://snyk.io/vuln/SNYK-PYTHON-WERKZEUG-6808933
+   Introduced by: werkzeug
+   Introduced through: not-python@0.0.0 > werkzeug@3.0.1
+   Risk Score: 292
+
+[32m[1mIssues to fix by upgrading:[0m[0m
+
+  Upgrade [1mjinja2@2.7.2[0m to [1mjinja2@3.1.6[0m to fix
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-1012994] in [1mjinja2@2.7.2[0m
+    introduced by not-python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mSandbox Escape[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-174126] in [1mjinja2@2.7.2[0m
+    introduced by not-python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-6150717] in [1mjinja2@2.7.2[0m
+    introduced by not-python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-6809379] in [1mjinja2@2.7.2[0m
+    introduced by not-python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mTemplate Injection[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-8548181] in [1mjinja2@2.7.2[0m
+    introduced by not-python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mImproper Neutralization[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-8548987] in [1mjinja2@2.7.2[0m
+    introduced by not-python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mTemplate Injection[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-9292516] in [1mjinja2@2.7.2[0m
+    introduced by not-python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [31m[1mSandbox Bypass[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-455616] in [1mjinja2@2.7.2[0m
+    introduced by not-python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+
+  Upgrade [1mwerkzeug@3.0.1[0m to [1mwerkzeug@3.0.6[0m to fix
+  ✗ [33m[1mDirectory Traversal[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309091] in [1mwerkzeug@3.0.1[0m
+    introduced by not-python@0.0.0 > werkzeug@3.0.1 and [36m1[0m other path
+  ✗ [33m[1mAllocation of Resources Without Limits or Throttling[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309092] in [1mwerkzeug@3.0.1[0m
+    introduced by not-python@0.0.0 > werkzeug@3.0.1 and [36m1[0m other path
+  ✗ [31m[1mRemote Code Execution (RCE)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-6808933] in [1mwerkzeug@3.0.1[0m
+    introduced by not-python@0.0.0 > werkzeug@3.0.1 and [36m1[0m other path
+
+╭──────────────────────────────────────────────────────────╮
+│ [1mTest Summary[0m                                             │
+│                                                          │
+│   Organization:      My Org                              │
+│   Test type:         Software Composition Analysis       │
+│   Project path:      multi-project                       │
+│   Target file:       not-python/requirements.txt         │
+│                                                          │
+│   Total security issues: 11                              │
+│   Ignored: [1m0[0m [[35m 0 CRITICAL [0m[31m 0 HIGH [0m[33m 0 MEDIUM [0m 0 LOW ]     │
+│   Open   : [1m11[0m [[35m 0 CRITICAL [0m[31m 2 HIGH [0m[33m 9 MEDIUM [0m 0 LOW ]    │
+╰──────────────────────────────────────────────────────────╯
+
+─────────────────────────────────────────────────────
+
+[1mTesting  (python/requirements.txt) ...[0m
+
+Tested 7 dependencies for known issues, found 11 issues, 22 vulnerable paths.
+
+[1mOpen Security issues: 11[0m
+
+ ✗ [33m[MEDIUM][0m [1mRegular Expression Denial of Service (ReDoS)[0m
+   Finding ID: SNYK-PYTHON-JINJA2-1012994
+   Info: https://snyk.io/vuln/SNYK-PYTHON-JINJA2-1012994
+   Introduced by: jinja2
+   Introduced through: python@0.0.0 > jinja2@2.7.2
+   Risk Score: 84
+
+ ✗ [33m[MEDIUM][0m [1mSandbox Escape[0m
+   Finding ID: SNYK-PYTHON-JINJA2-174126
+   Info: https://snyk.io/vuln/SNYK-PYTHON-JINJA2-174126
+   Introduced by: jinja2
+   Introduced through: python@0.0.0 > jinja2@2.7.2
+   Risk Score: 154
+
+ ✗ [33m[MEDIUM][0m [1mCross-site Scripting (XSS)[0m
+   Finding ID: SNYK-PYTHON-JINJA2-6150717
+   Info: https://snyk.io/vuln/SNYK-PYTHON-JINJA2-6150717
+   Introduced by: jinja2
+   Introduced through: python@0.0.0 > jinja2@2.7.2
+   Risk Score: 81
+
+ ✗ [33m[MEDIUM][0m [1mCross-site Scripting (XSS)[0m
+   Finding ID: SNYK-PYTHON-JINJA2-6809379
+   Info: https://snyk.io/vuln/SNYK-PYTHON-JINJA2-6809379
+   Introduced by: jinja2
+   Introduced through: python@0.0.0 > jinja2@2.7.2
+   Risk Score: 82
+
+ ✗ [33m[MEDIUM][0m [1mTemplate Injection[0m
+   Finding ID: SNYK-PYTHON-JINJA2-8548181
+   Info: https://snyk.io/vuln/SNYK-PYTHON-JINJA2-8548181
+   Introduced by: jinja2
+   Introduced through: python@0.0.0 > jinja2@2.7.2
+   Risk Score: 98
+
+ ✗ [33m[MEDIUM][0m [1mImproper Neutralization[0m
+   Finding ID: SNYK-PYTHON-JINJA2-8548987
+   Info: https://snyk.io/vuln/SNYK-PYTHON-JINJA2-8548987
+   Introduced by: jinja2
+   Introduced through: python@0.0.0 > jinja2@2.7.2
+   Risk Score: 190
+
+ ✗ [33m[MEDIUM][0m [1mTemplate Injection[0m
+   Finding ID: SNYK-PYTHON-JINJA2-9292516
+   Info: https://snyk.io/vuln/SNYK-PYTHON-JINJA2-9292516
+   Introduced by: jinja2
+   Introduced through: python@0.0.0 > jinja2@2.7.2
+   Risk Score: 190
+
+ ✗ [33m[MEDIUM][0m [1mDirectory Traversal[0m
+   Finding ID: SNYK-PYTHON-WERKZEUG-8309091
+   Info: https://snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309091
+   Introduced by: werkzeug
+   Introduced through: python@0.0.0 > werkzeug@3.0.1
+   Risk Score: 53
+
+ ✗ [33m[MEDIUM][0m [1mAllocation of Resources Without Limits or Throttling[0m
+   Finding ID: SNYK-PYTHON-WERKZEUG-8309092
+   Info: https://snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309092
+   Introduced by: werkzeug
+   Introduced through: python@0.0.0 > werkzeug@3.0.1
+   Risk Score: 61
+
+ ✗ [31m[HIGH][0m [1mSandbox Bypass[0m
+   Finding ID: SNYK-PYTHON-JINJA2-455616
+   Info: https://snyk.io/vuln/SNYK-PYTHON-JINJA2-455616
+   Introduced by: jinja2
+   Introduced through: python@0.0.0 > jinja2@2.7.2
+   Risk Score: 171
+
+ ✗ [31m[HIGH][0m [1mRemote Code Execution (RCE)[0m
+   Finding ID: SNYK-PYTHON-WERKZEUG-6808933
+   Info: https://snyk.io/vuln/SNYK-PYTHON-WERKZEUG-6808933
+   Introduced by: werkzeug
+   Introduced through: python@0.0.0 > werkzeug@3.0.1
+   Risk Score: 292
+
+[32m[1mIssues to fix by upgrading:[0m[0m
+
+  Upgrade [1mjinja2@2.7.2[0m to [1mjinja2@3.1.6[0m to fix
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-1012994] in [1mjinja2@2.7.2[0m
+    introduced by python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mSandbox Escape[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-174126] in [1mjinja2@2.7.2[0m
+    introduced by python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-6150717] in [1mjinja2@2.7.2[0m
+    introduced by python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-6809379] in [1mjinja2@2.7.2[0m
+    introduced by python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mTemplate Injection[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-8548181] in [1mjinja2@2.7.2[0m
+    introduced by python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mImproper Neutralization[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-8548987] in [1mjinja2@2.7.2[0m
+    introduced by python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [33m[1mTemplate Injection[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-9292516] in [1mjinja2@2.7.2[0m
+    introduced by python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+  ✗ [31m[1mSandbox Bypass[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-455616] in [1mjinja2@2.7.2[0m
+    introduced by python@0.0.0 > jinja2@2.7.2 and [36m1[0m other path
+
+  Upgrade [1mwerkzeug@3.0.1[0m to [1mwerkzeug@3.0.6[0m to fix
+  ✗ [33m[1mDirectory Traversal[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309091] in [1mwerkzeug@3.0.1[0m
+    introduced by python@0.0.0 > werkzeug@3.0.1 and [36m1[0m other path
+  ✗ [33m[1mAllocation of Resources Without Limits or Throttling[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309092] in [1mwerkzeug@3.0.1[0m
+    introduced by python@0.0.0 > werkzeug@3.0.1 and [36m1[0m other path
+  ✗ [31m[1mRemote Code Execution (RCE)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-6808933] in [1mwerkzeug@3.0.1[0m
+    introduced by python@0.0.0 > werkzeug@3.0.1 and [36m1[0m other path
+
+╭──────────────────────────────────────────────────────────╮
+│ [1mTest Summary[0m                                             │
+│                                                          │
+│   Organization:      My Org                              │
+│   Test type:         Software Composition Analysis       │
+│   Project path:      multi-project                       │
+│   Target file:       python/requirements.txt             │
+│                                                          │
+│   Total security issues: 11                              │
+│   Ignored: [1m0[0m [[35m 0 CRITICAL [0m[31m 0 HIGH [0m[33m 0 MEDIUM [0m 0 LOW ]     │
+│   Open   : [1m11[0m [[35m 0 CRITICAL [0m[31m 2 HIGH [0m[33m 9 MEDIUM [0m 0 LOW ]    │
+╰──────────────────────────────────────────────────────────╯
+
+─────────────────────────────────────────────────────
+
+[1mTesting  (tsc/package.json) ...[0m
+
+Tested 23 dependencies for known issues, found 19 issues, 27 vulnerable paths.
+
+[1mOpen Security issues: 19[0m
+
+ ✗ [LOW] [1mCross-site Scripting[0m
+   Finding ID: SNYK-JS-SEND-7926862
+   Info: https://snyk.io/vuln/SNYK-JS-SEND-7926862
+   Introduced by: send
+   Introduced through: tsc@1.0.0 > express@4.0.0 > send@0.2.0
+   Risk Score: 57
+
+ ✗ [LOW] [1mCross-site Scripting[0m
+   Finding ID: SNYK-JS-SERVESTATIC-7926865
+   Info: https://snyk.io/vuln/SNYK-JS-SERVESTATIC-7926865
+   Introduced by: serve-static
+   Introduced through: tsc@1.0.0 > express@4.0.0 > serve-static@1.0.1
+   Risk Score: 57
+
+ ✗ [LOW] [1mRegular Expression Denial of Service (ReDoS)[0m
+   Finding ID: npm:mime:20170907
+   Info: https://snyk.io/vuln/npm:mime:20170907
+   Introduced by: mime
+   Introduced through: tsc@1.0.0 > express@4.0.0 > accepts@1.0.0 > mime@1.2.11
+   Risk Score: 35
+
+ ✗ [LOW] [1mOpen Redirect[0m
+   Finding ID: npm:serve-static:20150113
+   Info: https://snyk.io/vuln/npm:serve-static:20150113
+   Introduced by: serve-static
+   Introduced through: tsc@1.0.0 > express@4.0.0 > serve-static@1.0.1
+   Risk Score: 24
+
+ ✗ [33m[MEDIUM][0m [1mCross-site Scripting (XSS)[0m
+   Finding ID: SNYK-JS-COOKIE-8163060
+   Info: https://snyk.io/vuln/SNYK-JS-COOKIE-8163060
+   Introduced by: cookie
+   Introduced through: tsc@1.0.0 > express@4.0.0 > cookie@0.1.0
+   Risk Score: 34
+
+ ✗ [33m[MEDIUM][0m [1mOpen Redirect[0m
+   Finding ID: SNYK-JS-EXPRESS-6474509
+   Info: https://snyk.io/vuln/SNYK-JS-EXPRESS-6474509
+   Introduced by: express
+   Introduced through: tsc@1.0.0 > express@4.0.0
+   Risk Score: 74
+
+ ✗ [33m[MEDIUM][0m [1mCross-site Scripting[0m
+   Finding ID: SNYK-JS-EXPRESS-7926867
+   Info: https://snyk.io/vuln/SNYK-JS-EXPRESS-7926867
+   Introduced by: express
+   Introduced through: tsc@1.0.0 > express@4.0.0
+   Risk Score: 75
+
+ ✗ [33m[MEDIUM][0m [1mRegular Expression Denial of Service (ReDoS)[0m
+   Finding ID: SNYK-JS-PATHTOREGEXP-7925106
+   Info: https://snyk.io/vuln/SNYK-JS-PATHTOREGEXP-7925106
+   Introduced by: path-to-regexp
+   Introduced through: tsc@1.0.0 > express@4.0.0 > path-to-regexp@0.1.2
+   Risk Score: 57
+
+ ✗ [33m[MEDIUM][0m [1mRegular Expression Denial of Service (ReDoS)[0m
+   Finding ID: SNYK-JS-PATHTOREGEXP-8482416
+   Info: https://snyk.io/vuln/SNYK-JS-PATHTOREGEXP-8482416
+   Introduced by: path-to-regexp
+   Introduced through: tsc@1.0.0 > express@4.0.0 > path-to-regexp@0.1.2
+   Risk Score: 61
+
+ ✗ [33m[MEDIUM][0m [1mNon-Constant Time String Comparison[0m
+   Finding ID: npm:cookie-signature:20160804
+   Info: https://snyk.io/vuln/npm:cookie-signature:20160804
+   Introduced by: cookie-signature
+   Introduced through: tsc@1.0.0 > express@4.0.0 > cookie-signature@1.0.3
+   Risk Score: 86
+
+ ✗ [33m[MEDIUM][0m [1mCross-site Scripting (XSS)[0m
+   Finding ID: npm:express:20140912
+   Info: https://snyk.io/vuln/npm:express:20140912
+   Introduced by: express
+   Introduced through: tsc@1.0.0 > express@4.0.0
+   Risk Score: 69
+
+ ✗ [33m[MEDIUM][0m [1mDenial of Service (DoS)[0m
+   Finding ID: npm:qs:20140806-1
+   Info: https://snyk.io/vuln/npm:qs:20140806-1
+   Introduced by: qs
+   Introduced through: tsc@1.0.0 > express@4.0.0 > qs@0.6.6
+   Risk Score: 74
+
+ ✗ [33m[MEDIUM][0m [1mDirectory Traversal[0m
+   Finding ID: npm:send:20140912
+   Info: https://snyk.io/vuln/npm:send:20140912
+   Introduced by: send
+   Introduced through: tsc@1.0.0 > express@4.0.0 > send@0.2.0
+   Risk Score: 39
+
+ ✗ [33m[MEDIUM][0m [1mRoot Path Disclosure[0m
+   Finding ID: npm:send:20151103
+   Info: https://snyk.io/vuln/npm:send:20151103
+   Introduced by: send
+   Introduced through: tsc@1.0.0 > express@4.0.0 > send@0.2.0
+   Risk Score: 40
+
+ ✗ [31m[HIGH][0m [1mPrototype Poisoning[0m
+   Finding ID: SNYK-JS-QS-3153490
+   Info: https://snyk.io/vuln/SNYK-JS-QS-3153490
+   Introduced by: qs
+   Introduced through: tsc@1.0.0 > express@4.0.0 > qs@0.6.6
+   Risk Score: 150
+
+ ✗ [31m[HIGH][0m [1mRegular Expression Denial of Service (ReDoS)[0m
+   Finding ID: npm:fresh:20170908
+   Info: https://snyk.io/vuln/npm:fresh:20170908
+   Introduced by: fresh
+   Introduced through: tsc@1.0.0 > express@4.0.0 > fresh@0.2.2
+   Risk Score: 101
+
+ ✗ [31m[HIGH][0m [1mRegular Expression Denial of Service (ReDoS)[0m
+   Finding ID: npm:negotiator:20160616
+   Info: https://snyk.io/vuln/npm:negotiator:20160616
+   Introduced by: negotiator
+   Introduced through: tsc@1.0.0 > express@4.0.0 > accepts@1.0.0 > negotiator@0.3.0
+   Risk Score: 101
+
+ ✗ [31m[HIGH][0m [1mDenial of Service (DoS)[0m
+   Finding ID: npm:qs:20140806
+   Info: https://snyk.io/vuln/npm:qs:20140806
+   Introduced by: qs
+   Introduced through: tsc@1.0.0 > express@4.0.0 > qs@0.6.6
+   Risk Score: 105
+
+ ✗ [31m[HIGH][0m [1mPrototype Override Protection Bypass[0m
+   Finding ID: npm:qs:20170213
+   Info: https://snyk.io/vuln/npm:qs:20170213
+   Introduced by: qs
+   Introduced through: tsc@1.0.0 > express@4.0.0 > qs@0.6.6
+   Risk Score: 101
+
+[32m[1mIssues to fix by upgrading:[0m[0m
+
+  Upgrade [1mexpress@4.0.0[0m to [1mexpress@4.21.2[0m to fix
+  ✗ [1mCross-site Scripting[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-SEND-7926862] in [1msend@0.2.0[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > send@0.2.0 and [36m1[0m other path
+  ✗ [1mCross-site Scripting[0m [LOW] [https://security.snyk.io/vuln/SNYK-JS-SERVESTATIC-7926865] in [1mserve-static@1.0.1[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > serve-static@1.0.1
+  ✗ [1mRegular Expression Denial of Service (ReDoS)[0m [LOW] [https://security.snyk.io/vuln/npm:mime:20170907] in [1mmime@1.2.11[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > accepts@1.0.0 > mime@1.2.11 and [36m3[0m other paths
+  ✗ [1mOpen Redirect[0m [LOW] [https://security.snyk.io/vuln/npm:serve-static:20150113] in [1mserve-static@1.0.1[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > serve-static@1.0.1
+  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-COOKIE-8163060] in [1mcookie@0.1.0[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > cookie@0.1.0
+  ✗ [33m[1mOpen Redirect[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-EXPRESS-6474509] in [1mexpress@4.0.0[0m
+    introduced by tsc@1.0.0 > express@4.0.0
+  ✗ [33m[1mCross-site Scripting[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-EXPRESS-7926867] in [1mexpress@4.0.0[0m
+    introduced by tsc@1.0.0 > express@4.0.0
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-PATHTOREGEXP-7925106] in [1mpath-to-regexp@0.1.2[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > path-to-regexp@0.1.2
+  ✗ [33m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/SNYK-JS-PATHTOREGEXP-8482416] in [1mpath-to-regexp@0.1.2[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > path-to-regexp@0.1.2
+  ✗ [33m[1mNon-Constant Time String Comparison[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:cookie-signature:20160804] in [1mcookie-signature@1.0.3[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > cookie-signature@1.0.3
+  ✗ [33m[1mCross-site Scripting (XSS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:express:20140912] in [1mexpress@4.0.0[0m
+    introduced by tsc@1.0.0 > express@4.0.0
+  ✗ [33m[1mDenial of Service (DoS)[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:qs:20140806-1] in [1mqs@0.6.6[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > qs@0.6.6
+  ✗ [33m[1mDirectory Traversal[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:send:20140912] in [1msend@0.2.0[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > send@0.2.0 and [36m1[0m other path
+  ✗ [33m[1mRoot Path Disclosure[0m[0m [33m[MEDIUM][0m [https://security.snyk.io/vuln/npm:send:20151103] in [1msend@0.2.0[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > send@0.2.0 and [36m1[0m other path
+  ✗ [31m[1mPrototype Poisoning[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/SNYK-JS-QS-3153490] in [1mqs@0.6.6[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > qs@0.6.6
+  ✗ [31m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:fresh:20170908] in [1mfresh@0.2.2[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > fresh@0.2.2 and [36m2[0m other paths
+  ✗ [31m[1mRegular Expression Denial of Service (ReDoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:negotiator:20160616] in [1mnegotiator@0.3.0[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > accepts@1.0.0 > negotiator@0.3.0
+  ✗ [31m[1mDenial of Service (DoS)[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:qs:20140806] in [1mqs@0.6.6[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > qs@0.6.6
+  ✗ [31m[1mPrototype Override Protection Bypass[0m[0m [31m[HIGH][0m [https://security.snyk.io/vuln/npm:qs:20170213] in [1mqs@0.6.6[0m
+    introduced by tsc@1.0.0 > express@4.0.0 > qs@0.6.6
+
+╭───────────────────────────────────────────────────────────╮
+│ [1mTest Summary[0m                                              │
+│                                                           │
+│   Organization:      My Org                               │
+│   Test type:         Software Composition Analysis        │
+│   Project path:      multi-project                        │
+│   Target file:       tsc/package.json                     │
+│                                                           │
+│   Total security issues: 19                               │
+│   Ignored: [1m0[0m [[35m 0 CRITICAL [0m[31m 0 HIGH [0m[33m 0 MEDIUM [0m 0 LOW ]      │
+│   Open   : [1m19[0m [[35m 0 CRITICAL [0m[31m 5 HIGH [0m[33m 10 MEDIUM [0m 4 LOW ]    │
+╰───────────────────────────────────────────────────────────╯
+
+─────────────────────────────────────────────────────
+
+╭────────────────────────────────────────────────────────────╮
+│ [1mOverall Test Summary[0m                                       │
+│                                                            │
+│   Organization:      My Org                                │
+│   Test type:         Software Composition Analysis         │
+│   Projects tested:   7 projects                            │
+│                                                            │
+│   Total security issues: 67                                │
+│   Ignored: [1m0[0m [[35m 0 CRITICAL [0m[31m 0 HIGH [0m[33m 0 MEDIUM [0m 0 LOW ]       │
+│   Open   : [1m67[0m [[35m 0 CRITICAL [0m[31m 19 HIGH [0m[33m 40 MEDIUM [0m 8 LOW ]    │
+╰────────────────────────────────────────────────────────────╯
+
+View your asset(s) at: [1mhttps://app.snyk.io/org/my-org/inventory/assets/01a01434-8c66-7ed7-b7b8-401a040153f1/overview[0m
+
+💡 Tip
+
+   To view ignored issues, use the --include-ignores option.
+                                                            

--- a/internal/presenters/testdata/ufm/multi_project.with-asset.testresult.json
+++ b/internal/presenters/testdata/ufm/multi_project.with-asset.testresult.json
@@ -1,0 +1,15463 @@
+[
+  {
+    "testId": "fb28964a-89ef-4663-beca-83a3024e2155",
+    "testConfiguration": {
+      "local_policy": {
+        "fail_on_upgradable": false,
+        "severity_threshold": "low",
+        "suppress_pending_ignores": false
+      },
+      "timeout": {
+        "outcome": "fail",
+        "seconds": 1200
+      }
+    },
+    "metadata": {
+      "project-name": "tpwe",
+      "display-target-file": "dotnet/obj/project.assets.json",
+      "target-directory": "multi-project",
+      "dependency-count": 84,
+      "asset": "https://app.snyk.io/org/my-org/inventory/assets/01a01434-8c66-7ed7-b7b8-401a040153f1/overview"
+    },
+    "createdAt": "2025-11-13T15:29:14.585711Z",
+    "testSubject": {
+      "locator": {
+        "paths": [
+          "dotnet/obj/project.assets.json"
+        ],
+        "type": "local_path"
+      },
+      "type": "dep_graph"
+    },
+    "executionState": "finished",
+    "passFail": "fail",
+    "outcomeReason": "policy_breach",
+    "effectiveSummary": {
+      "count": 6,
+      "count_by": {
+        "result_type": {
+          "dast": 0,
+          "other": 0,
+          "sast": 0,
+          "sca": 6
+        },
+        "severity": {
+          "critical": 0,
+          "high": 5,
+          "low": 0,
+          "medium": 1,
+          "none": 0,
+          "other": 0
+        }
+      }
+    },
+    "rawSummary": {
+      "count": 6,
+      "count_by": {
+        "result_type": {
+          "dast": 0,
+          "other": 0,
+          "sast": 0,
+          "sca": 6
+        },
+        "severity": {
+          "critical": 0,
+          "high": 5,
+          "low": 0,
+          "medium": 1,
+          "none": 0,
+          "other": 0
+        }
+      }
+    },
+    "findingsComplete": true,
+    "findings": [
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\n[System.Net.Http](https://www.nuget.org/packages/System.Net.Http/) is an Provides a programming interface for modern HTTP applications, including HTTP client components that allow applications to consume web services over HTTP and HTTP components that can be used by both clients and servers for parsing HTTP headers.\n\n\nAffected versions of this package are vulnerable to Denial of Service (DoS)\nas `ASP.NET Core` fails to properly validate web requests.\r\n\r\n**NOTE:** Microsoft has not commented on third-party claims that the issue is that the `TextEncoder.EncodeCore` function in the `System.Text.Encodings.Web` package in ASP.NET Core Mvc before 1.0.4 and 1.1.x before 1.1.3 allows remote attackers to cause a denial of service by leveraging failure to properly calculate the length of 4-byte characters in the Unicode Non-Character range.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## Remediation\n\nUpgrade `System.Net.Http` to version 4.1.2, 4.3.2 or higher.\n\n\n## References\n\n- [GitHub Issue](https://github.com/aspnet/Announcements/issues/239)\n\n- [Microsoft Security Advisory](https://technet.microsoft.com/en-us/library/security/4021279.aspx)\n\n- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2017-0247)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tpwe",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "NSubstitute",
+                  "version": "4.3.0"
+                },
+                {
+                  "name": "Castle.Core",
+                  "version": "4.4.1"
+                },
+                {
+                  "name": "NETStandard.Library",
+                  "version": "1.6.1"
+                },
+                {
+                  "name": "System.Net.Http",
+                  "version": "4.3.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000001",
+          "locations": [
+            {
+              "package": {
+                "name": "System.Net.Http",
+                "version": "4.3.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2017-0247",
+              "source": "cve"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,4.1.2)",
+                "[4.3.0,4.3.2)"
+              ],
+              "created_at": "2017-07-19T00:00:00Z",
+              "credits": [
+                "David Fernandez"
+              ],
+              "cvss_base_score": 7.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:06:08.284901Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:46:28.620317Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+              "disclosed_at": "2017-05-09T00:00:00Z",
+              "ecosystem": {
+                "language": "dotnet",
+                "package_manager": "nuget",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.93182",
+                "probability": "0.11122"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-DOTNET-SYSTEMNETHTTP-60045",
+              "initially_fixed_in_versions": [
+                "4.1.2",
+                "4.3.2"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:46:28.620317Z",
+              "package_name": "System.Net.Http",
+              "package_version": "",
+              "published_at": "2017-05-09T00:00:00Z",
+              "references": [
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/aspnet/Announcements/issues/239"
+                },
+                {
+                  "title": "Microsoft Security Advisory",
+                  "url": "https://technet.microsoft.com/en-us/library/security/4021279.aspx"
+                },
+                {
+                  "title": "NVD",
+                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-0247"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-254",
+              "source": "cwe"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 130
+            }
+          },
+          "title": "Denial of Service (DoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000001",
+        "links": {},
+        "relationships": {},
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\n[System.Text.RegularExpressions](https://www.nuget.org/packages/System.Text.RegularExpressions/) is a regular expression engine.\n\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS)\ndue to improperly processing of RegEx strings.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet\u2019s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn\u2019t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\n\nUpgrade `System.Text.RegularExpressions` to version 4.3.1 or higher.\n\n\n## References\n\n- [GitHub Issue](https://github.com/dotnet/announcements/issues/111)\n\n- [Microsoft Security Advisory](https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2019-0820)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tpwe",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "NSubstitute",
+                  "version": "4.3.0"
+                },
+                {
+                  "name": "Castle.Core",
+                  "version": "4.4.1"
+                },
+                {
+                  "name": "NETStandard.Library",
+                  "version": "1.6.1"
+                },
+                {
+                  "name": "System.Text.RegularExpressions",
+                  "version": "4.3.0"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "tpwe",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "NSubstitute",
+                  "version": "4.3.0"
+                },
+                {
+                  "name": "Castle.Core",
+                  "version": "4.4.1"
+                },
+                {
+                  "name": "NETStandard.Library",
+                  "version": "1.6.1"
+                },
+                {
+                  "name": "System.Xml.ReaderWriter",
+                  "version": "4.3.0"
+                },
+                {
+                  "name": "System.Text.RegularExpressions",
+                  "version": "4.3.0"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "tpwe",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "NSubstitute",
+                  "version": "4.3.0"
+                },
+                {
+                  "name": "Castle.Core",
+                  "version": "4.4.1"
+                },
+                {
+                  "name": "System.Xml.XmlDocument",
+                  "version": "4.3.0"
+                },
+                {
+                  "name": "System.Xml.ReaderWriter",
+                  "version": "4.3.0"
+                },
+                {
+                  "name": "System.Text.RegularExpressions",
+                  "version": "4.3.0"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "tpwe",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "NSubstitute",
+                  "version": "4.3.0"
+                },
+                {
+                  "name": "Castle.Core",
+                  "version": "4.4.1"
+                },
+                {
+                  "name": "NETStandard.Library",
+                  "version": "1.6.1"
+                },
+                {
+                  "name": "System.Xml.XDocument",
+                  "version": "4.3.0"
+                },
+                {
+                  "name": "System.Xml.ReaderWriter",
+                  "version": "4.3.0"
+                },
+                {
+                  "name": "System.Text.RegularExpressions",
+                  "version": "4.3.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000002",
+          "locations": [
+            {
+              "package": {
+                "name": "System.Text.RegularExpressions",
+                "version": "4.3.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[4.3.0, 4.3.1)"
+              ],
+              "created_at": "2019-05-15T16:00:51.866263Z",
+              "credits": [
+                "Unknown"
+              ],
+              "cvss_base_score": 7.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:55:54.16076Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:52:45.549435Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:51:14.000253Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "disclosed_at": "2019-05-14T07:00:00Z",
+              "ecosystem": {
+                "language": "dotnet",
+                "package_manager": "nuget",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.86521",
+                "probability": "0.03224"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-DOTNET-SYSTEMTEXTREGULAREXPRESSIONS-174708",
+              "initially_fixed_in_versions": [
+                "4.3.1"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:52:45.549435Z",
+              "package_name": "System.Text.RegularExpressions",
+              "package_version": "",
+              "published_at": "2019-05-16T15:55:53Z",
+              "references": [
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/dotnet/announcements/issues/111"
+                },
+                {
+                  "title": "Microsoft Security Advisory",
+                  "url": "https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2019-0820"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CVE-2019-0820",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-400",
+              "source": "cwe"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 119
+            }
+          },
+          "title": "Regular Expression Denial of Service (ReDoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000002",
+        "links": {},
+        "relationships": {},
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\n[System.Net.Http](https://www.nuget.org/packages/System.Net.Http/) Provides a programming interface for modern HTTP applications, including HTTP client components that allow applications to consume web services over HTTP and HTTP components that can be used by both clients and servers for parsing HTTP headers.\n\n\nAffected versions of this package are vulnerable to Privilege Escalation\ndue to failing to properly sanitize web requests.\n\n## Remediation\n\nUpgrade `System.Net.Http` to version 4.1.2, 4.3.2 or higher.\n\n\n## References\n\n- [GitHub Issue](https://github.com/aspnet/Announcements/issues/239)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tpwe",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "NSubstitute",
+                  "version": "4.3.0"
+                },
+                {
+                  "name": "Castle.Core",
+                  "version": "4.4.1"
+                },
+                {
+                  "name": "NETStandard.Library",
+                  "version": "1.6.1"
+                },
+                {
+                  "name": "System.Net.Http",
+                  "version": "4.3.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000003",
+          "locations": [
+            {
+              "package": {
+                "name": "System.Net.Http",
+                "version": "4.3.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2017-0249",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-269",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,4.1.2)",
+                "[4.3,4.3.2)"
+              ],
+              "created_at": "2017-07-19T00:00:00Z",
+              "credits": [
+                "Unknown"
+              ],
+              "cvss_base_score": 7.3,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 7.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:56:55.934503Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.3,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:46:27.393055Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+              "disclosed_at": "2017-05-12T00:00:00Z",
+              "ecosystem": {
+                "language": "dotnet",
+                "package_manager": "nuget",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.90075",
+                "probability": "0.05786"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-DOTNET-SYSTEMNETHTTP-60047",
+              "initially_fixed_in_versions": [
+                "4.1.2",
+                "4.3.2"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:46:27.393055Z",
+              "package_name": "System.Net.Http",
+              "package_version": "",
+              "published_at": "2017-05-12T00:00:00Z",
+              "references": [
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/aspnet/Announcements/issues/239"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 115
+            }
+          },
+          "title": "Privilege Escalation"
+        },
+        "id": "00000000-0000-0000-0000-000000000003",
+        "links": {},
+        "relationships": {},
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\nThe ASP.NET Core fails to properly sanitize the _Web Request Handler_ component, allowing an attacker to spoof web requests and bypass authentication.\n\n## References\n- [https://github.com/aspnet/Announcements/issues/239](https://github.com/aspnet/Announcements/issues/239)\n- [https://technet.microsoft.com/en-us/library/security/4021279.aspx](https://technet.microsoft.com/en-us/library/security/4021279.aspx)\n- [https://nvd.nist.gov/vuln/detail/2017-0256](https://nvd.nist.gov/vuln/detail/2017-0256)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tpwe",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "NSubstitute",
+                  "version": "4.3.0"
+                },
+                {
+                  "name": "Castle.Core",
+                  "version": "4.4.1"
+                },
+                {
+                  "name": "NETStandard.Library",
+                  "version": "1.6.1"
+                },
+                {
+                  "name": "System.Net.Http",
+                  "version": "4.3.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000004",
+          "locations": [
+            {
+              "package": {
+                "name": "System.Net.Http",
+                "version": "4.3.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,4.1.2)",
+                "[4.3,4.3.2)"
+              ],
+              "created_at": "2017-07-19T00:00:00Z",
+              "credits": [
+                "Mikhail Shcherbakov"
+              ],
+              "cvss_base_score": 5.3,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:57:34.932818Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 5.3,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:48:17.793073Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+              "disclosed_at": "2017-05-12T00:00:00Z",
+              "ecosystem": {
+                "language": "dotnet",
+                "package_manager": "nuget",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.88444",
+                "probability": "0.04349"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-DOTNET-SYSTEMNETHTTP-60048",
+              "initially_fixed_in_versions": [
+                "4.1.2",
+                "4.3.2"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:48:17.793073Z",
+              "package_name": "System.Net.Http",
+              "package_version": "",
+              "published_at": "2017-05-12T00:00:00Z",
+              "references": [
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/aspnet/Announcements/issues/239"
+                },
+                {
+                  "title": "Microsoft Security Advisory",
+                  "url": "https://technet.microsoft.com/en-us/library/security/4021279.aspx"
+                },
+                {
+                  "title": "NVD",
+                  "url": "https://nvd.nist.gov/vuln/detail/2017-0256"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CVE-2017-0256",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-20",
+              "source": "cwe"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 48
+            }
+          },
+          "title": "Authentication Bypass"
+        },
+        "id": "00000000-0000-0000-0000-000000000004",
+        "links": {},
+        "relationships": {},
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\n[System.Net.Http](https://www.nuget.org/packages/System.Net.Http/) Provides a programming interface for modern HTTP applications, including HTTP client components that allow applications to consume web services over HTTP and HTTP components that can be used by both clients and servers for parsing HTTP headers.\n\n\nAffected versions of this package are vulnerable to Information Exposure.\nWhen HTTP authentication information is inadvertently exposed in an outbound request that encounters an HTTP redirect. An attacker who successfully exploited this vulnerability could use the information to further compromise the web application.\r\n\r\n**Note:** The presence of `System.Net.Http` in the dependency graph of `netcoreapp2.0` isn't the final determination of what is loaded at runtime. The version conflict resolution logic will prefer what is present in `Microsoft.NETCore.App/2.1.5`, or the latest patch release. As such, is not considered an issue.\n\n## Remediation\n\nUpgrade `System.Net.Http` to version 2.0.20710, 4.0.1-beta-23225, 4.1.4, 4.3.4 or higher.\n\n\n## References\n\n- [GitHub Issue](https://github.com/dotnet/announcements/issues/88)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tpwe",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "NSubstitute",
+                  "version": "4.3.0"
+                },
+                {
+                  "name": "Castle.Core",
+                  "version": "4.4.1"
+                },
+                {
+                  "name": "NETStandard.Library",
+                  "version": "1.6.1"
+                },
+                {
+                  "name": "System.Net.Http",
+                  "version": "4.3.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000005",
+          "locations": [
+            {
+              "package": {
+                "name": "System.Net.Http",
+                "version": "4.3.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[2.0.20126.16343, 2.0.20710)",
+                "[4.0.0,4.0.1-beta-23225)",
+                "[4.1.0,4.1.4)",
+                "[4.3.0,4.3.4)"
+              ],
+              "created_at": "2018-10-11T06:50:22.41141Z",
+              "credits": [
+                "leecow"
+              ],
+              "cvss_base_score": 7.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:02:59.310959Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:48:29.429541Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 7.4,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:47:20.195925Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+              "disclosed_at": "2018-10-09T22:51:18Z",
+              "ecosystem": {
+                "language": "dotnet",
+                "package_manager": "nuget",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.90639",
+                "probability": "0.06478"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-DOTNET-SYSTEMNETHTTP-72439",
+              "initially_fixed_in_versions": [
+                "2.0.20710",
+                "4.0.1-beta-23225",
+                "4.1.4",
+                "4.3.4"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:48:29.429541Z",
+              "package_name": "System.Net.Http",
+              "package_version": "",
+              "published_at": "2018-10-10T15:24:52Z",
+              "references": [
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/dotnet/announcements/issues/88"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CVE-2018-8292",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-200",
+              "source": "cwe"
+            },
+            {
+              "id": "GHSA-7jgj-8wvc-jh57",
+              "source": "ghsa"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 123
+            }
+          },
+          "title": "Information Exposure"
+        },
+        "id": "00000000-0000-0000-0000-000000000005",
+        "links": {},
+        "relationships": {},
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[System.Net.Http](https://www.nuget.org/packages/System.Net.Http/) is a Provides a programming interface for modern HTTP applications, including HTTP client components that allow applications to consume web services over HTTP and HTTP components that can be used by both clients and servers for parsing HTTP headers.\n\nAffected versions of this package are vulnerable to Improper Certificate Validation. It allows an attacker to bypass _Enhanced Security Usage_ tagging when they present a certificate that is invalid for a specific use.\n## Remediation\nUpgrade `System.Net.Http` to version 4.1.2, 4.3.2 or higher.\n## References\n- [GitHub Issue](https://github.com/aspnet/Announcements/issues/239)\n- [Microsoft Security Advisory](https://technet.microsoft.com/en-us/library/security/4021279.aspx)\n- [NVD](https://nvd.nist.gov/vuln/detail/2017-0248)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tpwe",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "NSubstitute",
+                  "version": "4.3.0"
+                },
+                {
+                  "name": "Castle.Core",
+                  "version": "4.4.1"
+                },
+                {
+                  "name": "NETStandard.Library",
+                  "version": "1.6.1"
+                },
+                {
+                  "name": "System.Net.Http",
+                  "version": "4.3.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000006",
+          "locations": [
+            {
+              "package": {
+                "name": "System.Net.Http",
+                "version": "4.3.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CWE-287",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,4.1.2)",
+                "[4.3,4.3.2)"
+              ],
+              "created_at": "2017-07-19T00:00:00Z",
+              "credits": [
+                "Joonwoo Yu",
+                "Hyoung-Kee Choi"
+              ],
+              "cvss_base_score": 7.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:57:47.252278Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:46:27.276314Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+              "disclosed_at": "2017-05-12T00:00:00Z",
+              "ecosystem": {
+                "language": "dotnet",
+                "package_manager": "nuget",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.77241",
+                "probability": "0.01092"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-DOTNET-SYSTEMNETHTTP-60046",
+              "initially_fixed_in_versions": [
+                "4.1.2",
+                "4.3.2"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:46:27.276314Z",
+              "package_name": "System.Net.Http",
+              "package_version": "",
+              "published_at": "2017-05-12T00:00:00Z",
+              "references": [
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/aspnet/Announcements/issues/239"
+                },
+                {
+                  "title": "Microsoft Security Advisory",
+                  "url": "https://technet.microsoft.com/en-us/library/security/4021279.aspx"
+                },
+                {
+                  "title": "NVD",
+                  "url": "https://nvd.nist.gov/vuln/detail/2017-0248"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CVE-2017-0248",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 115
+            }
+          },
+          "title": "Improper Certificate Validation"
+        },
+        "id": "00000000-0000-0000-0000-000000000006",
+        "links": {},
+        "relationships": {},
+        "type": "findings"
+      }
+    ]
+  },
+  {
+    "testId": "7014746b-ec5c-49ec-ae6b-afa2d26aaacf",
+    "testConfiguration": {
+      "local_policy": {
+        "fail_on_upgradable": false,
+        "severity_threshold": "low",
+        "suppress_pending_ignores": false
+      },
+      "timeout": {
+        "outcome": "fail",
+        "seconds": 1200
+      }
+    },
+    "metadata": {
+      "project-name": "package.json",
+      "display-target-file": "ghost/package.json",
+      "target-directory": "multi-project",
+      "dependency-count": 23,
+      "asset": "https://app.snyk.io/org/my-org/inventory/assets/01a01434-8c66-7ed7-b7b8-401a040153f1/overview"
+    },
+    "createdAt": "2025-11-13T15:29:14.491151Z",
+    "testSubject": {
+      "locator": {
+        "paths": [
+          "ghost/package-lock.json"
+        ],
+        "type": "local_path"
+      },
+      "type": "dep_graph"
+    },
+    "executionState": "finished",
+    "passFail": "fail",
+    "outcomeReason": "policy_breach",
+    "effectiveSummary": {
+      "count": 23,
+      "count_by": {
+        "result_type": {
+          "dast": 0,
+          "other": 0,
+          "sast": 0,
+          "sca": 23
+        },
+        "severity": {
+          "critical": 0,
+          "high": 6,
+          "low": 5,
+          "medium": 12,
+          "none": 0,
+          "other": 0
+        }
+      }
+    },
+    "rawSummary": {
+      "count": 23,
+      "count_by": {
+        "result_type": {
+          "dast": 0,
+          "other": 0,
+          "sast": 0,
+          "sca": 23
+        },
+        "severity": {
+          "critical": 0,
+          "high": 6,
+          "low": 5,
+          "medium": 12,
+          "none": 0,
+          "other": 0
+        }
+      }
+    },
+    "findingsComplete": true,
+    "findings": [
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS) via the cookie `name`, `path`, or `domain`, which can be used to set unexpected values to other cookie fields.\r\n\r\n## Workaround\r\nUsers who are not able to upgrade to the fixed version should avoid passing untrusted or arbitrary values for the cookie fields and ensure they are set by the application instead of user input.\n## Details\n\nCross-site scripting (or XSS) is a code vulnerability that occurs when an attacker \u201cinjects\u201d a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user\u2019s browser when the user interacts with the compromised website.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser\u2019s Same Origin Policy.\n\nInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they\u2019ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user\u2019s browser.| \n|**DOM-based**|Client|The attacker forces the user\u2019s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `cookie` to version 0.7.0 or higher.\n## References\n- [GitHub Commit](https://github.com/jshttp/cookie/commit/e10042845354fea83bd8f34af72475eed1dadf5c)\n- [GitHub PR](https://github.com/jshttp/cookie/pull/167)\n- [Red Hat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=2316549)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "cookie",
+                  "version": "0.1.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000007",
+          "locations": [
+            {
+              "package": {
+                "name": "cookie",
+                "version": "0.1.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CWE-79",
+              "source": "cwe"
+            },
+            {
+              "id": "GHSA-pxg6-pf52-xh8x",
+              "source": "ghsa"
+            },
+            {
+              "id": "CVE-2024-47764",
+              "source": "cve"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.7.0"
+              ],
+              "created_at": "2024-10-06T09:52:27.790081Z",
+              "credits": [
+                "Unknown"
+              ],
+              "cvss_base_score": 6.3,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.3,
+                  "cvss_version": "4.0",
+                  "modified_at": "2025-03-10T06:41:09.255374Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 3.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-03-10T06:41:09.255374Z",
+                  "severity": "low",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 3.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-04-29T08:08:05.922006Z",
+                  "severity": "low",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N",
+              "disclosed_at": "2024-10-04T20:31:00Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.21369",
+                "probability": "0.00069"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-JS-COOKIE-8163060",
+              "initially_fixed_in_versions": [
+                "0.7.0"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-04-29T08:08:05.922006Z",
+              "package_name": "cookie",
+              "package_version": "",
+              "published_at": "2024-10-06T09:52:28.084562Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/jshttp/cookie/commit/e10042845354fea83bd8f34af72475eed1dadf5c"
+                },
+                {
+                  "title": "GitHub PR",
+                  "url": "https://github.com/jshttp/cookie/pull/167"
+                },
+                {
+                  "title": "Red Hat Bugzilla Bug",
+                  "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2316549"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 34
+            }
+          },
+          "title": "Cross-site Scripting (XSS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000007",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "cookie",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.21.1"
+                        },
+                        {
+                          "name": "cookie",
+                          "version": "0.7.1"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000007",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\r\n\r\nWhen using serve-static middleware version < 1.7.2 and it's configured to mount at the root, it creates an open redirect on the site.\r\n\r\n_Source: [Node Security Project](https://nodesecurity.io/advisories/35)_\r\n\r\n## Details\r\n\r\nFor example:\r\n\r\nIf a user visits `http://example.com//www.google.com/%2e%2e` they will be redirected to `//www.google.com/%2e%2e`, which some browsers interpret as `http://www.google.com/%2e%2e`.\r\n\r\n## Remediation\r\n\r\n  * Update to version 1.7.2 or greater (or 1.6.5 if sticking to the 1.6.x line).\r\n  * Disable redirects if not using the feature with 'redirect: false' option and cannot upgrade.\r\n\r\n## References\r\n\r\n- https://github.com/expressjs/serve-static/issues/26\r\n- https://www.owasp.org/index.php/Open_redirect",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "serve-static",
+                  "version": "1.0.1"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000008",
+          "locations": [
+            {
+              "package": {
+                "name": "serve-static",
+                "version": "1.0.1"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "GHSA-c3x7-gjmx-r2ff",
+              "source": "ghsa"
+            },
+            {
+              "id": "CWE-601",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<1.6.5",
+                ">=1.7.0 <1.7.2"
+              ],
+              "created_at": "2015-01-13T12:50:48Z",
+              "credits": [
+                "Pierre-\u00c9lie Fauch\u00e9"
+              ],
+              "cvss_base_score": 3.1,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 3.1,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:00:34.618417Z",
+                  "severity": "low",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 4.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:45:57.300865Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N",
+              "disclosed_at": "2015-01-13T12:50:48Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.52880",
+                "probability": "0.00300"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:serve-static:20150113",
+              "initially_fixed_in_versions": [
+                "1.6.5",
+                "1.7.2"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:45:57.300865Z",
+              "package_name": "serve-static",
+              "package_version": "",
+              "published_at": "2015-01-13T12:50:48Z",
+              "references": [
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/expressjs/serve-static/issues/26"
+                }
+              ],
+              "severity": "low",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CVE-2015-1164",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "low"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 24
+            }
+          },
+          "title": "Open Redirect"
+        },
+        "id": "00000000-0000-0000-0000-000000000008",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "serve-static",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.9.0"
+                        },
+                        {
+                          "name": "serve-static",
+                          "version": "1.6.5"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000008",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\n[negotiator](https://npmjs.org/package/negotiator) is an HTTP content negotiator for Node.js.\n\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS)\nwhen parsing `Accept-Language` http header.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet\u2019s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn\u2019t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\n\nUpgrade `negotiator` to version 0.6.1 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/jshttp/negotiator/commit/26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c)\n\n- [OWASP Advisory](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "accepts",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "negotiator",
+                  "version": "0.3.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000009",
+          "locations": [
+            {
+              "package": {
+                "name": "negotiator",
+                "version": "0.3.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "GHSA-7mc5-chhp-fmc3",
+              "source": "ghsa"
+            },
+            {
+              "id": "CWE-400",
+              "source": "cwe"
+            },
+            {
+              "id": "CVE-2016-10539",
+              "source": "cve"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.6.1"
+              ],
+              "created_at": "2016-06-16T18:00:02.24Z",
+              "credits": [
+                "Adam Baldwin"
+              ],
+              "cvss_base_score": 7.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-03-05T11:48:00.981412Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:46:38.432872Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "disclosed_at": "2016-06-16T17:36:06Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.55102",
+                "probability": "0.00328"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:negotiator:20160616",
+              "initially_fixed_in_versions": [
+                "0.6.1"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-03-05T11:48:00.981412Z",
+              "package_name": "negotiator",
+              "package_version": "",
+              "published_at": "2016-06-16T17:36:06Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/jshttp/negotiator/commit/26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c"
+                },
+                {
+                  "title": "OWASP Advisory",
+                  "url": "https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 101
+            }
+          },
+          "title": "Regular Expression Denial of Service (ReDoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000009",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "negotiator",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.14.0"
+                        },
+                        {
+                          "name": "accepts",
+                          "version": "1.3.8"
+                        },
+                        {
+                          "name": "negotiator",
+                          "version": "0.6.3"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000009",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[send](https://github.com/pillarjs/send) is a Better streaming static file server with Range and conditional-GET support\n\nAffected versions of this package are vulnerable to Cross-site Scripting due to improper user input sanitization passed to the `SendStream.redirect()` function, which executes untrusted code. An attacker can execute arbitrary code by manipulating the input parameters to this method.\r\n\r\n**Note:**\r\n\r\nExploiting this vulnerability requires the following:\r\n\r\n1) The attacker needs to control the input to `response.redirect()`\r\n\r\n2) Express MUST NOT redirect before the template appears\r\n\r\n3) The browser MUST NOT complete redirection before\r\n\r\n4) The user MUST click on the link in the template\n## Details\n\nCross-site scripting (or XSS) is a code vulnerability that occurs when an attacker \u201cinjects\u201d a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user\u2019s browser when the user interacts with the compromised website.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser\u2019s Same Origin Policy.\n\nInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they\u2019ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user\u2019s browser.| \n|**DOM-based**|Client|The attacker forces the user\u2019s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `send` to version 0.19.0, 1.1.0 or higher.\n## References\n- [GitHub Commit](https://github.com/pillarjs/send/commit/ae4f2989491b392ae2ef3b0015a019770ae65d35)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "send",
+                  "version": "0.2.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000010",
+          "locations": [
+            {
+              "package": {
+                "name": "send",
+                "version": "0.2.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.19.0",
+                ">=1.0.0-beta.1 <1.1.0"
+              ],
+              "created_at": "2024-09-11T06:19:15.660255Z",
+              "credits": [
+                "Adam Korcz"
+              ],
+              "cvss_base_score": 2.1,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 2.1,
+                  "cvss_version": "4.0",
+                  "modified_at": "2024-09-11T13:12:26.132451Z",
+                  "severity": "low",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:A/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-11T13:12:26.132451Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 4.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-21T01:11:53.646986Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-11T13:48:17.800297Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:A/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N",
+              "disclosed_at": "2024-09-10T15:15:17Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.27063",
+                "probability": "0.00095"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-JS-SEND-7926862",
+              "initially_fixed_in_versions": [
+                "0.19.0",
+                "1.1.0"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-09-21T01:11:53.646986Z",
+              "package_name": "send",
+              "package_version": "",
+              "published_at": "2024-09-11T11:48:01.490359Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pillarjs/send/commit/ae4f2989491b392ae2ef3b0015a019770ae65d35"
+                }
+              ],
+              "severity": "low",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-79",
+              "source": "cwe"
+            },
+            {
+              "id": "CVE-2024-43799",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "low"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 57
+            }
+          },
+          "title": "Cross-site Scripting"
+        },
+        "id": "00000000-0000-0000-0000-000000000010",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "send",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.20.0"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.19.0"
+                        }
+                      ],
+                      "is_drop": false
+                    },
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.21.0"
+                        },
+                        {
+                          "name": "serve-static",
+                          "version": "1.16.2"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.19.0"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000010",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[qs](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\n\nAffected versions of this package are vulnerable to Prototype Override Protection Bypass. By default `qs` protects against attacks that attempt to overwrite an object's existing prototype properties, such as `toString()`, `hasOwnProperty()`,etc.\r\n\r\nFrom [`qs` documentation](https://github.com/ljharb/qs):\r\n> By default parameters that would overwrite properties on the object prototype are ignored, if you wish to keep the data from those fields either use plainObjects as mentioned above, or set allowPrototypes to true which will allow user input to overwrite those properties. WARNING It is generally a bad idea to enable this option as it can cause problems when attempting to use the properties that have been overwritten. Always be careful with this option.\r\n\r\nOverwriting these properties can impact application logic, potentially allowing attackers to work around security controls, modify data, make the application unstable and more.\r\n\r\nIn versions of the package affected by this vulnerability, it is possible to circumvent this protection and overwrite prototype properties and functions by prefixing the name of the parameter with `[` or `]`. e.g. `qs.parse(\"]=toString\")` will return `{toString = true}`, as a result, calling `toString()` on the object will throw an exception.\r\n\r\n**Example:**\r\n```js\r\nqs.parse('toString=foo', { allowPrototypes: false })\r\n// {}\r\n\r\nqs.parse(\"]=toString\", { allowPrototypes: false })\r\n// {toString = true} <== prototype overwritten\r\n```\r\n\r\nFor more information, you can check out our [blog](https://snyk.io/blog/high-severity-vulnerability-qs/).\r\n\r\n## Disclosure Timeline\r\n- February 13th, 2017 - Reported the issue to package owner.\r\n- February 13th, 2017 - Issue acknowledged by package owner.\r\n- February 16th, 2017 - Partial fix released in versions `6.0.3`, `6.1.1`, `6.2.2`, `6.3.1`.\r\n- March 6th, 2017     - Final fix released in versions `6.4.0`,`6.3.2`, `6.2.3`, `6.1.2` and `6.0.4`\n## Remediation\nUpgrade `qs` to version 6.0.4, 6.1.2, 6.2.3, 6.3.2 or higher.\n## References\n- [GitHub Commit](https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d)\n- [GitHub Issue](https://github.com/ljharb/qs/issues/200)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "qs",
+                  "version": "0.6.6"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000011",
+          "locations": [
+            {
+              "package": {
+                "name": "qs",
+                "version": "0.6.6"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2017-1000048",
+              "source": "cve"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<6.0.4",
+                ">=6.1.0 <6.1.2",
+                ">=6.2.0 <6.2.3",
+                ">=6.3.0 <6.3.2"
+              ],
+              "created_at": "2017-02-14T11:44:54.163Z",
+              "credits": [
+                "Snyk Security Research Team"
+              ],
+              "cvss_base_score": 7.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:03:33.996696Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:46:34.338137Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5.3,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:48:53.414157Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "disclosed_at": "2017-02-13T00:00:00Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.66386",
+                "probability": "0.00532"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:qs:20170213",
+              "initially_fixed_in_versions": [
+                "6.0.4",
+                "6.1.2",
+                "6.2.3",
+                "6.3.2"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:48:53.414157Z",
+              "package_name": "qs",
+              "package_version": "",
+              "published_at": "2017-03-01T10:00:54Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d"
+                },
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/ljharb/qs/issues/200"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "GHSA-gqgv-6jq5-jjj9",
+              "source": "ghsa"
+            },
+            {
+              "id": "CWE-20",
+              "source": "cwe"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 101
+            }
+          },
+          "title": "Prototype Override Protection Bypass"
+        },
+        "id": "00000000-0000-0000-0000-000000000011",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "qs",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.15.2"
+                        },
+                        {
+                          "name": "qs",
+                          "version": "6.4.0"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000011",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[send](https://github.com/pillarjs/send) is a Better streaming static file server with Range and conditional-GET support\n\nAffected versions of this package are vulnerable to Cross-site Scripting due to improper user input sanitization passed to the `SendStream.redirect()` function, which executes untrusted code. An attacker can execute arbitrary code by manipulating the input parameters to this method.\r\n\r\n**Note:**\r\n\r\nExploiting this vulnerability requires the following:\r\n\r\n1) The attacker needs to control the input to `response.redirect()`\r\n\r\n2) Express MUST NOT redirect before the template appears\r\n\r\n3) The browser MUST NOT complete redirection before\r\n\r\n4) The user MUST click on the link in the template\n## Details\n\nCross-site scripting (or XSS) is a code vulnerability that occurs when an attacker \u201cinjects\u201d a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user\u2019s browser when the user interacts with the compromised website.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser\u2019s Same Origin Policy.\n\nInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they\u2019ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user\u2019s browser.| \n|**DOM-based**|Client|The attacker forces the user\u2019s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `send` to version 0.19.0, 1.1.0 or higher.\n## References\n- [GitHub Commit](https://github.com/pillarjs/send/commit/ae4f2989491b392ae2ef3b0015a019770ae65d35)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "serve-static",
+                  "version": "1.0.1"
+                },
+                {
+                  "name": "send",
+                  "version": "0.1.4"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000012",
+          "locations": [
+            {
+              "package": {
+                "name": "send",
+                "version": "0.1.4"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.19.0",
+                ">=1.0.0-beta.1 <1.1.0"
+              ],
+              "created_at": "2024-09-11T06:19:15.660255Z",
+              "credits": [
+                "Adam Korcz"
+              ],
+              "cvss_base_score": 2.1,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 2.1,
+                  "cvss_version": "4.0",
+                  "modified_at": "2024-09-11T13:12:26.132451Z",
+                  "severity": "low",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:A/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-11T13:12:26.132451Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 4.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-21T01:11:53.646986Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-11T13:48:17.800297Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:A/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N",
+              "disclosed_at": "2024-09-10T15:15:17Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.27063",
+                "probability": "0.00095"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-JS-SEND-7926862",
+              "initially_fixed_in_versions": [
+                "0.19.0",
+                "1.1.0"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-09-21T01:11:53.646986Z",
+              "package_name": "send",
+              "package_version": "",
+              "published_at": "2024-09-11T11:48:01.490359Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pillarjs/send/commit/ae4f2989491b392ae2ef3b0015a019770ae65d35"
+                }
+              ],
+              "severity": "low",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-79",
+              "source": "cwe"
+            },
+            {
+              "id": "CVE-2024-43799",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "low"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 57
+            }
+          },
+          "title": "Cross-site Scripting"
+        },
+        "id": "00000000-0000-0000-0000-000000000012",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "send",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.21.0"
+                        },
+                        {
+                          "name": "serve-static",
+                          "version": "1.16.2"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.19.0"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000012",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\r\n[`fresh`](https://www.npmjs.com/package/fresh) is HTTP response freshness testing.\r\n\r\nAffected versions of this package are vulnerable to Regular expression Denial of Service (ReDoS) attacks. A Regular Expression (`/ *, */`) was used for parsing HTTP headers and take about 2 seconds matching time for 50k characters.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet\u2019s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn\u2019t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `fresh` to version 0.5.2 or higher.\n\n## References\n- [https://github.com/jshttp/fresh/commit/21a0f0c2a5f447e0d40bc16be0c23fa98a7b46ec](https://github.com/jshttp/fresh/commit/21a0f0c2a5f447e0d40bc16be0c23fa98a7b46ec)\n- [https://github.com/jshttp/fresh/issues/24](https://github.com/jshttp/fresh/issues/24)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "fresh",
+                  "version": "0.2.2"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "send",
+                  "version": "0.2.0"
+                },
+                {
+                  "name": "fresh",
+                  "version": "0.2.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000013",
+          "locations": [
+            {
+              "package": {
+                "name": "fresh",
+                "version": "0.2.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.5.2"
+              ],
+              "created_at": "2017-09-27T08:48:49.286Z",
+              "credits": [
+                "Cristian-Alexandru Staicu"
+              ],
+              "cvss_base_score": 7.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:58:13.375741Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:47:01.837639Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2025-04-28T21:14:26.782658Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "disclosed_at": "2017-09-08T21:00:00Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.55102",
+                "probability": "0.00328"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:fresh:20170908",
+              "initially_fixed_in_versions": [
+                "0.5.2"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-04-28T21:14:26.782658Z",
+              "package_name": "fresh",
+              "package_version": "",
+              "published_at": "2017-09-27T08:48:49Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/jshttp/fresh/commit/21a0f0c2a5f447e0d40bc16be0c23fa98a7b46ec"
+                },
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/jshttp/fresh/issues/24"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-400",
+              "source": "cwe"
+            },
+            {
+              "id": "GHSA-9qj9-36jm-prpv",
+              "source": "ghsa"
+            },
+            {
+              "id": "CVE-2017-16119",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 101
+            }
+          },
+          "title": "Regular Expression Denial of Service (ReDoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000013",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "fresh",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.15.5"
+                        },
+                        {
+                          "name": "fresh",
+                          "version": "0.5.2"
+                        }
+                      ],
+                      "is_drop": false
+                    },
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.15.5"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.15.6"
+                        },
+                        {
+                          "name": "fresh",
+                          "version": "0.5.2"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000013",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\r\n[`fresh`](https://www.npmjs.com/package/fresh) is HTTP response freshness testing.\r\n\r\nAffected versions of this package are vulnerable to Regular expression Denial of Service (ReDoS) attacks. A Regular Expression (`/ *, */`) was used for parsing HTTP headers and take about 2 seconds matching time for 50k characters.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet\u2019s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn\u2019t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `fresh` to version 0.5.2 or higher.\n\n## References\n- [https://github.com/jshttp/fresh/commit/21a0f0c2a5f447e0d40bc16be0c23fa98a7b46ec](https://github.com/jshttp/fresh/commit/21a0f0c2a5f447e0d40bc16be0c23fa98a7b46ec)\n- [https://github.com/jshttp/fresh/issues/24](https://github.com/jshttp/fresh/issues/24)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "serve-static",
+                  "version": "1.0.1"
+                },
+                {
+                  "name": "send",
+                  "version": "0.1.4"
+                },
+                {
+                  "name": "fresh",
+                  "version": "0.2.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000014",
+          "locations": [
+            {
+              "package": {
+                "name": "fresh",
+                "version": "0.2.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.5.2"
+              ],
+              "created_at": "2017-09-27T08:48:49.286Z",
+              "credits": [
+                "Cristian-Alexandru Staicu"
+              ],
+              "cvss_base_score": 7.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:58:13.375741Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:47:01.837639Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2025-04-28T21:14:26.782658Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "disclosed_at": "2017-09-08T21:00:00Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.55102",
+                "probability": "0.00328"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:fresh:20170908",
+              "initially_fixed_in_versions": [
+                "0.5.2"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-04-28T21:14:26.782658Z",
+              "package_name": "fresh",
+              "package_version": "",
+              "published_at": "2017-09-27T08:48:49Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/jshttp/fresh/commit/21a0f0c2a5f447e0d40bc16be0c23fa98a7b46ec"
+                },
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/jshttp/fresh/issues/24"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-400",
+              "source": "cwe"
+            },
+            {
+              "id": "GHSA-9qj9-36jm-prpv",
+              "source": "ghsa"
+            },
+            {
+              "id": "CVE-2017-16119",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 101
+            }
+          },
+          "title": "Regular Expression Denial of Service (ReDoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000014",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "fresh",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.15.5"
+                        },
+                        {
+                          "name": "serve-static",
+                          "version": "1.12.6"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.15.6"
+                        },
+                        {
+                          "name": "fresh",
+                          "version": "0.5.2"
+                        }
+                      ],
+                      "is_drop": false
+                    },
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.15.5"
+                        },
+                        {
+                          "name": "fresh",
+                          "version": "0.5.2"
+                        }
+                      ],
+                      "is_drop": false
+                    },
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.15.5"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.15.6"
+                        },
+                        {
+                          "name": "fresh",
+                          "version": "0.5.2"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000014",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\r\n[Send](https://www.npmjs.com/package/send) is a library for streaming files from the file system as an http response. It supports partial responses (Ranges), conditional-GET negotiation, high test coverage, and granular events which may be leveraged to take appropriate actions in your application or framework.\r\n\r\nAffected versions of this package are vulnerable to a Root Path Disclosure.\r\n\r\n## Remediation\r\nUpgrade `send` to version 0.11.1 or higher. \r\nIf a direct dependency update is not possible, use [snyk wizard](https://snyk.io/docs/using-snyk#wizard) to patch this vulnerability.\r\n\r\n## References\r\n- [GitHub PR](https://github.com/pillarjs/send/pull/70)\r\n- [GitHub Commit](https://github.com/pillarjs/send/commit/98a5b89982b38e79db684177cf94730ce7fc7aed)\r\n- [GitHub History](https://github.com/expressjs/serve-static/blob/master/HISTORY.md#181--2015-01-20)\r\n- [Expressjs Security Update](http://expressjs.com/advanced/security-updates.html)",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "send",
+                  "version": "0.2.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000015",
+          "locations": [
+            {
+              "package": {
+                "name": "send",
+                "version": "0.2.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.11.1"
+              ],
+              "created_at": "2015-11-06T02:09:36.183Z",
+              "credits": [
+                "Dinis Cruz"
+              ],
+              "cvss_base_score": 5.3,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:57:30.018205Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:53:36.449777Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+              "disclosed_at": "2015-11-03T07:12:20Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.40434",
+                "probability": "0.00184"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:send:20151103",
+              "initially_fixed_in_versions": [
+                "0.11.1"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:53:36.449777Z",
+              "package_name": "send",
+              "package_version": "",
+              "published_at": "2015-11-06T02:09:36Z",
+              "references": [
+                {
+                  "title": "Expressjs Security Update",
+                  "url": "http://expressjs.com/advanced/security-updates.html"
+                },
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pillarjs/send/commit/98a5b89982b38e79db684177cf94730ce7fc7aed"
+                },
+                {
+                  "title": "GitHub History",
+                  "url": "https://github.com/expressjs/serve-static/blob/master/HISTORY.md%23181--2015-01-20"
+                },
+                {
+                  "title": "GitHub PR",
+                  "url": "https://github.com/pillarjs/send/pull/70"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "GHSA-jgqf-hwc5-hh37",
+              "source": "ghsa"
+            },
+            {
+              "id": "CVE-2015-8859",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-200",
+              "source": "cwe"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 40
+            }
+          },
+          "title": "Root Path Disclosure"
+        },
+        "id": "00000000-0000-0000-0000-000000000015",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "send",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.11.1"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.11.1"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000015",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\r\n[Send](https://www.npmjs.com/package/send) is a library for streaming files from the file system as an http response. It supports partial responses (Ranges), conditional-GET negotiation, high test coverage, and granular events which may be leveraged to take appropriate actions in your application or framework.\r\n\r\nAffected versions of this package are vulnerable to a Root Path Disclosure.\r\n\r\n## Remediation\r\nUpgrade `send` to version 0.11.1 or higher. \r\nIf a direct dependency update is not possible, use [snyk wizard](https://snyk.io/docs/using-snyk#wizard) to patch this vulnerability.\r\n\r\n## References\r\n- [GitHub PR](https://github.com/pillarjs/send/pull/70)\r\n- [GitHub Commit](https://github.com/pillarjs/send/commit/98a5b89982b38e79db684177cf94730ce7fc7aed)\r\n- [GitHub History](https://github.com/expressjs/serve-static/blob/master/HISTORY.md#181--2015-01-20)\r\n- [Expressjs Security Update](http://expressjs.com/advanced/security-updates.html)",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "serve-static",
+                  "version": "1.0.1"
+                },
+                {
+                  "name": "send",
+                  "version": "0.1.4"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000016",
+          "locations": [
+            {
+              "package": {
+                "name": "send",
+                "version": "0.1.4"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.11.1"
+              ],
+              "created_at": "2015-11-06T02:09:36.183Z",
+              "credits": [
+                "Dinis Cruz"
+              ],
+              "cvss_base_score": 5.3,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:57:30.018205Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:53:36.449777Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+              "disclosed_at": "2015-11-03T07:12:20Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.40434",
+                "probability": "0.00184"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:send:20151103",
+              "initially_fixed_in_versions": [
+                "0.11.1"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:53:36.449777Z",
+              "package_name": "send",
+              "package_version": "",
+              "published_at": "2015-11-06T02:09:36Z",
+              "references": [
+                {
+                  "title": "Expressjs Security Update",
+                  "url": "http://expressjs.com/advanced/security-updates.html"
+                },
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pillarjs/send/commit/98a5b89982b38e79db684177cf94730ce7fc7aed"
+                },
+                {
+                  "title": "GitHub History",
+                  "url": "https://github.com/expressjs/serve-static/blob/master/HISTORY.md%23181--2015-01-20"
+                },
+                {
+                  "title": "GitHub PR",
+                  "url": "https://github.com/pillarjs/send/pull/70"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "GHSA-jgqf-hwc5-hh37",
+              "source": "ghsa"
+            },
+            {
+              "id": "CVE-2015-8859",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-200",
+              "source": "cwe"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 40
+            }
+          },
+          "title": "Root Path Disclosure"
+        },
+        "id": "00000000-0000-0000-0000-000000000016",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "send",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.11.1"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.11.1"
+                        }
+                      ],
+                      "is_drop": false
+                    },
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.11.0"
+                        },
+                        {
+                          "name": "serve-static",
+                          "version": "1.8.1"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.11.1"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000016",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\r\n['cookie-signature'](https://www.npmjs.com/package/cookie-signature) is a library for signing cookies.\r\n\r\nVersions before `1.0.4` of the library use the built-in string comparison mechanism, `===`, and not a time constant string comparison. As a result, the comparison will fail faster when the first characters in the token are incorrect.\r\nAn attacker can use this difference to perform a timing attack, essentially allowing them to guess the secret one character at a time.\r\n\r\nYou can read more about timing attacks in Node.js on the Snyk blog: https://snyk.io/blog/node-js-timing-attack-ccc-ctf/\r\n\r\n## Remediation\r\nUpgrade to `1.0.4` or greater.\r\n\r\n## References\r\n- [GitHub History](https://github.com/tj/node-cookie-signature/blob/master/History.md#104--2014-06-25)\r\n- [GitHub Commit](https://github.com/tj/node-cookie-signature/commit/39791081692e9e14aa62855369e1c7f80fbfd50e)",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "cookie-signature",
+                  "version": "1.0.3"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000017",
+          "locations": [
+            {
+              "package": {
+                "name": "cookie-signature",
+                "version": "1.0.3"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "GHSA-92vm-wfm5-mxvv",
+              "source": "ghsa"
+            },
+            {
+              "id": "CWE-208",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<1.0.4"
+              ],
+              "created_at": "2016-08-04T03:44:13.904Z",
+              "credits": [
+                "tenbits"
+              ],
+              "cvss_base_score": 6.3,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:57:31.514713Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:N/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 4.4,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:46:32.176976Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:N/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5.4,
+                  "cvss_version": "3.0",
+                  "modified_at": "2025-04-28T21:11:56.989464Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:H/PR:H/UI:R/S:C/C:H/I:N/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:N/A:N",
+              "disclosed_at": "2014-01-28T00:00:00Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.66688",
+                "probability": "0.00539"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:cookie-signature:20160804",
+              "initially_fixed_in_versions": [
+                "1.0.4"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-04-28T21:11:56.989464Z",
+              "package_name": "cookie-signature",
+              "package_version": "",
+              "published_at": "2016-08-29T00:00:00Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/tj/node-cookie-signature/commit/39791081692e9e14aa62855369e1c7f80fbfd50e"
+                },
+                {
+                  "title": "GitHub History",
+                  "url": "https://github.com/tj/node-cookie-signature/blob/master/History.md%23104--2014-06-25"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CVE-2016-1000236",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 86
+            }
+          },
+          "title": "Non-Constant Time String Comparison"
+        },
+        "id": "00000000-0000-0000-0000-000000000017",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "cookie-signature",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.4.5"
+                        },
+                        {
+                          "name": "cookie-signature",
+                          "version": "1.0.4"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000017",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) when including multiple regular expression parameters in a single segment, when the separator is not `.` (e.g. no `/:a-:b`). Poor performance will block the event loop and can lead to a DoS.\r\n\r\n**Note:**\r\n\r\nThis issue is caused due to an incomplete fix for [CVE-2024-45296](https://security.snyk.io/vuln/SNYK-JS-PATHTOREGEXP-7925106).\r\n\r\n## Workarounds\r\n\r\nThis can be mitigated by avoiding using two parameters within a single path segment, when the separator is not `.` (e.g. no `/:a-:b`). Alternatively, the regex used for both parameters can be defined to ensure they do not overlap to allow backtracking.\n## PoC\n```js\r\n/a${'-a'.repeat(8_000)}/a\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet\u2019s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn\u2019t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `path-to-regexp` to version 0.1.12 or higher.\n## References\n- [Blog Post](https://blakeembrey.com/posts/2024-09-web-redos)\n- [GitHub Commit](https://github.com/pillarjs/path-to-regexp/commit/f01c26a013b1889f0c217c643964513acf17f6a4)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "path-to-regexp",
+                  "version": "0.1.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000018",
+          "locations": [
+            {
+              "package": {
+                "name": "path-to-regexp",
+                "version": "0.1.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.1.12"
+              ],
+              "created_at": "2024-12-06T07:48:23.835603Z",
+              "credits": [
+                "Unknown"
+              ],
+              "cvss_base_score": 6.9,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.9,
+                  "cvss_version": "4.0",
+                  "modified_at": "2025-04-06T10:02:44.3334Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N/E:P"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-04-06T10:02:44.3334Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-12-07T13:35:59.477578Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N/E:P",
+              "disclosed_at": "2024-12-05T22:40:47Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.25432",
+                "probability": "0.00086"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "proof of concept",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "proof of concept",
+                    "type": "primary"
+                  }
+                ],
+                "sources": [
+                  "Snyk"
+                ]
+              },
+              "id": "SNYK-JS-PATHTOREGEXP-8482416",
+              "initially_fixed_in_versions": [
+                "0.1.12"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-04-06T10:02:44.3334Z",
+              "package_name": "path-to-regexp",
+              "package_version": "",
+              "published_at": "2024-12-06T07:48:24.198166Z",
+              "references": [
+                {
+                  "title": "Blog Post",
+                  "url": "https://blakeembrey.com/posts/2024-09-web-redos"
+                },
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pillarjs/path-to-regexp/commit/f01c26a013b1889f0c217c643964513acf17f6a4"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "GHSA-rhx6-c78j-4q9w",
+              "source": "ghsa"
+            },
+            {
+              "id": "CVE-2024-52798",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-1333",
+              "source": "cwe"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 61
+            }
+          },
+          "title": "Regular Expression Denial of Service (ReDoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000018",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "path-to-regexp",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.21.2"
+                        },
+                        {
+                          "name": "path-to-regexp",
+                          "version": "0.1.12"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000018",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[qs](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS). When parsing a string representing a deeply nested object, qs will block the event loop for long periods of time. Such a delay may hold up the server's resources, keeping it from processing other requests in the meantime, thus enabling a Denial-of-Service attack.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet\u2019s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn\u2019t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `qs` to version 1.0.0 or higher.\n## References\n- [Node Security Advisory](https://nodesecurity.io/advisories/28)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "qs",
+                  "version": "0.6.6"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000019",
+          "locations": [
+            {
+              "package": {
+                "name": "qs",
+                "version": "0.6.6"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "GHSA-f9cm-p3w6-xvr3",
+              "source": "ghsa"
+            },
+            {
+              "id": "CVE-2014-10064",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-400",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<1.0.0"
+              ],
+              "created_at": "2014-08-06T06:10:23Z",
+              "credits": [
+                "Tom Steele"
+              ],
+              "cvss_base_score": 6.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:58:44.467015Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:45:55.210133Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+              "disclosed_at": "2014-08-06T06:10:23Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.67440",
+                "probability": "0.00562"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:qs:20140806-1",
+              "initially_fixed_in_versions": [
+                "1.0.0"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:45:55.210133Z",
+              "package_name": "qs",
+              "package_version": "",
+              "published_at": "2014-08-06T06:10:23Z",
+              "references": [
+                {
+                  "title": "Node Security Advisory",
+                  "url": "https://nodesecurity.io/advisories/28"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 74
+            }
+          },
+          "title": "Denial of Service (DoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000019",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "qs",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.8.0"
+                        },
+                        {
+                          "name": "qs",
+                          "version": "1.0.2"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000019",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[mime](https://www.npmjs.com/package/mime) is a comprehensive, compact MIME type module.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). It uses regex the following regex `/.*[\\.\\/\\\\]/` in its lookup, which can cause a slowdown of 2 seconds for 50k characters.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet\u2019s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn\u2019t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `mime` to version 1.4.1, 2.0.3 or higher.\n## References\n- [GitHub Commit](https://github.com/broofa/node-mime/commit/1df903fdeb9ae7eaa048795b8d580ce2c98f40b0)\n- [GitHub Commit](https://github.com/broofa/node-mime/commit/855d0c4b8b22e4a80b9401a81f2872058eae274d)\n- [GitHub Issue](https://github.com/broofa/node-mime/issues/167)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/535)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "accepts",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "mime",
+                  "version": "1.2.11"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "send",
+                  "version": "0.2.0"
+                },
+                {
+                  "name": "mime",
+                  "version": "1.2.11"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "type-is",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "mime",
+                  "version": "1.2.11"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "serve-static",
+                  "version": "1.0.1"
+                },
+                {
+                  "name": "send",
+                  "version": "0.1.4"
+                },
+                {
+                  "name": "mime",
+                  "version": "1.2.11"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000020",
+          "locations": [
+            {
+              "package": {
+                "name": "mime",
+                "version": "1.2.11"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<1.4.1",
+                ">=2.0.0 <2.0.3"
+              ],
+              "created_at": "2017-09-26T05:48:40.307Z",
+              "credits": [
+                "Cristian-Alexandru Staicu"
+              ],
+              "cvss_base_score": 3.7,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 3.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:58:13.405203Z",
+                  "severity": "low",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:47:01.954784Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5.3,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:53:48.285535Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+              "disclosed_at": "2017-09-07T21:00:00Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.61919",
+                "probability": "0.00433"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:mime:20170907",
+              "initially_fixed_in_versions": [
+                "1.4.1",
+                "2.0.3"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:53:48.285535Z",
+              "package_name": "mime",
+              "package_version": "",
+              "published_at": "2017-09-27T05:48:40Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/broofa/node-mime/commit/1df903fdeb9ae7eaa048795b8d580ce2c98f40b0"
+                },
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/broofa/node-mime/commit/855d0c4b8b22e4a80b9401a81f2872058eae274d"
+                },
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/broofa/node-mime/issues/167"
+                },
+                {
+                  "title": "NPM Security Advisory",
+                  "url": "https://www.npmjs.com/advisories/535"
+                }
+              ],
+              "severity": "low",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CVE-2017-16138",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-400",
+              "source": "cwe"
+            },
+            {
+              "id": "GHSA-wrvr-8mpx-r7pp",
+              "source": "ghsa"
+            }
+          ],
+          "rating": {
+            "severity": "low"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 35
+            }
+          },
+          "title": "Regular Expression Denial of Service (ReDoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000020",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "mime",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.4.4"
+                        },
+                        {
+                          "name": "accepts",
+                          "version": "1.0.7"
+                        }
+                      ],
+                      "is_drop": true
+                    },
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.16.0"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.16.0"
+                        },
+                        {
+                          "name": "mime",
+                          "version": "1.4.1"
+                        }
+                      ],
+                      "is_drop": false
+                    },
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.4.2"
+                        },
+                        {
+                          "name": "type-is",
+                          "version": "1.2.1"
+                        }
+                      ],
+                      "is_drop": true
+                    },
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.16.0"
+                        },
+                        {
+                          "name": "serve-static",
+                          "version": "1.13.0"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.16.0"
+                        },
+                        {
+                          "name": "mime",
+                          "version": "1.4.1"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000020",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[send](https://www.npmjs.com/package/send) is a library for streaming files from the file system.\n\nAffected versions of this package are vulnerable to Directory-Traversal attacks due to insecure comparison.\nWhen relying on the root option to restrict file access a malicious user may escape out of the restricted directory and access files in a similarly named directory. For example, a path like `/my-secret` is consedered fine for the root `/my`.\n\n## Details\nA Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with \"dot-dot-slash (../)\" sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.\r\n\r\nDirectory Traversal vulnerabilities can be generally divided into two types:\r\n\r\n- **Information Disclosure**: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.\r\n\r\n`st` is a module for serving static files on web pages, and contains a [vulnerability of this type](https://snyk.io/vuln/npm:st:20140206). In our example, we will serve files from the `public` route.\r\n\r\nIf an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.\r\n\r\n```\r\ncurl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa\r\n```\r\n**Note** `%2e` is the URL encoded version of `.` (dot).\r\n\r\n- **Writing arbitrary files**: Allows the attacker to create or replace existing files. This type of vulnerability is also known as `Zip-Slip`. \r\n\r\nOne way to achieve this is by using a malicious `zip` archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\r\n\r\nThe following is an example of a `zip` archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\r\n\r\n```\r\n2018-04-15 22:04:29 .....           19           19  good.txt\r\n2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys\r\n```\n \n\n## Remediation\nUpgrade to a version greater than or equal to 0.8.4.\n\n## References\n- [GitHub PR](https://github.com/visionmedia/send/pull/59)\n- [GitHub Commit](https://github.com/visionmedia/send/commit/9c6ca9b2c0b880afd3ff91ce0d211213c5fa5f9a)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "send",
+                  "version": "0.2.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000021",
+          "locations": [
+            {
+              "package": {
+                "name": "send",
+                "version": "0.2.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "< 0.8.4"
+              ],
+              "created_at": "2014-09-12T05:06:33Z",
+              "credits": [
+                "Ilya Kantor"
+              ],
+              "cvss_base_score": 4.3,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 4.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:02:18.15324Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:46:22.60294Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+              "disclosed_at": "2014-09-12T05:06:33Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.89003",
+                "probability": "0.04842"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:send:20140912",
+              "initially_fixed_in_versions": [
+                "0.8.4"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:46:22.60294Z",
+              "package_name": "send",
+              "package_version": "",
+              "published_at": "2014-09-12T05:06:33Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/visionmedia/send/commit/9c6ca9b2c0b880afd3ff91ce0d211213c5fa5f9a"
+                },
+                {
+                  "title": "GitHub PR",
+                  "url": "https://github.com/visionmedia/send/pull/59"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-23",
+              "source": "cwe"
+            },
+            {
+              "id": "GHSA-xwg4-93c6-3h42",
+              "source": "ghsa"
+            },
+            {
+              "id": "CVE-2014-6394",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 39
+            }
+          },
+          "title": "Directory Traversal"
+        },
+        "id": "00000000-0000-0000-0000-000000000021",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "send",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.8.8"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.8.5"
+                        }
+                      ],
+                      "is_drop": false
+                    },
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.8.0"
+                        },
+                        {
+                          "name": "serve-static",
+                          "version": "1.5.4"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.8.5"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000021",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\n[qs](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\n\n\nAffected versions of this package are vulnerable to Denial of Service (DoS).\nDuring parsing, the `qs` module may create a sparse area (an array where no elements are filled), and grow that array to the necessary size based on the indices used on it. An attacker can specify a high index value in a query string, thus making the server allocate a respectively big array. Truly large values can cause the server to run out of memory and cause it to crash - thus enabling a Denial-of-Service attack.\n\n## Remediation\n\nUpgrade `qs` to version 1.0.0 or higher.\n\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## References\n\n- [GitHub Commit](https://github.com/tj/node-querystring/pull/114/commits/43a604b7847e56bba49d0ce3e222fe89569354d8)\n\n- [GitHub Issue](https://github.com/visionmedia/node-querystring/issues/104)\n\n- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2014-7191)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "qs",
+                  "version": "0.6.6"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000022",
+          "locations": [
+            {
+              "package": {
+                "name": "qs",
+                "version": "0.6.6"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CWE-400",
+              "source": "cwe"
+            },
+            {
+              "id": "CVE-2014-7191",
+              "source": "cve"
+            },
+            {
+              "id": "GHSA-gqgv-6jq5-jjj9",
+              "source": "ghsa"
+            },
+            {
+              "id": "GHSA-jjv7-qpx3-h62q",
+              "source": "ghsa"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<1.0.0"
+              ],
+              "created_at": "2014-08-06T06:10:22Z",
+              "credits": [
+                "Dustin Shiver"
+              ],
+              "cvss_base_score": 7.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:59:04.389055Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:52:39.103034Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 4.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:48:53.430808Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "disclosed_at": "2014-08-06T06:10:22Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.86066",
+                "probability": "0.03001"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:qs:20140806",
+              "initially_fixed_in_versions": [
+                "1.0.0"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:52:39.103034Z",
+              "package_name": "qs",
+              "package_version": "",
+              "published_at": "2014-08-06T06:10:22Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/tj/node-querystring/pull/114/commits/43a604b7847e56bba49d0ce3e222fe89569354d8"
+                },
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/visionmedia/node-querystring/issues/104"
+                },
+                {
+                  "title": "NVD",
+                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-7191"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 105
+            }
+          },
+          "title": "Denial of Service (DoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000022",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "qs",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.8.0"
+                        },
+                        {
+                          "name": "qs",
+                          "version": "1.0.2"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000022",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) when including multiple regular expression parameters in a single segment, which will produce the regular expression `/^\\/([^\\/]+?)-([^\\/]+?)\\/?$/`, if two parameters within a single segment are separated by a character other than a `/` or `.`. Poor performance will block the event loop and can lead to a DoS.\r\n\r\n**Note:**\r\nWhile the 8.0.0 release has completely eliminated the vulnerable functionality, prior versions that have received the patch to mitigate backtracking may still be vulnerable if custom regular expressions are used. So it is strongly recommended for regular expression input to be controlled to avoid malicious performance degradation in those versions. This behavior is enforced as of version 7.1.0 via the `strict` option, which returns an error if a dangerous regular expression is detected.\r\n\r\n## Workaround\r\nThis vulnerability can be avoided by using a custom regular expression for parameters after the first in a segment, which excludes `-` and `/`.\n## PoC\n```js\r\n/a${'-a'.repeat(8_000)}/a\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet\u2019s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn\u2019t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `path-to-regexp` to version 0.1.10, 1.9.0, 3.3.0, 6.3.0, 8.0.0 or higher.\n## References\n- [GitHub Commit](https://github.com/pillarjs/path-to-regexp/commit/29b96b4a1de52824e1ca0f49a701183cc4ed476f)\n- [GitHub Commit](https://github.com/p",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "path-to-regexp",
+                  "version": "0.1.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000023",
+          "locations": [
+            {
+              "package": {
+                "name": "path-to-regexp",
+                "version": "0.1.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.1.10",
+                ">=0.2.0 <1.9.0",
+                ">=2.0.0 <3.3.0",
+                ">=4.0.0 <6.3.0",
+                ">=7.0.0 <8.0.0"
+              ],
+              "created_at": "2024-09-10T06:12:52.186963Z",
+              "credits": [
+                "Blake Embrey"
+              ],
+              "cvss_base_score": 6.9,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.9,
+                  "cvss_version": "4.0",
+                  "modified_at": "2025-06-16T06:59:36.219457Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N/E:P"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-06-16T06:59:36.219457Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-10T13:33:00.998289Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N/E:P",
+              "disclosed_at": "2024-09-09T19:40:10Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.20070",
+                "probability": "0.00064"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "proof of concept",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "proof of concept",
+                    "type": "primary"
+                  }
+                ],
+                "sources": [
+                  "Snyk"
+                ]
+              },
+              "id": "SNYK-JS-PATHTOREGEXP-7925106",
+              "initially_fixed_in_versions": [
+                "0.1.10",
+                "1.9.0",
+                "3.3.0",
+                "6.3.0",
+                "8.0.0"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-06-16T06:59:36.219457Z",
+              "package_name": "path-to-regexp",
+              "package_version": "",
+              "published_at": "2024-09-10T08:00:38.971163Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pillarjs/path-to-regexp/commit/29b96b4a1de52824e1ca0f49a701183cc4ed476f"
+                },
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pillarjs/path-to-regexp/commit/60f2121e9b66b7b622cc01080df0aabda9eedee6"
+                },
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pillarjs/path-to-regexp/commit/f73ec6c86b06f544b977119c2b62a16de480a6a9"
+                },
+                {
+                  "title": "Strict Mode Release Note",
+                  "url": "https://github.com/pillarjs/path-to-regexp/releases/tag/v7.1.0"
+                },
+                {
+                  "title": "Vulnerability Write-up",
+                  "url": "https://blakeembrey.com/posts/2024-09-web-redos/"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-1333",
+              "source": "cwe"
+            },
+            {
+              "id": "GHSA-9wv6-86v2-598j",
+              "source": "ghsa"
+            },
+            {
+              "id": "CVE-2024-45296",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 57
+            }
+          },
+          "title": "Regular Expression Denial of Service (ReDoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000023",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "path-to-regexp",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.20.0"
+                        },
+                        {
+                          "name": "path-to-regexp",
+                          "version": "0.1.10"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000023",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[serve-static](https://github.com/expressjs/serve-static) is a server.\n\nAffected versions of this package are vulnerable to Cross-site Scripting due to improper sanitization of user input in the `redirect` function. An attacker can manipulate the redirection process by injecting malicious code into the input. \r\n\r\n\r\n**Note**\r\n\r\nTo exploit this vulnerability, the following conditions are required:\r\n\r\n1) The attacker should be able to control the input to `response.redirect()`\r\n\r\n2) express must not redirect before the template appears\r\n\r\n3) the browser must not complete redirection before:\r\n\r\n4) the user must click on the link in the template\n## Details\n\nCross-site scripting (or XSS) is a code vulnerability that occurs when an attacker \u201cinjects\u201d a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user\u2019s browser when the user interacts with the compromised website.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser\u2019s Same Origin Policy.\n\nInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they\u2019ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user\u2019s browser.| \n|**DOM-based**|Client|The attacker forces the user\u2019s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `serve-static` to version 1.16.0, 2.1.0 or higher.\n## References\n- [GitHub Commit](https://github.com/expressjs/serve-static/commit/0c11fad159898cdc69fd9ab63269b72468ecaf6b)\n- [GitHub Commit](https://github.com/expressjs/serve-static/commit/ce730896fddce1588111d9ef6fdf20896de5c6fa)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "serve-static",
+                  "version": "1.0.1"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000024",
+          "locations": [
+            {
+              "package": {
+                "name": "serve-static",
+                "version": "1.0.1"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CWE-79",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<1.16.0",
+                ">=2.0.0 <2.1.0"
+              ],
+              "created_at": "2024-09-11T06:31:22.554663Z",
+              "credits": [
+                "Adam Korcz"
+              ],
+              "cvss_base_score": 2.1,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 2.1,
+                  "cvss_version": "4.0",
+                  "modified_at": "2024-09-11T12:14:57.834182Z",
+                  "severity": "low",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:A/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-11T12:14:57.834182Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 4.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-21T01:11:59.044439Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-11T13:49:16.84827Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:A/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N",
+              "disclosed_at": "2024-09-10T15:15:17Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.51064",
+                "probability": "0.00280"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-JS-SERVESTATIC-7926865",
+              "initially_fixed_in_versions": [
+                "1.16.0",
+                "2.1.0"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-09-21T01:11:59.044439Z",
+              "package_name": "serve-static",
+              "package_version": "",
+              "published_at": "2024-09-11T12:14:52.762373Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/expressjs/serve-static/commit/0c11fad159898cdc69fd9ab63269b72468ecaf6b"
+                },
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/expressjs/serve-static/commit/ce730896fddce1588111d9ef6fdf20896de5c6fa"
+                }
+              ],
+              "severity": "low",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CVE-2024-43800",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "low"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 57
+            }
+          },
+          "title": "Cross-site Scripting"
+        },
+        "id": "00000000-0000-0000-0000-000000000024",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "serve-static",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.20.0"
+                        },
+                        {
+                          "name": "serve-static",
+                          "version": "1.16.0"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000024",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[express](https://github.com/expressjs/express) is a minimalist web framework.\n\nAffected versions of this package are vulnerable to Cross-site Scripting due to improper handling of user input in the `response.redirect` method. An attacker can execute arbitrary code by passing malicious input to this method.\r\n\r\n\r\n**Note**\r\n\r\nTo exploit this vulnerability, the following conditions are required:\r\n\r\n1) The attacker should be able to control the input to `response.redirect()`\r\n\r\n2) express must not redirect before the template appears\r\n\r\n3) the browser must not complete redirection before:\r\n\r\n4) the user must click on the link in the template\n## Remediation\nUpgrade `express` to version 4.20.0, 5.0.0 or higher.\n## References\n- [GitHub Commit](https://github.com/expressjs/express/commit/54271f69b511fea198471e6ff3400ab805d6b553)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000025",
+          "locations": [
+            {
+              "package": {
+                "name": "express",
+                "version": "4.0.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2024-43796",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-79",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<4.20.0",
+                ">=5.0.0-alpha.1 <5.0.0"
+              ],
+              "created_at": "2024-09-11T06:44:36.87127Z",
+              "credits": [
+                "AdamKorcz"
+              ],
+              "cvss_base_score": 5.1,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.1,
+                  "cvss_version": "4.0",
+                  "modified_at": "2024-09-11T12:24:12.257485Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:A/VC:N/VI:L/VA:N/SC:L/SI:L/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-11T12:24:12.257485Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 4.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-21T01:11:54.115308Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-11T13:47:33.875106Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:A/VC:N/VI:L/VA:N/SC:L/SI:L/SA:N",
+              "disclosed_at": "2024-09-10T15:15:17Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.20267",
+                "probability": "0.00065"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-JS-EXPRESS-7926867",
+              "initially_fixed_in_versions": [
+                "4.20.0",
+                "5.0.0"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-09-21T01:11:54.115308Z",
+              "package_name": "express",
+              "package_version": "",
+              "published_at": "2024-09-11T12:24:12.250365Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/expressjs/express/commit/54271f69b511fea198471e6ff3400ab805d6b553"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 75
+            }
+          },
+          "title": "Cross-site Scripting"
+        },
+        "id": "00000000-0000-0000-0000-000000000025",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "express",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.20.0"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000025",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\r\n[`express`](https://www.npmjs.com/package/express) is a minimalist web framework.\r\n\r\nAffected versions of this package do not enforce the user's browser to set a specific charset in the content-type header while displaying 400 level response messages. This could be used by remote attackers to perform a cross-site scripting attack, by using non-standard encodings like UTF-7.\r\n\r\n## Details\r\n<<XSS>>\r\n\r\n\r\n## Recommendations\r\nUpdate express to `3.11.0`, `4.5.0` or higher.\r\n\r\n## References\r\n- [GitHub release 3.11.0](https://github.com/expressjs/express/releases/tag/3.11.0)\r\n- [GitHub release 4.5.0](https://github.com/expressjs/express/releases/tag/4.5.0)",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000026",
+          "locations": [
+            {
+              "package": {
+                "name": "express",
+                "version": "4.0.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "GHSA-gpvr-g6gh-9mc2",
+              "source": "ghsa"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<3.11.0",
+                ">=4.0.0 <4.5.0"
+              ],
+              "created_at": "2014-09-12T04:46:45Z",
+              "credits": [
+                "Pawe\u0142 Ha\u0142drzy\u0144ski"
+              ],
+              "cvss_base_score": 5.4,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.4,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:57:29.707396Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 6.1,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:49:01.539136Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N",
+              "disclosed_at": "2014-09-12T04:46:45Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.52034",
+                "probability": "0.00290"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:express:20140912",
+              "initially_fixed_in_versions": [
+                "3.11.0",
+                "4.5.0"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:49:01.539136Z",
+              "package_name": "express",
+              "package_version": "",
+              "published_at": "2014-09-12T04:46:45Z",
+              "references": [
+                {
+                  "title": "GitHub Release",
+                  "url": "https://github.com/expressjs/express/releases/tag/3.11.0"
+                },
+                {
+                  "title": "GitHub Release",
+                  "url": "https://github.com/expressjs/express/releases/tag/4.5.0"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-79",
+              "source": "cwe"
+            },
+            {
+              "id": "CVE-2014-6393",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 69
+            }
+          },
+          "title": "Cross-site Scripting (XSS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000026",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "express",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.5.0"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000026",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[send](https://www.npmjs.com/package/send) is a library for streaming files from the file system.\n\nAffected versions of this package are vulnerable to Directory-Traversal attacks due to insecure comparison.\nWhen relying on the root option to restrict file access a malicious user may escape out of the restricted directory and access files in a similarly named directory. For example, a path like `/my-secret` is consedered fine for the root `/my`.\n\n## Details\nA Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with \"dot-dot-slash (../)\" sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.\r\n\r\nDirectory Traversal vulnerabilities can be generally divided into two types:\r\n\r\n- **Information Disclosure**: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.\r\n\r\n`st` is a module for serving static files on web pages, and contains a [vulnerability of this type](https://snyk.io/vuln/npm:st:20140206). In our example, we will serve files from the `public` route.\r\n\r\nIf an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.\r\n\r\n```\r\ncurl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa\r\n```\r\n**Note** `%2e` is the URL encoded version of `.` (dot).\r\n\r\n- **Writing arbitrary files**: Allows the attacker to create or replace existing files. This type of vulnerability is also known as `Zip-Slip`. \r\n\r\nOne way to achieve this is by using a malicious `zip` archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\r\n\r\nThe following is an example of a `zip` archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\r\n\r\n```\r\n2018-04-15 22:04:29 .....           19           19  good.txt\r\n2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys\r\n```\n \n\n## Remediation\nUpgrade to a version greater than or equal to 0.8.4.\n\n## References\n- [GitHub PR](https://github.com/visionmedia/send/pull/59)\n- [GitHub Commit](https://github.com/visionmedia/send/commit/9c6ca9b2c0b880afd3ff91ce0d211213c5fa5f9a)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "serve-static",
+                  "version": "1.0.1"
+                },
+                {
+                  "name": "send",
+                  "version": "0.1.4"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000027",
+          "locations": [
+            {
+              "package": {
+                "name": "send",
+                "version": "0.1.4"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "< 0.8.4"
+              ],
+              "created_at": "2014-09-12T05:06:33Z",
+              "credits": [
+                "Ilya Kantor"
+              ],
+              "cvss_base_score": 4.3,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 4.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:02:18.15324Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:46:22.60294Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+              "disclosed_at": "2014-09-12T05:06:33Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.89003",
+                "probability": "0.04842"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:send:20140912",
+              "initially_fixed_in_versions": [
+                "0.8.4"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:46:22.60294Z",
+              "package_name": "send",
+              "package_version": "",
+              "published_at": "2014-09-12T05:06:33Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/visionmedia/send/commit/9c6ca9b2c0b880afd3ff91ce0d211213c5fa5f9a"
+                },
+                {
+                  "title": "GitHub PR",
+                  "url": "https://github.com/visionmedia/send/pull/59"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-23",
+              "source": "cwe"
+            },
+            {
+              "id": "GHSA-xwg4-93c6-3h42",
+              "source": "ghsa"
+            },
+            {
+              "id": "CVE-2014-6394",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 39
+            }
+          },
+          "title": "Directory Traversal"
+        },
+        "id": "00000000-0000-0000-0000-000000000027",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "send",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.8.0"
+                        },
+                        {
+                          "name": "serve-static",
+                          "version": "1.5.4"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.8.5"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000027",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[qs](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\n\nAffected versions of this package are vulnerable to Prototype Poisoning which allows attackers to cause a Node process to hang, processing an Array object whose prototype has been replaced by one with an excessive length value.\r\n\r\n**Note:** In many typical Express use cases, an unauthenticated remote attacker can place the attack payload in the query string of the URL that is used to visit the application, such as `a[__proto__]=b&a[__proto__]&a[length]=100000000`.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\n\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\n\nTwo common types of DoS vulnerabilities:\n\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](https://security.snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-30082).\n\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](https://snyk.io/vuln/npm:ws:20171108)\n\n## Remediation\nUpgrade `qs` to version 6.2.4, 6.3.3, 6.4.1, 6.5.3, 6.6.1, 6.7.3, 6.8.3, 6.9.7, 6.10.3 or higher.\n## References\n- [GitHub PR](https://github.com/ljharb/qs/pull/428)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=2150323)\n- [Researcher Advisory](https://github.com/n8tz/CVE-2022-24999)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "qs",
+                  "version": "0.6.6"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000028",
+          "locations": [
+            {
+              "package": {
+                "name": "qs",
+                "version": "0.6.6"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2022-24999",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-1321",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<6.2.4",
+                ">=6.3.0 <6.3.3",
+                ">=6.4.0 <6.4.1",
+                ">=6.5.0 <6.5.3",
+                ">=6.6.0 <6.6.1",
+                ">=6.7.0 <6.7.3",
+                ">=6.8.0 <6.8.3",
+                ">=6.9.0 <6.9.7",
+                ">=6.10.0 <6.10.3"
+              ],
+              "created_at": "2022-12-04T11:01:47.782869Z",
+              "credits": [
+                "BRAUN Nathanael",
+                "BRISSAUD Johan"
+              ],
+              "cvss_base_score": 7.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:06:01.312784Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:52:48.801266Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:53:59.571489Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P",
+              "disclosed_at": "2022-11-26T00:00:00Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.86312",
+                "probability": "0.03115"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "proof of concept",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "proof of concept",
+                    "type": "primary"
+                  }
+                ],
+                "sources": [
+                  "Snyk"
+                ]
+              },
+              "id": "SNYK-JS-QS-3153490",
+              "initially_fixed_in_versions": [
+                "6.2.4",
+                "6.3.3",
+                "6.4.1",
+                "6.5.3",
+                "6.6.1",
+                "6.7.3",
+                "6.8.3",
+                "6.9.7",
+                "6.10.3"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:53:59.571489Z",
+              "package_name": "qs",
+              "package_version": "",
+              "published_at": "2022-12-04T12:24:32.307833Z",
+              "references": [
+                {
+                  "title": "GitHub PR",
+                  "url": "https://github.com/ljharb/qs/pull/428"
+                },
+                {
+                  "title": "RedHat Bugzilla Bug",
+                  "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2150323"
+                },
+                {
+                  "title": "Researcher Advisory",
+                  "url": "https://github.com/n8tz/CVE-2022-24999"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 150
+            }
+          },
+          "title": "Prototype Poisoning"
+        },
+        "id": "00000000-0000-0000-0000-000000000028",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "qs",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.17.3"
+                        },
+                        {
+                          "name": "qs",
+                          "version": "6.9.7"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000028",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[express](https://github.com/expressjs/express) is a minimalist web framework.\n\nAffected versions of this package are vulnerable to Open Redirect due to the implementation of URL encoding using `encodeurl` before passing it to the `location` header. This can lead to unexpected evaluations of malformed URLs by common redirect allow list implementations in applications, allowing an attacker to bypass a properly implemented allow list and redirect users to malicious sites.\n## Remediation\nUpgrade `express` to version 4.19.2, 5.0.0-beta.3 or higher.\n## References\n- [Github Commit](https://github.com/expressjs/express/commit/0b746953c4bd8e377123527db11f9cd866e39f94)\n- [GitHub Commit](https://github.com/expressjs/express/commit/0867302ddbde0e9463d0564fea5861feb708c2dd)\n- [Github Issue](https://github.com/koajs/koa/issues/1800)\n- [GitHub PR](https://github.com/expressjs/express/pull/5551)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "package.json",
+                  "version": ""
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000029",
+          "locations": [
+            {
+              "package": {
+                "name": "express",
+                "version": "4.0.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2024-29041",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-601",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<4.19.2",
+                ">=5.0.0-alpha.1 <5.0.0-beta.3"
+              ],
+              "created_at": "2024-03-21T07:57:40.545565Z",
+              "credits": [
+                "FDrag0n"
+              ],
+              "cvss_base_score": 6.1,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.1,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-26T07:34:23.916299Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 6.1,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-06-08T14:11:46.700097Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+              "disclosed_at": "2024-03-20T15:16:03Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.12762",
+                "probability": "0.00043"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-JS-EXPRESS-6474509",
+              "initially_fixed_in_versions": [
+                "4.19.2",
+                "5.0.0-beta.3"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-06-08T14:11:46.700097Z",
+              "package_name": "express",
+              "package_version": "",
+              "published_at": "2024-03-26T07:34:23.916017Z",
+              "references": [
+                {
+                  "title": "Github Commit",
+                  "url": "https://github.com/expressjs/express/commit/0b746953c4bd8e377123527db11f9cd866e39f94"
+                },
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/expressjs/express/commit/0867302ddbde0e9463d0564fea5861feb708c2dd"
+                },
+                {
+                  "title": "Github Issue",
+                  "url": "https://github.com/koajs/koa/issues/1800"
+                },
+                {
+                  "title": "GitHub PR",
+                  "url": "https://github.com/expressjs/express/pull/5551"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 74
+            }
+          },
+          "title": "Open Redirect"
+        },
+        "id": "00000000-0000-0000-0000-000000000029",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "express",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "package.json",
+                          "version": ""
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.19.2"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000029",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      }
+    ]
+  },
+  {
+    "testId": "3ae38947-8c9c-4056-9da3-42570ad39d6e",
+    "testConfiguration": {
+      "local_policy": {
+        "fail_on_upgradable": false,
+        "severity_threshold": "low",
+        "suppress_pending_ignores": false
+      },
+      "timeout": {
+        "outcome": "fail",
+        "seconds": 1200
+      }
+    },
+    "metadata": {
+      "project-name": "golangproject",
+      "display-target-file": "golang/go.mod",
+      "target-directory": "multi-project",
+      "dependency-count": 29,
+      "asset": "https://app.snyk.io/org/my-org/inventory/assets/01a01434-8c66-7ed7-b7b8-401a040153f1/overview"
+    },
+    "createdAt": "2025-11-13T15:29:14.506347Z",
+    "testSubject": {
+      "locator": {
+        "paths": [
+          "golang/go.mod"
+        ],
+        "type": "local_path"
+      },
+      "type": "dep_graph"
+    },
+    "executionState": "finished",
+    "passFail": "fail",
+    "outcomeReason": "policy_breach",
+    "effectiveSummary": {
+      "count": 1,
+      "count_by": {
+        "result_type": {
+          "dast": 0,
+          "other": 0,
+          "sast": 0,
+          "sca": 1
+        },
+        "severity": {
+          "critical": 0,
+          "high": 0,
+          "low": 0,
+          "medium": 1,
+          "none": 0,
+          "other": 0
+        }
+      }
+    },
+    "rawSummary": {
+      "count": 1,
+      "count_by": {
+        "result_type": {
+          "dast": 0,
+          "other": 0,
+          "sast": 0,
+          "sca": 1
+        },
+        "severity": {
+          "critical": 0,
+          "high": 0,
+          "low": 0,
+          "medium": 1,
+          "none": 0,
+          "other": 0
+        }
+      }
+    },
+    "findingsComplete": true,
+    "findings": [
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[github.com/valyala/fasthttp](https://pkg.go.dev/github.com/valyala/fasthttp) is a fast HTTP server and client API.\n\nAffected versions of this package are vulnerable to Open Redirect due to improper handling of malformed URLs, allowing attackers to bypass the protections that users have set up for schemes and hosts. An attacker can send a URL involving a `,` to the Validator (e.g., `http://vulndetector.com,/`), bypassing the URL blocklist validation, and keep sending requests to the domain with a blocklisted hostname, leading to SSRF and RCE attacks.\n## PoC\n```\r\npackage main\r\n\r\nimport (\r\n\t\"fmt\"\r\n\t\"github.com/valyala/fasthttp\"\r\n\t\"net/url\"\r\n\t\"strings\"\r\n)\r\n\r\nfunc safeURLOpener(inputLink string) (*fasthttp.Response, error) {\r\n\tblockSchemes := map[string]bool{\r\n\t\t\"file\": true, \"gopher\": true, \"expect\": true,\r\n\t\t\"php\": true, \"dict\": true, \"ftp\": true,\r\n\t\t\"glob\": true, \"data\": true,\r\n\t}\r\n\tblockHost := map[string]bool{\r\n\t\t\"vulndetector.com\": true,\r\n\t}\r\n\r\n\tparsedUrl, err := url.Parse(inputLink)\r\n\tif err != nil {\r\n\t\tfmt.Println(\"Error parsing URL:\", err)\r\n\t\treturn nil, err\r\n\t}\r\n\r\n\tinputScheme := parsedUrl.Scheme\r\n\tinputHostname := parsedUrl.Hostname()\r\n\r\n\tif blockSchemes[inputScheme] {\r\n\t\tfmt.Println(\"input scheme is forbidden\")\r\n\t\treturn nil, nil\r\n\t}\r\n\r\n\tif blockHost[inputHostname] {\r\n\t\tfmt.Println(\"input hostname is forbidden\")\r\n\t\treturn nil, nil\r\n\t}\r\n\r\n\t// Create request and response objects\r\n\treq := fasthttp.AcquireRequest()\r\n\tresp := fasthttp.AcquireResponse()\r\n\tdefer fasthttp.ReleaseRequest(req)   // to reuse requests\r\n\tdefer fasthttp.ReleaseResponse(resp) // to reuse responses\r\n\r\n\treq.SetRequestURI(inputLink)\r\n\terr = fasthttp.Do(req, resp)\r\n\tif err != nil {\r\n\t\tfmt.Println(\"HTTP request failed:\", err)\r\n\t\treturn nil, err\r\n\t}\r\n\r\n\t// Since we need the body outside this function, we create a copy of the response\r\n\tnewResp := &fasthttp.Response{}\r\n\tresp.CopyTo(newResp)\r\n\treturn newResp, nil\r\n}\r\n\r\nfunc verify() {\r\n\tpayload := \"http://vulndetector.com,/\"\r\n\tresult, err := safeURLOpener(payload)\r\n\tif err != nil {\r\n\t\tfmt.Println(\"Failed to open URL:\", err)\r\n\t\treturn\r\n\t}\r\n\tif result != nil {\r\n\t\tbodyBytes := result.Body()\r\n\t\tbodyString := string(bodyBytes)\r\n\t\tif result.StatusCode() == 200 && strings.Contains(bodyString, \"FindVuln\") {\r\n\t\t\tfmt.Println(\"payload find! ==>\", payload)\r\n\t\t}\r\n\t}\r\n}\r\n\r\nfunc main() {\r\n\tverify()\r\n}\r\n```\n## Remediation\nUpgrade `github.com/valyala/fasthttp` to version 1.53.0 or higher.\n## References\n- [GitHub Commit](https://github.com/valyala/fasthttp/commit/a8fa9c04b493324b7805dd5c6f8439b1b15a9f92)\n- [GitHub PR](https://github.com/valyala/fasthttp/pull/1761#issuecomment-2100784469)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "golangproject",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "github.com/gofiber/fiber/v2",
+                  "version": "2.52.9"
+                },
+                {
+                  "name": "github.com/valyala/fasthttp",
+                  "version": "1.51.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000030",
+          "locations": [
+            {
+              "package": {
+                "name": "github.com/valyala/fasthttp",
+                "version": "1.51.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<1.53.0"
+              ],
+              "created_at": "2024-05-09T07:30:33.214759Z",
+              "credits": [
+                "zer0yu"
+              ],
+              "cvss_base_score": 5.4,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.4,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-05-15T10:57:31.085525Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N/E:P"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N/E:P",
+              "disclosed_at": "2024-05-08T14:58:18Z",
+              "ecosystem": {
+                "language": "golang",
+                "package_manager": "golang",
+                "type": "build"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "proof of concept",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "proof of concept",
+                    "type": "primary"
+                  }
+                ],
+                "sources": [
+                  "Snyk"
+                ]
+              },
+              "id": "SNYK-GOLANG-GITHUBCOMVALYALAFASTHTTP-6815320",
+              "initially_fixed_in_versions": [
+                "1.53.0"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-05-15T10:57:31.085525Z",
+              "package_name": "github.com/valyala/fasthttp",
+              "package_version": "",
+              "published_at": "2024-05-09T10:13:53.970876Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/valyala/fasthttp/commit/a8fa9c04b493324b7805dd5c6f8439b1b15a9f92"
+                },
+                {
+                  "title": "GitHub PR",
+                  "url": "https://github.com/valyala/fasthttp/pull/1761%23issuecomment-2100784469"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-601",
+              "source": "cwe"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 84
+            }
+          },
+          "title": "Open Redirect"
+        },
+        "id": "00000000-0000-0000-0000-000000000030",
+        "links": {},
+        "relationships": {},
+        "type": "findings"
+      }
+    ]
+  },
+  {
+    "testId": "5f3f0f49-8bf9-4d1a-a02b-cec38220bca3",
+    "testConfiguration": {
+      "local_policy": {
+        "fail_on_upgradable": false,
+        "severity_threshold": "low",
+        "suppress_pending_ignores": false
+      },
+      "timeout": {
+        "outcome": "fail",
+        "seconds": 1200
+      }
+    },
+    "metadata": {
+      "project-name": "demo:maven-demo",
+      "display-target-file": "maven/pom.xml",
+      "target-directory": "multi-project",
+      "dependency-count": 4,
+      "asset": "https://app.snyk.io/org/my-org/inventory/assets/01a01434-8c66-7ed7-b7b8-401a040153f1/overview"
+    },
+    "createdAt": "2025-11-13T15:29:14.480432Z",
+    "testSubject": {
+      "locator": {
+        "paths": [
+          "maven/pom.xml"
+        ],
+        "type": "local_path"
+      },
+      "type": "dep_graph"
+    },
+    "executionState": "finished",
+    "passFail": "pass",
+    "effectiveSummary": {
+      "count": 0,
+      "count_by": {
+        "result_type": {
+          "dast": 0,
+          "other": 0,
+          "sast": 0,
+          "sca": 0
+        },
+        "severity": {
+          "critical": 0,
+          "high": 0,
+          "low": 0,
+          "medium": 0,
+          "none": 0,
+          "other": 0
+        }
+      }
+    },
+    "rawSummary": {
+      "count": 0,
+      "count_by": {
+        "result_type": {
+          "dast": 0,
+          "other": 0,
+          "sast": 0,
+          "sca": 0
+        },
+        "severity": {
+          "critical": 0,
+          "high": 0,
+          "low": 0,
+          "medium": 0,
+          "none": 0,
+          "other": 0
+        }
+      }
+    },
+    "findingsComplete": true
+  },
+  {
+    "testId": "5ee27c0d-0aad-4af7-96ad-689272cc49bb",
+    "testConfiguration": {
+      "local_policy": {
+        "fail_on_upgradable": false,
+        "severity_threshold": "low",
+        "suppress_pending_ignores": false
+      },
+      "timeout": {
+        "outcome": "fail",
+        "seconds": 1200
+      }
+    },
+    "metadata": {
+      "project-name": "not-python",
+      "display-target-file": "not-python/requirements.txt",
+      "target-directory": "multi-project",
+      "dependency-count": 7,
+      "asset": "https://app.snyk.io/org/my-org/inventory/assets/01a01434-8c66-7ed7-b7b8-401a040153f1/overview"
+    },
+    "createdAt": "2025-11-13T15:29:14.440374Z",
+    "testSubject": {
+      "locator": {
+        "paths": [
+          "not-python/requirements.txt"
+        ],
+        "type": "local_path"
+      },
+      "type": "dep_graph"
+    },
+    "executionState": "finished",
+    "passFail": "fail",
+    "outcomeReason": "policy_breach",
+    "effectiveSummary": {
+      "count": 11,
+      "count_by": {
+        "result_type": {
+          "dast": 0,
+          "other": 0,
+          "sast": 0,
+          "sca": 11
+        },
+        "severity": {
+          "critical": 0,
+          "high": 2,
+          "low": 0,
+          "medium": 9,
+          "none": 0,
+          "other": 0
+        }
+      }
+    },
+    "rawSummary": {
+      "count": 11,
+      "count_by": {
+        "result_type": {
+          "dast": 0,
+          "other": 0,
+          "sast": 0,
+          "sca": 11
+        },
+        "severity": {
+          "critical": 0,
+          "high": 2,
+          "low": 0,
+          "medium": 9,
+          "none": 0,
+          "other": 0
+        }
+      }
+    },
+    "findingsComplete": true,
+    "findings": [
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[Jinja2](https://pypi.org/project/Jinja2/) is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). The ReDoS vulnerability is mainly due to the `_punctuation_re regex` operator and its use of multiple wildcards. The last wildcard is the most exploitable as it searches for trailing punctuation.\r\n\r\nThis issue can be mitigated by using Markdown to format user content instead of the urlize filter, or by implementing request timeouts or limiting process memory.\r\n\r\n### PoC by Yeting Li\r\n```\r\nfrom jinja2.utils import urlize\r\nfrom time import perf_counter\r\n\r\nfor i in range(3):\r\n    text = \"abc@\" + \".\" * (i+1)*5000 + \"!\"\r\n    LEN = len(text)\r\n    BEGIN = perf_counter()\r\n    urlize(text)\r\n    DURATION = perf_counter() - BEGIN\r\n    print(f\"{LEN}: took {DURATION} seconds!\")\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet\u2019s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn\u2019t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `Jinja2` to version 2.11.3 or higher.\n## References\n- [GitHub Additional Information](https://github.com/pallets/jinja/blob/ab81fd9c277900c85da0c322a2ff9d68a235b2e6/src/jinja2/utils.py#L20)\n- [GitHub PR](https://github.com/pallets/jinja/pull/1343)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000031",
+          "locations": [
+            {
+              "package": {
+                "name": "jinja2",
+                "version": "2.7.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,2.11.3)"
+              ],
+              "created_at": "2020-09-25T17:30:26.286074Z",
+              "credits": [
+                "Yeting Li"
+              ],
+              "cvss_base_score": 5.3,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:04:06.963646Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:50:53.40137Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:53:50.836875Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:49:33.018698Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P",
+              "disclosed_at": "2020-09-25T17:29:19Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.43083",
+                "probability": "0.00207"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "proof of concept",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "proof of concept",
+                    "type": "primary"
+                  }
+                ],
+                "sources": [
+                  "Snyk"
+                ]
+              },
+              "id": "SNYK-PYTHON-JINJA2-1012994",
+              "initially_fixed_in_versions": [
+                "2.11.3"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:53:50.836875Z",
+              "package_name": "jinja2",
+              "package_version": "",
+              "published_at": "2021-02-01T19:52:17Z",
+              "references": [
+                {
+                  "title": "GitHub Additional Information",
+                  "url": "https://github.com/pallets/jinja/blob/ab81fd9c277900c85da0c322a2ff9d68a235b2e6/src/jinja2/utils.py%23L20"
+                },
+                {
+                  "title": "GitHub PR",
+                  "url": "https://github.com/pallets/jinja/pull/1343"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-400",
+              "source": "cwe"
+            },
+            {
+              "id": "CVE-2020-28493",
+              "source": "cve"
+            },
+            {
+              "id": "GHSA-g3rq-g295-4j3m",
+              "source": "ghsa"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 84
+            }
+          },
+          "title": "Regular Expression Denial of Service (ReDoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000031",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "jinja2",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "not-python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "jinja2",
+                          "version": "2.11.3"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000031",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[Jinja2](https://pypi.org/project/Jinja2/) is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS) through the `xmlattr` filter. An attacker can manipulate the output of web pages by injecting additional attributes into elements, potentially leading to unauthorized actions or information disclosure.\r\n\r\n**Note:**\r\nThis vulnerability derives from an improper fix of [CVE-2024-22195](https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-6150717), which only addressed spaces but not other characters.\n## Details\n\nCross-site scripting (or XSS) is a code vulnerability that occurs when an attacker \u201cinjects\u201d a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user\u2019s browser when the user interacts with the compromised website.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser\u2019s Same Origin Policy.\n\nInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they\u2019ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user\u2019s browser.| \n|**DOM-based**|Client|The attacker forces the user\u2019s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `Jinja2` to version 3.1.4 or higher.\n## References\n- [GitHub Commit](https://github.com/pallets/jinja/commit/0668239dc6b44ef38e7a6c9f91f312fd4ca581cb)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000032",
+          "locations": [
+            {
+              "package": {
+                "name": "jinja2",
+                "version": "2.7.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "GHSA-h75v-3vvj-5mfj",
+              "source": "ghsa"
+            },
+            {
+              "id": "CWE-79",
+              "source": "cwe"
+            },
+            {
+              "id": "CVE-2024-34064",
+              "source": "cve"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,3.1.4)"
+              ],
+              "created_at": "2024-05-07T07:25:05.908377Z",
+              "credits": [
+                "Ry0taK"
+              ],
+              "cvss_base_score": 5.4,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.4,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-05-07T07:34:20.297801Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5.4,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-05-09T13:32:50.637457Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 6.1,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-08-20T12:55:14.911468Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N",
+              "disclosed_at": "2024-05-06T14:20:59Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.70584",
+                "probability": "0.00673"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-JINJA2-6809379",
+              "initially_fixed_in_versions": [
+                "3.1.4"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-08-20T12:55:14.911468Z",
+              "package_name": "jinja2",
+              "package_version": "",
+              "published_at": "2024-05-07T07:25:06.164752Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/jinja/commit/0668239dc6b44ef38e7a6c9f91f312fd4ca581cb"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 82
+            }
+          },
+          "title": "Cross-site Scripting (XSS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000032",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "jinja2",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "not-python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "jinja2",
+                          "version": "3.1.4"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000032",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[Werkzeug](https://werkzeug.palletsprojects.com/) is a WSGI web application library.\n\nAffected versions of this package are vulnerable to Directory Traversal due to a bypass for `os.path.isabs()`, which allows the improper handling of UNC paths beginning with `/`, in the `safe_join()` function. This allows an attacker to read some files on the affected server, if they are stored in an affected path.\n\n**Note:** This is only exploitable on Windows systems using Python versions prior to 3.11.\n\n## Details\n\nA Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with \"dot-dot-slash (../)\" sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.\n\nDirectory Traversal vulnerabilities can be generally divided into two types:\n\n- **Information Disclosure**: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.\n\n`st` is a module for serving static files on web pages, and contains a [vulnerability of this type](https://snyk.io/vuln/npm:st:20140206). In our example, we will serve files from the `public` route.\n\nIf an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.\n\n```\ncurl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa\n```\n**Note** `%2e` is the URL encoded version of `.` (dot).\n\n- **Writing arbitrary files**: Allows the attacker to create or replace existing files. This type of vulnerability is also known as `Zip-Slip`. \n\nOne way to achieve this is by using a malicious `zip` archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\n\nThe following is an example of a `zip` archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\n\n```\n2018-04-15 22:04:29 .....           19           19  good.txt\n2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys\n```\n\n## Remediation\nUpgrade `Werkzeug` to version 3.0.6 or higher.\n## References\n- [GitHub Commit](https://github.com/pallets/werkzeug/commit/2767bcb10a7dd1c297d812cc5e6d11a474c1f092)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "werkzeug",
+                  "version": "3.0.1"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "werkzeug",
+                  "version": "3.0.1"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000033",
+          "locations": [
+            {
+              "package": {
+                "name": "werkzeug",
+                "version": "3.0.1"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "GHSA-f9vj-2wh5-fj8j",
+              "source": "ghsa"
+            },
+            {
+              "id": "CWE-22",
+              "source": "cwe"
+            },
+            {
+              "id": "CVE-2024-49766",
+              "source": "cve"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,3.0.6)"
+              ],
+              "created_at": "2024-10-27T07:51:17.655825Z",
+              "credits": [
+                "nvn1729"
+              ],
+              "cvss_base_score": 6.3,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.3,
+                  "cvss_version": "4.0",
+                  "modified_at": "2024-10-27T07:51:18.284807Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 3.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-10-27T07:51:18.284807Z",
+                  "severity": "low",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 3.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-10-26T13:33:43.496915Z",
+                  "severity": "low",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
+              "disclosed_at": "2024-10-25T19:43:41Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.19428",
+                "probability": "0.00062"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-WERKZEUG-8309091",
+              "initially_fixed_in_versions": [
+                "3.0.6"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-10-27T07:51:18.284807Z",
+              "package_name": "werkzeug",
+              "package_version": "",
+              "published_at": "2024-10-27T07:51:18.252581Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/werkzeug/commit/2767bcb10a7dd1c297d812cc5e6d11a474c1f092"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 53
+            }
+          },
+          "title": "Directory Traversal"
+        },
+        "id": "00000000-0000-0000-0000-000000000033",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "werkzeug",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "not-python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "werkzeug",
+                          "version": "3.0.6"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000033",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\nAffected versions of this package are vulnerable to Remote Code Execution (RCE) due to insufficient hostname checks and the use of relative paths to resolve requests. When the debugger is enabled, an attacker can convince a user to enter their own PIN to interact with a domain and subdomain they control, and thereby cause malicious code to be executed.\r\n\r\nThe demonstrated attack vector requires a number of conditions that render this attack very difficult to achieve, especially if the victim application is running in the recommended configuration of not having the debugger enabled in production.\n## Remediation\nUpgrade `werkzeug` to version 3.0.3 or higher.\n## References\n- [GitHub Commit](https://github.com/pallets/werkzeug/commit/71b69dfb7df3d912e66bab87fbb1f21f83504967)\n- [GitHub Release](https://github.com/pallets/werkzeug/releases/tag/3.0.3)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "werkzeug",
+                  "version": "3.0.1"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "werkzeug",
+                  "version": "3.0.1"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000034",
+          "locations": [
+            {
+              "package": {
+                "name": "werkzeug",
+                "version": "3.0.1"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "GHSA-2g68-c3qc-8985",
+              "source": "ghsa"
+            },
+            {
+              "id": "CVE-2024-34069",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-94",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,3.0.3)"
+              ],
+              "created_at": "2024-05-06T07:14:00.654405Z",
+              "credits": [
+                "RyotaK"
+              ],
+              "cvss_base_score": 7.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-05-06T07:25:10.516775Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-05-09T13:32:47.011978Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-05-11T11:02:22.89022Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H",
+              "disclosed_at": "2024-05-06T01:48:44Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.97168",
+                "probability": "0.40316"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-WERKZEUG-6808933",
+              "initially_fixed_in_versions": [
+                "3.0.3"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-05-11T11:02:22.89022Z",
+              "package_name": "werkzeug",
+              "package_version": "",
+              "published_at": "2024-05-06T07:25:10.516467Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/werkzeug/commit/71b69dfb7df3d912e66bab87fbb1f21f83504967"
+                },
+                {
+                  "title": "GitHub Release",
+                  "url": "https://github.com/pallets/werkzeug/releases/tag/3.0.3"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 292
+            }
+          },
+          "title": "Remote Code Execution (RCE)"
+        },
+        "id": "00000000-0000-0000-0000-000000000034",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "werkzeug",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "not-python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "werkzeug",
+                          "version": "3.0.3"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000034",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[Jinja2](https://pypi.org/project/Jinja2/) is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.\n\nAffected versions of this package are vulnerable to Sandbox Escape via the `str.format_map`. This vulnerability requires the attacker to have information about sensitive attributes, and exploiting it could allow the attacker to access sensitive content.\r\n\r\n\r\n## Workaround\r\nOverride the `is_safe_attribute` method on the sandbox and explicitly disallow the `format_map` method on string objects.\n## Remediation\nUpgrade `Jinja2` to version 2.10.1 or higher.\n## References\n- [Release Notes](https://palletsprojects.com/blog/jinja-2-10-1-released)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000035",
+          "locations": [
+            {
+              "package": {
+                "name": "jinja2",
+                "version": "2.7.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2019-10906",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-265",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,2.10.1)"
+              ],
+              "created_at": "2019-04-07T10:24:16.310959Z",
+              "credits": [
+                "Brian Welch",
+                "Armin Ronacher"
+              ],
+              "cvss_base_score": 6.8,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.8,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:01:17.209056Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:N/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 8.6,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:52:57.063647Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 9,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:53:54.77586Z",
+                  "severity": "critical",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 8.1,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:50:04.210847Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:N/A:N",
+              "disclosed_at": "2019-04-07T00:42:43Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.85111",
+                "probability": "0.02615"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-JINJA2-174126",
+              "initially_fixed_in_versions": [
+                "2.10.1"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:53:54.77586Z",
+              "package_name": "jinja2",
+              "package_version": "",
+              "published_at": "2019-04-07T00:42:43Z",
+              "references": [
+                {
+                  "title": "Release Notes",
+                  "url": "https://palletsprojects.com/blog/jinja-2-10-1-released"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 154
+            }
+          },
+          "title": "Sandbox Escape"
+        },
+        "id": "00000000-0000-0000-0000-000000000035",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "jinja2",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "not-python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "jinja2",
+                          "version": "2.10.1"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000035",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\nAffected versions of this package are vulnerable to Improper Neutralization when importing a macro in a template whose filename is also a template. This will result in a `SyntaxError: f-string: invalid syntax` error message because the filename is not properly escaped, indicating that it is being treated as a format string.\r\n\r\n**Note:** This is only exploitable when the attacker controls both the content and filename of a template and the application executes untrusted templates.\n## Remediation\nUpgrade `jinja2` to version 3.1.5 or higher.\n## References\n- [GitHub Commit](https://github.com/pallets/jinja/commit/767b23617628419ae3709ccfb02f9602ae9fe51f)\n- [GitHub Issue](https://github.com/pallets/jinja/issues/1792)\n- [GitHub PR](https://github.com/pallets/jinja/pull/1852)\n- [GitHub Release](https://github.com/pallets/jinja/releases/tag/3.1.5)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000036",
+          "locations": [
+            {
+              "package": {
+                "name": "jinja2",
+                "version": "2.7.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CWE-150",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,3.1.5)"
+              ],
+              "created_at": "2024-12-24T11:51:17.721758Z",
+              "credits": [
+                "Simon Leiner"
+              ],
+              "cvss_base_score": 5.4,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.4,
+                  "cvss_version": "4.0",
+                  "modified_at": "2025-09-23T08:02:44.358322Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:P/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 8.8,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-09-23T08:02:44.358322Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 8.8,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-09-23T01:14:01.784017Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 7.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-12-24T14:17:27.023982Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 8.1,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-01-04T11:01:10.944302Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:P/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+              "disclosed_at": "2024-12-23T17:54:12Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.08120",
+                "probability": "0.00031"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-JINJA2-8548987",
+              "initially_fixed_in_versions": [
+                "3.1.5"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-09-23T08:02:44.358322Z",
+              "package_name": "jinja2",
+              "package_version": "",
+              "published_at": "2024-12-24T12:02:30.762445Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/jinja/commit/767b23617628419ae3709ccfb02f9602ae9fe51f"
+                },
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/pallets/jinja/issues/1792"
+                },
+                {
+                  "title": "GitHub PR",
+                  "url": "https://github.com/pallets/jinja/pull/1852"
+                },
+                {
+                  "title": "GitHub Release",
+                  "url": "https://github.com/pallets/jinja/releases/tag/3.1.5"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CVE-2024-56201",
+              "source": "cve"
+            },
+            {
+              "id": "GHSA-gmj6-6f8f-6699",
+              "source": "ghsa"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 190
+            }
+          },
+          "title": "Improper Neutralization"
+        },
+        "id": "00000000-0000-0000-0000-000000000036",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "jinja2",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "not-python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "jinja2",
+                          "version": "3.1.5"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000036",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[Jinja2](https://pypi.org/project/Jinja2/) is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.\n\nAffected versions of this package are vulnerable to Sandbox Bypass. Users were allowed to insert `str.format` through web templates, leading to an escape from sandbox.\n## Remediation\nUpgrade `Jinja2` to version 2.8.1 or higher.\n## References\n- [GitHub Commit](https://github.com/pallets/jinja/commit/9b53045c34e61013dc8f09b7e52a555fa16bed16)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000037",
+          "locations": [
+            {
+              "package": {
+                "name": "jinja2",
+                "version": "2.7.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CWE-234",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[2.5, 2.8.1)"
+              ],
+              "created_at": "2019-07-29T13:28:48.288799Z",
+              "credits": [
+                "Unknown"
+              ],
+              "cvss_base_score": 8.6,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 8.6,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:01:45.822509Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 8.6,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:49:01.839274Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 9,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:53:54.746382Z",
+                  "severity": "critical",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 8.7,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:50:04.202472Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N",
+              "disclosed_at": "2016-12-29T13:27:18Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.76752",
+                "probability": "0.01042"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-JINJA2-455616",
+              "initially_fixed_in_versions": [
+                "2.8.1"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:53:54.746382Z",
+              "package_name": "jinja2",
+              "package_version": "",
+              "published_at": "2019-07-30T13:11:16Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/jinja/commit/9b53045c34e61013dc8f09b7e52a555fa16bed16"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CVE-2016-10745",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 171
+            }
+          },
+          "title": "Sandbox Bypass"
+        },
+        "id": "00000000-0000-0000-0000-000000000037",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "jinja2",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "not-python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "jinja2",
+                          "version": "2.8.1"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000037",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\nAffected versions of this package are vulnerable to Template Injection when an attacker controls the content of a template. This is due to an oversight in the sandboxed environment's method detection when using a stored reference to a malicious string's `format` method, which can then be executed through a filter.\r\n\r\n**Note:** This is only exploitable through custom filters in an application.\n## Remediation\nUpgrade `jinja2` to version 3.1.5 or higher.\n## References\n- [GitHub Commit](https://github.com/pallets/jinja/commit/48b0687e05a5466a91cd5812d604fa37ad0943b4)\n- [GitHub Release](https://github.com/pallets/jinja/releases/tag/3.1.5)\n- [Jinja Chnanges](https://jinja.palletsprojects.com/en/stable/changes/#version-3-1-5)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000038",
+          "locations": [
+            {
+              "package": {
+                "name": "jinja2",
+                "version": "2.7.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "GHSA-q2x7-8rv6-6q7h",
+              "source": "ghsa"
+            },
+            {
+              "id": "CWE-1336",
+              "source": "cwe"
+            },
+            {
+              "id": "CVE-2024-56326",
+              "source": "cve"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,3.1.5)"
+              ],
+              "created_at": "2024-12-24T09:40:26.148979Z",
+              "credits": [
+                "Lydxn"
+              ],
+              "cvss_base_score": 5.4,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.4,
+                  "cvss_version": "4.0",
+                  "modified_at": "2024-12-24T09:53:47.782999Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:P/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-12-24T09:53:47.782999Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 6.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-12-31T14:46:25.398031Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:U/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 8.1,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-01-04T11:01:11.700479Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:P/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+              "disclosed_at": "2024-12-23T16:40:18Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.31655",
+                "probability": "0.00120"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-JINJA2-8548181",
+              "initially_fixed_in_versions": [
+                "3.1.5"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-01-04T11:01:11.700479Z",
+              "package_name": "jinja2",
+              "package_version": "",
+              "published_at": "2024-12-24T09:53:47.773828Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/jinja/commit/48b0687e05a5466a91cd5812d604fa37ad0943b4"
+                },
+                {
+                  "title": "GitHub Release",
+                  "url": "https://github.com/pallets/jinja/releases/tag/3.1.5"
+                },
+                {
+                  "title": "Jinja Chnanges",
+                  "url": "https://jinja.palletsprojects.com/en/stable/changes/%23version-3-1-5"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 98
+            }
+          },
+          "title": "Template Injection"
+        },
+        "id": "00000000-0000-0000-0000-000000000038",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "jinja2",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "not-python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "jinja2",
+                          "version": "3.1.5"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000038",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[Jinja2](https://pypi.org/project/Jinja2/) is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS) via the `xmlattr` filter, when using keys containing spaces in an application accepts keys as user input. An attacker can inject arbitrary HTML attributes into the rendered HTML template, bypassing the auto-escaping mechanism, which may lead to the execution of untrusted scripts in the context of the user's browser session.\r\n\r\n**Note**\r\nAccepting keys as user input is not common or a particularly intended use case of the `xmlattr` filter, and an application doing so should already be verifying what keys are provided regardless of this fix.\n## Details\n\nCross-site scripting (or XSS) is a code vulnerability that occurs when an attacker \u201cinjects\u201d a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user\u2019s browser when the user interacts with the compromised website.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser\u2019s Same Origin Policy.\n\nInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they\u2019ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user\u2019s browser.| \n|**DOM-based**|Client|The attacker forces the user\u2019s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `Jinja2` to version 3.1.3 or higher.\n## References\n- [GitHub Commit](https://github.com/pallets/jinja/commit/7dd3680e6eea0d77fde024763657aa4d884ddb23)\n- [GitHub Release](https://github.com/pallets/jinja/releases/tag/3.1.3)\n- [Snyk Blog](https://snyk.io/blog/jinja2-xss-vulnerability/)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000039",
+          "locations": [
+            {
+              "package": {
+                "name": "jinja2",
+                "version": "2.7.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CWE-79",
+              "source": "cwe"
+            },
+            {
+              "id": "CVE-2024-22195",
+              "source": "cve"
+            },
+            {
+              "id": "GHSA-h5c8-rqwp-cp95",
+              "source": "ghsa"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,3.1.3)"
+              ],
+              "created_at": "2024-01-11T11:25:09.41142Z",
+              "credits": [
+                "Calum Hutton - Snyk Research Team"
+              ],
+              "cvss_base_score": 5.4,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.4,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:09:45.934904Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 6.1,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:49:28.614817Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5.4,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:49:09.732576Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 5.4,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-08-20T12:57:33.703043Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N",
+              "disclosed_at": "2024-01-11T04:07:02Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.30236",
+                "probability": "0.00111"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-JINJA2-6150717",
+              "initially_fixed_in_versions": [
+                "3.1.3"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-08-20T12:57:33.703043Z",
+              "package_name": "jinja2",
+              "package_version": "",
+              "published_at": "2024-01-11T11:25:09.594006Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/jinja/commit/7dd3680e6eea0d77fde024763657aa4d884ddb23"
+                },
+                {
+                  "title": "GitHub Release",
+                  "url": "https://github.com/pallets/jinja/releases/tag/3.1.3"
+                },
+                {
+                  "title": "Snyk Blog",
+                  "url": "https://snyk.io/blog/jinja2-xss-vulnerability/"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 81
+            }
+          },
+          "title": "Cross-site Scripting (XSS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000039",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "jinja2",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "not-python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "jinja2",
+                          "version": "3.1.3"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000039",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\nAffected versions of this package are vulnerable to Allocation of Resources Without Limits or Throttling in `formparser.MultiPartParser()`. An attacker can cause the parser to consume more memory than the upload size, in excess of `max_form_memory_size`, by sending malicious data in a non-file field of a  `multipart/form-data` request.\n## Remediation\nUpgrade `werkzeug` to version 3.0.6 or higher.\n## References\n- [GitHub Commit](https://github.com/pallets/quart/commit/5e78c4169b8eb66b91ead3e62d44721b9e1644ee)\n- [GitHub Commit](https://github.com/pallets/werkzeug/commit/50cfeebcb0727e18cc52ffbeb125f4a66551179b)\n- [GitHub Release](https://github.com/pallets/werkzeug/releases/tag/3.0.6)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "werkzeug",
+                  "version": "3.0.1"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "werkzeug",
+                  "version": "3.0.1"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000040",
+          "locations": [
+            {
+              "package": {
+                "name": "werkzeug",
+                "version": "3.0.1"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "GHSA-q34m-jh98-gwm2",
+              "source": "ghsa"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,3.0.6)"
+              ],
+              "created_at": "2024-10-27T07:59:29.444255Z",
+              "credits": [
+                "Marcel Hellkamp"
+              ],
+              "cvss_base_score": 6.9,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.9,
+                  "cvss_version": "4.0",
+                  "modified_at": "2024-10-27T07:59:29.915337Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-10-27T07:59:29.915337Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-11-06T01:12:38.829485Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-10-31T11:03:44.375939Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N",
+              "disclosed_at": "2024-10-25T20:41:17.907Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.74358",
+                "probability": "0.00865"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-WERKZEUG-8309092",
+              "initially_fixed_in_versions": [
+                "3.0.6"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-11-06T01:12:38.829485Z",
+              "package_name": "werkzeug",
+              "package_version": "",
+              "published_at": "2024-10-27T07:59:29.673376Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/quart/commit/5e78c4169b8eb66b91ead3e62d44721b9e1644ee"
+                },
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/werkzeug/commit/50cfeebcb0727e18cc52ffbeb125f4a66551179b"
+                },
+                {
+                  "title": "GitHub Release",
+                  "url": "https://github.com/pallets/werkzeug/releases/tag/3.0.6"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-770",
+              "source": "cwe"
+            },
+            {
+              "id": "CVE-2024-49767",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 61
+            }
+          },
+          "title": "Allocation of Resources Without Limits or Throttling"
+        },
+        "id": "00000000-0000-0000-0000-000000000040",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "werkzeug",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "not-python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "werkzeug",
+                          "version": "3.0.6"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000040",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[Jinja2](https://pypi.org/project/Jinja2/) is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.\n\nAffected versions of this package are vulnerable to Template Injection through the `|attr` filter. An attacker that controls the content of a template can escape the sandbox and execute arbitrary Python code by using the `|attr` filter to get a reference to a string's plain format method, bypassing the environment's attribute lookup.\r\n\r\n**Note:**\r\n\r\nThis is only exploitable if the application executes untrusted templates.\n## Remediation\nUpgrade `Jinja2` to version 3.1.6 or higher.\n## References\n- [GitHub Commit](https://github.com/pallets/jinja/commit/90457bbf33b8662926ae65cdde4c4c32e756e403)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "not-python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000041",
+          "locations": [
+            {
+              "package": {
+                "name": "jinja2",
+                "version": "2.7.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,3.1.6)"
+              ],
+              "created_at": "2025-03-06T07:35:01.694695Z",
+              "credits": [
+                "securingapps"
+              ],
+              "cvss_base_score": 5.4,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.4,
+                  "cvss_version": "4.0",
+                  "modified_at": "2025-09-23T08:02:28.951339Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:P/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 8.8,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-09-23T08:02:28.951339Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 8.8,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-09-23T01:14:06.79181Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 7.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-03-07T06:01:18.866548Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 6.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-03-20T11:02:43.03158Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:P/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+              "disclosed_at": "2025-03-05T20:40:14Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.34457",
+                "probability": "0.00138"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-JINJA2-9292516",
+              "initially_fixed_in_versions": [
+                "3.1.6"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-09-23T08:02:28.951339Z",
+              "package_name": "jinja2",
+              "package_version": "",
+              "published_at": "2025-03-06T07:38:27.746434Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/jinja/commit/90457bbf33b8662926ae65cdde4c4c32e756e403"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "GHSA-cpwx-vrp4-4pq7",
+              "source": "ghsa"
+            },
+            {
+              "id": "CWE-1336",
+              "source": "cwe"
+            },
+            {
+              "id": "CVE-2025-27516",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 190
+            }
+          },
+          "title": "Template Injection"
+        },
+        "id": "00000000-0000-0000-0000-000000000041",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "jinja2",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "not-python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "jinja2",
+                          "version": "3.1.6"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000041",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      }
+    ]
+  },
+  {
+    "testId": "28f531e9-079d-4f26-ade8-f3f3ab28ac47",
+    "testConfiguration": {
+      "local_policy": {
+        "fail_on_upgradable": false,
+        "severity_threshold": "low",
+        "suppress_pending_ignores": false
+      },
+      "timeout": {
+        "outcome": "fail",
+        "seconds": 1200
+      }
+    },
+    "metadata": {
+      "project-name": "python",
+      "display-target-file": "python/requirements.txt",
+      "target-directory": "multi-project",
+      "dependency-count": 7,
+      "asset": "https://app.snyk.io/org/my-org/inventory/assets/01a01434-8c66-7ed7-b7b8-401a040153f1/overview"
+    },
+    "createdAt": "2025-11-13T15:29:18.009229Z",
+    "testSubject": {
+      "locator": {
+        "paths": [
+          "python/requirements.txt"
+        ],
+        "type": "local_path"
+      },
+      "type": "dep_graph"
+    },
+    "executionState": "finished",
+    "passFail": "fail",
+    "outcomeReason": "policy_breach",
+    "effectiveSummary": {
+      "count": 11,
+      "count_by": {
+        "result_type": {
+          "dast": 0,
+          "other": 0,
+          "sast": 0,
+          "sca": 11
+        },
+        "severity": {
+          "critical": 0,
+          "high": 2,
+          "low": 0,
+          "medium": 9,
+          "none": 0,
+          "other": 0
+        }
+      }
+    },
+    "rawSummary": {
+      "count": 11,
+      "count_by": {
+        "result_type": {
+          "dast": 0,
+          "other": 0,
+          "sast": 0,
+          "sca": 11
+        },
+        "severity": {
+          "critical": 0,
+          "high": 2,
+          "low": 0,
+          "medium": 9,
+          "none": 0,
+          "other": 0
+        }
+      }
+    },
+    "findingsComplete": true,
+    "findings": [
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\nAffected versions of this package are vulnerable to Template Injection when an attacker controls the content of a template. This is due to an oversight in the sandboxed environment's method detection when using a stored reference to a malicious string's `format` method, which can then be executed through a filter.\r\n\r\n**Note:** This is only exploitable through custom filters in an application.\n## Remediation\nUpgrade `jinja2` to version 3.1.5 or higher.\n## References\n- [GitHub Commit](https://github.com/pallets/jinja/commit/48b0687e05a5466a91cd5812d604fa37ad0943b4)\n- [GitHub Release](https://github.com/pallets/jinja/releases/tag/3.1.5)\n- [Jinja Chnanges](https://jinja.palletsprojects.com/en/stable/changes/#version-3-1-5)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000042",
+          "locations": [
+            {
+              "package": {
+                "name": "jinja2",
+                "version": "2.7.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2024-56326",
+              "source": "cve"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,3.1.5)"
+              ],
+              "created_at": "2024-12-24T09:40:26.148979Z",
+              "credits": [
+                "Lydxn"
+              ],
+              "cvss_base_score": 5.4,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.4,
+                  "cvss_version": "4.0",
+                  "modified_at": "2024-12-24T09:53:47.782999Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:P/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-12-24T09:53:47.782999Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 6.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-12-31T14:46:25.398031Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:U/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 8.1,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-01-04T11:01:11.700479Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:P/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+              "disclosed_at": "2024-12-23T16:40:18Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.31655",
+                "probability": "0.00120"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-JINJA2-8548181",
+              "initially_fixed_in_versions": [
+                "3.1.5"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-01-04T11:01:11.700479Z",
+              "package_name": "jinja2",
+              "package_version": "",
+              "published_at": "2024-12-24T09:53:47.773828Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/jinja/commit/48b0687e05a5466a91cd5812d604fa37ad0943b4"
+                },
+                {
+                  "title": "GitHub Release",
+                  "url": "https://github.com/pallets/jinja/releases/tag/3.1.5"
+                },
+                {
+                  "title": "Jinja Chnanges",
+                  "url": "https://jinja.palletsprojects.com/en/stable/changes/%23version-3-1-5"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "GHSA-q2x7-8rv6-6q7h",
+              "source": "ghsa"
+            },
+            {
+              "id": "CWE-1336",
+              "source": "cwe"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 98
+            }
+          },
+          "title": "Template Injection"
+        },
+        "id": "00000000-0000-0000-0000-000000000042",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "jinja2",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "jinja2",
+                          "version": "3.1.5"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000042",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[Jinja2](https://pypi.org/project/Jinja2/) is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.\n\nAffected versions of this package are vulnerable to Sandbox Escape via the `str.format_map`. This vulnerability requires the attacker to have information about sensitive attributes, and exploiting it could allow the attacker to access sensitive content.\r\n\r\n\r\n## Workaround\r\nOverride the `is_safe_attribute` method on the sandbox and explicitly disallow the `format_map` method on string objects.\n## Remediation\nUpgrade `Jinja2` to version 2.10.1 or higher.\n## References\n- [Release Notes](https://palletsprojects.com/blog/jinja-2-10-1-released)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000043",
+          "locations": [
+            {
+              "package": {
+                "name": "jinja2",
+                "version": "2.7.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CWE-265",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,2.10.1)"
+              ],
+              "created_at": "2019-04-07T10:24:16.310959Z",
+              "credits": [
+                "Brian Welch",
+                "Armin Ronacher"
+              ],
+              "cvss_base_score": 6.8,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.8,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:01:17.209056Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:N/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 8.6,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:52:57.063647Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 9,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:53:54.77586Z",
+                  "severity": "critical",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 8.1,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:50:04.210847Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:N/A:N",
+              "disclosed_at": "2019-04-07T00:42:43Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.85111",
+                "probability": "0.02615"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-JINJA2-174126",
+              "initially_fixed_in_versions": [
+                "2.10.1"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:53:54.77586Z",
+              "package_name": "jinja2",
+              "package_version": "",
+              "published_at": "2019-04-07T00:42:43Z",
+              "references": [
+                {
+                  "title": "Release Notes",
+                  "url": "https://palletsprojects.com/blog/jinja-2-10-1-released"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CVE-2019-10906",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 154
+            }
+          },
+          "title": "Sandbox Escape"
+        },
+        "id": "00000000-0000-0000-0000-000000000043",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "jinja2",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "jinja2",
+                          "version": "2.10.1"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000043",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[Jinja2](https://pypi.org/project/Jinja2/) is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS) through the `xmlattr` filter. An attacker can manipulate the output of web pages by injecting additional attributes into elements, potentially leading to unauthorized actions or information disclosure.\r\n\r\n**Note:**\r\nThis vulnerability derives from an improper fix of [CVE-2024-22195](https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-6150717), which only addressed spaces but not other characters.\n## Details\n\nCross-site scripting (or XSS) is a code vulnerability that occurs when an attacker \u201cinjects\u201d a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user\u2019s browser when the user interacts with the compromised website.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser\u2019s Same Origin Policy.\n\nInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they\u2019ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user\u2019s browser.| \n|**DOM-based**|Client|The attacker forces the user\u2019s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `Jinja2` to version 3.1.4 or higher.\n## References\n- [GitHub Commit](https://github.com/pallets/jinja/commit/0668239dc6b44ef38e7a6c9f91f312fd4ca581cb)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000044",
+          "locations": [
+            {
+              "package": {
+                "name": "jinja2",
+                "version": "2.7.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,3.1.4)"
+              ],
+              "created_at": "2024-05-07T07:25:05.908377Z",
+              "credits": [
+                "Ry0taK"
+              ],
+              "cvss_base_score": 5.4,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.4,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-05-07T07:34:20.297801Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5.4,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-05-09T13:32:50.637457Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 6.1,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-08-20T12:55:14.911468Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N",
+              "disclosed_at": "2024-05-06T14:20:59Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.70584",
+                "probability": "0.00673"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-JINJA2-6809379",
+              "initially_fixed_in_versions": [
+                "3.1.4"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-08-20T12:55:14.911468Z",
+              "package_name": "jinja2",
+              "package_version": "",
+              "published_at": "2024-05-07T07:25:06.164752Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/jinja/commit/0668239dc6b44ef38e7a6c9f91f312fd4ca581cb"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-79",
+              "source": "cwe"
+            },
+            {
+              "id": "GHSA-h75v-3vvj-5mfj",
+              "source": "ghsa"
+            },
+            {
+              "id": "CVE-2024-34064",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 82
+            }
+          },
+          "title": "Cross-site Scripting (XSS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000044",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "jinja2",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "jinja2",
+                          "version": "3.1.4"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000044",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\nAffected versions of this package are vulnerable to Improper Neutralization when importing a macro in a template whose filename is also a template. This will result in a `SyntaxError: f-string: invalid syntax` error message because the filename is not properly escaped, indicating that it is being treated as a format string.\r\n\r\n**Note:** This is only exploitable when the attacker controls both the content and filename of a template and the application executes untrusted templates.\n## Remediation\nUpgrade `jinja2` to version 3.1.5 or higher.\n## References\n- [GitHub Commit](https://github.com/pallets/jinja/commit/767b23617628419ae3709ccfb02f9602ae9fe51f)\n- [GitHub Issue](https://github.com/pallets/jinja/issues/1792)\n- [GitHub PR](https://github.com/pallets/jinja/pull/1852)\n- [GitHub Release](https://github.com/pallets/jinja/releases/tag/3.1.5)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000045",
+          "locations": [
+            {
+              "package": {
+                "name": "jinja2",
+                "version": "2.7.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,3.1.5)"
+              ],
+              "created_at": "2024-12-24T11:51:17.721758Z",
+              "credits": [
+                "Simon Leiner"
+              ],
+              "cvss_base_score": 5.4,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.4,
+                  "cvss_version": "4.0",
+                  "modified_at": "2025-09-23T08:02:44.358322Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:P/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 8.8,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-09-23T08:02:44.358322Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 8.8,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-09-23T01:14:01.784017Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 7.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-12-24T14:17:27.023982Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 8.1,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-01-04T11:01:10.944302Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:P/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+              "disclosed_at": "2024-12-23T17:54:12Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.08120",
+                "probability": "0.00031"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-JINJA2-8548987",
+              "initially_fixed_in_versions": [
+                "3.1.5"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-09-23T08:02:44.358322Z",
+              "package_name": "jinja2",
+              "package_version": "",
+              "published_at": "2024-12-24T12:02:30.762445Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/jinja/commit/767b23617628419ae3709ccfb02f9602ae9fe51f"
+                },
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/pallets/jinja/issues/1792"
+                },
+                {
+                  "title": "GitHub PR",
+                  "url": "https://github.com/pallets/jinja/pull/1852"
+                },
+                {
+                  "title": "GitHub Release",
+                  "url": "https://github.com/pallets/jinja/releases/tag/3.1.5"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CVE-2024-56201",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-150",
+              "source": "cwe"
+            },
+            {
+              "id": "GHSA-gmj6-6f8f-6699",
+              "source": "ghsa"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 190
+            }
+          },
+          "title": "Improper Neutralization"
+        },
+        "id": "00000000-0000-0000-0000-000000000045",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "jinja2",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "jinja2",
+                          "version": "3.1.5"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000045",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[Werkzeug](https://werkzeug.palletsprojects.com/) is a WSGI web application library.\n\nAffected versions of this package are vulnerable to Directory Traversal due to a bypass for `os.path.isabs()`, which allows the improper handling of UNC paths beginning with `/`, in the `safe_join()` function. This allows an attacker to read some files on the affected server, if they are stored in an affected path.\n\n**Note:** This is only exploitable on Windows systems using Python versions prior to 3.11.\n\n## Details\n\nA Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with \"dot-dot-slash (../)\" sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.\n\nDirectory Traversal vulnerabilities can be generally divided into two types:\n\n- **Information Disclosure**: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.\n\n`st` is a module for serving static files on web pages, and contains a [vulnerability of this type](https://snyk.io/vuln/npm:st:20140206). In our example, we will serve files from the `public` route.\n\nIf an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.\n\n```\ncurl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa\n```\n**Note** `%2e` is the URL encoded version of `.` (dot).\n\n- **Writing arbitrary files**: Allows the attacker to create or replace existing files. This type of vulnerability is also known as `Zip-Slip`. \n\nOne way to achieve this is by using a malicious `zip` archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\n\nThe following is an example of a `zip` archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\n\n```\n2018-04-15 22:04:29 .....           19           19  good.txt\n2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys\n```\n\n## Remediation\nUpgrade `Werkzeug` to version 3.0.6 or higher.\n## References\n- [GitHub Commit](https://github.com/pallets/werkzeug/commit/2767bcb10a7dd1c297d812cc5e6d11a474c1f092)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "werkzeug",
+                  "version": "3.0.1"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "werkzeug",
+                  "version": "3.0.1"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000046",
+          "locations": [
+            {
+              "package": {
+                "name": "werkzeug",
+                "version": "3.0.1"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CWE-22",
+              "source": "cwe"
+            },
+            {
+              "id": "CVE-2024-49766",
+              "source": "cve"
+            },
+            {
+              "id": "GHSA-f9vj-2wh5-fj8j",
+              "source": "ghsa"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,3.0.6)"
+              ],
+              "created_at": "2024-10-27T07:51:17.655825Z",
+              "credits": [
+                "nvn1729"
+              ],
+              "cvss_base_score": 6.3,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.3,
+                  "cvss_version": "4.0",
+                  "modified_at": "2024-10-27T07:51:18.284807Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 3.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-10-27T07:51:18.284807Z",
+                  "severity": "low",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 3.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-10-26T13:33:43.496915Z",
+                  "severity": "low",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
+              "disclosed_at": "2024-10-25T19:43:41Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.19428",
+                "probability": "0.00062"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-WERKZEUG-8309091",
+              "initially_fixed_in_versions": [
+                "3.0.6"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-10-27T07:51:18.284807Z",
+              "package_name": "werkzeug",
+              "package_version": "",
+              "published_at": "2024-10-27T07:51:18.252581Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/werkzeug/commit/2767bcb10a7dd1c297d812cc5e6d11a474c1f092"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 53
+            }
+          },
+          "title": "Directory Traversal"
+        },
+        "id": "00000000-0000-0000-0000-000000000046",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "werkzeug",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "werkzeug",
+                          "version": "3.0.6"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000046",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\nAffected versions of this package are vulnerable to Remote Code Execution (RCE) due to insufficient hostname checks and the use of relative paths to resolve requests. When the debugger is enabled, an attacker can convince a user to enter their own PIN to interact with a domain and subdomain they control, and thereby cause malicious code to be executed.\r\n\r\nThe demonstrated attack vector requires a number of conditions that render this attack very difficult to achieve, especially if the victim application is running in the recommended configuration of not having the debugger enabled in production.\n## Remediation\nUpgrade `werkzeug` to version 3.0.3 or higher.\n## References\n- [GitHub Commit](https://github.com/pallets/werkzeug/commit/71b69dfb7df3d912e66bab87fbb1f21f83504967)\n- [GitHub Release](https://github.com/pallets/werkzeug/releases/tag/3.0.3)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "werkzeug",
+                  "version": "3.0.1"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "werkzeug",
+                  "version": "3.0.1"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000047",
+          "locations": [
+            {
+              "package": {
+                "name": "werkzeug",
+                "version": "3.0.1"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CWE-94",
+              "source": "cwe"
+            },
+            {
+              "id": "CVE-2024-34069",
+              "source": "cve"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,3.0.3)"
+              ],
+              "created_at": "2024-05-06T07:14:00.654405Z",
+              "credits": [
+                "RyotaK"
+              ],
+              "cvss_base_score": 7.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-05-06T07:25:10.516775Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-05-09T13:32:47.011978Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-05-11T11:02:22.89022Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H",
+              "disclosed_at": "2024-05-06T01:48:44Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.97168",
+                "probability": "0.40316"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-WERKZEUG-6808933",
+              "initially_fixed_in_versions": [
+                "3.0.3"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-05-11T11:02:22.89022Z",
+              "package_name": "werkzeug",
+              "package_version": "",
+              "published_at": "2024-05-06T07:25:10.516467Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/werkzeug/commit/71b69dfb7df3d912e66bab87fbb1f21f83504967"
+                },
+                {
+                  "title": "GitHub Release",
+                  "url": "https://github.com/pallets/werkzeug/releases/tag/3.0.3"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "GHSA-2g68-c3qc-8985",
+              "source": "ghsa"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 292
+            }
+          },
+          "title": "Remote Code Execution (RCE)"
+        },
+        "id": "00000000-0000-0000-0000-000000000047",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "werkzeug",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "werkzeug",
+                          "version": "3.0.3"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000047",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\nAffected versions of this package are vulnerable to Allocation of Resources Without Limits or Throttling in `formparser.MultiPartParser()`. An attacker can cause the parser to consume more memory than the upload size, in excess of `max_form_memory_size`, by sending malicious data in a non-file field of a  `multipart/form-data` request.\n## Remediation\nUpgrade `werkzeug` to version 3.0.6 or higher.\n## References\n- [GitHub Commit](https://github.com/pallets/quart/commit/5e78c4169b8eb66b91ead3e62d44721b9e1644ee)\n- [GitHub Commit](https://github.com/pallets/werkzeug/commit/50cfeebcb0727e18cc52ffbeb125f4a66551179b)\n- [GitHub Release](https://github.com/pallets/werkzeug/releases/tag/3.0.6)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "werkzeug",
+                  "version": "3.0.1"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "werkzeug",
+                  "version": "3.0.1"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000048",
+          "locations": [
+            {
+              "package": {
+                "name": "werkzeug",
+                "version": "3.0.1"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "GHSA-q34m-jh98-gwm2",
+              "source": "ghsa"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,3.0.6)"
+              ],
+              "created_at": "2024-10-27T07:59:29.444255Z",
+              "credits": [
+                "Marcel Hellkamp"
+              ],
+              "cvss_base_score": 6.9,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.9,
+                  "cvss_version": "4.0",
+                  "modified_at": "2024-10-27T07:59:29.915337Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-10-27T07:59:29.915337Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-11-06T01:12:38.829485Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-10-31T11:03:44.375939Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N",
+              "disclosed_at": "2024-10-25T20:41:17.907Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.74358",
+                "probability": "0.00865"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-WERKZEUG-8309092",
+              "initially_fixed_in_versions": [
+                "3.0.6"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-11-06T01:12:38.829485Z",
+              "package_name": "werkzeug",
+              "package_version": "",
+              "published_at": "2024-10-27T07:59:29.673376Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/quart/commit/5e78c4169b8eb66b91ead3e62d44721b9e1644ee"
+                },
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/werkzeug/commit/50cfeebcb0727e18cc52ffbeb125f4a66551179b"
+                },
+                {
+                  "title": "GitHub Release",
+                  "url": "https://github.com/pallets/werkzeug/releases/tag/3.0.6"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-770",
+              "source": "cwe"
+            },
+            {
+              "id": "CVE-2024-49767",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 61
+            }
+          },
+          "title": "Allocation of Resources Without Limits or Throttling"
+        },
+        "id": "00000000-0000-0000-0000-000000000048",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "werkzeug",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "werkzeug",
+                          "version": "3.0.6"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000048",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[Jinja2](https://pypi.org/project/Jinja2/) is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS) via the `xmlattr` filter, when using keys containing spaces in an application accepts keys as user input. An attacker can inject arbitrary HTML attributes into the rendered HTML template, bypassing the auto-escaping mechanism, which may lead to the execution of untrusted scripts in the context of the user's browser session.\r\n\r\n**Note**\r\nAccepting keys as user input is not common or a particularly intended use case of the `xmlattr` filter, and an application doing so should already be verifying what keys are provided regardless of this fix.\n## Details\n\nCross-site scripting (or XSS) is a code vulnerability that occurs when an attacker \u201cinjects\u201d a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user\u2019s browser when the user interacts with the compromised website.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser\u2019s Same Origin Policy.\n\nInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they\u2019ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user\u2019s browser.| \n|**DOM-based**|Client|The attacker forces the user\u2019s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `Jinja2` to version 3.1.3 or higher.\n## References\n- [GitHub Commit](https://github.com/pallets/jinja/commit/7dd3680e6eea0d77fde024763657aa4d884ddb23)\n- [GitHub Release](https://github.com/pallets/jinja/releases/tag/3.1.3)\n- [Snyk Blog](https://snyk.io/blog/jinja2-xss-vulnerability/)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000049",
+          "locations": [
+            {
+              "package": {
+                "name": "jinja2",
+                "version": "2.7.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,3.1.3)"
+              ],
+              "created_at": "2024-01-11T11:25:09.41142Z",
+              "credits": [
+                "Calum Hutton - Snyk Research Team"
+              ],
+              "cvss_base_score": 5.4,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.4,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:09:45.934904Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 6.1,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:49:28.614817Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5.4,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:49:09.732576Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 5.4,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-08-20T12:57:33.703043Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N",
+              "disclosed_at": "2024-01-11T04:07:02Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.30236",
+                "probability": "0.00111"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-JINJA2-6150717",
+              "initially_fixed_in_versions": [
+                "3.1.3"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-08-20T12:57:33.703043Z",
+              "package_name": "jinja2",
+              "package_version": "",
+              "published_at": "2024-01-11T11:25:09.594006Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/jinja/commit/7dd3680e6eea0d77fde024763657aa4d884ddb23"
+                },
+                {
+                  "title": "GitHub Release",
+                  "url": "https://github.com/pallets/jinja/releases/tag/3.1.3"
+                },
+                {
+                  "title": "Snyk Blog",
+                  "url": "https://snyk.io/blog/jinja2-xss-vulnerability/"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-79",
+              "source": "cwe"
+            },
+            {
+              "id": "GHSA-h5c8-rqwp-cp95",
+              "source": "ghsa"
+            },
+            {
+              "id": "CVE-2024-22195",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 81
+            }
+          },
+          "title": "Cross-site Scripting (XSS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000049",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "jinja2",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "jinja2",
+                          "version": "3.1.3"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000049",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[Jinja2](https://pypi.org/project/Jinja2/) is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). The ReDoS vulnerability is mainly due to the `_punctuation_re regex` operator and its use of multiple wildcards. The last wildcard is the most exploitable as it searches for trailing punctuation.\r\n\r\nThis issue can be mitigated by using Markdown to format user content instead of the urlize filter, or by implementing request timeouts or limiting process memory.\r\n\r\n### PoC by Yeting Li\r\n```\r\nfrom jinja2.utils import urlize\r\nfrom time import perf_counter\r\n\r\nfor i in range(3):\r\n    text = \"abc@\" + \".\" * (i+1)*5000 + \"!\"\r\n    LEN = len(text)\r\n    BEGIN = perf_counter()\r\n    urlize(text)\r\n    DURATION = perf_counter() - BEGIN\r\n    print(f\"{LEN}: took {DURATION} seconds!\")\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet\u2019s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn\u2019t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `Jinja2` to version 2.11.3 or higher.\n## References\n- [GitHub Additional Information](https://github.com/pallets/jinja/blob/ab81fd9c277900c85da0c322a2ff9d68a235b2e6/src/jinja2/utils.py#L20)\n- [GitHub PR](https://github.com/pallets/jinja/pull/1343)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000050",
+          "locations": [
+            {
+              "package": {
+                "name": "jinja2",
+                "version": "2.7.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2020-28493",
+              "source": "cve"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,2.11.3)"
+              ],
+              "created_at": "2020-09-25T17:30:26.286074Z",
+              "credits": [
+                "Yeting Li"
+              ],
+              "cvss_base_score": 5.3,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:04:06.963646Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:50:53.40137Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:53:50.836875Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:49:33.018698Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P",
+              "disclosed_at": "2020-09-25T17:29:19Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.43083",
+                "probability": "0.00207"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "proof of concept",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "proof of concept",
+                    "type": "primary"
+                  }
+                ],
+                "sources": [
+                  "Snyk"
+                ]
+              },
+              "id": "SNYK-PYTHON-JINJA2-1012994",
+              "initially_fixed_in_versions": [
+                "2.11.3"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:53:50.836875Z",
+              "package_name": "jinja2",
+              "package_version": "",
+              "published_at": "2021-02-01T19:52:17Z",
+              "references": [
+                {
+                  "title": "GitHub Additional Information",
+                  "url": "https://github.com/pallets/jinja/blob/ab81fd9c277900c85da0c322a2ff9d68a235b2e6/src/jinja2/utils.py%23L20"
+                },
+                {
+                  "title": "GitHub PR",
+                  "url": "https://github.com/pallets/jinja/pull/1343"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-400",
+              "source": "cwe"
+            },
+            {
+              "id": "GHSA-g3rq-g295-4j3m",
+              "source": "ghsa"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 84
+            }
+          },
+          "title": "Regular Expression Denial of Service (ReDoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000050",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "jinja2",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "jinja2",
+                          "version": "2.11.3"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000050",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[Jinja2](https://pypi.org/project/Jinja2/) is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.\n\nAffected versions of this package are vulnerable to Sandbox Bypass. Users were allowed to insert `str.format` through web templates, leading to an escape from sandbox.\n## Remediation\nUpgrade `Jinja2` to version 2.8.1 or higher.\n## References\n- [GitHub Commit](https://github.com/pallets/jinja/commit/9b53045c34e61013dc8f09b7e52a555fa16bed16)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000051",
+          "locations": [
+            {
+              "package": {
+                "name": "jinja2",
+                "version": "2.7.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2016-10745",
+              "source": "cve"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[2.5, 2.8.1)"
+              ],
+              "created_at": "2019-07-29T13:28:48.288799Z",
+              "credits": [
+                "Unknown"
+              ],
+              "cvss_base_score": 8.6,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 8.6,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:01:45.822509Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 8.6,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:49:01.839274Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 9,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:53:54.746382Z",
+                  "severity": "critical",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 8.7,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:50:04.202472Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N",
+              "disclosed_at": "2016-12-29T13:27:18Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.76752",
+                "probability": "0.01042"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-JINJA2-455616",
+              "initially_fixed_in_versions": [
+                "2.8.1"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:53:54.746382Z",
+              "package_name": "jinja2",
+              "package_version": "",
+              "published_at": "2019-07-30T13:11:16Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/jinja/commit/9b53045c34e61013dc8f09b7e52a555fa16bed16"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-234",
+              "source": "cwe"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 171
+            }
+          },
+          "title": "Sandbox Bypass"
+        },
+        "id": "00000000-0000-0000-0000-000000000051",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "jinja2",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "jinja2",
+                          "version": "2.8.1"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000051",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[Jinja2](https://pypi.org/project/Jinja2/) is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.\n\nAffected versions of this package are vulnerable to Template Injection through the `|attr` filter. An attacker that controls the content of a template can escape the sandbox and execute arbitrary Python code by using the `|attr` filter to get a reference to a string's plain format method, bypassing the environment's attribute lookup.\r\n\r\n**Note:**\r\n\r\nThis is only exploitable if the application executes untrusted templates.\n## Remediation\nUpgrade `Jinja2` to version 3.1.6 or higher.\n## References\n- [GitHub Commit](https://github.com/pallets/jinja/commit/90457bbf33b8662926ae65cdde4c4c32e756e403)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "python",
+                  "version": "0.0.0"
+                },
+                {
+                  "name": "flask",
+                  "version": "3.0.0"
+                },
+                {
+                  "name": "jinja2",
+                  "version": "2.7.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000052",
+          "locations": [
+            {
+              "package": {
+                "name": "jinja2",
+                "version": "2.7.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2025-27516",
+              "source": "cve"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "[,3.1.6)"
+              ],
+              "created_at": "2025-03-06T07:35:01.694695Z",
+              "credits": [
+                "securingapps"
+              ],
+              "cvss_base_score": 5.4,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.4,
+                  "cvss_version": "4.0",
+                  "modified_at": "2025-09-23T08:02:28.951339Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:P/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 8.8,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-09-23T08:02:28.951339Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 8.8,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-09-23T01:14:06.79181Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 7.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-03-07T06:01:18.866548Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H"
+                },
+                {
+                  "assigner": "SUSE",
+                  "base_score": 6.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-03-20T11:02:43.03158Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:L/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:P/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+              "disclosed_at": "2025-03-05T20:40:14Z",
+              "ecosystem": {
+                "language": "python",
+                "package_manager": "pip",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.34457",
+                "probability": "0.00138"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-PYTHON-JINJA2-9292516",
+              "initially_fixed_in_versions": [
+                "3.1.6"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-09-23T08:02:28.951339Z",
+              "package_name": "jinja2",
+              "package_version": "",
+              "published_at": "2025-03-06T07:38:27.746434Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pallets/jinja/commit/90457bbf33b8662926ae65cdde4c4c32e756e403"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-1336",
+              "source": "cwe"
+            },
+            {
+              "id": "GHSA-cpwx-vrp4-4pq7",
+              "source": "ghsa"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 190
+            }
+          },
+          "title": "Template Injection"
+        },
+        "id": "00000000-0000-0000-0000-000000000052",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "jinja2",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "python",
+                          "version": "0.0.0"
+                        },
+                        {
+                          "name": "jinja2",
+                          "version": "3.1.6"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000052",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      }
+    ]
+  },
+  {
+    "testId": "3a3f152c-a6f1-4588-804a-34221361f235",
+    "testConfiguration": {
+      "local_policy": {
+        "fail_on_upgradable": false,
+        "severity_threshold": "low",
+        "suppress_pending_ignores": false
+      },
+      "timeout": {
+        "outcome": "fail",
+        "seconds": 1200
+      }
+    },
+    "metadata": {
+      "project-name": "tsc",
+      "display-target-file": "tsc/package.json",
+      "target-directory": "multi-project",
+      "dependency-count": 23,
+      "asset": "https://app.snyk.io/org/my-org/inventory/assets/01a01434-8c66-7ed7-b7b8-401a040153f1/overview"
+    },
+    "createdAt": "2025-11-13T15:29:19.594887Z",
+    "testSubject": {
+      "locator": {
+        "paths": [
+          "tsc/package-lock.json"
+        ],
+        "type": "local_path"
+      },
+      "type": "dep_graph"
+    },
+    "executionState": "finished",
+    "passFail": "fail",
+    "outcomeReason": "policy_breach",
+    "effectiveSummary": {
+      "count": 23,
+      "count_by": {
+        "result_type": {
+          "dast": 0,
+          "other": 0,
+          "sast": 0,
+          "sca": 23
+        },
+        "severity": {
+          "critical": 0,
+          "high": 6,
+          "low": 5,
+          "medium": 12,
+          "none": 0,
+          "other": 0
+        }
+      }
+    },
+    "rawSummary": {
+      "count": 23,
+      "count_by": {
+        "result_type": {
+          "dast": 0,
+          "other": 0,
+          "sast": 0,
+          "sca": 23
+        },
+        "severity": {
+          "critical": 0,
+          "high": 6,
+          "low": 5,
+          "medium": 12,
+          "none": 0,
+          "other": 0
+        }
+      }
+    },
+    "findingsComplete": true,
+    "findings": [
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) when including multiple regular expression parameters in a single segment, when the separator is not `.` (e.g. no `/:a-:b`). Poor performance will block the event loop and can lead to a DoS.\r\n\r\n**Note:**\r\n\r\nThis issue is caused due to an incomplete fix for [CVE-2024-45296](https://security.snyk.io/vuln/SNYK-JS-PATHTOREGEXP-7925106).\r\n\r\n## Workarounds\r\n\r\nThis can be mitigated by avoiding using two parameters within a single path segment, when the separator is not `.` (e.g. no `/:a-:b`). Alternatively, the regex used for both parameters can be defined to ensure they do not overlap to allow backtracking.\n## PoC\n```js\r\n/a${'-a'.repeat(8_000)}/a\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet\u2019s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn\u2019t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `path-to-regexp` to version 0.1.12 or higher.\n## References\n- [Blog Post](https://blakeembrey.com/posts/2024-09-web-redos)\n- [GitHub Commit](https://github.com/pillarjs/path-to-regexp/commit/f01c26a013b1889f0c217c643964513acf17f6a4)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "path-to-regexp",
+                  "version": "0.1.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000053",
+          "locations": [
+            {
+              "package": {
+                "name": "path-to-regexp",
+                "version": "0.1.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CWE-1333",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.1.12"
+              ],
+              "created_at": "2024-12-06T07:48:23.835603Z",
+              "credits": [
+                "Unknown"
+              ],
+              "cvss_base_score": 6.9,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.9,
+                  "cvss_version": "4.0",
+                  "modified_at": "2025-04-06T10:02:44.3334Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N/E:P"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-04-06T10:02:44.3334Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-12-07T13:35:59.477578Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N/E:P",
+              "disclosed_at": "2024-12-05T22:40:47Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.25432",
+                "probability": "0.00086"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "proof of concept",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "proof of concept",
+                    "type": "primary"
+                  }
+                ],
+                "sources": [
+                  "Snyk"
+                ]
+              },
+              "id": "SNYK-JS-PATHTOREGEXP-8482416",
+              "initially_fixed_in_versions": [
+                "0.1.12"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-04-06T10:02:44.3334Z",
+              "package_name": "path-to-regexp",
+              "package_version": "",
+              "published_at": "2024-12-06T07:48:24.198166Z",
+              "references": [
+                {
+                  "title": "Blog Post",
+                  "url": "https://blakeembrey.com/posts/2024-09-web-redos"
+                },
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pillarjs/path-to-regexp/commit/f01c26a013b1889f0c217c643964513acf17f6a4"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "GHSA-rhx6-c78j-4q9w",
+              "source": "ghsa"
+            },
+            {
+              "id": "CVE-2024-52798",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 61
+            }
+          },
+          "title": "Regular Expression Denial of Service (ReDoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000053",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "path-to-regexp",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.21.2"
+                        },
+                        {
+                          "name": "path-to-regexp",
+                          "version": "0.1.12"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000053",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[express](https://github.com/expressjs/express) is a minimalist web framework.\n\nAffected versions of this package are vulnerable to Cross-site Scripting due to improper handling of user input in the `response.redirect` method. An attacker can execute arbitrary code by passing malicious input to this method.\r\n\r\n\r\n**Note**\r\n\r\nTo exploit this vulnerability, the following conditions are required:\r\n\r\n1) The attacker should be able to control the input to `response.redirect()`\r\n\r\n2) express must not redirect before the template appears\r\n\r\n3) the browser must not complete redirection before:\r\n\r\n4) the user must click on the link in the template\n## Remediation\nUpgrade `express` to version 4.20.0, 5.0.0 or higher.\n## References\n- [GitHub Commit](https://github.com/expressjs/express/commit/54271f69b511fea198471e6ff3400ab805d6b553)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000054",
+          "locations": [
+            {
+              "package": {
+                "name": "express",
+                "version": "4.0.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<4.20.0",
+                ">=5.0.0-alpha.1 <5.0.0"
+              ],
+              "created_at": "2024-09-11T06:44:36.87127Z",
+              "credits": [
+                "AdamKorcz"
+              ],
+              "cvss_base_score": 5.1,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.1,
+                  "cvss_version": "4.0",
+                  "modified_at": "2024-09-11T12:24:12.257485Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:A/VC:N/VI:L/VA:N/SC:L/SI:L/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-11T12:24:12.257485Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 4.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-21T01:11:54.115308Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-11T13:47:33.875106Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:A/VC:N/VI:L/VA:N/SC:L/SI:L/SA:N",
+              "disclosed_at": "2024-09-10T15:15:17Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.20267",
+                "probability": "0.00065"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-JS-EXPRESS-7926867",
+              "initially_fixed_in_versions": [
+                "4.20.0",
+                "5.0.0"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-09-21T01:11:54.115308Z",
+              "package_name": "express",
+              "package_version": "",
+              "published_at": "2024-09-11T12:24:12.250365Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/expressjs/express/commit/54271f69b511fea198471e6ff3400ab805d6b553"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CVE-2024-43796",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-79",
+              "source": "cwe"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 75
+            }
+          },
+          "title": "Cross-site Scripting"
+        },
+        "id": "00000000-0000-0000-0000-000000000054",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "express",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.20.0"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000054",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\r\n[`express`](https://www.npmjs.com/package/express) is a minimalist web framework.\r\n\r\nAffected versions of this package do not enforce the user's browser to set a specific charset in the content-type header while displaying 400 level response messages. This could be used by remote attackers to perform a cross-site scripting attack, by using non-standard encodings like UTF-7.\r\n\r\n## Details\r\n<<XSS>>\r\n\r\n\r\n## Recommendations\r\nUpdate express to `3.11.0`, `4.5.0` or higher.\r\n\r\n## References\r\n- [GitHub release 3.11.0](https://github.com/expressjs/express/releases/tag/3.11.0)\r\n- [GitHub release 4.5.0](https://github.com/expressjs/express/releases/tag/4.5.0)",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000055",
+          "locations": [
+            {
+              "package": {
+                "name": "express",
+                "version": "4.0.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "GHSA-gpvr-g6gh-9mc2",
+              "source": "ghsa"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<3.11.0",
+                ">=4.0.0 <4.5.0"
+              ],
+              "created_at": "2014-09-12T04:46:45Z",
+              "credits": [
+                "Pawe\u0142 Ha\u0142drzy\u0144ski"
+              ],
+              "cvss_base_score": 5.4,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.4,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:57:29.707396Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 6.1,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:49:01.539136Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N",
+              "disclosed_at": "2014-09-12T04:46:45Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.52034",
+                "probability": "0.00290"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:express:20140912",
+              "initially_fixed_in_versions": [
+                "3.11.0",
+                "4.5.0"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:49:01.539136Z",
+              "package_name": "express",
+              "package_version": "",
+              "published_at": "2014-09-12T04:46:45Z",
+              "references": [
+                {
+                  "title": "GitHub Release",
+                  "url": "https://github.com/expressjs/express/releases/tag/3.11.0"
+                },
+                {
+                  "title": "GitHub Release",
+                  "url": "https://github.com/expressjs/express/releases/tag/4.5.0"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CVE-2014-6393",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-79",
+              "source": "cwe"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 69
+            }
+          },
+          "title": "Cross-site Scripting (XSS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000055",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "express",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.5.0"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000055",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\r\n[Send](https://www.npmjs.com/package/send) is a library for streaming files from the file system as an http response. It supports partial responses (Ranges), conditional-GET negotiation, high test coverage, and granular events which may be leveraged to take appropriate actions in your application or framework.\r\n\r\nAffected versions of this package are vulnerable to a Root Path Disclosure.\r\n\r\n## Remediation\r\nUpgrade `send` to version 0.11.1 or higher. \r\nIf a direct dependency update is not possible, use [snyk wizard](https://snyk.io/docs/using-snyk#wizard) to patch this vulnerability.\r\n\r\n## References\r\n- [GitHub PR](https://github.com/pillarjs/send/pull/70)\r\n- [GitHub Commit](https://github.com/pillarjs/send/commit/98a5b89982b38e79db684177cf94730ce7fc7aed)\r\n- [GitHub History](https://github.com/expressjs/serve-static/blob/master/HISTORY.md#181--2015-01-20)\r\n- [Expressjs Security Update](http://expressjs.com/advanced/security-updates.html)",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "send",
+                  "version": "0.2.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000056",
+          "locations": [
+            {
+              "package": {
+                "name": "send",
+                "version": "0.2.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.11.1"
+              ],
+              "created_at": "2015-11-06T02:09:36.183Z",
+              "credits": [
+                "Dinis Cruz"
+              ],
+              "cvss_base_score": 5.3,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:57:30.018205Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:53:36.449777Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+              "disclosed_at": "2015-11-03T07:12:20Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.40434",
+                "probability": "0.00184"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:send:20151103",
+              "initially_fixed_in_versions": [
+                "0.11.1"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:53:36.449777Z",
+              "package_name": "send",
+              "package_version": "",
+              "published_at": "2015-11-06T02:09:36Z",
+              "references": [
+                {
+                  "title": "Expressjs Security Update",
+                  "url": "http://expressjs.com/advanced/security-updates.html"
+                },
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pillarjs/send/commit/98a5b89982b38e79db684177cf94730ce7fc7aed"
+                },
+                {
+                  "title": "GitHub History",
+                  "url": "https://github.com/expressjs/serve-static/blob/master/HISTORY.md%23181--2015-01-20"
+                },
+                {
+                  "title": "GitHub PR",
+                  "url": "https://github.com/pillarjs/send/pull/70"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "GHSA-jgqf-hwc5-hh37",
+              "source": "ghsa"
+            },
+            {
+              "id": "CWE-200",
+              "source": "cwe"
+            },
+            {
+              "id": "CVE-2015-8859",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 40
+            }
+          },
+          "title": "Root Path Disclosure"
+        },
+        "id": "00000000-0000-0000-0000-000000000056",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "send",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.11.1"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.11.1"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000056",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\r\n[Send](https://www.npmjs.com/package/send) is a library for streaming files from the file system as an http response. It supports partial responses (Ranges), conditional-GET negotiation, high test coverage, and granular events which may be leveraged to take appropriate actions in your application or framework.\r\n\r\nAffected versions of this package are vulnerable to a Root Path Disclosure.\r\n\r\n## Remediation\r\nUpgrade `send` to version 0.11.1 or higher. \r\nIf a direct dependency update is not possible, use [snyk wizard](https://snyk.io/docs/using-snyk#wizard) to patch this vulnerability.\r\n\r\n## References\r\n- [GitHub PR](https://github.com/pillarjs/send/pull/70)\r\n- [GitHub Commit](https://github.com/pillarjs/send/commit/98a5b89982b38e79db684177cf94730ce7fc7aed)\r\n- [GitHub History](https://github.com/expressjs/serve-static/blob/master/HISTORY.md#181--2015-01-20)\r\n- [Expressjs Security Update](http://expressjs.com/advanced/security-updates.html)",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "serve-static",
+                  "version": "1.0.1"
+                },
+                {
+                  "name": "send",
+                  "version": "0.1.4"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000057",
+          "locations": [
+            {
+              "package": {
+                "name": "send",
+                "version": "0.1.4"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.11.1"
+              ],
+              "created_at": "2015-11-06T02:09:36.183Z",
+              "credits": [
+                "Dinis Cruz"
+              ],
+              "cvss_base_score": 5.3,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:57:30.018205Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:53:36.449777Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+              "disclosed_at": "2015-11-03T07:12:20Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.40434",
+                "probability": "0.00184"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:send:20151103",
+              "initially_fixed_in_versions": [
+                "0.11.1"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:53:36.449777Z",
+              "package_name": "send",
+              "package_version": "",
+              "published_at": "2015-11-06T02:09:36Z",
+              "references": [
+                {
+                  "title": "Expressjs Security Update",
+                  "url": "http://expressjs.com/advanced/security-updates.html"
+                },
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pillarjs/send/commit/98a5b89982b38e79db684177cf94730ce7fc7aed"
+                },
+                {
+                  "title": "GitHub History",
+                  "url": "https://github.com/expressjs/serve-static/blob/master/HISTORY.md%23181--2015-01-20"
+                },
+                {
+                  "title": "GitHub PR",
+                  "url": "https://github.com/pillarjs/send/pull/70"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "GHSA-jgqf-hwc5-hh37",
+              "source": "ghsa"
+            },
+            {
+              "id": "CWE-200",
+              "source": "cwe"
+            },
+            {
+              "id": "CVE-2015-8859",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 40
+            }
+          },
+          "title": "Root Path Disclosure"
+        },
+        "id": "00000000-0000-0000-0000-000000000057",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "send",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.11.0"
+                        },
+                        {
+                          "name": "serve-static",
+                          "version": "1.8.1"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.11.1"
+                        }
+                      ],
+                      "is_drop": false
+                    },
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.11.1"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.11.1"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000057",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[serve-static](https://github.com/expressjs/serve-static) is a server.\n\nAffected versions of this package are vulnerable to Cross-site Scripting due to improper sanitization of user input in the `redirect` function. An attacker can manipulate the redirection process by injecting malicious code into the input. \r\n\r\n\r\n**Note**\r\n\r\nTo exploit this vulnerability, the following conditions are required:\r\n\r\n1) The attacker should be able to control the input to `response.redirect()`\r\n\r\n2) express must not redirect before the template appears\r\n\r\n3) the browser must not complete redirection before:\r\n\r\n4) the user must click on the link in the template\n## Details\n\nCross-site scripting (or XSS) is a code vulnerability that occurs when an attacker \u201cinjects\u201d a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user\u2019s browser when the user interacts with the compromised website.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser\u2019s Same Origin Policy.\n\nInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they\u2019ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user\u2019s browser.| \n|**DOM-based**|Client|The attacker forces the user\u2019s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `serve-static` to version 1.16.0, 2.1.0 or higher.\n## References\n- [GitHub Commit](https://github.com/expressjs/serve-static/commit/0c11fad159898cdc69fd9ab63269b72468ecaf6b)\n- [GitHub Commit](https://github.com/expressjs/serve-static/commit/ce730896fddce1588111d9ef6fdf20896de5c6fa)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "serve-static",
+                  "version": "1.0.1"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000058",
+          "locations": [
+            {
+              "package": {
+                "name": "serve-static",
+                "version": "1.0.1"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2024-43800",
+              "source": "cve"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<1.16.0",
+                ">=2.0.0 <2.1.0"
+              ],
+              "created_at": "2024-09-11T06:31:22.554663Z",
+              "credits": [
+                "Adam Korcz"
+              ],
+              "cvss_base_score": 2.1,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 2.1,
+                  "cvss_version": "4.0",
+                  "modified_at": "2024-09-11T12:14:57.834182Z",
+                  "severity": "low",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:A/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-11T12:14:57.834182Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 4.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-21T01:11:59.044439Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-11T13:49:16.84827Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:A/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N",
+              "disclosed_at": "2024-09-10T15:15:17Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.51064",
+                "probability": "0.00280"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-JS-SERVESTATIC-7926865",
+              "initially_fixed_in_versions": [
+                "1.16.0",
+                "2.1.0"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-09-21T01:11:59.044439Z",
+              "package_name": "serve-static",
+              "package_version": "",
+              "published_at": "2024-09-11T12:14:52.762373Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/expressjs/serve-static/commit/0c11fad159898cdc69fd9ab63269b72468ecaf6b"
+                },
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/expressjs/serve-static/commit/ce730896fddce1588111d9ef6fdf20896de5c6fa"
+                }
+              ],
+              "severity": "low",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-79",
+              "source": "cwe"
+            }
+          ],
+          "rating": {
+            "severity": "low"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 57
+            }
+          },
+          "title": "Cross-site Scripting"
+        },
+        "id": "00000000-0000-0000-0000-000000000058",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "serve-static",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.20.0"
+                        },
+                        {
+                          "name": "serve-static",
+                          "version": "1.16.0"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000058",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[qs](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\n\nAffected versions of this package are vulnerable to Prototype Poisoning which allows attackers to cause a Node process to hang, processing an Array object whose prototype has been replaced by one with an excessive length value.\r\n\r\n**Note:** In many typical Express use cases, an unauthenticated remote attacker can place the attack payload in the query string of the URL that is used to visit the application, such as `a[__proto__]=b&a[__proto__]&a[length]=100000000`.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\n\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\n\nTwo common types of DoS vulnerabilities:\n\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](https://security.snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-30082).\n\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](https://snyk.io/vuln/npm:ws:20171108)\n\n## Remediation\nUpgrade `qs` to version 6.2.4, 6.3.3, 6.4.1, 6.5.3, 6.6.1, 6.7.3, 6.8.3, 6.9.7, 6.10.3 or higher.\n## References\n- [GitHub PR](https://github.com/ljharb/qs/pull/428)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=2150323)\n- [Researcher Advisory](https://github.com/n8tz/CVE-2022-24999)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "qs",
+                  "version": "0.6.6"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000059",
+          "locations": [
+            {
+              "package": {
+                "name": "qs",
+                "version": "0.6.6"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CWE-1321",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<6.2.4",
+                ">=6.3.0 <6.3.3",
+                ">=6.4.0 <6.4.1",
+                ">=6.5.0 <6.5.3",
+                ">=6.6.0 <6.6.1",
+                ">=6.7.0 <6.7.3",
+                ">=6.8.0 <6.8.3",
+                ">=6.9.0 <6.9.7",
+                ">=6.10.0 <6.10.3"
+              ],
+              "created_at": "2022-12-04T11:01:47.782869Z",
+              "credits": [
+                "BRAUN Nathanael",
+                "BRISSAUD Johan"
+              ],
+              "cvss_base_score": 7.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:06:01.312784Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:52:48.801266Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:53:59.571489Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P",
+              "disclosed_at": "2022-11-26T00:00:00Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.86312",
+                "probability": "0.03115"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "proof of concept",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "proof of concept",
+                    "type": "primary"
+                  }
+                ],
+                "sources": [
+                  "Snyk"
+                ]
+              },
+              "id": "SNYK-JS-QS-3153490",
+              "initially_fixed_in_versions": [
+                "6.2.4",
+                "6.3.3",
+                "6.4.1",
+                "6.5.3",
+                "6.6.1",
+                "6.7.3",
+                "6.8.3",
+                "6.9.7",
+                "6.10.3"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:53:59.571489Z",
+              "package_name": "qs",
+              "package_version": "",
+              "published_at": "2022-12-04T12:24:32.307833Z",
+              "references": [
+                {
+                  "title": "GitHub PR",
+                  "url": "https://github.com/ljharb/qs/pull/428"
+                },
+                {
+                  "title": "RedHat Bugzilla Bug",
+                  "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2150323"
+                },
+                {
+                  "title": "Researcher Advisory",
+                  "url": "https://github.com/n8tz/CVE-2022-24999"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CVE-2022-24999",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 150
+            }
+          },
+          "title": "Prototype Poisoning"
+        },
+        "id": "00000000-0000-0000-0000-000000000059",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "qs",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.17.3"
+                        },
+                        {
+                          "name": "qs",
+                          "version": "6.9.7"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000059",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[send](https://www.npmjs.com/package/send) is a library for streaming files from the file system.\n\nAffected versions of this package are vulnerable to Directory-Traversal attacks due to insecure comparison.\nWhen relying on the root option to restrict file access a malicious user may escape out of the restricted directory and access files in a similarly named directory. For example, a path like `/my-secret` is consedered fine for the root `/my`.\n\n## Details\nA Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with \"dot-dot-slash (../)\" sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.\r\n\r\nDirectory Traversal vulnerabilities can be generally divided into two types:\r\n\r\n- **Information Disclosure**: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.\r\n\r\n`st` is a module for serving static files on web pages, and contains a [vulnerability of this type](https://snyk.io/vuln/npm:st:20140206). In our example, we will serve files from the `public` route.\r\n\r\nIf an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.\r\n\r\n```\r\ncurl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa\r\n```\r\n**Note** `%2e` is the URL encoded version of `.` (dot).\r\n\r\n- **Writing arbitrary files**: Allows the attacker to create or replace existing files. This type of vulnerability is also known as `Zip-Slip`. \r\n\r\nOne way to achieve this is by using a malicious `zip` archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\r\n\r\nThe following is an example of a `zip` archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\r\n\r\n```\r\n2018-04-15 22:04:29 .....           19           19  good.txt\r\n2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys\r\n```\n \n\n## Remediation\nUpgrade to a version greater than or equal to 0.8.4.\n\n## References\n- [GitHub PR](https://github.com/visionmedia/send/pull/59)\n- [GitHub Commit](https://github.com/visionmedia/send/commit/9c6ca9b2c0b880afd3ff91ce0d211213c5fa5f9a)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "send",
+                  "version": "0.2.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000060",
+          "locations": [
+            {
+              "package": {
+                "name": "send",
+                "version": "0.2.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2014-6394",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-23",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "< 0.8.4"
+              ],
+              "created_at": "2014-09-12T05:06:33Z",
+              "credits": [
+                "Ilya Kantor"
+              ],
+              "cvss_base_score": 4.3,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 4.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:02:18.15324Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:46:22.60294Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+              "disclosed_at": "2014-09-12T05:06:33Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.89003",
+                "probability": "0.04842"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:send:20140912",
+              "initially_fixed_in_versions": [
+                "0.8.4"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:46:22.60294Z",
+              "package_name": "send",
+              "package_version": "",
+              "published_at": "2014-09-12T05:06:33Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/visionmedia/send/commit/9c6ca9b2c0b880afd3ff91ce0d211213c5fa5f9a"
+                },
+                {
+                  "title": "GitHub PR",
+                  "url": "https://github.com/visionmedia/send/pull/59"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "GHSA-xwg4-93c6-3h42",
+              "source": "ghsa"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 39
+            }
+          },
+          "title": "Directory Traversal"
+        },
+        "id": "00000000-0000-0000-0000-000000000060",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "send",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.8.8"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.8.5"
+                        }
+                      ],
+                      "is_drop": false
+                    },
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.8.0"
+                        },
+                        {
+                          "name": "serve-static",
+                          "version": "1.5.4"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.8.5"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000060",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\r\n\r\nWhen using serve-static middleware version < 1.7.2 and it's configured to mount at the root, it creates an open redirect on the site.\r\n\r\n_Source: [Node Security Project](https://nodesecurity.io/advisories/35)_\r\n\r\n## Details\r\n\r\nFor example:\r\n\r\nIf a user visits `http://example.com//www.google.com/%2e%2e` they will be redirected to `//www.google.com/%2e%2e`, which some browsers interpret as `http://www.google.com/%2e%2e`.\r\n\r\n## Remediation\r\n\r\n  * Update to version 1.7.2 or greater (or 1.6.5 if sticking to the 1.6.x line).\r\n  * Disable redirects if not using the feature with 'redirect: false' option and cannot upgrade.\r\n\r\n## References\r\n\r\n- https://github.com/expressjs/serve-static/issues/26\r\n- https://www.owasp.org/index.php/Open_redirect",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "serve-static",
+                  "version": "1.0.1"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000061",
+          "locations": [
+            {
+              "package": {
+                "name": "serve-static",
+                "version": "1.0.1"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2015-1164",
+              "source": "cve"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<1.6.5",
+                ">=1.7.0 <1.7.2"
+              ],
+              "created_at": "2015-01-13T12:50:48Z",
+              "credits": [
+                "Pierre-\u00c9lie Fauch\u00e9"
+              ],
+              "cvss_base_score": 3.1,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 3.1,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:00:34.618417Z",
+                  "severity": "low",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 4.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:45:57.300865Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N",
+              "disclosed_at": "2015-01-13T12:50:48Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.52880",
+                "probability": "0.00300"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:serve-static:20150113",
+              "initially_fixed_in_versions": [
+                "1.6.5",
+                "1.7.2"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:45:57.300865Z",
+              "package_name": "serve-static",
+              "package_version": "",
+              "published_at": "2015-01-13T12:50:48Z",
+              "references": [
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/expressjs/serve-static/issues/26"
+                }
+              ],
+              "severity": "low",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "GHSA-c3x7-gjmx-r2ff",
+              "source": "ghsa"
+            },
+            {
+              "id": "CWE-601",
+              "source": "cwe"
+            }
+          ],
+          "rating": {
+            "severity": "low"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 24
+            }
+          },
+          "title": "Open Redirect"
+        },
+        "id": "00000000-0000-0000-0000-000000000061",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "serve-static",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.9.0"
+                        },
+                        {
+                          "name": "serve-static",
+                          "version": "1.6.5"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000061",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS) via the cookie `name`, `path`, or `domain`, which can be used to set unexpected values to other cookie fields.\r\n\r\n## Workaround\r\nUsers who are not able to upgrade to the fixed version should avoid passing untrusted or arbitrary values for the cookie fields and ensure they are set by the application instead of user input.\n## Details\n\nCross-site scripting (or XSS) is a code vulnerability that occurs when an attacker \u201cinjects\u201d a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user\u2019s browser when the user interacts with the compromised website.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser\u2019s Same Origin Policy.\n\nInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they\u2019ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user\u2019s browser.| \n|**DOM-based**|Client|The attacker forces the user\u2019s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `cookie` to version 0.7.0 or higher.\n## References\n- [GitHub Commit](https://github.com/jshttp/cookie/commit/e10042845354fea83bd8f34af72475eed1dadf5c)\n- [GitHub PR](https://github.com/jshttp/cookie/pull/167)\n- [Red Hat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=2316549)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "cookie",
+                  "version": "0.1.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000062",
+          "locations": [
+            {
+              "package": {
+                "name": "cookie",
+                "version": "0.1.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.7.0"
+              ],
+              "created_at": "2024-10-06T09:52:27.790081Z",
+              "credits": [
+                "Unknown"
+              ],
+              "cvss_base_score": 6.3,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.3,
+                  "cvss_version": "4.0",
+                  "modified_at": "2025-03-10T06:41:09.255374Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 3.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-03-10T06:41:09.255374Z",
+                  "severity": "low",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 3.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-04-29T08:08:05.922006Z",
+                  "severity": "low",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N",
+              "disclosed_at": "2024-10-04T20:31:00Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.21369",
+                "probability": "0.00069"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-JS-COOKIE-8163060",
+              "initially_fixed_in_versions": [
+                "0.7.0"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-04-29T08:08:05.922006Z",
+              "package_name": "cookie",
+              "package_version": "",
+              "published_at": "2024-10-06T09:52:28.084562Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/jshttp/cookie/commit/e10042845354fea83bd8f34af72475eed1dadf5c"
+                },
+                {
+                  "title": "GitHub PR",
+                  "url": "https://github.com/jshttp/cookie/pull/167"
+                },
+                {
+                  "title": "Red Hat Bugzilla Bug",
+                  "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2316549"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CVE-2024-47764",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-79",
+              "source": "cwe"
+            },
+            {
+              "id": "GHSA-pxg6-pf52-xh8x",
+              "source": "ghsa"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 34
+            }
+          },
+          "title": "Cross-site Scripting (XSS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000062",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "cookie",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.21.1"
+                        },
+                        {
+                          "name": "cookie",
+                          "version": "0.7.1"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000062",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[qs](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\n\nAffected versions of this package are vulnerable to Prototype Override Protection Bypass. By default `qs` protects against attacks that attempt to overwrite an object's existing prototype properties, such as `toString()`, `hasOwnProperty()`,etc.\r\n\r\nFrom [`qs` documentation](https://github.com/ljharb/qs):\r\n> By default parameters that would overwrite properties on the object prototype are ignored, if you wish to keep the data from those fields either use plainObjects as mentioned above, or set allowPrototypes to true which will allow user input to overwrite those properties. WARNING It is generally a bad idea to enable this option as it can cause problems when attempting to use the properties that have been overwritten. Always be careful with this option.\r\n\r\nOverwriting these properties can impact application logic, potentially allowing attackers to work around security controls, modify data, make the application unstable and more.\r\n\r\nIn versions of the package affected by this vulnerability, it is possible to circumvent this protection and overwrite prototype properties and functions by prefixing the name of the parameter with `[` or `]`. e.g. `qs.parse(\"]=toString\")` will return `{toString = true}`, as a result, calling `toString()` on the object will throw an exception.\r\n\r\n**Example:**\r\n```js\r\nqs.parse('toString=foo', { allowPrototypes: false })\r\n// {}\r\n\r\nqs.parse(\"]=toString\", { allowPrototypes: false })\r\n// {toString = true} <== prototype overwritten\r\n```\r\n\r\nFor more information, you can check out our [blog](https://snyk.io/blog/high-severity-vulnerability-qs/).\r\n\r\n## Disclosure Timeline\r\n- February 13th, 2017 - Reported the issue to package owner.\r\n- February 13th, 2017 - Issue acknowledged by package owner.\r\n- February 16th, 2017 - Partial fix released in versions `6.0.3`, `6.1.1`, `6.2.2`, `6.3.1`.\r\n- March 6th, 2017     - Final fix released in versions `6.4.0`,`6.3.2`, `6.2.3`, `6.1.2` and `6.0.4`\n## Remediation\nUpgrade `qs` to version 6.0.4, 6.1.2, 6.2.3, 6.3.2 or higher.\n## References\n- [GitHub Commit](https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d)\n- [GitHub Issue](https://github.com/ljharb/qs/issues/200)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "qs",
+                  "version": "0.6.6"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000063",
+          "locations": [
+            {
+              "package": {
+                "name": "qs",
+                "version": "0.6.6"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "GHSA-gqgv-6jq5-jjj9",
+              "source": "ghsa"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<6.0.4",
+                ">=6.1.0 <6.1.2",
+                ">=6.2.0 <6.2.3",
+                ">=6.3.0 <6.3.2"
+              ],
+              "created_at": "2017-02-14T11:44:54.163Z",
+              "credits": [
+                "Snyk Security Research Team"
+              ],
+              "cvss_base_score": 7.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:03:33.996696Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:46:34.338137Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5.3,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:48:53.414157Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "disclosed_at": "2017-02-13T00:00:00Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.66386",
+                "probability": "0.00532"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:qs:20170213",
+              "initially_fixed_in_versions": [
+                "6.0.4",
+                "6.1.2",
+                "6.2.3",
+                "6.3.2"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:48:53.414157Z",
+              "package_name": "qs",
+              "package_version": "",
+              "published_at": "2017-03-01T10:00:54Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d"
+                },
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/ljharb/qs/issues/200"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-20",
+              "source": "cwe"
+            },
+            {
+              "id": "CVE-2017-1000048",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 101
+            }
+          },
+          "title": "Prototype Override Protection Bypass"
+        },
+        "id": "00000000-0000-0000-0000-000000000063",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "qs",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.15.2"
+                        },
+                        {
+                          "name": "qs",
+                          "version": "6.4.0"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000063",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[send](https://www.npmjs.com/package/send) is a library for streaming files from the file system.\n\nAffected versions of this package are vulnerable to Directory-Traversal attacks due to insecure comparison.\nWhen relying on the root option to restrict file access a malicious user may escape out of the restricted directory and access files in a similarly named directory. For example, a path like `/my-secret` is consedered fine for the root `/my`.\n\n## Details\nA Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with \"dot-dot-slash (../)\" sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.\r\n\r\nDirectory Traversal vulnerabilities can be generally divided into two types:\r\n\r\n- **Information Disclosure**: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.\r\n\r\n`st` is a module for serving static files on web pages, and contains a [vulnerability of this type](https://snyk.io/vuln/npm:st:20140206). In our example, we will serve files from the `public` route.\r\n\r\nIf an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.\r\n\r\n```\r\ncurl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa\r\n```\r\n**Note** `%2e` is the URL encoded version of `.` (dot).\r\n\r\n- **Writing arbitrary files**: Allows the attacker to create or replace existing files. This type of vulnerability is also known as `Zip-Slip`. \r\n\r\nOne way to achieve this is by using a malicious `zip` archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\r\n\r\nThe following is an example of a `zip` archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\r\n\r\n```\r\n2018-04-15 22:04:29 .....           19           19  good.txt\r\n2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys\r\n```\n \n\n## Remediation\nUpgrade to a version greater than or equal to 0.8.4.\n\n## References\n- [GitHub PR](https://github.com/visionmedia/send/pull/59)\n- [GitHub Commit](https://github.com/visionmedia/send/commit/9c6ca9b2c0b880afd3ff91ce0d211213c5fa5f9a)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "serve-static",
+                  "version": "1.0.1"
+                },
+                {
+                  "name": "send",
+                  "version": "0.1.4"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000064",
+          "locations": [
+            {
+              "package": {
+                "name": "send",
+                "version": "0.1.4"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2014-6394",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-23",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "< 0.8.4"
+              ],
+              "created_at": "2014-09-12T05:06:33Z",
+              "credits": [
+                "Ilya Kantor"
+              ],
+              "cvss_base_score": 4.3,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 4.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T14:02:18.15324Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:46:22.60294Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+              "disclosed_at": "2014-09-12T05:06:33Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.89003",
+                "probability": "0.04842"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:send:20140912",
+              "initially_fixed_in_versions": [
+                "0.8.4"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:46:22.60294Z",
+              "package_name": "send",
+              "package_version": "",
+              "published_at": "2014-09-12T05:06:33Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/visionmedia/send/commit/9c6ca9b2c0b880afd3ff91ce0d211213c5fa5f9a"
+                },
+                {
+                  "title": "GitHub PR",
+                  "url": "https://github.com/visionmedia/send/pull/59"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "GHSA-xwg4-93c6-3h42",
+              "source": "ghsa"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 39
+            }
+          },
+          "title": "Directory Traversal"
+        },
+        "id": "00000000-0000-0000-0000-000000000064",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "send",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.8.0"
+                        },
+                        {
+                          "name": "serve-static",
+                          "version": "1.5.4"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.8.5"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000064",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[express](https://github.com/expressjs/express) is a minimalist web framework.\n\nAffected versions of this package are vulnerable to Open Redirect due to the implementation of URL encoding using `encodeurl` before passing it to the `location` header. This can lead to unexpected evaluations of malformed URLs by common redirect allow list implementations in applications, allowing an attacker to bypass a properly implemented allow list and redirect users to malicious sites.\n## Remediation\nUpgrade `express` to version 4.19.2, 5.0.0-beta.3 or higher.\n## References\n- [Github Commit](https://github.com/expressjs/express/commit/0b746953c4bd8e377123527db11f9cd866e39f94)\n- [GitHub Commit](https://github.com/expressjs/express/commit/0867302ddbde0e9463d0564fea5861feb708c2dd)\n- [Github Issue](https://github.com/koajs/koa/issues/1800)\n- [GitHub PR](https://github.com/expressjs/express/pull/5551)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000065",
+          "locations": [
+            {
+              "package": {
+                "name": "express",
+                "version": "4.0.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2024-29041",
+              "source": "cve"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<4.19.2",
+                ">=5.0.0-alpha.1 <5.0.0-beta.3"
+              ],
+              "created_at": "2024-03-21T07:57:40.545565Z",
+              "credits": [
+                "FDrag0n"
+              ],
+              "cvss_base_score": 6.1,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.1,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-26T07:34:23.916299Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 6.1,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-06-08T14:11:46.700097Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+              "disclosed_at": "2024-03-20T15:16:03Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.12762",
+                "probability": "0.00043"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-JS-EXPRESS-6474509",
+              "initially_fixed_in_versions": [
+                "4.19.2",
+                "5.0.0-beta.3"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-06-08T14:11:46.700097Z",
+              "package_name": "express",
+              "package_version": "",
+              "published_at": "2024-03-26T07:34:23.916017Z",
+              "references": [
+                {
+                  "title": "Github Commit",
+                  "url": "https://github.com/expressjs/express/commit/0b746953c4bd8e377123527db11f9cd866e39f94"
+                },
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/expressjs/express/commit/0867302ddbde0e9463d0564fea5861feb708c2dd"
+                },
+                {
+                  "title": "Github Issue",
+                  "url": "https://github.com/koajs/koa/issues/1800"
+                },
+                {
+                  "title": "GitHub PR",
+                  "url": "https://github.com/expressjs/express/pull/5551"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-601",
+              "source": "cwe"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 74
+            }
+          },
+          "title": "Open Redirect"
+        },
+        "id": "00000000-0000-0000-0000-000000000065",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "express",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.19.2"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000065",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[send](https://github.com/pillarjs/send) is a Better streaming static file server with Range and conditional-GET support\n\nAffected versions of this package are vulnerable to Cross-site Scripting due to improper user input sanitization passed to the `SendStream.redirect()` function, which executes untrusted code. An attacker can execute arbitrary code by manipulating the input parameters to this method.\r\n\r\n**Note:**\r\n\r\nExploiting this vulnerability requires the following:\r\n\r\n1) The attacker needs to control the input to `response.redirect()`\r\n\r\n2) Express MUST NOT redirect before the template appears\r\n\r\n3) The browser MUST NOT complete redirection before\r\n\r\n4) The user MUST click on the link in the template\n## Details\n\nCross-site scripting (or XSS) is a code vulnerability that occurs when an attacker \u201cinjects\u201d a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user\u2019s browser when the user interacts with the compromised website.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser\u2019s Same Origin Policy.\n\nInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they\u2019ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user\u2019s browser.| \n|**DOM-based**|Client|The attacker forces the user\u2019s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `send` to version 0.19.0, 1.1.0 or higher.\n## References\n- [GitHub Commit](https://github.com/pillarjs/send/commit/ae4f2989491b392ae2ef3b0015a019770ae65d35)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "send",
+                  "version": "0.2.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000066",
+          "locations": [
+            {
+              "package": {
+                "name": "send",
+                "version": "0.2.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2024-43799",
+              "source": "cve"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.19.0",
+                ">=1.0.0-beta.1 <1.1.0"
+              ],
+              "created_at": "2024-09-11T06:19:15.660255Z",
+              "credits": [
+                "Adam Korcz"
+              ],
+              "cvss_base_score": 2.1,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 2.1,
+                  "cvss_version": "4.0",
+                  "modified_at": "2024-09-11T13:12:26.132451Z",
+                  "severity": "low",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:A/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-11T13:12:26.132451Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 4.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-21T01:11:53.646986Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-11T13:48:17.800297Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:A/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N",
+              "disclosed_at": "2024-09-10T15:15:17Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.27063",
+                "probability": "0.00095"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-JS-SEND-7926862",
+              "initially_fixed_in_versions": [
+                "0.19.0",
+                "1.1.0"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-09-21T01:11:53.646986Z",
+              "package_name": "send",
+              "package_version": "",
+              "published_at": "2024-09-11T11:48:01.490359Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pillarjs/send/commit/ae4f2989491b392ae2ef3b0015a019770ae65d35"
+                }
+              ],
+              "severity": "low",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-79",
+              "source": "cwe"
+            }
+          ],
+          "rating": {
+            "severity": "low"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 57
+            }
+          },
+          "title": "Cross-site Scripting"
+        },
+        "id": "00000000-0000-0000-0000-000000000066",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "send",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.20.0"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.19.0"
+                        }
+                      ],
+                      "is_drop": false
+                    },
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.21.0"
+                        },
+                        {
+                          "name": "serve-static",
+                          "version": "1.16.2"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.19.0"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000066",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\r\n[`fresh`](https://www.npmjs.com/package/fresh) is HTTP response freshness testing.\r\n\r\nAffected versions of this package are vulnerable to Regular expression Denial of Service (ReDoS) attacks. A Regular Expression (`/ *, */`) was used for parsing HTTP headers and take about 2 seconds matching time for 50k characters.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet\u2019s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn\u2019t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `fresh` to version 0.5.2 or higher.\n\n## References\n- [https://github.com/jshttp/fresh/commit/21a0f0c2a5f447e0d40bc16be0c23fa98a7b46ec](https://github.com/jshttp/fresh/commit/21a0f0c2a5f447e0d40bc16be0c23fa98a7b46ec)\n- [https://github.com/jshttp/fresh/issues/24](https://github.com/jshttp/fresh/issues/24)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "fresh",
+                  "version": "0.2.2"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "send",
+                  "version": "0.2.0"
+                },
+                {
+                  "name": "fresh",
+                  "version": "0.2.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000067",
+          "locations": [
+            {
+              "package": {
+                "name": "fresh",
+                "version": "0.2.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2017-16119",
+              "source": "cve"
+            },
+            {
+              "id": "GHSA-9qj9-36jm-prpv",
+              "source": "ghsa"
+            },
+            {
+              "id": "CWE-400",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.5.2"
+              ],
+              "created_at": "2017-09-27T08:48:49.286Z",
+              "credits": [
+                "Cristian-Alexandru Staicu"
+              ],
+              "cvss_base_score": 7.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:58:13.375741Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:47:01.837639Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2025-04-28T21:14:26.782658Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "disclosed_at": "2017-09-08T21:00:00Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.55102",
+                "probability": "0.00328"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:fresh:20170908",
+              "initially_fixed_in_versions": [
+                "0.5.2"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-04-28T21:14:26.782658Z",
+              "package_name": "fresh",
+              "package_version": "",
+              "published_at": "2017-09-27T08:48:49Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/jshttp/fresh/commit/21a0f0c2a5f447e0d40bc16be0c23fa98a7b46ec"
+                },
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/jshttp/fresh/issues/24"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 101
+            }
+          },
+          "title": "Regular Expression Denial of Service (ReDoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000067",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "fresh",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.15.5"
+                        },
+                        {
+                          "name": "fresh",
+                          "version": "0.5.2"
+                        }
+                      ],
+                      "is_drop": false
+                    },
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.15.5"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.15.6"
+                        },
+                        {
+                          "name": "fresh",
+                          "version": "0.5.2"
+                        }
+                      ],
+                      "is_drop": false
+                    },
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.15.5"
+                        },
+                        {
+                          "name": "serve-static",
+                          "version": "1.12.6"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.15.6"
+                        },
+                        {
+                          "name": "fresh",
+                          "version": "0.5.2"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000067",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\r\n[`fresh`](https://www.npmjs.com/package/fresh) is HTTP response freshness testing.\r\n\r\nAffected versions of this package are vulnerable to Regular expression Denial of Service (ReDoS) attacks. A Regular Expression (`/ *, */`) was used for parsing HTTP headers and take about 2 seconds matching time for 50k characters.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet\u2019s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn\u2019t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `fresh` to version 0.5.2 or higher.\n\n## References\n- [https://github.com/jshttp/fresh/commit/21a0f0c2a5f447e0d40bc16be0c23fa98a7b46ec](https://github.com/jshttp/fresh/commit/21a0f0c2a5f447e0d40bc16be0c23fa98a7b46ec)\n- [https://github.com/jshttp/fresh/issues/24](https://github.com/jshttp/fresh/issues/24)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "serve-static",
+                  "version": "1.0.1"
+                },
+                {
+                  "name": "send",
+                  "version": "0.1.4"
+                },
+                {
+                  "name": "fresh",
+                  "version": "0.2.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000068",
+          "locations": [
+            {
+              "package": {
+                "name": "fresh",
+                "version": "0.2.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2017-16119",
+              "source": "cve"
+            },
+            {
+              "id": "GHSA-9qj9-36jm-prpv",
+              "source": "ghsa"
+            },
+            {
+              "id": "CWE-400",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.5.2"
+              ],
+              "created_at": "2017-09-27T08:48:49.286Z",
+              "credits": [
+                "Cristian-Alexandru Staicu"
+              ],
+              "cvss_base_score": 7.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:58:13.375741Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:47:01.837639Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2025-04-28T21:14:26.782658Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "disclosed_at": "2017-09-08T21:00:00Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.55102",
+                "probability": "0.00328"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:fresh:20170908",
+              "initially_fixed_in_versions": [
+                "0.5.2"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-04-28T21:14:26.782658Z",
+              "package_name": "fresh",
+              "package_version": "",
+              "published_at": "2017-09-27T08:48:49Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/jshttp/fresh/commit/21a0f0c2a5f447e0d40bc16be0c23fa98a7b46ec"
+                },
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/jshttp/fresh/issues/24"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 101
+            }
+          },
+          "title": "Regular Expression Denial of Service (ReDoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000068",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "fresh",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.15.5"
+                        },
+                        {
+                          "name": "serve-static",
+                          "version": "1.12.6"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.15.6"
+                        },
+                        {
+                          "name": "fresh",
+                          "version": "0.5.2"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000068",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\n[qs](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\n\n\nAffected versions of this package are vulnerable to Denial of Service (DoS).\nDuring parsing, the `qs` module may create a sparse area (an array where no elements are filled), and grow that array to the necessary size based on the indices used on it. An attacker can specify a high index value in a query string, thus making the server allocate a respectively big array. Truly large values can cause the server to run out of memory and cause it to crash - thus enabling a Denial-of-Service attack.\n\n## Remediation\n\nUpgrade `qs` to version 1.0.0 or higher.\n\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## References\n\n- [GitHub Commit](https://github.com/tj/node-querystring/pull/114/commits/43a604b7847e56bba49d0ce3e222fe89569354d8)\n\n- [GitHub Issue](https://github.com/visionmedia/node-querystring/issues/104)\n\n- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2014-7191)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "qs",
+                  "version": "0.6.6"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000069",
+          "locations": [
+            {
+              "package": {
+                "name": "qs",
+                "version": "0.6.6"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2014-7191",
+              "source": "cve"
+            },
+            {
+              "id": "GHSA-gqgv-6jq5-jjj9",
+              "source": "ghsa"
+            },
+            {
+              "id": "GHSA-jjv7-qpx3-h62q",
+              "source": "ghsa"
+            },
+            {
+              "id": "CWE-400",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<1.0.0"
+              ],
+              "created_at": "2014-08-06T06:10:22Z",
+              "credits": [
+                "Dustin Shiver"
+              ],
+              "cvss_base_score": 7.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:59:04.389055Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:52:39.103034Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 4.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:48:53.430808Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "disclosed_at": "2014-08-06T06:10:22Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.86066",
+                "probability": "0.03001"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:qs:20140806",
+              "initially_fixed_in_versions": [
+                "1.0.0"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:52:39.103034Z",
+              "package_name": "qs",
+              "package_version": "",
+              "published_at": "2014-08-06T06:10:22Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/tj/node-querystring/pull/114/commits/43a604b7847e56bba49d0ce3e222fe89569354d8"
+                },
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/visionmedia/node-querystring/issues/104"
+                },
+                {
+                  "title": "NVD",
+                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-7191"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 105
+            }
+          },
+          "title": "Denial of Service (DoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000069",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "qs",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.8.0"
+                        },
+                        {
+                          "name": "qs",
+                          "version": "1.0.2"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000069",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[qs](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS). When parsing a string representing a deeply nested object, qs will block the event loop for long periods of time. Such a delay may hold up the server's resources, keeping it from processing other requests in the meantime, thus enabling a Denial-of-Service attack.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet\u2019s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn\u2019t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `qs` to version 1.0.0 or higher.\n## References\n- [Node Security Advisory](https://nodesecurity.io/advisories/28)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "qs",
+                  "version": "0.6.6"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000070",
+          "locations": [
+            {
+              "package": {
+                "name": "qs",
+                "version": "0.6.6"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "GHSA-f9cm-p3w6-xvr3",
+              "source": "ghsa"
+            },
+            {
+              "id": "CVE-2014-10064",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-400",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<1.0.0"
+              ],
+              "created_at": "2014-08-06T06:10:23Z",
+              "credits": [
+                "Tom Steele"
+              ],
+              "cvss_base_score": 6.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:58:44.467015Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:45:55.210133Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+              "disclosed_at": "2014-08-06T06:10:23Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.67440",
+                "probability": "0.00562"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:qs:20140806-1",
+              "initially_fixed_in_versions": [
+                "1.0.0"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:45:55.210133Z",
+              "package_name": "qs",
+              "package_version": "",
+              "published_at": "2014-08-06T06:10:23Z",
+              "references": [
+                {
+                  "title": "Node Security Advisory",
+                  "url": "https://nodesecurity.io/advisories/28"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 74
+            }
+          },
+          "title": "Denial of Service (DoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000070",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "qs",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.8.0"
+                        },
+                        {
+                          "name": "qs",
+                          "version": "1.0.2"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000070",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) when including multiple regular expression parameters in a single segment, which will produce the regular expression `/^\\/([^\\/]+?)-([^\\/]+?)\\/?$/`, if two parameters within a single segment are separated by a character other than a `/` or `.`. Poor performance will block the event loop and can lead to a DoS.\r\n\r\n**Note:**\r\nWhile the 8.0.0 release has completely eliminated the vulnerable functionality, prior versions that have received the patch to mitigate backtracking may still be vulnerable if custom regular expressions are used. So it is strongly recommended for regular expression input to be controlled to avoid malicious performance degradation in those versions. This behavior is enforced as of version 7.1.0 via the `strict` option, which returns an error if a dangerous regular expression is detected.\r\n\r\n## Workaround\r\nThis vulnerability can be avoided by using a custom regular expression for parameters after the first in a segment, which excludes `-` and `/`.\n## PoC\n```js\r\n/a${'-a'.repeat(8_000)}/a\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet\u2019s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn\u2019t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `path-to-regexp` to version 0.1.10, 1.9.0, 3.3.0, 6.3.0, 8.0.0 or higher.\n## References\n- [GitHub Commit](https://github.com/pillarjs/path-to-regexp/commit/29b96b4a1de52824e1ca0f49a701183cc4ed476f)\n- [GitHub Commit](https://github.com/p",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "path-to-regexp",
+                  "version": "0.1.2"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000071",
+          "locations": [
+            {
+              "package": {
+                "name": "path-to-regexp",
+                "version": "0.1.2"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CWE-1333",
+              "source": "cwe"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.1.10",
+                ">=0.2.0 <1.9.0",
+                ">=2.0.0 <3.3.0",
+                ">=4.0.0 <6.3.0",
+                ">=7.0.0 <8.0.0"
+              ],
+              "created_at": "2024-09-10T06:12:52.186963Z",
+              "credits": [
+                "Blake Embrey"
+              ],
+              "cvss_base_score": 6.9,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.9,
+                  "cvss_version": "4.0",
+                  "modified_at": "2025-06-16T06:59:36.219457Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N/E:P"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-06-16T06:59:36.219457Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-10T13:33:00.998289Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N/E:P",
+              "disclosed_at": "2024-09-09T19:40:10Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.20070",
+                "probability": "0.00064"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "proof of concept",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "proof of concept",
+                    "type": "primary"
+                  }
+                ],
+                "sources": [
+                  "Snyk"
+                ]
+              },
+              "id": "SNYK-JS-PATHTOREGEXP-7925106",
+              "initially_fixed_in_versions": [
+                "0.1.10",
+                "1.9.0",
+                "3.3.0",
+                "6.3.0",
+                "8.0.0"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-06-16T06:59:36.219457Z",
+              "package_name": "path-to-regexp",
+              "package_version": "",
+              "published_at": "2024-09-10T08:00:38.971163Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pillarjs/path-to-regexp/commit/29b96b4a1de52824e1ca0f49a701183cc4ed476f"
+                },
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pillarjs/path-to-regexp/commit/60f2121e9b66b7b622cc01080df0aabda9eedee6"
+                },
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pillarjs/path-to-regexp/commit/f73ec6c86b06f544b977119c2b62a16de480a6a9"
+                },
+                {
+                  "title": "Strict Mode Release Note",
+                  "url": "https://github.com/pillarjs/path-to-regexp/releases/tag/v7.1.0"
+                },
+                {
+                  "title": "Vulnerability Write-up",
+                  "url": "https://blakeembrey.com/posts/2024-09-web-redos/"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "GHSA-9wv6-86v2-598j",
+              "source": "ghsa"
+            },
+            {
+              "id": "CVE-2024-45296",
+              "source": "cve"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 57
+            }
+          },
+          "title": "Regular Expression Denial of Service (ReDoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000071",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "path-to-regexp",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.20.0"
+                        },
+                        {
+                          "name": "path-to-regexp",
+                          "version": "0.1.10"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000071",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\r\n['cookie-signature'](https://www.npmjs.com/package/cookie-signature) is a library for signing cookies.\r\n\r\nVersions before `1.0.4` of the library use the built-in string comparison mechanism, `===`, and not a time constant string comparison. As a result, the comparison will fail faster when the first characters in the token are incorrect.\r\nAn attacker can use this difference to perform a timing attack, essentially allowing them to guess the secret one character at a time.\r\n\r\nYou can read more about timing attacks in Node.js on the Snyk blog: https://snyk.io/blog/node-js-timing-attack-ccc-ctf/\r\n\r\n## Remediation\r\nUpgrade to `1.0.4` or greater.\r\n\r\n## References\r\n- [GitHub History](https://github.com/tj/node-cookie-signature/blob/master/History.md#104--2014-06-25)\r\n- [GitHub Commit](https://github.com/tj/node-cookie-signature/commit/39791081692e9e14aa62855369e1c7f80fbfd50e)",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "cookie-signature",
+                  "version": "1.0.3"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000072",
+          "locations": [
+            {
+              "package": {
+                "name": "cookie-signature",
+                "version": "1.0.3"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CWE-208",
+              "source": "cwe"
+            },
+            {
+              "id": "CVE-2016-1000236",
+              "source": "cve"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<1.0.4"
+              ],
+              "created_at": "2016-08-04T03:44:13.904Z",
+              "credits": [
+                "tenbits"
+              ],
+              "cvss_base_score": 6.3,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 6.3,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:57:31.514713Z",
+                  "severity": "medium",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:N/A:N"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 4.4,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-11T09:46:32.176976Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:N/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5.4,
+                  "cvss_version": "3.0",
+                  "modified_at": "2025-04-28T21:11:56.989464Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:H/PR:H/UI:R/S:C/C:H/I:N/A:N"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:N/A:N",
+              "disclosed_at": "2014-01-28T00:00:00Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.66688",
+                "probability": "0.00539"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:cookie-signature:20160804",
+              "initially_fixed_in_versions": [
+                "1.0.4"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-04-28T21:11:56.989464Z",
+              "package_name": "cookie-signature",
+              "package_version": "",
+              "published_at": "2016-08-29T00:00:00Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/tj/node-cookie-signature/commit/39791081692e9e14aa62855369e1c7f80fbfd50e"
+                },
+                {
+                  "title": "GitHub History",
+                  "url": "https://github.com/tj/node-cookie-signature/blob/master/History.md%23104--2014-06-25"
+                }
+              ],
+              "severity": "medium",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "GHSA-92vm-wfm5-mxvv",
+              "source": "ghsa"
+            }
+          ],
+          "rating": {
+            "severity": "medium"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 86
+            }
+          },
+          "title": "Non-Constant Time String Comparison"
+        },
+        "id": "00000000-0000-0000-0000-000000000072",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "cookie-signature",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.4.5"
+                        },
+                        {
+                          "name": "cookie-signature",
+                          "version": "1.0.4"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000072",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[mime](https://www.npmjs.com/package/mime) is a comprehensive, compact MIME type module.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). It uses regex the following regex `/.*[\\.\\/\\\\]/` in its lookup, which can cause a slowdown of 2 seconds for 50k characters.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet\u2019s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn\u2019t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `mime` to version 1.4.1, 2.0.3 or higher.\n## References\n- [GitHub Commit](https://github.com/broofa/node-mime/commit/1df903fdeb9ae7eaa048795b8d580ce2c98f40b0)\n- [GitHub Commit](https://github.com/broofa/node-mime/commit/855d0c4b8b22e4a80b9401a81f2872058eae274d)\n- [GitHub Issue](https://github.com/broofa/node-mime/issues/167)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/535)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "accepts",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "mime",
+                  "version": "1.2.11"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "send",
+                  "version": "0.2.0"
+                },
+                {
+                  "name": "mime",
+                  "version": "1.2.11"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "type-is",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "mime",
+                  "version": "1.2.11"
+                }
+              ],
+              "source": "dependency_path"
+            },
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "serve-static",
+                  "version": "1.0.1"
+                },
+                {
+                  "name": "send",
+                  "version": "0.1.4"
+                },
+                {
+                  "name": "mime",
+                  "version": "1.2.11"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000073",
+          "locations": [
+            {
+              "package": {
+                "name": "mime",
+                "version": "1.2.11"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2017-16138",
+              "source": "cve"
+            },
+            {
+              "id": "GHSA-wrvr-8mpx-r7pp",
+              "source": "ghsa"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<1.4.1",
+                ">=2.0.0 <2.0.3"
+              ],
+              "created_at": "2017-09-26T05:48:40.307Z",
+              "credits": [
+                "Cristian-Alexandru Staicu"
+              ],
+              "cvss_base_score": 3.7,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 3.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-03-06T13:58:13.405203Z",
+                  "severity": "low",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:47:01.954784Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5.3,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:53:48.285535Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+              "disclosed_at": "2017-09-07T21:00:00Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.61919",
+                "probability": "0.00433"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:mime:20170907",
+              "initially_fixed_in_versions": [
+                "1.4.1",
+                "2.0.3"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-03-11T09:53:48.285535Z",
+              "package_name": "mime",
+              "package_version": "",
+              "published_at": "2017-09-27T05:48:40Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/broofa/node-mime/commit/1df903fdeb9ae7eaa048795b8d580ce2c98f40b0"
+                },
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/broofa/node-mime/commit/855d0c4b8b22e4a80b9401a81f2872058eae274d"
+                },
+                {
+                  "title": "GitHub Issue",
+                  "url": "https://github.com/broofa/node-mime/issues/167"
+                },
+                {
+                  "title": "NPM Security Advisory",
+                  "url": "https://www.npmjs.com/advisories/535"
+                }
+              ],
+              "severity": "low",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-400",
+              "source": "cwe"
+            }
+          ],
+          "rating": {
+            "severity": "low"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 35
+            }
+          },
+          "title": "Regular Expression Denial of Service (ReDoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000073",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "mime",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.4.4"
+                        },
+                        {
+                          "name": "accepts",
+                          "version": "1.0.7"
+                        }
+                      ],
+                      "is_drop": true
+                    },
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.16.0"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.16.0"
+                        },
+                        {
+                          "name": "mime",
+                          "version": "1.4.1"
+                        }
+                      ],
+                      "is_drop": false
+                    },
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.4.2"
+                        },
+                        {
+                          "name": "type-is",
+                          "version": "1.2.1"
+                        }
+                      ],
+                      "is_drop": true
+                    },
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.16.0"
+                        },
+                        {
+                          "name": "serve-static",
+                          "version": "1.13.0"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.16.0"
+                        },
+                        {
+                          "name": "mime",
+                          "version": "1.4.1"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000073",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n[send](https://github.com/pillarjs/send) is a Better streaming static file server with Range and conditional-GET support\n\nAffected versions of this package are vulnerable to Cross-site Scripting due to improper user input sanitization passed to the `SendStream.redirect()` function, which executes untrusted code. An attacker can execute arbitrary code by manipulating the input parameters to this method.\r\n\r\n**Note:**\r\n\r\nExploiting this vulnerability requires the following:\r\n\r\n1) The attacker needs to control the input to `response.redirect()`\r\n\r\n2) Express MUST NOT redirect before the template appears\r\n\r\n3) The browser MUST NOT complete redirection before\r\n\r\n4) The user MUST click on the link in the template\n## Details\n\nCross-site scripting (or XSS) is a code vulnerability that occurs when an attacker \u201cinjects\u201d a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user\u2019s browser when the user interacts with the compromised website.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser\u2019s Same Origin Policy.\n\nInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they\u2019ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user\u2019s browser.| \n|**DOM-based**|Client|The attacker forces the user\u2019s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `send` to version 0.19.0, 1.1.0 or higher.\n## References\n- [GitHub Commit](https://github.com/pillarjs/send/commit/ae4f2989491b392ae2ef3b0015a019770ae65d35)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "serve-static",
+                  "version": "1.0.1"
+                },
+                {
+                  "name": "send",
+                  "version": "0.1.4"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000074",
+          "locations": [
+            {
+              "package": {
+                "name": "send",
+                "version": "0.1.4"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "id": "CVE-2024-43799",
+              "source": "cve"
+            },
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.19.0",
+                ">=1.0.0-beta.1 <1.1.0"
+              ],
+              "created_at": "2024-09-11T06:19:15.660255Z",
+              "credits": [
+                "Adam Korcz"
+              ],
+              "cvss_base_score": 2.1,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 2.1,
+                  "cvss_version": "4.0",
+                  "modified_at": "2024-09-11T13:12:26.132451Z",
+                  "severity": "low",
+                  "type": "primary",
+                  "vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:A/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N"
+                },
+                {
+                  "assigner": "Snyk",
+                  "base_score": 5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-11T13:12:26.132451Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 4.7,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-21T01:11:53.646986Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N"
+                },
+                {
+                  "assigner": "Red Hat",
+                  "base_score": 5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2024-09-11T13:48:17.800297Z",
+                  "severity": "medium",
+                  "type": "secondary",
+                  "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:L"
+                }
+              ],
+              "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:A/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N",
+              "disclosed_at": "2024-09-10T15:15:17Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.27063",
+                "probability": "0.00095"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "SNYK-JS-SEND-7926862",
+              "initially_fixed_in_versions": [
+                "0.19.0",
+                "1.1.0"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2024-09-21T01:11:53.646986Z",
+              "package_name": "send",
+              "package_version": "",
+              "published_at": "2024-09-11T11:48:01.490359Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/pillarjs/send/commit/ae4f2989491b392ae2ef3b0015a019770ae65d35"
+                }
+              ],
+              "severity": "low",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "CWE-79",
+              "source": "cwe"
+            }
+          ],
+          "rating": {
+            "severity": "low"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 57
+            }
+          },
+          "title": "Cross-site Scripting"
+        },
+        "id": "00000000-0000-0000-0000-000000000074",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "send",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.21.0"
+                        },
+                        {
+                          "name": "serve-static",
+                          "version": "1.16.2"
+                        },
+                        {
+                          "name": "send",
+                          "version": "0.19.0"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000074",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      },
+      {
+        "attributes": {
+          "cause_of_failure": false,
+          "description": "## Overview\n\n[negotiator](https://npmjs.org/package/negotiator) is an HTTP content negotiator for Node.js.\n\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS)\nwhen parsing `Accept-Language` http header.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet\u2019s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn\u2019t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\n\nUpgrade `negotiator` to version 0.6.1 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/jshttp/negotiator/commit/26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c)\n\n- [OWASP Advisory](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS)\n",
+          "evidence": [
+            {
+              "path": [
+                {
+                  "name": "tsc",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "express",
+                  "version": "4.0.0"
+                },
+                {
+                  "name": "accepts",
+                  "version": "1.0.0"
+                },
+                {
+                  "name": "negotiator",
+                  "version": "0.3.0"
+                }
+              ],
+              "source": "dependency_path"
+            }
+          ],
+          "finding_type": "sca",
+          "key": "00000000-0000-0000-0000-000000000075",
+          "locations": [
+            {
+              "package": {
+                "name": "negotiator",
+                "version": "0.3.0"
+              },
+              "type": "package"
+            }
+          ],
+          "policy_modifications": [],
+          "problems": [
+            {
+              "affected_hash_ranges": [],
+              "affected_hashes": [],
+              "affected_versions": [
+                "<0.6.1"
+              ],
+              "created_at": "2016-06-16T18:00:02.24Z",
+              "credits": [
+                "Adam Baldwin"
+              ],
+              "cvss_base_score": 7.5,
+              "cvss_sources": [
+                {
+                  "assigner": "Snyk",
+                  "base_score": 7.5,
+                  "cvss_version": "3.1",
+                  "modified_at": "2025-03-05T11:48:00.981412Z",
+                  "severity": "high",
+                  "type": "primary",
+                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                },
+                {
+                  "assigner": "NVD",
+                  "base_score": 7.5,
+                  "cvss_version": "3.0",
+                  "modified_at": "2024-03-11T09:46:38.432872Z",
+                  "severity": "high",
+                  "type": "secondary",
+                  "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                }
+              ],
+              "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "disclosed_at": "2016-06-16T17:36:06Z",
+              "ecosystem": {
+                "language": "js",
+                "package_manager": "npm",
+                "type": "build"
+              },
+              "epss_details": {
+                "model_version": "v2025.03.14",
+                "percentile": "0.55102",
+                "probability": "0.00328"
+              },
+              "exploit_details": {
+                "maturity_levels": [
+                  {
+                    "format": "CVSSv3",
+                    "level": "not defined",
+                    "type": "secondary"
+                  },
+                  {
+                    "format": "CVSSv4",
+                    "level": "not defined",
+                    "type": "primary"
+                  }
+                ],
+                "sources": []
+              },
+              "id": "npm:negotiator:20160616",
+              "initially_fixed_in_versions": [
+                "0.6.1"
+              ],
+              "is_fixable": true,
+              "is_malicious": false,
+              "is_social_media_trending": false,
+              "modified_at": "2025-03-05T11:48:00.981412Z",
+              "package_name": "negotiator",
+              "package_version": "",
+              "published_at": "2016-06-16T17:36:06Z",
+              "references": [
+                {
+                  "title": "GitHub Commit",
+                  "url": "https://github.com/jshttp/negotiator/commit/26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c"
+                },
+                {
+                  "title": "OWASP Advisory",
+                  "url": "https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS"
+                }
+              ],
+              "severity": "high",
+              "source": "snyk_vuln"
+            },
+            {
+              "id": "GHSA-7mc5-chhp-fmc3",
+              "source": "ghsa"
+            },
+            {
+              "id": "CVE-2016-10539",
+              "source": "cve"
+            },
+            {
+              "id": "CWE-400",
+              "source": "cwe"
+            }
+          ],
+          "rating": {
+            "severity": "high"
+          },
+          "risk": {
+            "risk_score": {
+              "value": 101
+            }
+          },
+          "title": "Regular Expression Denial of Service (ReDoS)"
+        },
+        "id": "00000000-0000-0000-0000-000000000075",
+        "links": {},
+        "relationships": {
+          "fix": {
+            "data": {
+              "attributes": {
+                "action": {
+                  "format": "upgrade_package_advice",
+                  "package_name": "negotiator",
+                  "upgrade_paths": [
+                    {
+                      "dependency_path": [
+                        {
+                          "name": "tsc",
+                          "version": "1.0.0"
+                        },
+                        {
+                          "name": "express",
+                          "version": "4.14.0"
+                        },
+                        {
+                          "name": "accepts",
+                          "version": "1.3.8"
+                        },
+                        {
+                          "name": "negotiator",
+                          "version": "0.6.3"
+                        }
+                      ],
+                      "is_drop": false
+                    }
+                  ]
+                },
+                "outcome": "fully_resolved"
+              },
+              "id": "00000000-0000-0000-0000-000000000075",
+              "type": "fixes"
+            }
+          }
+        },
+        "type": "findings"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
### Description

The UFM human readable template renders the asset inventory link inside `resultFooter`, so it appears under an individual result, before the overall test summary.

That is wrong for any test whose results are reported per component: each result carries a copy of the same run-wide link, so each one prints it. An SBOM test covering six components printed this six times, none of them at the end of the output:

```
╭───────────────────────────────────────────────────────╮
│ Test Summary                                          │
│   ...                                                 │
╰───────────────────────────────────────────────────────╯

View your asset(s) at: https://app.dev.snyk.io/org/…/overview   <- once per component

─────────────────────────────────────────────────────

╭─────────────────────────────────────────────────────────╮
│ Overall Test Summary                                    │
```

A run has a single asset, so the link now renders once below the overall test summary:

```
╰────────────────────────────────────────────────────────────╯

View your asset(s) at: https://app.snyk.io/org/my-org/inventory/assets/…/overview

💡 Tip

   To view ignored issues, use the --include-ignores option.
```

`getFirstMetadataValue(testResults, key)` reads the link from the first result that carries one. It scans rather than taking `index 0` because the producer strips the run-wide keys from every result but the last, so the first result has no asset — scanning keeps this correct whichever result carries it, or if they all do.

Verified by rendering:

| Input | Output |
|---|---|
| Multiple results, one asset repeated per component | one link, below the overall summary |
| Single result (no overall summary box) | link still last, spacing unchanged |
| No asset metadata | no link line |

The single-result path needs a conditional newline: a result footer ends its own line, the summary box does not.

Two notes for reviewers:

- **`report-url`** sits in the same block and has the same problem. Left alone to keep this focused — happy to fold it in.
- **This leaves a modelling gap open.** `asset` is a property of the *test*, but the UFM payload is a bare array of results with nowhere to put test-level facts, so it is copied onto every result and then stripped from all but one by the producer. Giving the payload a test to hang those facts on would delete both this helper and the producer-side stripping. That is a wire-format change and is prepared separately on `feat/ufm-test-metadata`, stacked on this branch.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [ ] Regenerated mocks, etc. (`make generate`) — n/a, no mocked interfaces changed
- [x] Linted (`make lint`)
- [ ] Test your changes work for the CLI — see below

Notes on the unticked boxes:

- There was no test covering the asset link at all before this. Added `multi_project.with-asset.{testresult.json,human.readable}` and a `multi_project_with_asset` case in `Test_UfmPresenter_HumanReadable` — seven results all carrying the same asset, which is the shape that surfaced the bug.
- `go test ./...` passes apart from `connectivity_check_extension/connectivity`, which fails identically on a clean tree in my environment (a local `NODE_EXTRA_CA_CERTS` value leaks into `TestDetectProxyConfig`). Unrelated.
- Paired CLI PR: **snyk/cli#7149**. I have not run the CLI end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to CLI human-readable output; no auth, API, or data handling.
> 
> **Overview**
> Fixes duplicate **asset inventory** lines in UFM human-readable output when a run has multiple per-component results (e.g. SBOM multi-project scans) that all carry the same run-wide `asset` metadata.
> 
> The **“View your asset(s) at:”** line is removed from `resultFooter` and rendered once at the end of `main`, after the overall test summary box when applicable. A new template helper **`assetLink`** scans `$.TestResults` for the first non-empty `asset` metadata value instead of reading only the current result.
> 
> Coverage adds **`multi_project_with_asset`** in `Test_UfmPresenter_HumanReadable` with fixture `multi_project.with-asset.*` (seven results sharing one asset URL).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53729422c5cdf6b8abea5b995b424ee929fc236e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->