### PR TITLE
fix: IANDT-237 retry middleware test build failure

### DIFF
--- a/pkg/networking/middleware/retry_interval_test.go
+++ b/pkg/networking/middleware/retry_interval_test.go
@@ -41,7 +41,7 @@ func elapsedForRetries(t *testing.T, config configuration.Configuration, opts ..
 func TestWithRetryInterval_ShortensBackoff(t *testing.T) {
 	config := configuration.NewWithOpts()
 	config.Set(ConfigurationKeyRequestAttempts, 2)
-	config.Set(configurationKeyRetryAfter, 30)
+	config.Set(ConfigurationKeyRetryAfter, 30)
 
 	elapsed, attempts := elapsedForRetries(t, config, WithRetryInterval(50*time.Millisecond))
 
@@ -52,7 +52,7 @@ func TestWithRetryInterval_ShortensBackoff(t *testing.T) {
 func TestWithRetryInterval_AbsentOptionKeepsConfiguredBackoff(t *testing.T) {
 	config := configuration.NewWithOpts()
 	config.Set(ConfigurationKeyRequestAttempts, 2)
-	config.Set(configurationKeyRetryAfter, 1)
+	config.Set(ConfigurationKeyRetryAfter, 1)
 
 	// Backoff is jittered around the configured 1s, so assert a floor well below it
 	// that a 50ms override could not reach.
@@ -65,11 +65,11 @@ func TestWithRetryInterval_AbsentOptionKeepsConfiguredBackoff(t *testing.T) {
 func TestWithRetryInterval_DoesNotAffectOtherInstances(t *testing.T) {
 	config := configuration.NewWithOpts()
 	config.Set(ConfigurationKeyRequestAttempts, 2)
-	config.Set(configurationKeyRetryAfter, 1)
+	config.Set(ConfigurationKeyRetryAfter, 1)
 
 	overridden, _ := elapsedForRetries(t, config, WithRetryInterval(10*time.Millisecond))
 	shared, _ := elapsedForRetries(t, config)
 
 	assert.Less(t, overridden, shared, "the override is per instance and must not leak into the shared configuration")
-	assert.Equal(t, 1, config.GetInt(configurationKeyRetryAfter), "the configuration itself is untouched")
+	assert.Equal(t, 1, config.GetInt(ConfigurationKeyRetryAfter), "the configuration itself is untouched")
 }


### PR DESCRIPTION
### Description

This PR fixes the retry middleware test build failure on main introduced by the merge of #697.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- (n/a) Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.