### PR TITLE
fix: Skip symbolic links in file discovery and upload

### DIFF
--- a/pkg/apiclients/fileupload/batch.go
+++ b/pkg/apiclients/fileupload/batch.go
@@ -109,9 +109,13 @@ func createUploadFile(
 
 	relPath = encodePath(relPath)
 
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	if err != nil {
 		return uploadrevision.UploadFile{}, &SkippedFile{Path: relPath, Reason: uploadrevision.NewFileAccessError(path, err)}
+	}
+
+	if info.Mode()&os.ModeSymlink != 0 {
+		return uploadrevision.UploadFile{}, &SkippedFile{Path: relPath, Reason: uploadrevision.NewSpecialFileError(relPath, info.Mode())}
 	}
 
 	// Reading a device file would never return, so this has to be decided before the read.

--- a/pkg/apiclients/fileupload/client_options_test.go
+++ b/pkg/apiclients/fileupload/client_options_test.go
@@ -182,8 +182,8 @@ func Test_CreateRevisionFromChan_Options(t *testing.T) {
 		assert.NotErrorAs(t, res.SkippedFiles[0].Reason, &fileAccessErr)
 	})
 
-	t.Run("uploads a symlink to a regular file", func(t *testing.T) {
-		ctx, fakeSealableClient, client, dir := setupOptionsTest(t, defaultLimits, files)
+	t.Run("skips a symlink to a regular file", func(t *testing.T) {
+		ctx, _, client, dir := setupOptionsTest(t, defaultLimits, files)
 
 		link := path.Join(dir.Name(), "link.go")
 		require.NoError(t, os.Symlink(path.Join(dir.Name(), "my file.go"), link))
@@ -193,12 +193,12 @@ func Test_CreateRevisionFromChan_Options(t *testing.T) {
 		close(paths)
 
 		res, err := client.CreateRevisionFromChan(ctx, paths, dir.Name())
-		require.NoError(t, err)
+		require.ErrorIs(t, err, fileupload.ErrNoFilesProvided)
 
-		uploadedFiles, err := fakeSealableClient.GetSealedRevisionFiles(res.RevisionID)
-		require.NoError(t, err)
-		require.Len(t, uploadedFiles, 1)
-		assert.Equal(t, "package main", uploadedFiles[0].Content)
+		var specialFileErr *uploadrevision2.SpecialFileError
+		require.Len(t, res.SkippedFiles, 1)
+		assert.Equal(t, "link.go", res.SkippedFiles[0].Path)
+		require.ErrorAs(t, res.SkippedFiles[0].Reason, &specialFileErr)
 	})
 }
 

--- a/pkg/utils/file_filter.go
+++ b/pkg/utils/file_filter.go
@@ -27,6 +27,7 @@ import (
 const (
 	FF_FILE_FILTER_METACHARACTER_FIX   string = "internal_snyk_file_filter_metacharacter_fix_enabled"   // FF_FILE_FILTER_METACHARACTER_FIX (boolean) enables the fix for ignore rules and paths containing regex metacharacters
 	FF_GITIGNORE_RESPECT_TRACKED_FILES string = "internal_snyk_gitignore_respect_tracked_files_enabled" // FF_GITIGNORE_RESPECT_TRACKED_FILES (boolean) enables tracked-file-aware .gitignore filtering (CLI-1411)
+	FF_FILE_FILTER_SKIP_SYMLINKS       string = "internal_snyk_file_filter_skip_symlinks_enabled"       // FF_FILE_FILTER_SKIP_SYMLINKS (boolean) skips symbolic links during file discovery to prevent reading files outside the scan root
 )
 
 // by default, all rules are valid
@@ -217,6 +218,8 @@ func NewFileFilterFromConfig(path string, logger *zerolog.Logger, config configu
 
 // GetAllFiles traverses a given dir path and fetches all filesToFilter in the directory
 func (fw *FileFilter) GetAllFiles() chan string {
+	skipSymlinks := fw.config.GetBool(FF_FILE_FILTER_SKIP_SYMLINKS)
+
 	var filesCh = make(chan string)
 	go func() {
 		defer close(filesCh)
@@ -224,6 +227,10 @@ func (fw *FileFilter) GetAllFiles() chan string {
 		err := filepath.WalkDir(fw.path, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
+			}
+
+			if skipSymlinks && d.Type()&fs.ModeSymlink != 0 {
+				return nil
 			}
 
 			if !d.IsDir() {


### PR DESCRIPTION
### Description

Prevents scanners from following symbolic links during file discovery and upload, closing a path where files outside the scan root could be read and uploaded.

- `GetAllFiles` (`file_filter.go`) now skips symlink entries when `FF_FILE_FILTER_SKIP_SYMLINKS` is enabled, gated behind a new feature flag `internal_snyk_file_filter_skip_symlinks_enabled`.
- `createUploadFile` (`batch.go`) switches from `os.Stat` to `os.Lstat` and rejects symlinks as `SpecialFileError` (defence in depth, unconditional).
- The test "uploads a symlink to a regular file" is inverted to assert symlinks are skipped.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.