### PR TITLE
fix: update agent rules to prohibit including non-public information in checked-in files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,33 @@ Before changing anything under `pkg/`, ask:
 
 ---
 
+## This repository is public
+
+GAF's source, full git history, issues, and PRs are **publicly visible on
+GitHub**, regardless of the fact that contributions currently come from Snyk
+employees only (see [CONTRIBUTING.md](CONTRIBUTING.md)). Anything you commit
+is exposed externally forever, even if a later commit reverts it.
+
+**Never include, in code, comments, docs, commit messages, or PR
+descriptions:**
+
+- Names, URLs, or code copied/paraphrased from Snyk-internal or other private
+  repositories.
+- Internal hostnames, service names, API endpoints, or architecture details
+  not already public.
+- Contents of internal tickets, Slack threads, or wiki/Confluence pages beyond
+  the bare `[XXX-XXXX]` ticket ID token already used in commit messages.
+- Customer, partner, or employee names not relevant to an external
+  contributor.
+- Credentials, tokens, or other secrets (even test/dummy-looking ones pulled
+  from an internal fixture).
+
+If a task's context comes from an internal source, **restate the requirement
+in your own words** for anything that lands in this repo — do not paste or
+closely mirror the source material.
+
+---
+
 ## Documentation map
 
 | Read this | When |
@@ -132,12 +159,18 @@ Tests live **next to their source files** (`foo.go` → `foo_test.go`).
   (stage anything the tools changed).
 - **Security:** run `snyk code test <absolute-project-path>` after code edits
   and `snyk test <absolute-project-path>` after `go.mod` changes. Fix fixable
-  findings (not in test data).
+  findings (not in test data). Before pushing, also re-read your diff
+  specifically for internal-only repo names, hostnames, ticket contents, or
+  other non-public references (see
+  [This repository is public](#this-repository-is-public)) — Snyk Code and
+  secrets scanning will not catch these.
 - **Commits:** [Conventional Commits](https://www.conventionalcommits.org/)
   (`type: summary`); subject under 72 chars + descriptive body; append
-  `[XXX-XXXX]` from the branch name. Each commit must stand on its own without
-  breaking the release pipeline. Never force-push; always confirm with the user
-  before pushing.
+  `[XXX-XXXX]` from the branch name — the bare ID only; do not paste the
+  internal ticket's title or description verbatim, as it may contain
+  internal-only context. Each commit must stand on its own without breaking
+  the release pipeline. Never force-push; always confirm with the user before
+  pushing.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,10 @@
 # Contributing
 
 This repo is intended for internal (Snyk) contributions only at this time.
+Note this governs who *contributes*, not who can *see* it — the repository,
+including its full history, is public. See AGENTS.md §
+["This repository is public"](AGENTS.md#this-repository-is-public) before
+referencing any internal system, ticket, or repo in your changes.
 
 ## Creating a new extension
 


### PR DESCRIPTION
### Description

_Provide description of this PR and changes._

### Checklist

- [ ] Tests added and all succeed (`make test`)
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to AGENTS.md and CONTRIBUTING.md with no runtime or API changes.
> 
> **Overview**
> Adds contributor and agent rules that treat **go-application-framework** as **public on GitHub** (full history, issues, PRs), not merely “internal contributors only.”
> 
> **AGENTS.md** introduces a **“This repository is public”** section listing what must never appear in code, comments, docs, commits, or PR text (internal repo names/URLs, private hostnames, ticket/Slack/wiki content beyond bare `[XXX-XXXX]`, etc.), and requires restating internal-sourced requirements in your own words. **Working agreements** now tell contributors to re-scan diffs for non-public references before push (beyond Snyk Code/secrets scans) and to use only the bare ticket ID in commit messages—not pasted internal ticket titles or descriptions.
> 
> **CONTRIBUTING.md** clarifies that internal-only contribution policy does **not** mean the repo is private, and points readers to the new AGENTS.md section before referencing internal systems in changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d19416e658f22d88b82fd94414429328aa3b1567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->