### PR TITLE
fix: prevent log scrubbing from corrupting adjacent JSON

### DIFF
--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -273,7 +273,12 @@ func addMandatoryMasking(dict ScrubbingDict) ScrubbingDict {
 
 	// The legacy CLI's snyk-config package prints the entire configuration in debug mode.
 	// It begins with some pseudo-JSON structure, which we can redact.
-	s = `(?s)_:\s*\[(?<everything_inside_hard_brackets>.*)\]`
+	// The capture must not be a plain greedy `.*`: that runs to the *last* `]` in the whole
+	// buffer and swallows any structure that follows the dump (see CLI-1732). Instead the
+	// capture may cross a balanced `[...]` pair (the dump nests one), but never an unpaired
+	// closing bracket, so it always stops at the dump's own `]`. The final `\[` alternative
+	// keeps a stray, unbalanced `[` inside the dump from failing the match altogether.
+	s = `_:\s*\[(?<everything_inside_hard_brackets>(?:\[[^\]]*\]|[^\[\]]|\[)*)\]`
 	dict[s] = scrubStruct{
 		groupToRedact: 1,
 		regex:         regexp.MustCompile(s),
@@ -290,7 +295,7 @@ func addMandatoryMasking(dict ScrubbingDict) ScrubbingDict {
 	// Same as above, only with short form
 	shorts := []string{"p", "u"}
 	shortForm := strings.Join(shorts, "")
-	s = fmt.Sprintf(`(?im)'[%s]=(?<value>.*)'`, shortForm)
+	s = fmt.Sprintf(`(?im)'[%s]=(?<value>[^'\n]*)'`, shortForm)
 	dict[s] = scrubStruct{
 		groupToRedact: 2,
 		regex:         regexp.MustCompile(s),
@@ -299,17 +304,28 @@ func addMandatoryMasking(dict ScrubbingDict) ScrubbingDict {
 	// Specific short-form scrubbing of the JSON-ish log structures
 	// Appear in the snyk-config debug logging as various constellations of { 'u': 'john.doe', } with or without quotes,
 	// and values can contain spaces, double and/or single quotes.
-
-	s = fmt.Sprintf(`(?i)(?<short_form_key>\b[%s]\b)[,'":]+\s*(?:['"](?<short_form_value>.*)['"]|([^,'"\s]+))[,}]?`, shortForm)
-	dict[s] = scrubStruct{
-		groupToRedact: 2,
-		regex:         regexp.MustCompile(s),
+	//
+	// Single- and double-quoted values get their own pattern so each value can be bounded by
+	// its own quote character. A single pattern bounded by `['"]` needs a greedy `.*` to allow
+	// the opposite quote inside the value, and that greedy run reaches the *last* quote on the
+	// line, swallowing every field that follows it (see CLI-1732). `\n` stays excluded so the
+	// bounded classes keep the line-at-a-time reach the previous `.` had.
+	for _, quote := range []string{`'`, `"`} {
+		s = fmt.Sprintf(`(?i)(?<short_form_key>\b[%s]\b)[,'":]+\s*(?:%s(?<short_form_value>[^%s\n]*)%s|([^,'"\s]+))[,}]?`, shortForm, quote, quote, quote)
+		dict[s] = scrubStruct{
+			groupToRedact: 2,
+			regex:         regexp.MustCompile(s),
+		}
 	}
 
 	// CLI argument-style-specific scrubbing
 	// Many cases are already covered by the JSON scrubbing above, thus this might seem incomplete.
 	// Refer to the unit tests for the full set of covered cases.
-	s = fmt.Sprintf(`(?im)\-[%s][\s=](?<short_form_value>\S*)`, shortForm)
+	// An unescaped `"` ends the value: when the argument list is logged inside a JSON string that
+	// quote closes the string, and a plain `\S*` would run on through the rest of the event and
+	// redact every field after it (see CLI-1732). An *escaped* quote is still part of the value,
+	// so `\\.` keeps `-p hun\"ter2` (and Windows paths such as `-p C:\dir\file`) fully redacted.
+	s = fmt.Sprintf(`(?im)\-[%s][\s=](?<short_form_value>(?:[^\s"\\]|\\.)*)`, shortForm)
 	dict[s] = scrubStruct{
 		groupToRedact: 1,
 		regex:         regexp.MustCompile(s),
@@ -347,15 +363,40 @@ func scrub(p []byte, scrubDict ScrubbingDict) []byte {
 			continue
 		}
 		// then scrub from the regex list
-		matches := entry.regex.FindAllStringSubmatch(s, -1)
-		for _, match := range matches {
-			if entry.groupToRedact >= len(match) || match[entry.groupToRedact] == "" {
-				continue
-			}
-			s = strings.Replace(s, match[entry.groupToRedact], SANITIZE_REPLACEMENT_STRING, -1)
-		}
+		s = redactMatchedGroup(s, entry.regex, entry.groupToRedact)
 	}
 	return []byte(s)
+}
+
+// redactMatchedGroup replaces capture group groupToRedact of every match of regex in s,
+// addressing each occurrence by the position the regex matched it at.
+//
+// Addressing by position matters: looking the captured *text* back up in s and replacing every
+// occurrence of it lets a short or structural capture — a one-character value, or a value that
+// happens to be `{`, `,` or `"` — blank out identical text elsewhere in the same event, which
+// corrupts the surrounding payload (see CLI-1732). Matches returned by FindAll are non-overlapping
+// and in order, so the spans can be stitched back together in a single pass.
+func redactMatchedGroup(s string, regex *regexp.Regexp, groupToRedact int) string {
+	matches := regex.FindAllStringSubmatchIndex(s, -1)
+	if len(matches) == 0 {
+		return s
+	}
+
+	var builder strings.Builder
+	builder.Grow(len(s))
+	end := 0
+	for _, match := range matches {
+		lo, hi := 2*groupToRedact, 2*groupToRedact+1
+		// group out of range, or it did not participate in the match, or it matched empty
+		if hi >= len(match) || match[lo] < 0 || match[hi] <= match[lo] {
+			continue
+		}
+		builder.WriteString(s[end:match[lo]])
+		builder.WriteString(SANITIZE_REPLACEMENT_STRING)
+		end = match[hi]
+	}
+	builder.WriteString(s[end:])
+	return builder.String()
 }
 
 func (w *scrubbingIoWriter) Write(p []byte) (int, error) {

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -278,7 +278,10 @@ func addMandatoryMasking(dict ScrubbingDict) ScrubbingDict {
 	// capture may cross a balanced `[...]` pair (the dump nests one), but never an unpaired
 	// closing bracket, so it always stops at the dump's own `]`. The final `\[` alternative
 	// keeps a stray, unbalanced `[` inside the dump from failing the match altogether.
-	s = `_:\s*\[(?<everything_inside_hard_brackets>(?:\[[^\]]*\]|[^\[\]]|\[)*)\]`
+	// Quoted spans are consumed whole, before the bracket-tracking alternatives get a look —
+	// otherwise a `]` or `[` inside a quoted value (e.g. `'a]b'`) reads as real bracket nesting
+	// and the capture closes early, right at that inner bracket.
+	s = `_:\s*\[(?<everything_inside_hard_brackets>(?:'[^']*'|"[^"]*"|\[[^\]]*\]|[^\[\]]|\[)*)\]`
 	dict[s] = scrubStruct{
 		groupToRedact: 1,
 		regex:         regexp.MustCompile(s),
@@ -297,7 +300,7 @@ func addMandatoryMasking(dict ScrubbingDict) ScrubbingDict {
 	shortForm := strings.Join(shorts, "")
 	s = fmt.Sprintf(`(?im)'[%s]=(?<value>[^'\n]*)'`, shortForm)
 	dict[s] = scrubStruct{
-		groupToRedact: 2,
+		groupToRedact: 1,
 		regex:         regexp.MustCompile(s),
 	}
 
@@ -309,13 +312,25 @@ func addMandatoryMasking(dict ScrubbingDict) ScrubbingDict {
 	// its own quote character. A single pattern bounded by `['"]` needs a greedy `.*` to allow
 	// the opposite quote inside the value, and that greedy run reaches the *last* quote on the
 	// line, swallowing every field that follows it (see CLI-1732). `\n` stays excluded so the
-	// bounded classes keep the line-at-a-time reach the previous `.` had.
+	// bounded classes keep the line-at-a-time reach the previous `.` had. An escaped instance of
+	// the bounding quote (e.g. `Nick\'s`) is kept part of the value via `\\.`, the same idiom the
+	// CLI-argument pattern below uses — without it, the class stops at that escaped quote instead
+	// of the value's real closing one and leaks the remainder of the value.
 	for _, quote := range []string{`'`, `"`} {
-		s = fmt.Sprintf(`(?i)(?<short_form_key>\b[%s]\b)[,'":]+\s*(?:%s(?<short_form_value>[^%s\n]*)%s|([^,'"\s]+))[,}]?`, shortForm, quote, quote, quote)
+		s = fmt.Sprintf(`(?i)(?<short_form_key>\b[%s]\b)[,'":]+\s*%s(?<short_form_value>(?:[^%s\n\\]|\\.)*)%s[,}]?`, shortForm, quote, quote, quote)
 		dict[s] = scrubStruct{
 			groupToRedact: 2,
 			regex:         regexp.MustCompile(s),
 		}
+	}
+
+	// Same as above, but for values with no surrounding quotes at all, e.g. u: john.doe,
+	// The value class excludes ':' too: without that, a greedy separator backtracking off an
+	// already-redacted 'key': '***' leaves the colon for this group to swallow instead.
+	s = fmt.Sprintf(`(?i)(?<short_form_key>\b[%s]\b)[,'":]+\s*(?<short_form_value>[^,'":\s]+)[,}]?`, shortForm)
+	dict[s] = scrubStruct{
+		groupToRedact: 2,
+		regex:         regexp.MustCompile(s),
 	}
 
 	// CLI argument-style-specific scrubbing

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -280,8 +280,9 @@ func addMandatoryMasking(dict ScrubbingDict) ScrubbingDict {
 	// keeps a stray, unbalanced `[` inside the dump from failing the match altogether.
 	// Quoted spans are consumed whole, before the bracket-tracking alternatives get a look —
 	// otherwise a `]` or `[` inside a quoted value (e.g. `'a]b'`) reads as real bracket nesting
-	// and the capture closes early, right at that inner bracket.
-	s = `_:\s*\[(?<everything_inside_hard_brackets>(?:'[^']*'|"[^"]*"|\[[^\]]*\]|[^\[\]]|\[)*)\]`
+	// and the capture closes early, right at that inner bracket. `\\.` keeps a backslash-escaped
+	// bounding quote (e.g. `'a\'b]c'`) part of the same span instead of ending it prematurely.
+	s = `_:\s*\[(?<everything_inside_hard_brackets>(?:'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|\[[^\]]*\]|[^\[\]]|\[)*)\]`
 	dict[s] = scrubStruct{
 		groupToRedact: 1,
 		regex:         regexp.MustCompile(s),

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -328,6 +328,13 @@ func TestAddDefaults(t *testing.T) {
 			expected: `_: [***],`,
 		},
 		{
+			// A backslash-escaped bounding quote inside a dump value must not end the quoted
+			// span early — otherwise a later `]` in the dump reads as its closing bracket.
+			name:     "bracket dump with an escaped quote inside a quoted value",
+			input:    `_: [ 'a\'b]c', 'd' ], next`,
+			expected: `_: [***], next`,
+		},
+		{
 			name: "username and password constellations passed in a JSON-ish structure with verbatim output from snyk-config",
 			input: `{
 				unrelated: dont-scrub,

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -18,6 +18,7 @@ package logging
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os/user"
 	"regexp"
@@ -388,6 +389,145 @@ func TestAddDefaults(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			actual := scrub([]byte(test.input), dict)
 			assert.Equal(t, test.expected, string(actual))
+		})
+	}
+}
+
+// requireOnlyExpectedFieldsChanged decodes input and output as JSON objects and asserts that the
+// only fields whose value differs are the ones named in changed. It is the structural half of the
+// CLI-1732 regression tests: scrubbing has to redact the sensitive field and leave everything
+// around it — other fields, and the JSON framing itself — exactly as it found it.
+func requireOnlyExpectedFieldsChanged(t *testing.T, input, output string, changed map[string]any) {
+	t.Helper()
+
+	var before, after map[string]any
+	require.NoError(t, json.Unmarshal([]byte(input), &before), "test input must be valid JSON to begin with")
+	require.NoError(t, json.Unmarshal([]byte(output), &after),
+		"scrubbed output must still be valid JSON, got: %s", output)
+	require.Len(t, after, len(before), "scrubbing must not add or drop fields")
+
+	for key, originalValue := range before {
+		if expected, ok := changed[key]; ok {
+			assert.Equal(t, expected, after[key], "field %q should have been redacted", key)
+			continue
+		}
+		assert.Equal(t, originalValue, after[key], "field %q should have been left untouched", key)
+	}
+}
+
+// TestScrub_RedactsOnlyTheMatchedSpan covers CLI-1732 bug A: scrub() used to look the captured
+// value back up in the event and replace every occurrence of that text. A sensitive field whose
+// value happens to be a JSON structural character (or any short string that recurs elsewhere)
+// therefore blanked out unrelated parts of the event, up to and including the event's opening
+// brace — which is what produced the customer's
+// "zerolog: could not write event: cannot decode event: invalid character '*'".
+func TestScrub_RedactsOnlyTheMatchedSpan(t *testing.T) {
+	dict := addMandatoryMasking(ScrubbingDict{})
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		changed  map[string]any
+	}{
+		{
+			name:     "value is an opening brace that also opens the event",
+			input:    `{"level":"debug","tokenHint":"{","message":"scanning"}`,
+			expected: `{"level":"debug","tokenHint":"***","message":"scanning"}`,
+			changed:  map[string]any{"tokenHint": SANITIZE_REPLACEMENT_STRING},
+		},
+		{
+			name:     "value is a comma that also separates fields",
+			input:    `{"level":"debug","userKind":",","message":"a,b,c"}`,
+			expected: `{"level":"debug","userKind":"***","message":"a,b,c"}`,
+			changed:  map[string]any{"userKind": SANITIZE_REPLACEMENT_STRING},
+		},
+		{
+			name:     "value is a closing brace that also closes the event",
+			input:    `{"level":"debug","tokenHint":"}","tail":"end"}`,
+			expected: `{"level":"debug","tokenHint":"***","tail":"end"}`,
+			changed:  map[string]any{"tokenHint": SANITIZE_REPLACEMENT_STRING},
+		},
+		{
+			name:     "single character value that recurs in an unrelated field",
+			input:    `{"level":"debug","apiKey":"a","path":"/a/b/a"}`,
+			expected: `{"level":"debug","apiKey":"***","path":"/a/b/a"}`,
+			changed:  map[string]any{"apiKey": SANITIZE_REPLACEMENT_STRING},
+		},
+		{
+			name:     "value that also appears verbatim inside another field name",
+			input:    `{"userName":"log","logLevel":"debug"}`,
+			expected: `{"userName":"***","logLevel":"debug"}`,
+			changed:  map[string]any{"userName": SANITIZE_REPLACEMENT_STRING},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := string(scrub([]byte(test.input), dict))
+
+			assert.Equal(t, test.expected, actual)
+			assert.True(t, json.Valid([]byte(actual)),
+				"scrubbed output must remain decodable by zerolog, got: %s", actual)
+			requireOnlyExpectedFieldsChanged(t, test.input, actual, test.changed)
+		})
+	}
+}
+
+// TestScrub_GreedyCapturesStopAtTheirOwnDelimiter covers CLI-1732 bug B: the `_: [...]` and the
+// short-form `u`/`p` patterns captured with an unbounded greedy `.*`, so a match ran on to the
+// last delimiter anywhere in the event and redacted every field in between.
+func TestScrub_GreedyCapturesStopAtTheirOwnDelimiter(t *testing.T) {
+	dict := addMandatoryMasking(ScrubbingDict{})
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		changed  map[string]any
+	}{
+		{
+			name:     "snyk-config bracket dump followed by more JSON",
+			input:    `{"level":"debug","message":"_: [ 'test', 'monitor' ]","tags":["a","b"],"ok":true}`,
+			expected: `{"level":"debug","message":"_: [***]","tags":["a","b"],"ok":true}`,
+			changed:  map[string]any{"message": "_: [***]"},
+		},
+		{
+			name:     "bracket dump with a nested bracket group is still redacted as a whole",
+			input:    `{"message":"_: [ 'a', [nested], 'b' ]","after":"keepme"}`,
+			expected: `{"message":"_: [***]","after":"keepme"}`,
+			changed:  map[string]any{"message": "_: [***]"},
+		},
+		{
+			name:     "short-form CLI arguments followed by more JSON",
+			input:    `{"level":"debug","args":"-u john.doe -p hunter2","org":"acme","ok":true}`,
+			expected: `{"level":"debug","args":"-u *** -p ***","org":"acme","ok":true}`,
+			changed:  map[string]any{"args": "-u *** -p ***"},
+		},
+		{
+			name:     "short-form quoted value followed by more JSON",
+			input:    `{"u": "john.doe", "next": "keepme", "arr": [1,2]}`,
+			expected: `{"u": "***", "next": "keepme", "arr": [1,2]}`,
+			changed:  map[string]any{"u": SANITIZE_REPLACEMENT_STRING},
+		},
+		{
+			// Bounding the value at `"` must not stop at a quote the value itself contains:
+			// the escape belongs to the argument, so the whole secret still has to go.
+			name:     "short-form argument value containing an escaped quote stays fully redacted",
+			input:    `{"cfg":"-p hun\"ter2","next":"keepme"}`,
+			expected: `{"cfg":"-p ***","next":"keepme"}`,
+			changed:  map[string]any{"cfg": "-p ***"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := string(scrub([]byte(test.input), dict))
+
+			assert.Equal(t, test.expected, actual)
+			assert.True(t, json.Valid([]byte(actual)),
+				"scrubbed output must remain decodable by zerolog, got: %s", actual)
+			requireOnlyExpectedFieldsChanged(t, test.input, actual, test.changed)
 		})
 	}
 }

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -384,6 +384,18 @@ func TestAddDefaults(t *testing.T) {
 			input:    `container test gcr.io/distroless/nodejs:latest --platform=linux/arm64 --unrelated-argument --unrelated-argument-with-value "value" --unrelated-argument-with-equals-sign="value" -u=john.doe -p=hunter2 --log-level=trace`,
 			expected: `container test gcr.io/distroless/nodejs:latest --platform=linux/arm64 --unrelated-argument --unrelated-argument-with-value "value" --unrelated-argument-with-equals-sign="value" -u=*** -p=*** --log-level=trace`,
 		},
+		{
+			name:     "single-quoted key=value short form",
+			input:    `before 'u=john.doe' 'p=hunter2' after`,
+			expected: `before 'u=***' 'p=***' after`,
+		},
+		{
+			// An escaped instance of the value's own bounding quote must not be read as the
+			// value's closing delimiter.
+			name:     "short-form single-quoted value containing an escaped apostrophe",
+			input:    `'u': 'Nick\'s', 'other': 'keepme'`,
+			expected: `'u': '***', 'other': 'keepme'`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -517,6 +529,28 @@ func TestScrub_GreedyCapturesStopAtTheirOwnDelimiter(t *testing.T) {
 			input:    `{"cfg":"-p hun\"ter2","next":"keepme"}`,
 			expected: `{"cfg":"-p ***","next":"keepme"}`,
 			changed:  map[string]any{"cfg": "-p ***"},
+		},
+		{
+			// A `]` inside a quoted dump value used to read as the dump's own closing bracket,
+			// truncating the capture and leaking the rest of the entry unredacted (see CLI-1732).
+			name:     "bracket dump with a `]` inside a quoted value is still redacted as a whole",
+			input:    `{"message":"_: [ 'a]b', 'c' ]","after":"keepme"}`,
+			expected: `{"message":"_: [***]","after":"keepme"}`,
+			changed:  map[string]any{"message": "_: [***]"},
+		},
+		{
+			// Same as above for `[`: a quoted value containing an unmatched opening bracket must
+			// not be read as the start of a new nested pair.
+			name:     "bracket dump with a `[` inside a quoted value is still redacted as a whole",
+			input:    `{"message":"_: [ 'a[b', 'c' ]","after":"keepme"}`,
+			expected: `{"message":"_: [***]","after":"keepme"}`,
+			changed:  map[string]any{"message": "_: [***]"},
+		},
+		{
+			name:     "short-form value with no surrounding quotes at all",
+			input:    `{"message":"u: john.doe, next: keepme"}`,
+			expected: `{"message":"u: ***, next: keepme"}`,
+			changed:  map[string]any{"message": "u: ***, next: keepme"},
 		},
 	}
 


### PR DESCRIPTION
## Summary

Fixes [CLI-1732](https://snyksec.atlassian.net/browse/CLI-1732): customers running `snyk monitor -d` (or any command with debug logging) intermittently see `zerolog: could not write event: cannot decode event: invalid character '*' looking for beginning of value`. Cosmetic (the underlying command still succeeds), but it makes debug output unusable for troubleshooting.

Two independent bugs in `pkg/logging/scrubbingLogWriter.go`, both stemming from redaction not respecting the boundaries of the already-serialized JSON log event it's operating on:

- **`scrub()`** redacted a matched capture group by re-searching the whole string for the captured *text* and replacing every occurrence, instead of replacing just the matched *span*. A short or structural redacted value (a one-character field value that happens to equal `{`, `,`, or `"`) could wipe out identical text elsewhere in the same event, corrupting the JSON. This reproduces the customer's exact error string.
- **`addMandatoryMasking`** had unbounded greedy captures in two places (the legacy snyk-config `_: [...]` debug dump, and the `'p='/'u='` / `-p`/`-u` short forms) that matched through to the *last* delimiter anywhere later in the event instead of their own closing one, swallowing any JSON that followed.

## Changes

- `scrub()` now redacts by matched position (`FindAllStringSubmatchIndex` + span rebuild) rather than re-searching for captured text.
- Bounded the two greedy regexes so they stop at their own delimiter; split the single-pattern short-form quote matcher into single- and double-quoted variants since a shared bound needs backreferences RE2 doesn't support.
- Added 9 new tests reproducing both failure modes and asserting the scrubbed output stays valid JSON; all 85 pre-existing tests pass unchanged.

## Test plan
- [x] `go test ./pkg/logging/...` — 85 passing (sub)tests, 0 failures
- [x] `go test ./pkg/analytics/...` (only other consumer of the scrub path) — clean
- [x] `go build ./...`, `go vet`, `golangci-lint run ./pkg/logging/...`, `gofmt -l` — all clean
- [x] Verified new tests actually catch the regression: reverting only the source file fails 8/9 new subtests, with the pre-fix failure being the customer's literal error string

[CLI-1732]: https://snyksec.atlassian.net/browse/CLI-1732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core log redaction behavior on every debug/analytics write path; fixes are well-tested but incorrect regex edge cases could still leak secrets or skip redaction.
> 
> **Overview**
> Fixes debug-log corruption where zerolog could fail with invalid JSON after scrubbing (**CLI-1732**).
> 
> **Position-based redaction:** Regex redaction no longer replaces every occurrence of the captured *text* in the event. A new `redactMatchedGroup` helper rewrites only the matched byte span (via `FindAllStringSubmatchIndex`), so one-character or structural secret values like `{`, `,`, or `"` cannot wipe the same characters elsewhere in the JSON.
> 
> **Tighter mandatory masking patterns:** Greedy captures in the legacy snyk-config `_: [...]` dump and in `u`/`p` short-form patterns are bounded so matches stop at their own delimiters (quoted spans, nested `[...]`, escaped quotes) instead of running to the last `]`, `'`, or `"` in the whole line/event. CLI `-u`/`-p` values similarly stop at unescaped `"` while still treating escaped quotes as part of the value.
> 
> **Tests:** Adds CLI-1732 regression suites that assert scrubbed output stays valid JSON and only the intended fields change, plus cases for escaped quotes and bracket dumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 951924fe58ba877bbd2ee7af3595b79fa3be408a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->