### PR TITLE
fix: prevent static-term scrubbing from corrupting JSON

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -368,11 +368,20 @@ func SanitizeUsername(rawUserName string, userHomeDir string, replacementValue s
 	return SanitizeStaticValues(valuesToSanitize, replacementValue, content)
 }
 
+// SanitizeStaticValues is exported API, so content isn't guaranteed to be the full, valid JSON its
+// two current callers (GetRequest, GetV2InstrumentationObject) always pass -- both feed it
+// json.Marshal output. RedactStaticTerm's bare-value quoting is only correct against real JSON; a
+// non-JSON snippet falls back to a plain literal replace, the same non-JSON path ScrubValue uses.
 func SanitizeStaticValues(valuesToSanitize []string, replacementValue string, content []byte) ([]byte, error) {
 	contentStr := string(content)
+	jsonAware := json.Valid(content)
 
 	for _, valueToReplace := range valuesToSanitize {
-		contentStr = logging.RedactStaticTerm(contentStr, valueToReplace, replacementValue)
+		if jsonAware {
+			contentStr = logging.RedactStaticTerm(contentStr, valueToReplace, replacementValue)
+		} else {
+			contentStr = strings.ReplaceAll(contentStr, valueToReplace, replacementValue)
+		}
 	}
 
 	return []byte(contentStr), nil

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -377,6 +377,9 @@ func SanitizeStaticValues(valuesToSanitize []string, replacementValue string, co
 	jsonAware := json.Valid(content)
 
 	for _, valueToReplace := range valuesToSanitize {
+		if valueToReplace == "" {
+			continue // strings.ReplaceAll inserts replacementValue between every rune for an empty old string
+		}
 		if jsonAware {
 			contentStr = logging.RedactStaticTerm(contentStr, valueToReplace, replacementValue)
 		} else {

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -368,10 +368,10 @@ func SanitizeUsername(rawUserName string, userHomeDir string, replacementValue s
 	return SanitizeStaticValues(valuesToSanitize, replacementValue, content)
 }
 
-// SanitizeStaticValues is exported API, so content isn't guaranteed to be the full, valid JSON its
-// two current callers (GetRequest, GetV2InstrumentationObject) always pass -- both feed it
-// json.Marshal output. RedactStaticTerm's bare-value quoting is only correct against real JSON; a
-// non-JSON snippet falls back to a plain literal replace, the same non-JSON path ScrubValue uses.
+// SanitizeStaticValues replaces every occurrence of each valuesToSanitize entry in content with
+// replacementValue. Replacement is JSON-aware (see logging.RedactStaticTerm) only when content is
+// itself valid JSON: the bare-value quoting that keeps a redacted JSON payload parseable would
+// otherwise inject stray quotes into a plain-text snippet, which exported API has to expect.
 func SanitizeStaticValues(valuesToSanitize []string, replacementValue string, content []byte) ([]byte, error) {
 	contentStr := string(content)
 	jsonAware := json.Valid(content)

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -371,7 +371,8 @@ func SanitizeUsername(rawUserName string, userHomeDir string, replacementValue s
 // SanitizeStaticValues replaces every occurrence of each valuesToSanitize entry in content with
 // replacementValue. Replacement is JSON-aware (see logging.RedactStaticTerm) only when content is
 // itself valid JSON: the bare-value quoting that keeps a redacted JSON payload parseable would
-// otherwise inject stray quotes into a plain-text snippet, which exported API has to expect.
+// otherwise inject stray quotes into a plain-text snippet -- something an exported function has to
+// tolerate, since it can't assume every caller passes valid JSON.
 func SanitizeStaticValues(valuesToSanitize []string, replacementValue string, content []byte) ([]byte, error) {
 	contentStr := string(content)
 	jsonAware := json.Valid(content)

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -372,7 +372,7 @@ func SanitizeStaticValues(valuesToSanitize []string, replacementValue string, co
 	contentStr := string(content)
 
 	for _, valueToReplace := range valuesToSanitize {
-		contentStr = strings.ReplaceAll(contentStr, valueToReplace, replacementValue)
+		contentStr = logging.RedactStaticTerm(contentStr, valueToReplace, replacementValue)
 	}
 
 	return []byte(contentStr), nil

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -235,10 +235,9 @@ func Test_SanitizeUsername(t *testing.T) {
 	}
 }
 
-// Test_SanitizeUsername_NumericUsernameCollision covers os/user.Current falling back to a
-// numeric UID as Username (documented behavior when NSS/cgo lookup fails, common in
-// scratch/musl containers). A numeric username can collide with an unrelated bare JSON number
-// elsewhere in the payload; SanitizeStaticValues must not corrupt that number into invalid JSON.
+// Test_SanitizeUsername_NumericUsernameCollision guards against a numeric username (os/user.Current
+// falls back to a numeric UID when NSS/cgo lookup fails) colliding with an unrelated bare JSON
+// number and corrupting the payload.
 func Test_SanitizeUsername_NumericUsernameCollision(t *testing.T) {
 	input := []byte(`{"durationMs":10001234,"count":1000,"other":"x"}`)
 
@@ -246,6 +245,30 @@ func Test_SanitizeUsername_NumericUsernameCollision(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.True(t, json.Valid(output), "sanitizing produced invalid JSON: %s", output)
+	assert.Equal(t, `{"durationMs":10001234,"count":"***","other":"x"}`, string(output))
+}
+
+// Test_GetRequest_RedactsNumericUsernameFromMarshaledPayload proves the fix survives the real
+// GetRequest() pipeline, not just a hand-built JSON blob: a numeric username embedded in an error
+// message must be redacted without corrupting the rest of the marshaled payload.
+func Test_GetRequest_RedactsNumericUsernameFromMarshaledPayload(t *testing.T) {
+	a := New().(*AnalyticsImpl) //nolint:errcheck //in this test, the type is clear
+	a.userCurrent = func() (*user.User, error) {
+		return &user.User{Username: "1000", HomeDir: t.TempDir()}, nil
+	}
+	a.AddError(fmt.Errorf("permission denied for user 1000"))
+
+	req, err := a.GetRequest()
+	assert.NoError(t, err)
+
+	body, err := io.ReadAll(req.Body)
+	assert.NoError(t, err)
+	assert.True(t, json.Valid(body), "GetRequest produced invalid JSON: %s", body)
+
+	var decoded dataOutput
+	assert.NoError(t, json.Unmarshal(body, &decoded))
+	assert.NotContains(t, decoded.Data.Metadata.ErrorMessage, "1000")
+	assert.NotEmpty(t, decoded.Data.Id)
 }
 
 func newTestAnalytics(t *testing.T) Analytics {

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -235,9 +235,9 @@ func Test_SanitizeUsername(t *testing.T) {
 	}
 }
 
-// Test_SanitizeUsername_NumericUsernameCollision guards against a numeric username (os/user.Current
-// falls back to a numeric UID when NSS/cgo lookup fails) colliding with an unrelated bare JSON
-// number and corrupting the payload.
+// Test_SanitizeUsername_NumericUsernameCollision guards against a numeric username -- a realistic
+// value in containerized environments where $USER is set to a raw UID with no matching
+// /etc/passwd entry -- colliding with an unrelated bare JSON number and corrupting the payload.
 func Test_SanitizeUsername_NumericUsernameCollision(t *testing.T) {
 	input := []byte(`{"durationMs":10001234,"count":1000,"other":"x"}`)
 

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -248,6 +248,17 @@ func Test_SanitizeUsername_NumericUsernameCollision(t *testing.T) {
 	assert.Equal(t, `{"durationMs":10001234,"count":"***","other":"x"}`, string(output))
 }
 
+// Test_SanitizeStaticValues_NonJSONSnippetIsNotStrayQuoted covers SanitizeStaticValues being
+// called on a non-JSON snippet, not the full valid JSON its current callers always pass -- it's
+// exported API, so a future caller isn't bound to that. Without gating on content's own validity,
+// a term next to ": "/"," here would get RedactStaticTerm's bare-value quoting even though there's
+// no JSON to protect, injecting stray quotes into plain text.
+func Test_SanitizeStaticValues_NonJSONSnippetIsNotStrayQuoted(t *testing.T) {
+	output, err := SanitizeStaticValues([]string{"1000"}, "***", []byte("user: 1000, retry: 2000"))
+	assert.NoError(t, err)
+	assert.Equal(t, "user: ***, retry: 2000", string(output))
+}
+
 // Test_GetRequest_RedactsNumericUsernameFromMarshaledPayload proves the fix survives the real
 // GetRequest() pipeline, not just a hand-built JSON blob: a numeric username embedded in an error
 // message must be redacted without corrupting the rest of the marshaled payload.

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -259,6 +259,23 @@ func Test_SanitizeStaticValues_NonJSONSnippetIsNotStrayQuoted(t *testing.T) {
 	assert.Equal(t, "user: ***, retry: 2000", string(output))
 }
 
+// Test_SanitizeStaticValues_EmptyValueIsNoop covers both branches of the jsonAware split: unlike
+// RedactStaticTerm, strings.ReplaceAll has no built-in guard against an empty old string -- it
+// inserts replacementValue between every rune instead of leaving the content untouched.
+func Test_SanitizeStaticValues_EmptyValueIsNoop(t *testing.T) {
+	t.Run("non-JSON content", func(t *testing.T) {
+		output, err := SanitizeStaticValues([]string{""}, "***", []byte("plain text"))
+		assert.NoError(t, err)
+		assert.Equal(t, "plain text", string(output))
+	})
+
+	t.Run("JSON content", func(t *testing.T) {
+		output, err := SanitizeStaticValues([]string{""}, "***", []byte(`{"a":1}`))
+		assert.NoError(t, err)
+		assert.Equal(t, `{"a":1}`, string(output))
+	})
+}
+
 // Test_GetRequest_RedactsNumericUsernameFromMarshaledPayload proves the fix survives the real
 // GetRequest() pipeline, not just a hand-built JSON blob: a numeric username embedded in an error
 // message must be redacted without corrupting the rest of the marshaled payload.

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -235,6 +235,19 @@ func Test_SanitizeUsername(t *testing.T) {
 	}
 }
 
+// Test_SanitizeUsername_NumericUsernameCollision covers os/user.Current falling back to a
+// numeric UID as Username (documented behavior when NSS/cgo lookup fails, common in
+// scratch/musl containers). A numeric username can collide with an unrelated bare JSON number
+// elsewhere in the payload; SanitizeStaticValues must not corrupt that number into invalid JSON.
+func Test_SanitizeUsername_NumericUsernameCollision(t *testing.T) {
+	input := []byte(`{"durationMs":10001234,"count":1000,"other":"x"}`)
+
+	output, err := SanitizeUsername("1000", "/home/1000", "***", input)
+	assert.NoError(t, err)
+
+	assert.True(t, json.Valid(output), "sanitizing produced invalid JSON: %s", output)
+}
+
 func newTestAnalytics(t *testing.T) Analytics {
 	t.Helper()
 	a := New()

--- a/pkg/analytics/instrumentation_collector.go
+++ b/pkg/analytics/instrumentation_collector.go
@@ -188,7 +188,7 @@ func (ic *instrumentationCollectorImpl) getV2InstrumentationObject(options *seri
 func (ic *instrumentationCollectorImpl) sanitizeExtensionData(options *serializeOptions, d api.AnalyticsData) *api.AnalyticsRequestBody {
 	logger := options.logger
 
-	// Scrub string leaf values before marshaling, never the marshaled JSON bytes: logging.Scrub
+	// Scrub string leaf values before marshaling, never the marshaled JSON bytes: logging.ScrubValue
 	// does whole-string literal replacement, so running it over raw JSON would let a redacted
 	// value collide with an unrelated field that happens to contain the same substring.
 	if options.cfg != nil && d.Attributes.Interaction.Extension != nil {

--- a/pkg/analytics/instrumentation_collector.go
+++ b/pkg/analytics/instrumentation_collector.go
@@ -264,7 +264,7 @@ func scrubExtensionMapSeen(m map[string]interface{}, dict logging.ScrubbingDict,
 func scrubExtensionValueSeen(v interface{}, dict logging.ScrubbingDict, seen map[uintptr]bool) interface{} {
 	switch val := v.(type) {
 	case string:
-		return string(logging.Scrub([]byte(val), dict))
+		return string(logging.ScrubValue([]byte(val), dict))
 	case map[string]interface{}:
 		return scrubExtensionMapSeen(val, dict, seen)
 	case []interface{}:

--- a/pkg/analytics/instrumentation_collector_test.go
+++ b/pkg/analytics/instrumentation_collector_test.go
@@ -16,6 +16,7 @@ import (
 	api "github.com/snyk/go-application-framework/internal/api/analytics/2024-03-07"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
+	"github.com/snyk/go-application-framework/pkg/logging"
 	"github.com/snyk/go-application-framework/pkg/networking"
 )
 
@@ -287,6 +288,38 @@ func Test_InstrumentationCollector(t *testing.T) {
 		expectedV2InstrumentationObject.Data.Attributes.Interaction.Extension = &mockExtension
 
 		actualV2InstrumentationObject, err := GetV2InstrumentationObject(ic, WithLogger(&logger), WithConfiguration(configuration.NewInMemory()))
+		assert.NoError(t, err)
+		expectedV2InstrumentationJson, err := json.Marshal(expectedV2InstrumentationObject)
+		assert.NoError(t, err)
+		actualV2InstrumentationJson, err := json.Marshal(actualV2InstrumentationObject)
+		assert.NoError(t, err)
+
+		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
+	})
+
+	t.Run("it should redact a static term embedded in freeform extension text without corrupting or under-redacting it", func(t *testing.T) {
+		// Extension leaves are scrubbed as plain values, not JSON (ScrubValue, not Scrub): a term
+		// adjacent to `:`/`,` or fused to another digit must still be redacted verbatim, with no
+		// JSON-value quoting or digit-fusion skip injected, since there is no JSON syntax here to
+		// protect and the leaf is properly quoted by json.Marshal regardless of its content.
+		ic := setupBaseCollector(t)
+		expectedV2InstrumentationObject := buildExpectedBaseObject(t)
+
+		cfg := configuration.NewInMemory()
+		cfg.Set(logging.REDACTION_TERMS, []string{"1000"})
+
+		ic.AddExtension("note", "port:1000,timeout:3000")
+		ic.AddExtension("adjacent", "trace id 10001234 seen")
+
+		mockExtension := map[string]interface{}{
+			"strings":  "hello world",
+			"note":     "port:***,timeout:3000",
+			"adjacent": "trace id ***1234 seen",
+		}
+
+		expectedV2InstrumentationObject.Data.Attributes.Interaction.Extension = &mockExtension
+
+		actualV2InstrumentationObject, err := GetV2InstrumentationObject(ic, WithLogger(&logger), WithConfiguration(cfg))
 		assert.NoError(t, err)
 		expectedV2InstrumentationJson, err := json.Marshal(expectedV2InstrumentationObject)
 		assert.NoError(t, err)

--- a/pkg/analytics/instrumentation_collector_test.go
+++ b/pkg/analytics/instrumentation_collector_test.go
@@ -298,10 +298,8 @@ func Test_InstrumentationCollector(t *testing.T) {
 	})
 
 	t.Run("it should redact a static term embedded in freeform extension text without corrupting or under-redacting it", func(t *testing.T) {
-		// Extension leaves are scrubbed as plain values, not JSON (ScrubValue, not Scrub): a term
-		// adjacent to `:`/`,` or fused to another digit must still be redacted verbatim, with no
-		// JSON-value quoting or digit-fusion skip injected, since there is no JSON syntax here to
-		// protect and the leaf is properly quoted by json.Marshal regardless of its content.
+		// Extension leaves are scrubbed via ScrubValue, not Scrub: a term adjacent to `:`/`,` or
+		// fused to a digit must still be redacted verbatim, with no JSON-value quoting or digit-fusion skip.
 		ic := setupBaseCollector(t)
 		expectedV2InstrumentationObject := buildExpectedBaseObject(t)
 

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -420,7 +420,7 @@ func RedactStaticTerm(s, term, replacement string) string {
 	var builder strings.Builder
 	builder.Grow(len(s))
 	end := 0
-	quoted := false
+	var qs quoteState
 	for {
 		idx := strings.Index(s[end:], term)
 		if idx < 0 {
@@ -428,7 +428,8 @@ func RedactStaticTerm(s, term, replacement string) string {
 		}
 		start := end + idx
 		matchEnd := start + len(term)
-		quoted = advanceQuoteState(quoted, s[end:start])
+		qs = qs.advance(s[end:start])
+		quoted := qs.inQuotes
 		builder.WriteString(s[end:start])
 		switch {
 		case !quoted && isFusedToAdjacentDigit(s, start, matchEnd):
@@ -440,26 +441,39 @@ func RedactStaticTerm(s, term, replacement string) string {
 		default:
 			builder.WriteString(replacement)
 		}
-		quoted = advanceQuoteState(quoted, s[start:matchEnd])
+		qs = qs.advance(s[start:matchEnd])
 		end = matchEnd
 	}
 	builder.WriteString(s[end:])
 	return builder.String()
 }
 
-// advanceQuoteState scans span and reports whether s is inside an open, unescaped double-quoted
-// JSON string once span has been consumed, given inQuotes was the state before span. An escaped
-// character (`\"`, `\\`, ...) is skipped whole so it can't toggle the state on its own.
-func advanceQuoteState(inQuotes bool, span string) bool {
+// quoteState tracks whether a scan position sits inside an open, unescaped double-quoted JSON
+// string, plus whether the most recently scanned span ended on an unresolved backslash. That
+// second field matters because RedactStaticTerm scans in separate pieces (the text before a match,
+// then the match itself) rather than the whole string in one pass: without it, a backslash landing
+// as the very last byte of one piece would have its escaped character re-examined as fresh, unescaped
+// input by the next piece, flipping inQuotes on a quote that was actually just escaped.
+type quoteState struct {
+	inQuotes bool
+	escaping bool
+}
+
+// advance scans span and returns the state after it, given qs was the state before span.
+func (qs quoteState) advance(span string) quoteState {
 	for i := 0; i < len(span); i++ {
+		if qs.escaping {
+			qs.escaping = false
+			continue
+		}
 		switch span[i] {
 		case '\\':
-			i++
+			qs.escaping = true
 		case '"':
-			inQuotes = !inQuotes
+			qs.inQuotes = !qs.inQuotes
 		}
 	}
-	return inQuotes
+	return qs
 }
 
 // isBareJSONValueSpan reports whether s[start:end] is an unquoted JSON value: preceded by `:`,

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -485,7 +485,7 @@ func (qs quoteState) advance(span string) quoteState {
 // prose as a bare value when that prose sits outside any JSON string and next to a real `:`/`,` —
 // callers that gate jsonAware on the input actually being valid JSON (see internalWrite) rule that
 // out, since prose inside valid JSON is always inside a quoted string, where the `quoted` check in
-// RedactStaticTerm's caller already skips this function entirely.
+// RedactStaticTerm itself already skips this function entirely.
 func isBareJSONValueSpan(s string, start, end int) bool {
 	i := start - 1
 	for i >= 0 && isJSONWhitespace(s[i]) {

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -401,18 +401,20 @@ func scrub(p []byte, scrubDict ScrubbingDict, jsonAware bool) []byte {
 
 // RedactStaticTerm replaces every occurrence of term in s with replacement, quoting the
 // replacement when term sits in a bare (unquoted) JSON value position, and leaving an occurrence
-// untouched when it's only a digit-fused slice of a larger bare number.
+// untouched when it's only a token-fused slice of a larger bare number/true/false/null.
 //
 // term has no regex capture to bound it, so only the characters immediately around each match are
-// checked. A term preceded by `:`, `,` or `[` and followed by `,`, `}` or `]` is a bare value
+// checked. A term preceded by `:`, `,` or `[` and followed by `,`, `}` or `]` — or with no
+// boundary character on *either* side, i.e. term is the whole document — is a bare value
 // (number/bool/null); an unquoted replacement there is invalid JSON (see CLI-1732), so the
-// replacement gets quoted instead. A term at the very start or end of s, with no boundary
-// character on that side, is left bare rather than guessed at. A term already inside a quoted
-// string is also left bare, and never treated as digit-fused.
+// replacement gets quoted instead. A term missing the boundary character on only one side is an
+// ambiguous fragment and is left bare rather than guessed at. A term already inside a quoted
+// string is also left bare, and never treated as token-fused.
 //
 // A numeric term can also land mid-number in a bare position (e.g. redacting "1000" out of an
-// unrelated "durationMs":10001234) — there it's a slice of a larger number token, and no amount of
-// quoting keeps that valid, so the occurrence is left alone rather than corrupting the number.
+// unrelated "durationMs":10001234), and a term like "rue" can land mid-keyword (inside "true") —
+// in both cases it's a slice of a larger bare token, and no amount of quoting keeps that valid, so
+// the occurrence is left alone rather than corrupting the token.
 //
 // Exported for reuse by pkg/analytics's SanitizeStaticValues, which has the same corruption risk.
 func RedactStaticTerm(s, term, replacement string) string {
@@ -434,7 +436,7 @@ func RedactStaticTerm(s, term, replacement string) string {
 		quoted := qs.inQuotes
 		builder.WriteString(s[end:start])
 		switch {
-		case !quoted && isFusedToAdjacentNumberChar(s, start, matchEnd):
+		case !quoted && isFusedToAdjacentBareTokenChar(s, start, matchEnd):
 			builder.WriteString(s[start:matchEnd])
 		case !quoted && isBareJSONValueSpan(s, start, matchEnd):
 			builder.WriteByte('"')
@@ -486,17 +488,25 @@ func (qs quoteState) advance(span string) quoteState {
 // callers that gate jsonAware on the input actually being valid JSON (see internalWrite) rule that
 // out, since prose inside valid JSON is always inside a quoted string, where the `quoted` check in
 // RedactStaticTerm itself already skips this function entirely.
+//
+// A span with no boundary character on *either* side, once whitespace is skipped, is the entire
+// document by itself — a top-level bare scalar, still a JSON value even though nothing encloses
+// it. A span missing only one side's boundary is an ambiguous fragment (see RedactStaticTerm's
+// start/end-of-s case) and stays unquoted rather than guessed at.
 func isBareJSONValueSpan(s string, start, end int) bool {
 	i := start - 1
 	for i >= 0 && isJSONWhitespace(s[i]) {
 		i--
 	}
-	precededByValueStart := i >= 0 && strings.ContainsRune(":,[", rune(s[i]))
-
 	j := end
 	for j < len(s) && isJSONWhitespace(s[j]) {
 		j++
 	}
+	if i < 0 && j >= len(s) {
+		return true
+	}
+
+	precededByValueStart := i >= 0 && strings.ContainsRune(":,[", rune(s[i]))
 	followedByValueEnd := j < len(s) && strings.ContainsRune(",}]", rune(s[j]))
 
 	return precededByValueStart && followedByValueEnd
@@ -506,13 +516,20 @@ func isJSONWhitespace(b byte) bool {
 	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
 }
 
-// isFusedToAdjacentNumberChar reports whether s[start:end] touches a digit or other
-// numeric-literal character (`.`, `-`, `+`, `e`, `E`) on either side — i.e. it's a slice of a
-// larger unquoted number, not a complete value.
-func isFusedToAdjacentNumberChar(s string, start, end int) bool {
-	precededByNumberChar := start > 0 && isJSONNumberChar(s[start-1])
-	followedByNumberChar := end < len(s) && isJSONNumberChar(s[end])
-	return precededByNumberChar || followedByNumberChar
+// isFusedToAdjacentBareTokenChar reports whether s[start:end] touches a character that only ever
+// appears inside a larger unquoted JSON token — a digit or other numeric-literal character (`.`,
+// `-`, `+`, `e`, `E`), or a lowercase letter — on either side, i.e. it's a slice of a bigger bare
+// number/true/false/null, not a complete value by itself. jsonAware callers only reach here once
+// the whole buffer is confirmed valid JSON, so an unquoted letter can only belong to one of those
+// three keywords; there's no other bare token it could be part of.
+func isFusedToAdjacentBareTokenChar(s string, start, end int) bool {
+	precededByTokenChar := start > 0 && isJSONBareTokenChar(s[start-1])
+	followedByTokenChar := end < len(s) && isJSONBareTokenChar(s[end])
+	return precededByTokenChar || followedByTokenChar
+}
+
+func isJSONBareTokenChar(b byte) bool {
+	return isJSONNumberChar(b) || (b >= 'a' && b <= 'z')
 }
 
 func isJSONNumberChar(b byte) bool {

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -432,7 +432,7 @@ func RedactStaticTerm(s, term, replacement string) string {
 		quoted := qs.inQuotes
 		builder.WriteString(s[end:start])
 		switch {
-		case !quoted && isFusedToAdjacentDigit(s, start, matchEnd):
+		case !quoted && isFusedToAdjacentNumberChar(s, start, matchEnd):
 			builder.WriteString(s[start:matchEnd])
 		case !quoted && isBareJSONValueSpan(s, start, matchEnd):
 			builder.WriteByte('"')
@@ -504,10 +504,10 @@ func isJSONWhitespace(b byte) bool {
 	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
 }
 
-// isFusedToAdjacentDigit reports whether s[start:end] touches a digit or other numeric-literal
-// character (`.`, `-`, `+`, `e`, `E`) on either side — i.e. it's a slice of a larger unquoted
-// number, not a complete value.
-func isFusedToAdjacentDigit(s string, start, end int) bool {
+// isFusedToAdjacentNumberChar reports whether s[start:end] touches a digit or other
+// numeric-literal character (`.`, `-`, `+`, `e`, `E`) on either side — i.e. it's a slice of a
+// larger unquoted number, not a complete value.
+func isFusedToAdjacentNumberChar(s string, start, end int) bool {
 	precededByNumberChar := start > 0 && isJSONNumberChar(s[start-1])
 	followedByNumberChar := end < len(s) && isJSONNumberChar(s[end])
 	return precededByNumberChar || followedByNumberChar

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -17,6 +17,7 @@
 package logging
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os/user"
@@ -357,20 +358,15 @@ func (w *scrubbingLevelWriter) Write(p []byte) (int, error) {
 	return internalWrite(w.scrubDict, p, w.writer.Write)
 }
 
-// Scrub applies scrubDict's redaction rules to data, the same logic used internally by ScrubbingLogWriter.
-// data is treated as a JSON-structured log line: a static-term match is quoted or skipped as
-// needed to keep the result valid JSON (see RedactStaticTerm). Use ScrubValue instead for a bare
-// value that isn't itself JSON, e.g. a string leaf that a later json.Marshal will quote for you.
+// Scrub applies scrubDict's redaction rules to data, treated as a JSON-structured log line.
+// Use ScrubValue for a bare, non-JSON leaf value.
 func Scrub(data []byte, scrubDict ScrubbingDict) []byte {
 	return scrub(data, scrubDict, true)
 }
 
 // ScrubValue applies scrubDict's redaction rules to a value that is not itself JSON-structured,
-// e.g. a single leaf string an AddExtension caller supplied, destined to be embedded as an
-// already-quoted JSON string value by a later json.Marshal. RedactStaticTerm's JSON-value quoting
-// and digit-fusion skip exist only to protect JSON syntax in Scrub's whole-log-line input;
-// applying them to arbitrary leaf text instead injects stray quote characters into unrelated
-// content, or worse, skips redacting a real secret that happens to sit next to a digit.
+// e.g. a leaf string that a later json.Marshal will quote. Skips Scrub's JSON-value quoting and
+// digit-fusion protections, which would otherwise stray-quote or under-redact plain text.
 func ScrubValue(data []byte, scrubDict ScrubbingDict) []byte {
 	return scrub(data, scrubDict, false)
 }
@@ -402,30 +398,21 @@ func scrub(p []byte, scrubDict ScrubbingDict, jsonAware bool) []byte {
 }
 
 // RedactStaticTerm replaces every occurrence of term in s with replacement, quoting the
-// replacement when term occupies a bare (unquoted) JSON value position, and leaving an
-// occurrence untouched when it is only a partial, digit-fused slice of a larger bare number.
+// replacement when term sits in a bare (unquoted) JSON value position, and leaving an occurrence
+// untouched when it's only a digit-fused slice of a larger bare number.
 //
-// term is an exact secret/token value (e.g. from AddTermsToReplace), so unlike redactMatchedGroup
-// this has no regex capture to bound the match — it can only look at the characters immediately
-// around each occurrence. A term that sits right after a JSON `:`, `,` or `[` and right before a
-// `,`, `}`, `]` or end-of-string is standing in for a bare value (a number, bool, or null), and an
-// unquoted replacement is not a legal token there — replacing it unquoted produces invalid JSON
-// (see CLI-1732). Quoting the replacement in that position keeps it a valid JSON string instead.
-// A term inside an existing quoted string is left bare, since it is already bounded by quotes
-// that this function did not consume — and, being already-quoted text rather than a bare value,
-// it is never treated as digit-fused either: the fusion check below only protects bare numbers.
+// term has no regex capture to bound it, so only the characters immediately around each match are
+// checked. A term preceded by `:`, `,` or `[` and followed by `,`, `}` or `]` is a bare value
+// (number/bool/null); an unquoted replacement there is invalid JSON (see CLI-1732), so the
+// replacement gets quoted instead. A term at the very start or end of s, with no boundary
+// character on that side, is left bare rather than guessed at. A term already inside a quoted
+// string is also left bare, and never treated as digit-fused.
 //
-// A purely numeric term can also land mid-number in a *bare* (unquoted) position — e.g. redacting
-// a numeric username "1000" out of an unrelated "durationMs":10001234 — where one side touches a
-// JSON boundary and the other touches another digit or numeric-literal character (`.`, `-`, `+`,
-// `e`/`E`). There, term is a slice of one larger JSON number token, not the whole value: no amount
-// of quoting the replacement keeps the result valid, since splicing "***" into the middle of a
-// number always breaks it into two tokens with no separator. The safe move is to leave that
-// occurrence alone rather than corrupt the surrounding number; the coincidental digit overlap
-// isn't a real exposure of the redacted term as its own value anyway.
+// A numeric term can also land mid-number in a bare position (e.g. redacting "1000" out of an
+// unrelated "durationMs":10001234) — there it's a slice of a larger number token, and no amount of
+// quoting keeps that valid, so the occurrence is left alone rather than corrupting the number.
 //
-// Exported for reuse by other packages that scrub exact values out of already-marshaled JSON
-// (e.g. pkg/analytics's SanitizeStaticValues), which has the identical corruption risk.
+// Exported for reuse by pkg/analytics's SanitizeStaticValues, which has the same corruption risk.
 func RedactStaticTerm(s, term, replacement string) string {
 	if term == "" {
 		return s
@@ -475,26 +462,22 @@ func advanceQuoteState(inQuotes bool, span string) bool {
 	return inQuotes
 }
 
-// isBareJSONValueSpan reports whether s[start:end] stands alone as an unquoted JSON value —
-// preceded by `:`, `,` or `[` and followed by `,`, `}` or `]`. Both neighbors must actually be
-// present: a term at the very start or end of s has no JSON structure to confirm it's a value
-// rather than plain text, so it is left unquoted.
+// isBareJSONValueSpan reports whether s[start:end] is an unquoted JSON value: preceded by `:`,
+// `,` or `[` and followed by `,`, `}` or `]`, with both neighbors required.
 //
-// This deliberately does not tolerate whitespace around those neighbors (e.g. `: 12345,`):
-// RedactStaticTerm runs unconditionally on every log line, JSON or not (see internalWrite), and
-// zerolog's own encoder never emits such whitespace in the JSON it actually produces. Tolerating
-// it here would only make ordinary prose — "reason: password, retry: token, ..." — misdetected as
-// a bare JSON value and wrapped in stray quotes.
+// No whitespace tolerance (e.g. `: 12345,`): RedactStaticTerm runs on every log line whether or
+// not it's JSON, and zerolog's own encoder never emits such whitespace. Tolerating it would
+// misdetect ordinary prose like "reason: password, retry: token, ..." as a bare value and wrap it
+// in stray quotes.
 func isBareJSONValueSpan(s string, start, end int) bool {
 	precededByValueStart := start > 0 && strings.ContainsRune(":,[", rune(s[start-1]))
 	followedByValueEnd := end < len(s) && strings.ContainsRune(",}]", rune(s[end]))
 	return precededByValueStart && followedByValueEnd
 }
 
-// isFusedToAdjacentDigit reports whether s[start:end] directly touches a digit or other
-// numeric-literal character (`.`, `-`, `+`, `e`, `E`) on either side, meaning it is a slice of a
-// larger unquoted number — including a float, negative, or exponent form — rather than a complete
-// value on its own.
+// isFusedToAdjacentDigit reports whether s[start:end] touches a digit or other numeric-literal
+// character (`.`, `-`, `+`, `e`, `E`) on either side — i.e. it's a slice of a larger unquoted
+// number, not a complete value.
 func isFusedToAdjacentDigit(s string, start, end int) bool {
 	precededByNumberChar := start > 0 && isJSONNumberChar(s[start-1])
 	followedByNumberChar := end < len(s) && isJSONNumberChar(s[end])
@@ -543,9 +526,14 @@ func (w *scrubbingIoWriter) Write(p []byte) (int, error) {
 	return internalWrite(w.scrubDict, p, w.writer.Write)
 }
 
+// internalWrite scrubs p and writes it out via writeFunc. p is usually the compact JSON zerolog
+// itself encodes, but a writer misconfigured downstream of a non-JSON formatter (e.g. a console
+// writer that reformats JSON into human-readable text before it reaches here) can hand it prose
+// instead — RedactStaticTerm's bare-value quoting is only correct against real JSON, so p's own
+// validity, not the caller's assumption, decides which mode applies.
 func internalWrite(dict ScrubbingDict, p []byte, writeFunc func(p []byte) (int, error)) (int, error) {
 	scrubbedDataWritten := 0
-	scrubbedData := scrub(p, dict, true)
+	scrubbedData := scrub(p, dict, json.Valid(p))
 	var err error
 	var written int
 	for errorsSeen := 0; scrubbedDataWritten < len(scrubbedData); {

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -463,16 +463,31 @@ func advanceQuoteState(inQuotes bool, span string) bool {
 }
 
 // isBareJSONValueSpan reports whether s[start:end] is an unquoted JSON value: preceded by `:`,
-// `,` or `[` and followed by `,`, `}` or `]`, with both neighbors required.
-//
-// No whitespace tolerance (e.g. `: 12345,`): RedactStaticTerm runs on every log line whether or
-// not it's JSON, and zerolog's own encoder never emits such whitespace. Tolerating it would
-// misdetect ordinary prose like "reason: password, retry: token, ..." as a bare value and wrap it
-// in stray quotes.
+// `,` or `[` and followed by `,`, `}` or `]`, with both neighbors required (skipping over any
+// insignificant JSON whitespace — space, tab, CR, LF — in between, so pretty-printed JSON like
+// `: 12345,` is recognized the same as compact `:12345,`). This only risks misreading ordinary
+// prose as a bare value when that prose sits outside any JSON string and next to a real `:`/`,` —
+// callers that gate jsonAware on the input actually being valid JSON (see internalWrite) rule that
+// out, since prose inside valid JSON is always inside a quoted string, where the `quoted` check in
+// RedactStaticTerm's caller already skips this function entirely.
 func isBareJSONValueSpan(s string, start, end int) bool {
-	precededByValueStart := start > 0 && strings.ContainsRune(":,[", rune(s[start-1]))
-	followedByValueEnd := end < len(s) && strings.ContainsRune(",}]", rune(s[end]))
+	i := start - 1
+	for i >= 0 && isJSONWhitespace(s[i]) {
+		i--
+	}
+	precededByValueStart := i >= 0 && strings.ContainsRune(":,[", rune(s[i]))
+
+	j := end
+	for j < len(s) && isJSONWhitespace(s[j]) {
+		j++
+	}
+	followedByValueEnd := j < len(s) && strings.ContainsRune(",}]", rune(s[j]))
+
 	return precededByValueStart && followedByValueEnd
+}
+
+func isJSONWhitespace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
 }
 
 // isFusedToAdjacentDigit reports whether s[start:end] touches a digit or other numeric-literal

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -358,11 +358,24 @@ func (w *scrubbingLevelWriter) Write(p []byte) (int, error) {
 }
 
 // Scrub applies scrubDict's redaction rules to data, the same logic used internally by ScrubbingLogWriter.
+// data is treated as a JSON-structured log line: a static-term match is quoted or skipped as
+// needed to keep the result valid JSON (see RedactStaticTerm). Use ScrubValue instead for a bare
+// value that isn't itself JSON, e.g. a string leaf that a later json.Marshal will quote for you.
 func Scrub(data []byte, scrubDict ScrubbingDict) []byte {
-	return scrub(data, scrubDict)
+	return scrub(data, scrubDict, true)
 }
 
-func scrub(p []byte, scrubDict ScrubbingDict) []byte {
+// ScrubValue applies scrubDict's redaction rules to a value that is not itself JSON-structured,
+// e.g. a single leaf string an AddExtension caller supplied, destined to be embedded as an
+// already-quoted JSON string value by a later json.Marshal. RedactStaticTerm's JSON-value quoting
+// and digit-fusion skip exist only to protect JSON syntax in Scrub's whole-log-line input;
+// applying them to arbitrary leaf text instead injects stray quote characters into unrelated
+// content, or worse, skips redacting a real secret that happens to sit next to a digit.
+func ScrubValue(data []byte, scrubDict ScrubbingDict) []byte {
+	return scrub(data, scrubDict, false)
+}
+
+func scrub(p []byte, scrubDict ScrubbingDict, jsonAware bool) []byte {
 	s := string(p)
 	// The dictionary order is important here, as we want potentially overlapping regexes to be applied
 	// in a specific order every time. Since dictionaries are unordered, we sort the keys here.
@@ -375,7 +388,11 @@ func scrub(p []byte, scrubDict ScrubbingDict) []byte {
 		entry := scrubDict[key]
 		// scrub from the replacement list first
 		if entry.replace != "" {
-			s = RedactStaticTerm(s, entry.replace, SANITIZE_REPLACEMENT_STRING)
+			if jsonAware {
+				s = RedactStaticTerm(s, entry.replace, SANITIZE_REPLACEMENT_STRING)
+			} else {
+				s = strings.ReplaceAll(s, entry.replace, SANITIZE_REPLACEMENT_STRING)
+			}
 			continue
 		}
 		// then scrub from the regex list
@@ -395,15 +412,17 @@ func scrub(p []byte, scrubDict ScrubbingDict) []byte {
 // unquoted replacement is not a legal token there — replacing it unquoted produces invalid JSON
 // (see CLI-1732). Quoting the replacement in that position keeps it a valid JSON string instead.
 // A term inside an existing quoted string is left bare, since it is already bounded by quotes
-// that this function did not consume.
+// that this function did not consume — and, being already-quoted text rather than a bare value,
+// it is never treated as digit-fused either: the fusion check below only protects bare numbers.
 //
-// A purely numeric term can also land mid-number — e.g. redacting a numeric username "1000" out
-// of an unrelated "durationMs":10001234 — where one side touches a JSON boundary and the other
-// touches another digit. There, term is a slice of one larger JSON number token, not the whole
-// value: no amount of quoting the replacement keeps the result valid, since splicing "***" into
-// the middle of a number always breaks it into two tokens with no separator. The safe move is to
-// leave that occurrence alone rather than corrupt the surrounding number; the coincidental digit
-// overlap isn't a real exposure of the redacted term as its own value anyway.
+// A purely numeric term can also land mid-number in a *bare* (unquoted) position — e.g. redacting
+// a numeric username "1000" out of an unrelated "durationMs":10001234 — where one side touches a
+// JSON boundary and the other touches another digit or numeric-literal character (`.`, `-`, `+`,
+// `e`/`E`). There, term is a slice of one larger JSON number token, not the whole value: no amount
+// of quoting the replacement keeps the result valid, since splicing "***" into the middle of a
+// number always breaks it into two tokens with no separator. The safe move is to leave that
+// occurrence alone rather than corrupt the surrounding number; the coincidental digit overlap
+// isn't a real exposure of the redacted term as its own value anyway.
 //
 // Exported for reuse by other packages that scrub exact values out of already-marshaled JSON
 // (e.g. pkg/analytics's SanitizeStaticValues), which has the identical corruption risk.
@@ -414,6 +433,7 @@ func RedactStaticTerm(s, term, replacement string) string {
 	var builder strings.Builder
 	builder.Grow(len(s))
 	end := 0
+	quoted := false
 	for {
 		idx := strings.Index(s[end:], term)
 		if idx < 0 {
@@ -421,39 +441,68 @@ func RedactStaticTerm(s, term, replacement string) string {
 		}
 		start := end + idx
 		matchEnd := start + len(term)
+		quoted = advanceQuoteState(quoted, s[end:start])
 		builder.WriteString(s[end:start])
 		switch {
-		case isFusedToAdjacentDigit(s, start, matchEnd):
+		case !quoted && isFusedToAdjacentDigit(s, start, matchEnd):
 			builder.WriteString(s[start:matchEnd])
-		case isBareJSONValueSpan(s, start, matchEnd):
+		case !quoted && isBareJSONValueSpan(s, start, matchEnd):
 			builder.WriteByte('"')
 			builder.WriteString(replacement)
 			builder.WriteByte('"')
 		default:
 			builder.WriteString(replacement)
 		}
+		quoted = advanceQuoteState(quoted, s[start:matchEnd])
 		end = matchEnd
 	}
 	builder.WriteString(s[end:])
 	return builder.String()
 }
 
+// advanceQuoteState scans span and reports whether s is inside an open, unescaped double-quoted
+// JSON string once span has been consumed, given inQuotes was the state before span. An escaped
+// character (`\"`, `\\`, ...) is skipped whole so it can't toggle the state on its own.
+func advanceQuoteState(inQuotes bool, span string) bool {
+	for i := 0; i < len(span); i++ {
+		switch span[i] {
+		case '\\':
+			i++
+		case '"':
+			inQuotes = !inQuotes
+		}
+	}
+	return inQuotes
+}
+
 // isBareJSONValueSpan reports whether s[start:end] stands alone as an unquoted JSON value —
 // preceded by `:`, `,` or `[` and followed by `,`, `}` or `]`. Both neighbors must actually be
 // present: a term at the very start or end of s has no JSON structure to confirm it's a value
 // rather than plain text, so it is left unquoted.
+//
+// This deliberately does not tolerate whitespace around those neighbors (e.g. `: 12345,`):
+// RedactStaticTerm runs unconditionally on every log line, JSON or not (see internalWrite), and
+// zerolog's own encoder never emits such whitespace in the JSON it actually produces. Tolerating
+// it here would only make ordinary prose — "reason: password, retry: token, ..." — misdetected as
+// a bare JSON value and wrapped in stray quotes.
 func isBareJSONValueSpan(s string, start, end int) bool {
 	precededByValueStart := start > 0 && strings.ContainsRune(":,[", rune(s[start-1]))
 	followedByValueEnd := end < len(s) && strings.ContainsRune(",}]", rune(s[end]))
 	return precededByValueStart && followedByValueEnd
 }
 
-// isFusedToAdjacentDigit reports whether s[start:end] directly touches a digit on either side,
-// meaning it is a slice of a larger unquoted number rather than a complete value on its own.
+// isFusedToAdjacentDigit reports whether s[start:end] directly touches a digit or other
+// numeric-literal character (`.`, `-`, `+`, `e`, `E`) on either side, meaning it is a slice of a
+// larger unquoted number — including a float, negative, or exponent form — rather than a complete
+// value on its own.
 func isFusedToAdjacentDigit(s string, start, end int) bool {
-	precededByDigit := start > 0 && s[start-1] >= '0' && s[start-1] <= '9'
-	followedByDigit := end < len(s) && s[end] >= '0' && s[end] <= '9'
-	return precededByDigit || followedByDigit
+	precededByNumberChar := start > 0 && isJSONNumberChar(s[start-1])
+	followedByNumberChar := end < len(s) && isJSONNumberChar(s[end])
+	return precededByNumberChar || followedByNumberChar
+}
+
+func isJSONNumberChar(b byte) bool {
+	return (b >= '0' && b <= '9') || b == '.' || b == '-' || b == '+' || b == 'e' || b == 'E'
 }
 
 // redactMatchedGroup replaces capture group groupToRedact of every match of regex in s,
@@ -496,7 +545,7 @@ func (w *scrubbingIoWriter) Write(p []byte) (int, error) {
 
 func internalWrite(dict ScrubbingDict, p []byte, writeFunc func(p []byte) (int, error)) (int, error) {
 	scrubbedDataWritten := 0
-	scrubbedData := scrub(p, dict)
+	scrubbedData := scrub(p, dict, true)
 	var err error
 	var written int
 	for errorsSeen := 0; scrubbedDataWritten < len(scrubbedData); {

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -375,13 +375,85 @@ func scrub(p []byte, scrubDict ScrubbingDict) []byte {
 		entry := scrubDict[key]
 		// scrub from the replacement list first
 		if entry.replace != "" {
-			s = strings.ReplaceAll(s, entry.replace, SANITIZE_REPLACEMENT_STRING)
+			s = RedactStaticTerm(s, entry.replace, SANITIZE_REPLACEMENT_STRING)
 			continue
 		}
 		// then scrub from the regex list
 		s = redactMatchedGroup(s, entry.regex, entry.groupToRedact)
 	}
 	return []byte(s)
+}
+
+// RedactStaticTerm replaces every occurrence of term in s with replacement, quoting the
+// replacement when term occupies a bare (unquoted) JSON value position, and leaving an
+// occurrence untouched when it is only a partial, digit-fused slice of a larger bare number.
+//
+// term is an exact secret/token value (e.g. from AddTermsToReplace), so unlike redactMatchedGroup
+// this has no regex capture to bound the match — it can only look at the characters immediately
+// around each occurrence. A term that sits right after a JSON `:`, `,` or `[` and right before a
+// `,`, `}`, `]` or end-of-string is standing in for a bare value (a number, bool, or null), and an
+// unquoted replacement is not a legal token there — replacing it unquoted produces invalid JSON
+// (see CLI-1732). Quoting the replacement in that position keeps it a valid JSON string instead.
+// A term inside an existing quoted string is left bare, since it is already bounded by quotes
+// that this function did not consume.
+//
+// A purely numeric term can also land mid-number — e.g. redacting a numeric username "1000" out
+// of an unrelated "durationMs":10001234 — where one side touches a JSON boundary and the other
+// touches another digit. There, term is a slice of one larger JSON number token, not the whole
+// value: no amount of quoting the replacement keeps the result valid, since splicing "***" into
+// the middle of a number always breaks it into two tokens with no separator. The safe move is to
+// leave that occurrence alone rather than corrupt the surrounding number; the coincidental digit
+// overlap isn't a real exposure of the redacted term as its own value anyway.
+//
+// Exported for reuse by other packages that scrub exact values out of already-marshaled JSON
+// (e.g. pkg/analytics's SanitizeStaticValues), which has the identical corruption risk.
+func RedactStaticTerm(s, term, replacement string) string {
+	if term == "" {
+		return s
+	}
+	var builder strings.Builder
+	builder.Grow(len(s))
+	end := 0
+	for {
+		idx := strings.Index(s[end:], term)
+		if idx < 0 {
+			break
+		}
+		start := end + idx
+		matchEnd := start + len(term)
+		builder.WriteString(s[end:start])
+		switch {
+		case isFusedToAdjacentDigit(s, start, matchEnd):
+			builder.WriteString(s[start:matchEnd])
+		case isBareJSONValueSpan(s, start, matchEnd):
+			builder.WriteByte('"')
+			builder.WriteString(replacement)
+			builder.WriteByte('"')
+		default:
+			builder.WriteString(replacement)
+		}
+		end = matchEnd
+	}
+	builder.WriteString(s[end:])
+	return builder.String()
+}
+
+// isBareJSONValueSpan reports whether s[start:end] stands alone as an unquoted JSON value —
+// preceded by `:`, `,` or `[` and followed by `,`, `}` or `]`. Both neighbors must actually be
+// present: a term at the very start or end of s has no JSON structure to confirm it's a value
+// rather than plain text, so it is left unquoted.
+func isBareJSONValueSpan(s string, start, end int) bool {
+	precededByValueStart := start > 0 && strings.ContainsRune(":,[", rune(s[start-1]))
+	followedByValueEnd := end < len(s) && strings.ContainsRune(",}]", rune(s[end]))
+	return precededByValueStart && followedByValueEnd
+}
+
+// isFusedToAdjacentDigit reports whether s[start:end] directly touches a digit on either side,
+// meaning it is a slice of a larger unquoted number rather than a complete value on its own.
+func isFusedToAdjacentDigit(s string, start, end int) bool {
+	precededByDigit := start > 0 && s[start-1] >= '0' && s[start-1] <= '9'
+	followedByDigit := end < len(s) && s[end] >= '0' && s[end] <= '9'
+	return precededByDigit || followedByDigit
 }
 
 // redactMatchedGroup replaces capture group groupToRedact of every match of regex in s,

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -358,10 +358,12 @@ func (w *scrubbingLevelWriter) Write(p []byte) (int, error) {
 	return internalWrite(w.scrubDict, p, w.writer.Write)
 }
 
-// Scrub applies scrubDict's redaction rules to data, treated as a JSON-structured log line.
-// Use ScrubValue for a bare, non-JSON leaf value.
+// Scrub applies scrubDict's redaction rules to data. JSON-value quoting and digit-fusion
+// protection apply only when data is itself valid JSON; the caller's intent doesn't override
+// what data actually is (see internalWrite). Use ScrubValue for a value already known to be a
+// bare, non-JSON leaf.
 func Scrub(data []byte, scrubDict ScrubbingDict) []byte {
-	return scrub(data, scrubDict, true)
+	return scrub(data, scrubDict, json.Valid(data))
 }
 
 // ScrubValue applies scrubDict's redaction rules to a value that is not itself JSON-structured,

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -254,10 +254,9 @@ func TestScrub_MatchesPrivateScrubPath(t *testing.T) {
 	assert.Equal(t, "Authorization: Bearer ***", string(actual), "Scrub should redact the token, not just mirror the input")
 }
 
-// TestScrub_NonJSONInputStillRedactsStaticTerms guards against Scrub trusting its own doc comment
-// ("data, treated as a JSON-structured log line") over what data actually is: a static term
-// landing next to a digit in plain, non-JSON text must not be silently skipped by the JSON-only
-// digit-fusion guard, which exists to protect real JSON numbers, not prose.
+// TestScrub_NonJSONInputStillRedactsStaticTerms guards against a static term landing next to a
+// digit in plain, non-JSON text being silently skipped by the JSON-only digit-fusion guard, which
+// exists to protect real JSON numbers, not prose.
 func TestScrub_NonJSONInputStillRedactsStaticTerms(t *testing.T) {
 	config := configuration.NewInMemory()
 	config.Set(REDACTION_TERMS, []string{"12345"})
@@ -921,7 +920,7 @@ func TestStaticTermReplacementPreservesJSONValidity(t *testing.T) {
 // prefix and the match itself as two separate calls to quoteState.advance: a trailing backslash at
 // the very end of one span must still escape the next span's first character, or a quote that was
 // actually already escaped gets freshly toggled as if it were real, and inQuotes desyncs from the
-// text's true state. Flagged during PR review.
+// text's true state.
 func TestQuoteState_CarriesEscapeAcrossSeparateScans(t *testing.T) {
 	var qs quoteState
 	qs = qs.advance(`"X\`) // opens a string, then ends on an unresolved backslash
@@ -933,9 +932,9 @@ func TestQuoteState_CarriesEscapeAcrossSeparateScans(t *testing.T) {
 }
 
 // An empty term must not loop forever: strings.Index(s, "") matches at every position, so without
-// this guard RedactStaticTerm would never advance past index 0. SanitizeUsername/SanitizeStaticValues
-// call RedactStaticTerm per value with no empty-string filter, and an empty HomeDir/Username from
-// os/user.Current() is a real input on some minimal environments.
+// this guard RedactStaticTerm would never advance past index 0. RedactStaticTerm is exported, so a
+// caller isn't guaranteed to filter an empty term before calling it directly, and an empty
+// HomeDir/Username from os/user.Current() is a real input on some minimal environments.
 func TestRedactStaticTerm_EmptyTermIsNoop(t *testing.T) {
 	input := `{"count":12345}`
 	done := make(chan string, 1)

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -1022,3 +1022,59 @@ func TestScrubValue(t *testing.T) {
 		})
 	}
 }
+
+func TestStaticTermReplacementPreservesJSONScalarValidity(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		term     string
+		expected string
+	}{
+		{
+			name:     "top-level number",
+			input:    `12345`,
+			term:     "12345",
+			expected: `"***"`,
+		},
+		{
+			name:     "partial true literal",
+			input:    `{"enabled":true}`,
+			term:     "rue",
+			expected: `{"enabled":true}`,
+		},
+		{
+			name:     "partial false literal",
+			input:    `{"enabled":false}`,
+			term:     "alse", //nolint:misspell // substring of "false", not a typo
+			expected: `{"enabled":false}`,
+		},
+		{
+			name:     "partial null literal",
+			input:    `{"value":null}`,
+			term:     "ull",
+			expected: `{"value":null}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var output bytes.Buffer
+			writer := NewScrubbingIoWriter(&output, ScrubbingDict{})
+
+			scrubbingWriter, ok := writer.(ScrubbingLogWriter)
+			require.True(t, ok)
+			scrubbingWriter.AddTermsToReplace([]string{test.term})
+
+			_, err := writer.Write([]byte(test.input))
+			require.NoError(t, err)
+
+			assert.True(
+				t,
+				json.Valid(output.Bytes()),
+				"scrubbing produced invalid JSON: %s",
+				output.Bytes(),
+			)
+			assert.Equal(t, test.expected, output.String())
+		})
+	}
+}

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -24,6 +24,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -103,6 +104,37 @@ func TestScrubbingWriter_GetScrubDictFromConfig_RedactionTerms(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, len("my-literal-secret"), n)
 	require.Equal(t, "***", string(mockWriter.written), "configured redaction term should be scrubbed")
+}
+
+// TestScrubbingWriter_Write_JSONAwarenessFollowsInputValidity guards the fix for a real corruption
+// path: a consumer that wraps this writer's output in a non-JSON formatter (e.g. zerolog's
+// ConsoleWriter, which decodes the JSON zerolog encodes and re-emits human-readable prose before
+// forwarding it here) was getting the JSON-aware bare-value quoting applied to that prose, which
+// has no JSON to protect — injecting stray quote characters into a log line whenever a redacted
+// term happened to sit right next to a `:` or `,`. internalWrite now decides jsonAware from p's own
+// validity rather than assuming every Write is JSON.
+func TestScrubbingWriter_Write_JSONAwarenessFollowsInputValidity(t *testing.T) {
+	config := configuration.NewInMemory()
+	config.Set(REDACTION_TERMS, []string{"12345"})
+	dict := GetScrubDictFromConfig(config)
+
+	t.Run("valid JSON input still gets bare-value quoting", func(t *testing.T) {
+		mockWriter := &mockWriter{}
+		writer := NewScrubbingWriter(mockWriter, dict)
+
+		_, err := writer.Write([]byte(`{"count":12345}`))
+		assert.NoError(t, err)
+		assert.Equal(t, `{"count":"***"}`, string(mockWriter.written))
+	})
+
+	t.Run("non-JSON input is left bare instead of stray-quoted", func(t *testing.T) {
+		mockWriter := &mockWriter{}
+		writer := NewScrubbingWriter(mockWriter, dict)
+
+		_, err := writer.Write([]byte("count:12345, retrying"))
+		assert.NoError(t, err)
+		assert.Equal(t, "count:***, retrying", string(mockWriter.written))
+	})
 }
 
 func TestScrubbingIoWriter(t *testing.T) {
@@ -789,6 +821,30 @@ func TestStaticTermReplacementPreservesJSONValidity(t *testing.T) {
 			input:    `{"traceId":"1234598765"}`,
 			expected: `{"traceId":"***98765"}`,
 		},
+		{
+			// Term sits after an escaped quote, with `:`/`,` neighbors — same shape as a bare
+			// value. A tracker that toggles on escaped quotes too would misread this as
+			// unquoted and inject stray quotes, corrupting the string.
+			name:     "term downstream of an escaped quote in the same string stays unquoted",
+			input:    `{"note":"a\"count:12345,done"}`,
+			expected: `{"note":"a\"count:***,done"}`,
+		},
+		{
+			// Second match must see the quote state left by the first (open string closed at
+			// index 22): a regression that drops the carried `quoted` state between matches
+			// would leave "count" wrongly treated as still-quoted and emit it unquoted.
+			name:     "quote state threads correctly across two matches in one string",
+			input:    `{"a":"has 12345 inside","b":12345}`,
+			expected: `{"a":"has *** inside","b":"***"}`,
+		},
+		{
+			// The escaped backslash right before the closing quote must consume its pair (\\),
+			// not be mistaken for escaping that quote — otherwise the string never closes and
+			// "count" gets wrongly left unquoted.
+			name:     "term after a string ending in an escaped backslash is still recognized as bare",
+			input:    `{"path":"C:\\","count":12345}`,
+			expected: `{"path":"C:\\","count":"***"}`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -807,11 +863,68 @@ func TestStaticTermReplacementPreservesJSONValidity(t *testing.T) {
 	}
 }
 
-// TestScrubValue covers callers that scrub a single leaf value which is not itself JSON, e.g.
-// AddExtension's pre-marshal string leaves (pkg/analytics's scrubExtensionValueSeen). Scrub's
-// JSON-value quoting and digit-fusion skip protect JSON syntax in a whole log line; applied to
-// arbitrary leaf text they would instead inject stray quote characters or silently skip a real
-// secret that happens to sit next to a digit, since there is no JSON number token to protect.
+// An empty term must not loop forever: strings.Index(s, "") matches at every position, so without
+// this guard RedactStaticTerm would never advance past index 0. SanitizeUsername/SanitizeStaticValues
+// call RedactStaticTerm per value with no empty-string filter, and an empty HomeDir/Username from
+// os/user.Current() is a real input on some minimal environments.
+func TestRedactStaticTerm_EmptyTermIsNoop(t *testing.T) {
+	input := `{"count":12345}`
+	done := make(chan string, 1)
+	go func() { done <- RedactStaticTerm(input, "", "***") }()
+
+	select {
+	case actual := <-done:
+		assert.Equal(t, input, actual)
+	case <-time.After(time.Second):
+		t.Fatal("RedactStaticTerm did not return for an empty term — possible infinite loop")
+	}
+}
+
+// TestRedactStaticTerm pins the exported function's direct contract, including the start/end
+// boundary case: a term with no boundary character on one side has nothing to confirm it's a
+// bare value, so it's left unquoted rather than guessed at.
+func TestRedactStaticTerm(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "bare value with both boundaries present is quoted",
+			input:    `{"count":12345,"ok":true}`,
+			expected: `{"count":"***","ok":true}`,
+		},
+		{
+			name:     "term at start of s has no left boundary, left bare",
+			input:    `12345,"b":2`,
+			expected: `***,"b":2`,
+		},
+		{
+			name:     "term at end of s has no right boundary, left bare",
+			input:    `{"a":1,"b":12345`,
+			expected: `{"a":1,"b":***`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, RedactStaticTerm(test.input, "12345", "***"))
+		})
+	}
+}
+
+// TestScrub_VsScrubValue contrasts the jsonAware split on identical input: Scrub quotes a bare
+// match to keep JSON syntax valid, ScrubValue leaves it bare since there's no JSON to protect.
+func TestScrub_VsScrubValue(t *testing.T) {
+	dict := ScrubbingDict{}
+	addStaticTermToDict("8080", dict)
+	input := "port:8080,timeout:3000"
+
+	assert.Equal(t, `port:"***",timeout:3000`, string(Scrub([]byte(input), dict)))
+	assert.Equal(t, `port:***,timeout:3000`, string(ScrubValue([]byte(input), dict)))
+}
+
+// TestScrubValue covers non-JSON leaf values, e.g. AddExtension's pre-marshal string leaves.
+// Scrub's JSON-value quoting and digit-fusion skip don't apply here — there's no JSON to protect.
 func TestScrubValue(t *testing.T) {
 	dict := ScrubbingDict{}
 	addStaticTermToDict("8080", dict)

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -247,11 +247,25 @@ func TestScrub_MatchesPrivateScrubPath(t *testing.T) {
 	dict := addMandatoryMasking(ScrubbingDict{})
 	input := []byte("Authorization: Bearer sometoken123456")
 
-	expected := scrub(input, dict, true)
+	expected := scrub(input, dict, json.Valid(input))
 	actual := Scrub(input, dict)
 
 	assert.Equal(t, string(expected), string(actual))
 	assert.Equal(t, "Authorization: Bearer ***", string(actual), "Scrub should redact the token, not just mirror the input")
+}
+
+// TestScrub_NonJSONInputStillRedactsStaticTerms guards against Scrub trusting its own doc comment
+// ("data, treated as a JSON-structured log line") over what data actually is: a static term
+// landing next to a digit in plain, non-JSON text must not be silently skipped by the JSON-only
+// digit-fusion guard, which exists to protect real JSON numbers, not prose.
+func TestScrub_NonJSONInputStillRedactsStaticTerms(t *testing.T) {
+	config := configuration.NewInMemory()
+	config.Set(REDACTION_TERMS, []string{"12345"})
+	dict := GetScrubDictFromConfig(config)
+
+	actual := Scrub([]byte("id: 123451234"), dict)
+
+	assert.Equal(t, "id: ***1234", string(actual))
 }
 
 func TestAddDefaults(t *testing.T) {
@@ -807,6 +821,11 @@ func TestStaticTermReplacementPreservesJSONValidity(t *testing.T) {
 			expected: `{"ids":["***",67890]}`,
 		},
 		{
+			name:     "static term as bare value at end of array",
+			input:    `{"ids":[67890,12345]}`,
+			expected: `{"ids":[67890,"***"]}`,
+		},
+		{
 			name:     "static term fused to a decimal point is left alone",
 			input:    `{"ratio":123.12345}`,
 			expected: `{"ratio":123.12345}`,
@@ -962,15 +981,16 @@ func TestRedactStaticTerm(t *testing.T) {
 	}
 }
 
-// TestScrub_VsScrubValue contrasts the jsonAware split on identical input: Scrub quotes a bare
-// match to keep JSON syntax valid, ScrubValue leaves it bare since there's no JSON to protect.
+// TestScrub_VsScrubValue contrasts the jsonAware split on identical, valid-JSON input: Scrub
+// detects the input is JSON and quotes a bare match to keep it valid; ScrubValue always treats
+// its input as a non-JSON leaf, so it leaves the same match bare regardless of what it's given.
 func TestScrub_VsScrubValue(t *testing.T) {
 	dict := ScrubbingDict{}
 	addStaticTermToDict("8080", dict)
-	input := "port:8080,timeout:3000"
+	input := `{"port":8080,"timeout":3000}`
 
-	assert.Equal(t, `port:"***",timeout:3000`, string(Scrub([]byte(input), dict)))
-	assert.Equal(t, `port:***,timeout:3000`, string(ScrubValue([]byte(input), dict)))
+	assert.Equal(t, `{"port":"***","timeout":3000}`, string(Scrub([]byte(input), dict)))
+	assert.Equal(t, `{"port":***,"timeout":3000}`, string(ScrubValue([]byte(input), dict)))
 }
 
 // TestScrubValue covers non-JSON leaf values, e.g. AddExtension's pre-marshal string leaves.

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -188,7 +188,7 @@ func TestScrubFunction(t *testing.T) {
 		input := "This is my secret message, which might not be special but definitely should not be disclosed."
 		expected := "This is my *** message, which might not be *** but definitely should not ***."
 
-		actual := scrub([]byte(input), dict)
+		actual := scrub([]byte(input), dict, true)
 		assert.Equal(t, expected, string(actual))
 	})
 
@@ -197,7 +197,7 @@ func TestScrubFunction(t *testing.T) {
 		expected := "abc http://***@host.com asdf \nabc https://***@host.com asdf"
 		dict := addMandatoryMasking(ScrubbingDict{})
 
-		actual := scrub([]byte(input), dict)
+		actual := scrub([]byte(input), dict, true)
 		assert.Equal(t, expected, string(actual))
 	})
 
@@ -206,7 +206,7 @@ func TestScrubFunction(t *testing.T) {
 		expected := "abc http://host.com asdf \nabc https://***@host.com asdf"
 		dict := addMandatoryMasking(ScrubbingDict{})
 
-		actual := scrub([]byte(input), dict)
+		actual := scrub([]byte(input), dict, true)
 		assert.Equal(t, expected, string(actual))
 	})
 }
@@ -215,7 +215,7 @@ func TestScrub_MatchesPrivateScrubPath(t *testing.T) {
 	dict := addMandatoryMasking(ScrubbingDict{})
 	input := []byte("Authorization: Bearer sometoken123456")
 
-	expected := scrub(input, dict)
+	expected := scrub(input, dict, true)
 	actual := Scrub(input, dict)
 
 	assert.Equal(t, string(expected), string(actual))
@@ -406,7 +406,7 @@ func TestAddDefaults(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := scrub([]byte(test.input), dict)
+			actual := scrub([]byte(test.input), dict, true)
 			assert.Equal(t, test.expected, string(actual))
 		})
 	}
@@ -483,7 +483,7 @@ func TestScrub_RedactsOnlyTheMatchedSpan(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := string(scrub([]byte(test.input), dict))
+			actual := string(scrub([]byte(test.input), dict, true))
 
 			assert.Equal(t, test.expected, actual)
 			assert.True(t, json.Valid([]byte(actual)),
@@ -563,7 +563,7 @@ func TestScrub_GreedyCapturesStopAtTheirOwnDelimiter(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := string(scrub([]byte(test.input), dict))
+			actual := string(scrub([]byte(test.input), dict, true))
 
 			assert.Equal(t, test.expected, actual)
 			assert.True(t, json.Valid([]byte(actual)),
@@ -742,7 +742,7 @@ func TestSnykPATScrubbing(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := scrub([]byte(test.input), dict)
+			actual := scrub([]byte(test.input), dict, true)
 			assert.Equal(t, test.expected, string(actual))
 		})
 	}
@@ -774,6 +774,21 @@ func TestStaticTermReplacementPreservesJSONValidity(t *testing.T) {
 			input:    `{"ids":[12345,67890]}`,
 			expected: `{"ids":["***",67890]}`,
 		},
+		{
+			name:     "static term fused to a decimal point is left alone",
+			input:    `{"ratio":123.12345}`,
+			expected: `{"ratio":123.12345}`,
+		},
+		{
+			name:     "static term fused to a leading minus sign is left alone",
+			input:    `{"delta":-12345}`,
+			expected: `{"delta":-12345}`,
+		},
+		{
+			name:     "digit-adjacent term inside a quoted string is still redacted",
+			input:    `{"traceId":"1234598765"}`,
+			expected: `{"traceId":"***98765"}`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -788,6 +803,40 @@ func TestStaticTermReplacementPreservesJSONValidity(t *testing.T) {
 
 			assert.True(t, json.Valid(output.Bytes()), "scrubbing produced invalid JSON: %s", output.Bytes())
 			assert.Equal(t, test.expected, output.String())
+		})
+	}
+}
+
+// TestScrubValue covers callers that scrub a single leaf value which is not itself JSON, e.g.
+// AddExtension's pre-marshal string leaves (pkg/analytics's scrubExtensionValueSeen). Scrub's
+// JSON-value quoting and digit-fusion skip protect JSON syntax in a whole log line; applied to
+// arbitrary leaf text they would instead inject stray quote characters or silently skip a real
+// secret that happens to sit next to a digit, since there is no JSON number token to protect.
+func TestScrubValue(t *testing.T) {
+	dict := ScrubbingDict{}
+	addStaticTermToDict("8080", dict)
+	addStaticTermToDict("12345", dict)
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "term adjacent to colon and comma in freeform text is not quoted",
+			input:    "port:8080,timeout:3000",
+			expected: "port:***,timeout:3000",
+		},
+		{
+			name:     "term fused to an adjacent digit in freeform text is still redacted",
+			input:    "id: 123451234",
+			expected: "id: ***1234",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := string(ScrubValue([]byte(test.input), dict))
+			assert.Equal(t, test.expected, actual)
 		})
 	}
 }

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -822,6 +822,34 @@ func TestStaticTermReplacementPreservesJSONValidity(t *testing.T) {
 			expected: `{"traceId":"***98765"}`,
 		},
 		{
+			name:     "pretty-printed JSON with spaces around colon and comma is still quoted",
+			input:    `{"count" : 12345 , "ok" : true}`,
+			expected: `{"count" : "***" , "ok" : true}`,
+		},
+		{
+			name:     "whitespace run including a newline and a tab before the boundary is skipped",
+			input:    "{\"count\":\n\t12345,\n\"ok\":true}",
+			expected: "{\"count\":\n\t\"***\",\n\"ok\":true}",
+		},
+		{
+			name:     "space before comma is tolerated",
+			input:    `{"count":12345 ,"ok":true}`,
+			expected: `{"count":"***" ,"ok":true}`,
+		},
+		{
+			name:     "padded array brackets are tolerated",
+			input:    `{"ids": [ 12345, 67890 ]}`,
+			expected: `{"ids": [ "***", 67890 ]}`,
+		},
+		{
+			// Whitespace-tolerant boundary detection could misread this prose's ": " and ", " as
+			// bare-value boundaries -- the `quoted` guard in RedactStaticTerm must still keep it
+			// from ever reaching isBareJSONValueSpan, since it's inside a quoted string value.
+			name:     "term embedded in prose inside a quoted string is not misdetected as bare",
+			input:    `{"msg":"reason: 12345, retry: token"}`,
+			expected: `{"msg":"reason: ***, retry: token"}`,
+		},
+		{
 			// Term sits after an escaped quote, with `:`/`,` neighbors — same shape as a bare
 			// value. A tracker that toggles on escaped quotes too would misread this as
 			// unquoted and inject stray quotes, corrupting the string.

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -873,6 +873,15 @@ func TestStaticTermReplacementPreservesJSONValidity(t *testing.T) {
 			input:    `{"path":"C:\\","count":12345}`,
 			expected: `{"path":"C:\\","count":"***"}`,
 		},
+		{
+			// A JSON escape (`\n`) mid-string, not adjacent to the closing quote, must still let
+			// the string close normally: advanceQuoteState's `case '\\': i++` skips exactly the
+			// escaped character, and the for loop's own i++ then lands on the next real character
+			// -- it does not also skip that next character.
+			name:     "escaped character in the middle of a string doesn't skip an extra character past it",
+			input:    `{"a":"path\nnext","count":12345}`,
+			expected: `{"a":"path\nnext","count":"***"}`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -747,3 +747,47 @@ func TestSnykPATScrubbing(t *testing.T) {
 		})
 	}
 }
+
+func TestStaticTermReplacementPreservesJSONValidity(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "static term as bare JSON number value",
+			input:    `{"level":"debug","count":12345,"message":"ok"}`,
+			expected: `{"level":"debug","count":"***","message":"ok"}`,
+		},
+		{
+			name:     "static term inside a quoted JSON string stays unquoted",
+			input:    `{"message":"session id 12345 started"}`,
+			expected: `{"message":"session id *** started"}`,
+		},
+		{
+			name:     "static term as the entire quoted JSON string value",
+			input:    `{"userId":"12345"}`,
+			expected: `{"userId":"***"}`,
+		},
+		{
+			name:     "static term as bare value at start of array",
+			input:    `{"ids":[12345,67890]}`,
+			expected: `{"ids":["***",67890]}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var output bytes.Buffer
+			w := NewScrubbingIoWriter(&output, ScrubbingDict{})
+			scrubbingWriter, ok := w.(ScrubbingLogWriter)
+			require.True(t, ok)
+			scrubbingWriter.AddTermsToReplace([]string{"12345"})
+
+			_, err := w.Write([]byte(test.input))
+			require.NoError(t, err)
+
+			assert.True(t, json.Valid(output.Bytes()), "scrubbing produced invalid JSON: %s", output.Bytes())
+			assert.Equal(t, test.expected, output.String())
+		})
+	}
+}

--- a/pkg/logging/scrubbingLogWriter_test.go
+++ b/pkg/logging/scrubbingLogWriter_test.go
@@ -875,9 +875,7 @@ func TestStaticTermReplacementPreservesJSONValidity(t *testing.T) {
 		},
 		{
 			// A JSON escape (`\n`) mid-string, not adjacent to the closing quote, must still let
-			// the string close normally: advanceQuoteState's `case '\\': i++` skips exactly the
-			// escaped character, and the for loop's own i++ then lands on the next real character
-			// -- it does not also skip that next character.
+			// the string close normally rather than getting stuck treating the rest as escaped.
 			name:     "escaped character in the middle of a string doesn't skip an extra character past it",
 			input:    `{"a":"path\nnext","count":12345}`,
 			expected: `{"a":"path\nnext","count":"***"}`,
@@ -898,6 +896,21 @@ func TestStaticTermReplacementPreservesJSONValidity(t *testing.T) {
 			assert.Equal(t, test.expected, output.String())
 		})
 	}
+}
+
+// TestQuoteState_CarriesEscapeAcrossSeparateScans covers RedactStaticTerm scanning a match's
+// prefix and the match itself as two separate calls to quoteState.advance: a trailing backslash at
+// the very end of one span must still escape the next span's first character, or a quote that was
+// actually already escaped gets freshly toggled as if it were real, and inQuotes desyncs from the
+// text's true state. Flagged during PR review.
+func TestQuoteState_CarriesEscapeAcrossSeparateScans(t *testing.T) {
+	var qs quoteState
+	qs = qs.advance(`"X\`) // opens a string, then ends on an unresolved backslash
+	require.True(t, qs.inQuotes)
+	require.True(t, qs.escaping)
+
+	qs = qs.advance(`"Y`) // this leading quote is the escaped character, not a fresh one
+	assert.True(t, qs.inQuotes, "an escaped quote arriving in a later scan must not close the string")
 }
 
 // An empty term must not loop forever: strings.Index(s, "") matches at every position, so without


### PR DESCRIPTION
## Summary

Follow-up to #712 (CLI-1732). That fix made the regex-entry path in `scrub()` position-aware. The static-term branch (`AddTermsToReplace` / `GetScrubDictFromConfig` -- tokens, client secret/id, `REDACTION_TERMS`) still did a blind `strings.ReplaceAll`, with no JSON-quote awareness.

Fixed:

- A registered term matching a bare (unquoted) JSON value -- a number, bool, or null -- got swapped for unquoted `***`, producing invalid JSON (`"count":12345` -> `"count":***`). New `RedactStaticTerm` quotes the replacement when the match sits in a bare JSON value position.
- A term that's only a digit-fused slice of a larger number (e.g. redacting "1000" out of an unrelated "durationMs":10001234) is left alone instead of splitting one JSON number into two invalid pieces. A numeric username is a realistic trigger for this: some container setups set `$USER` to a raw UID with no matching `/etc/passwd` entry, not because `os/user.Current` itself falls back to one.
- A writer downstream of a non-JSON formatter (e.g. zerolog's `ConsoleWriter`, which decodes JSON and re-emits human-readable text before the scrubber sees it) was still getting JSON-only quoting rules applied to plain prose, corrupting it. `internalWrite` and the exported `Scrub` now decide JSON-aware mode from `json.Valid` on the actual bytes, not from what the caller assumed it was passing.
- New `ScrubValue` scrubs a single non-JSON leaf value (e.g. an analytics extension field before marshaling) without the JSON-value quoting or digit-fusion protections, which would otherwise stray-quote or under-redact plain text.
- `pkg/analytics.SanitizeStaticValues` had the identical bug on already-marshaled JSON, with two production call sites (`analytics.go`, `instrumentation_collector.go`) feeding numeric fields like `durationMs`. It now routes through the same `logging.RedactStaticTerm` helper when its input is valid JSON, and falls back to plain replacement otherwise.
- Quote/escape state tracking (`quoteState`) now carries correctly across `RedactStaticTerm`'s two scan calls per match (the text before it, then the match itself). A trailing unresolved backslash at the boundary between those two scans used to have its escaped character re-examined as fresh input by the next scan, desyncing whether a later match was inside a quoted string.

Two edge cases are deliberately left alone, both inherent to splicing an exact literal match into JSON text rather than parsing it: a redaction term that is itself a bare `"` character, and a term whose first character lands on the target of a preceding unresolved backslash escape.

## Test plan

- [x] `go test ./...` -- full module green
- [x] `make lint` -- 0 issues
- [x] `snyk code test` -- no new findings
- [x] New tests: `TestStaticTermReplacementPreservesJSONValidity`, `TestQuoteState_CarriesEscapeAcrossSeparateScans`, `TestScrub_NonJSONInputStillRedactsStaticTerms`, `Test_SanitizeUsername_NumericUsernameCollision`, `Test_GetRequest_RedactsNumericUsernameFromMarshaledPayload`, plus empty-term/empty-value no-op guards for both `RedactStaticTerm` and `SanitizeStaticValues`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared log/analytics redaction on every scrubbed write and marshaled analytics payload; behavior changes are intentional but subtle (JSON vs non-JSON, fusion skips).
> 
> **Overview**
> Replaces blind `strings.ReplaceAll` for configured literal redaction terms with **`RedactStaticTerm`**, which quotes replacements in bare JSON value positions, skips digit-fused substrings inside larger numbers/keywords, and tracks quote/escape state across matches. **`Scrub`** and log **`internalWrite`** enable that behavior only when `json.Valid` on the actual bytes; **`ScrubValue`** is added for pre-marshal string leaves (analytics extension scrubbing now uses it instead of **`Scrub`**).
> 
> **`SanitizeStaticValues`** in analytics follows the same JSON gate and **`RedactStaticTerm`** path, with empty-term no-ops, so numeric usernames no longer split unrelated JSON numbers or inject stray quotes into plain-text snippets.
> 
> Extensive regression tests cover numeric-username collisions, **`GetRequest`** redaction, console-writer non-JSON prose, and **`RedactStaticTerm`** edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed24e1e578957b02cd9e06c1104b864a756fadc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

