### PR TITLE
feat: Reduce requests for feature flag lookups

### DIFF
--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -38,9 +38,11 @@ import (
 	"github.com/snyk/go-application-framework/internal/constants"
 	"github.com/snyk/go-application-framework/internal/mocks"
 	"github.com/snyk/go-application-framework/pkg/analytics"
+	v20241015 "github.com/snyk/go-application-framework/pkg/apiclients/feature_flag_gateway/2024-10-15"
 	"github.com/snyk/go-application-framework/pkg/auth"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/config_utils"
 	pkgMocks "github.com/snyk/go-application-framework/pkg/mocks"
 	"github.com/snyk/go-application-framework/pkg/networking/middleware"
 	"github.com/snyk/go-application-framework/pkg/runtimeinfo"
@@ -1905,4 +1907,69 @@ func Test_WithPostInvokeHooks(t *testing.T) {
 	_, err = engine.Invoke(wfId)
 	assert.NoError(t, err)
 	assert.True(t, hookCalled, "hook registered via WithPostInvokeHooks should fire")
+}
+
+// Test_CreateAppEngine_featureFlagOfDownstreamExtensionIsResolved guards an
+// ordering property that is easy to break: the framework's own extension
+// initializers all run before those of the consuming application, and some of
+// them read a feature flag while initializing. A lookup that fixes the set of
+// known flags at that moment would silently resolve every flag registered by a
+// downstream extension to false.
+func Test_CreateAppEngine_featureFlagOfDownstreamExtensionIsResolved(t *testing.T) {
+	orgId := "0d2bc57c-1df9-4115-996f-4f19aa12912b"
+	downstreamFlag := "downstream-extension-flag"
+	downstreamConfigKey := "internal_downstream_extension_enabled"
+
+	var mutex sync.Mutex
+	var requestedFlags []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "feature_flags") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		var request v20241015.FeatureFlagRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+
+		mutex.Lock()
+		requestedFlags = append(requestedFlags, request.Data.Attributes.Flags...)
+		mutex.Unlock()
+
+		enabled := true
+		evaluations := make([]v20241015.FeatureFlagAttributes, 0, len(request.Data.Attributes.Flags))
+		for _, flag := range request.Data.Attributes.Flags {
+			evaluations = append(evaluations, v20241015.FeatureFlagAttributes{Key: flag, Value: &enabled})
+		}
+
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": v20241015.FeatureFlagsDataItem{
+				Attributes: v20241015.FeatureFlagAttributesList{Evaluations: evaluations},
+			},
+		}))
+	}))
+	t.Cleanup(server.Close)
+
+	config := configuration.NewInMemory()
+	config.Set(configuration.API_URL, server.URL)
+	config.Set(configuration.ORGANIZATION, orgId)
+
+	engine := CreateAppEngineWithOptions(WithConfiguration(config))
+
+	// mimics an extension of the consuming application, which is initialized
+	// after every extension the framework brings along
+	engine.AddExtensionInitializer(func(e workflow.Engine) error {
+		config_utils.AddFeatureFlagsToConfig(e, map[string]string{downstreamConfigKey: downstreamFlag})
+		return nil
+	})
+
+	require.NoError(t, engine.Init())
+
+	assert.True(t, config.GetBool(downstreamConfigKey),
+		"a feature flag registered by a downstream extension must be looked up")
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	assert.Contains(t, requestedFlags, downstreamFlag)
 }

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1909,6 +1910,62 @@ func Test_WithPostInvokeHooks(t *testing.T) {
 	assert.True(t, hookCalled, "hook registered via WithPostInvokeHooks should fire")
 }
 
+// flagGatewayRecorder stands in for the feature flag gateway. It reports every
+// requested flag as enabled and records what it was asked to evaluate.
+type flagGatewayRecorder struct {
+	mutex sync.Mutex
+	flags []string
+}
+
+func (r *flagGatewayRecorder) requestedFlags() []string {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return slices.Clone(r.flags)
+}
+
+func newFlagGatewayServer(t *testing.T) (*httptest.Server, *flagGatewayRecorder) {
+	t.Helper()
+
+	recorder := &flagGatewayRecorder{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "feature_flags") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		// The handler runs on its own goroutine, where t.FailNow - and with it
+		// require - must not be called: it would abandon the handler without a
+		// response and surface as an opaque client side error instead of this
+		// assertion. Report and answer with a status the caller can act on.
+		var request v20241015.FeatureFlagRequest
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&request)) {
+			http.Error(w, "malformed feature flag request", http.StatusInternalServerError)
+			return
+		}
+
+		recorder.mutex.Lock()
+		recorder.flags = append(recorder.flags, request.Data.Attributes.Flags...)
+		recorder.mutex.Unlock()
+
+		enabled := true
+		evaluations := make([]v20241015.FeatureFlagAttributes, 0, len(request.Data.Attributes.Flags))
+		for _, flag := range request.Data.Attributes.Flags {
+			evaluations = append(evaluations, v20241015.FeatureFlagAttributes{Key: flag, Value: &enabled})
+		}
+
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		err := json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": v20241015.FeatureFlagsDataItem{
+				Attributes: v20241015.FeatureFlagAttributesList{Evaluations: evaluations},
+			},
+		})
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	return server, recorder
+}
+
 // Test_CreateAppEngine_featureFlagOfDownstreamExtensionIsResolved guards an
 // ordering property that is easy to break: the framework's own extension
 // initializers all run before those of the consuming application, and some of
@@ -1920,36 +1977,7 @@ func Test_CreateAppEngine_featureFlagOfDownstreamExtensionIsResolved(t *testing.
 	downstreamFlag := "downstream-extension-flag"
 	downstreamConfigKey := "internal_downstream_extension_enabled"
 
-	var mutex sync.Mutex
-	var requestedFlags []string
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.Contains(r.URL.Path, "feature_flags") {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-
-		var request v20241015.FeatureFlagRequest
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
-
-		mutex.Lock()
-		requestedFlags = append(requestedFlags, request.Data.Attributes.Flags...)
-		mutex.Unlock()
-
-		enabled := true
-		evaluations := make([]v20241015.FeatureFlagAttributes, 0, len(request.Data.Attributes.Flags))
-		for _, flag := range request.Data.Attributes.Flags {
-			evaluations = append(evaluations, v20241015.FeatureFlagAttributes{Key: flag, Value: &enabled})
-		}
-
-		w.Header().Set("Content-Type", "application/vnd.api+json")
-		require.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{
-			"data": v20241015.FeatureFlagsDataItem{
-				Attributes: v20241015.FeatureFlagAttributesList{Evaluations: evaluations},
-			},
-		}))
-	}))
-	t.Cleanup(server.Close)
+	server, gateway := newFlagGatewayServer(t)
 
 	config := configuration.NewInMemory()
 	config.Set(configuration.API_URL, server.URL)
@@ -1969,7 +1997,42 @@ func Test_CreateAppEngine_featureFlagOfDownstreamExtensionIsResolved(t *testing.
 	assert.True(t, config.GetBool(downstreamConfigKey),
 		"a feature flag registered by a downstream extension must be looked up")
 
-	mutex.Lock()
-	defer mutex.Unlock()
-	assert.Contains(t, requestedFlags, downstreamFlag)
+	assert.Contains(t, gateway.requestedFlags(), downstreamFlag)
+}
+
+// Test_CreateAppEngine_locallySetFeatureFlagIsNotEvaluatedRemotely pins the
+// contract a consumer relies on when it forces a feature on or off: a key that
+// already holds a value never consults its default value function, so its flag
+// must not be evaluated remotely. Batching makes that easy to lose, because an
+// extension initializer reading its own flag drags every registered flag into
+// one request while the engine starts up.
+func Test_CreateAppEngine_locallySetFeatureFlagIsNotEvaluatedRemotely(t *testing.T) {
+	orgId := "0d2bc57c-1df9-4115-996f-4f19aa12912b"
+
+	server, gateway := newFlagGatewayServer(t)
+
+	config := configuration.NewInMemory()
+	config.Set(configuration.API_URL, server.URL)
+	config.Set(configuration.ORGANIZATION, orgId)
+
+	engine := CreateAppEngineWithOptions(WithConfiguration(config))
+
+	// mimics an application forcing the feature off while it registers its
+	// extensions, which is before the engine initializes them and therefore
+	// before any of them reads a feature flag
+	config.Set(pkg_utils.FF_GITIGNORE_RESPECT_TRACKED_FILES, false)
+
+	require.NoError(t, engine.Init())
+
+	// The sibling flag is registered next to the overridden one and is not set
+	// locally, so it has to be in the batch. Requiring it keeps the assertion
+	// below meaningful: without it, renaming either flag would leave a negative
+	// assertion that passes because nothing matches it any more.
+	requested := gateway.requestedFlags()
+	require.Contains(t, requested, "clientFileFilterGitignore_MetaCharFix",
+		"the batch must cover the registration group the overridden flag belongs to")
+	assert.NotContains(t, requested, "clientFileFilterGitignore_TrackedFilesRollout",
+		"the flag behind a locally set key must not be evaluated remotely")
+	assert.False(t, config.GetBool(pkg_utils.FF_GITIGNORE_RESPECT_TRACKED_FILES),
+		"the local value must win over the remote one")
 }

--- a/pkg/local_workflows/config_utils/feature_flag_gateway.go
+++ b/pkg/local_workflows/config_utils/feature_flag_gateway.go
@@ -44,18 +44,25 @@ var registries sync.Map
 
 func getFlagRegistry(config configuration.Configuration) *flagRegistry {
 	if r, ok := registries.Load(config); ok {
-		return r.(*flagRegistry)
+		if reg, ok := r.(*flagRegistry); ok {
+			return reg
+		}
 	}
 	return nil
 }
 
 func getOrCreateFlagRegistry(config configuration.Configuration) *flagRegistry {
 	if r, ok := registries.Load(config); ok {
-		return r.(*flagRegistry)
+		if reg, ok := r.(*flagRegistry); ok {
+			return reg
+		}
 	}
 	created := &flagRegistry{flags: make(map[string]struct{})}
 	actual, _ := registries.LoadOrStore(config, created)
-	return actual.(*flagRegistry)
+	if reg, ok := actual.(*flagRegistry); ok {
+		return reg
+	}
+	return created
 }
 
 func AddFeatureFlagsToConfig(
@@ -109,7 +116,10 @@ func AddFeatureFlagsToConfig(
 				return false, fmt.Errorf("check feature flags batch: %w", err)
 			}
 
-			res := result.(map[string]bool)
+			res, ok := result.(map[string]bool)
+			if !ok {
+				return false, fmt.Errorf("check feature flags batch: unexpected result type")
+			}
 			return res[flagName], nil
 		}
 		config.AddDefaultValue(configKey, callback)

--- a/pkg/local_workflows/config_utils/feature_flag_gateway.go
+++ b/pkg/local_workflows/config_utils/feature_flag_gateway.go
@@ -3,28 +3,73 @@ package config_utils
 import (
 	"errors"
 	"fmt"
-	"maps"
-	"slices"
-	"sort"
-	"strings"
+	"sync"
 
 	"github.com/google/uuid"
+	"golang.org/x/sync/singleflight"
+
 	featureflaggateway "github.com/snyk/go-application-framework/pkg/apiclients/feature_flag_gateway"
 	v20241015 "github.com/snyk/go-application-framework/pkg/apiclients/feature_flag_gateway/2024-10-15"
 	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/utils"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )
 
 var evaluateFlags = featureflaggateway.EvaluateFlags
 var errInvalidEvaluateFlagsResponse = errors.New("invalid evaluateFlags response")
 
+type flagRegistry struct {
+	mu    sync.Mutex
+	flags map[string]struct{}
+	sf    singleflight.Group
+}
+
+func (r *flagRegistry) addFlags(names []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, name := range names {
+		r.flags[name] = struct{}{}
+	}
+}
+
+func (r *flagRegistry) allFlags() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return utils.SortedMapKeys(r.flags)
+}
+
+// registries maps Configuration instances to their flag registry.
+// Stored outside the config keyspace to avoid env-var collisions and AllKeys() pollution.
+var registries sync.Map
+
+func getFlagRegistry(config configuration.Configuration) *flagRegistry {
+	if r, ok := registries.Load(config); ok {
+		return r.(*flagRegistry)
+	}
+	return nil
+}
+
+func getOrCreateFlagRegistry(config configuration.Configuration) *flagRegistry {
+	if r, ok := registries.Load(config); ok {
+		return r.(*flagRegistry)
+	}
+	created := &flagRegistry{flags: make(map[string]struct{})}
+	actual, _ := registries.LoadOrStore(config, created)
+	return actual.(*flagRegistry)
+}
+
 func AddFeatureFlagsToConfig(
 	engine workflow.Engine,
 	configKeyToFlag map[string]string,
 ) {
 	config := engine.GetConfiguration()
-	flags := slices.Collect(maps.Values(configKeyToFlag))
-	sort.Strings(flags)
+	registry := getOrCreateFlagRegistry(config)
+
+	flagNames := make([]string, 0, len(configKeyToFlag))
+	for _, flagName := range configKeyToFlag {
+		flagNames = append(flagNames, flagName)
+	}
+	registry.addFlags(flagNames)
 
 	for configKey, flagName := range configKeyToFlag {
 		err := config.AddKeyDependency(configKey, configuration.ORGANIZATION)
@@ -38,22 +83,33 @@ func AddFeatureFlagsToConfig(
 			}
 
 			orgID := c.GetString(configuration.ORGANIZATION)
-			cacheKey := fmt.Sprintf("hidden_flags_%s:%s", orgID, strings.Join(flags, ","))
+			cacheKey := fmt.Sprintf("hidden_flags_%s", orgID)
+
 			if cached := c.Get(cacheKey); cached != nil {
 				if m, ok := cached.(map[string]bool); ok {
-					return m[flagName], nil
+					if _, exists := m[flagName]; exists {
+						return m[flagName], nil
+					}
 				}
 			}
 
-			res, err := areFeaturesEnabled(c, engine, orgID, flags...)
+			result, err, _ := registry.sf.Do(cacheKey, func() (interface{}, error) {
+				allFlags := registry.allFlags()
+				res, err := areFeaturesEnabled(c, engine, orgID, allFlags...)
+				if err != nil {
+					return nil, err
+				}
+				if addErr := c.AddKeyDependency(cacheKey, configuration.ORGANIZATION); addErr != nil {
+					engine.GetLogger().Err(addErr).Msgf("failed to add dependency for %s", cacheKey)
+				}
+				c.Set(cacheKey, res)
+				return res, nil
+			})
 			if err != nil {
 				return false, fmt.Errorf("check feature flags batch: %w", err)
 			}
-			if err := config.AddKeyDependency(cacheKey, configuration.ORGANIZATION); err != nil {
-				engine.GetLogger().Err(err).Msgf("failed to add dependency for %s", cacheKey)
-			}
-			c.Set(cacheKey, res)
 
+			res := result.(map[string]bool)
 			return res[flagName], nil
 		}
 		config.AddDefaultValue(configKey, callback)
@@ -81,10 +137,24 @@ func areFeaturesEnabled(
 	}
 
 	results := make(map[string]bool, len(flags))
+	for _, f := range flags {
+		results[f] = false
+	}
+
 	evaluations := resp.ApplicationvndApiJSON200.Data.Attributes.Evaluations
+	evaluated := make(map[string]struct{}, len(evaluations))
 	for _, e := range evaluations {
+		evaluated[e.Key] = struct{}{}
 		if e.Value != nil {
 			results[e.Key] = *e.Value
+		}
+	}
+
+	if engine != nil {
+		for _, f := range flags {
+			if _, ok := evaluated[f]; !ok {
+				engine.GetLogger().Debug().Msgf("feature flag %q: no evaluation returned, defaulting to false", f)
+			}
 		}
 	}
 

--- a/pkg/local_workflows/config_utils/feature_flag_gateway.go
+++ b/pkg/local_workflows/config_utils/feature_flag_gateway.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/google/uuid"
+
 	featureflaggateway "github.com/snyk/go-application-framework/pkg/apiclients/feature_flag_gateway"
 	v20241015 "github.com/snyk/go-application-framework/pkg/apiclients/feature_flag_gateway/2024-10-15"
 	"github.com/snyk/go-application-framework/pkg/configuration"
@@ -20,32 +21,51 @@ var errInvalidEvaluateFlagsResponse = errors.New("invalid evaluateFlags response
 
 const registryConfigKey = "hidden_feature_flag_registry"
 
+// registryMu guards the get-or-create of a registry, because Configuration
+// offers no atomic equivalent. It holds no state of its own.
 var registryMu sync.Mutex
 
+// fetchKey scopes lookup results. The API endpoint is part of the key because
+// cloned configurations may address different endpoints while sharing an org.
+type fetchKey struct {
+	orgID  string
+	apiURL string
+}
+
+// flagRegistry collects every flag registered against one configuration, so that
+// an access can look all of them up in a single request.
 type flagRegistry struct {
 	mu       sync.RWMutex
 	flags    map[string]struct{}
-	orgFetch sync.Map
+	orgFetch map[fetchKey]*orgFetchResult
 }
 
+// orgFetchResult memorizes the flags already looked up for one fetchKey. A flag
+// present in values has been looked up, an absent one still needs fetching.
 type orgFetchResult struct {
 	mu     sync.Mutex
 	values map[string]bool
-	done   bool
 }
 
 func getOrCreateRegistry(config configuration.Configuration) *flagRegistry {
 	registryMu.Lock()
 	defer registryMu.Unlock()
 
-	if v := config.Get(registryConfigKey); v != nil {
-		if r, ok := v.(*flagRegistry); ok {
-			return r
-		}
+	if registry, ok := config.Get(registryConfigKey).(*flagRegistry); ok {
+		return registry
 	}
-	r := &flagRegistry{flags: make(map[string]struct{})}
-	config.Set(registryConfigKey, r)
-	return r
+
+	registry := &flagRegistry{
+		flags:    make(map[string]struct{}),
+		orgFetch: make(map[fetchKey]*orgFetchResult),
+	}
+
+	// The registry is registered as an immutable default rather than being set as
+	// a value, so that it never enters the configuration's value space where it
+	// could be persisted or shadowed.
+	config.AddDefaultValue(registryConfigKey, configuration.ImmutableDefaultValueFunction(registry))
+
+	return registry
 }
 
 func (r *flagRegistry) addFlags(flags []string) {
@@ -67,26 +87,68 @@ func (r *flagRegistry) allFlags() []string {
 	return result
 }
 
-func (r *flagRegistry) resolve(c configuration.Configuration, engine workflow.Engine, orgID string, flagName string) (bool, error) {
-	fetchI, _ := r.orgFetch.LoadOrStore(orgID, &orgFetchResult{})
-	f := fetchI.(*orgFetchResult)
+func (r *flagRegistry) fetchResultFor(key fetchKey) *orgFetchResult {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
-	if !f.done {
-		allFlags := r.allFlags()
-		var err error
-		f.values, err = areFeaturesEnabled(c, engine, orgID, allFlags...)
-		if err != nil {
-			return false, fmt.Errorf("check feature flags batch: %w", err)
-		}
-		f.done = true
+	result, ok := r.orgFetch[key]
+	if !ok {
+		result = &orgFetchResult{values: make(map[string]bool)}
+		r.orgFetch[key] = result
 	}
-
-	return f.values[flagName], nil
+	return result
 }
 
+// resolve returns the value of flagName and looks up every flag that is
+// registered but not yet known in a single request. Flags registered after an
+// earlier lookup are picked up here, flags already looked up are not requested
+// again.
+func (r *flagRegistry) resolve(c configuration.Configuration, engine workflow.Engine, orgID string, flagName string) (bool, error) {
+	fetched := r.fetchResultFor(fetchKey{orgID: orgID, apiURL: c.GetString(configuration.API_URL)})
+
+	fetched.mu.Lock()
+	defer fetched.mu.Unlock()
+
+	if value, known := fetched.values[flagName]; known {
+		return value, nil
+	}
+
+	missing := make([]string, 0)
+	for _, name := range r.allFlags() {
+		if _, known := fetched.values[name]; !known {
+			missing = append(missing, name)
+		}
+	}
+
+	// Requesting no flags at all would be rejected by the gateway and, since
+	// nothing would be memorized, repeated on every single access.
+	if len(missing) == 0 {
+		return false, nil
+	}
+
+	values, err := areFeaturesEnabled(c, engine, orgID, missing...)
+	if err != nil {
+		return false, fmt.Errorf("check feature flags batch: %w", err)
+	}
+
+	// Every requested flag is memorized, including the ones the gateway did not
+	// return, so that an unknown flag resolves to false instead of being
+	// requested again on every access.
+	for _, name := range missing {
+		fetched.values[name] = values[name]
+	}
+
+	return fetched.values[flagName], nil
+}
+
+// AddFeatureFlagsToConfig registers configuration keys that are backed by remote
+// feature flags. Flags are looked up lazily: the first access to any of them
+// looks up every flag registered so far in a single request, and flags
+// registered afterwards are picked up by the next access that needs them.
+//
+// Registration has to happen before a configuration is cloned. Clone copies the
+// default value functions that exist at that moment, so a configuration cloned
+// before a flag is registered resolves that flag to false.
 func AddFeatureFlagsToConfig(
 	engine workflow.Engine,
 	configKeyToFlag map[string]string,

--- a/pkg/local_workflows/config_utils/feature_flag_gateway.go
+++ b/pkg/local_workflows/config_utils/feature_flag_gateway.go
@@ -3,8 +3,6 @@ package config_utils
 import (
 	"errors"
 	"fmt"
-	"maps"
-	"slices"
 	"sort"
 	"sync"
 
@@ -35,9 +33,17 @@ type fetchKey struct {
 // flagRegistry collects every flag registered against one configuration, so that
 // an access can look all of them up in a single request.
 type flagRegistry struct {
-	mu       sync.RWMutex
-	flags    map[string]struct{}
+	mu sync.RWMutex
+	// flags maps a flag name to the configuration key it backs.
+	flags    map[string]string
 	orgFetch map[fetchKey]*orgFetchResult
+}
+
+// registeredFlag is a remote feature flag together with the configuration key it
+// backs.
+type registeredFlag struct {
+	name      string
+	configKey string
 }
 
 // orgFetchResult memorizes the flags already looked up for one fetchKey. A flag
@@ -56,7 +62,7 @@ func getOrCreateRegistry(config configuration.Configuration) *flagRegistry {
 	}
 
 	registry := &flagRegistry{
-		flags:    make(map[string]struct{}),
+		flags:    make(map[string]string),
 		orgFetch: make(map[fetchKey]*orgFetchResult),
 	}
 
@@ -68,22 +74,22 @@ func getOrCreateRegistry(config configuration.Configuration) *flagRegistry {
 	return registry
 }
 
-func (r *flagRegistry) addFlags(flags []string) {
+func (r *flagRegistry) addFlags(configKeyToFlag map[string]string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	for _, f := range flags {
-		r.flags[f] = struct{}{}
+	for configKey, flagName := range configKeyToFlag {
+		r.flags[flagName] = configKey
 	}
 }
 
-func (r *flagRegistry) allFlags() []string {
+func (r *flagRegistry) allFlags() []registeredFlag {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	result := make([]string, 0, len(r.flags))
-	for f := range r.flags {
-		result = append(result, f)
+	result := make([]registeredFlag, 0, len(r.flags))
+	for flagName, configKey := range r.flags {
+		result = append(result, registeredFlag{name: flagName, configKey: configKey})
 	}
-	sort.Strings(result)
+	sort.Slice(result, func(i, j int) bool { return result[i].name < result[j].name })
 	return result
 }
 
@@ -102,7 +108,7 @@ func (r *flagRegistry) fetchResultFor(key fetchKey) *orgFetchResult {
 // resolve returns the value of flagName and looks up every flag that is
 // registered but not yet known in a single request. Flags registered after an
 // earlier lookup are picked up here, flags already looked up are not requested
-// again.
+// again, and neither are flags whose configuration key is locally overridden.
 func (r *flagRegistry) resolve(c configuration.Configuration, engine workflow.Engine, orgID string, flagName string) (bool, error) {
 	fetched := r.fetchResultFor(fetchKey{orgID: orgID, apiURL: c.GetString(configuration.API_URL)})
 
@@ -114,10 +120,20 @@ func (r *flagRegistry) resolve(c configuration.Configuration, engine workflow.En
 	}
 
 	missing := make([]string, 0)
-	for _, name := range r.allFlags() {
-		if _, known := fetched.values[name]; !known {
-			missing = append(missing, name)
+	for _, flag := range r.allFlags() {
+		if _, known := fetched.values[flag.name]; known {
+			continue
 		}
+
+		// A key that already holds a value never consults its default value
+		// function, so evaluating its flag remotely would report an exposure for a
+		// value nobody reads. The flag this call is for is exempt: it is being
+		// resolved right now, which means its key has no value.
+		if flag.name != flagName && c.IsSet(flag.configKey) {
+			continue
+		}
+
+		missing = append(missing, flag.name)
 	}
 
 	// Requesting no flags at all would be rejected by the gateway and, since
@@ -146,6 +162,15 @@ func (r *flagRegistry) resolve(c configuration.Configuration, engine workflow.En
 // looks up every flag registered so far in a single request, and flags
 // registered afterwards are picked up by the next access that needs them.
 //
+// A key that already holds a value keeps it, and its flag is left out of the
+// batch another key triggers, so it is not evaluated remotely for nothing. Two
+// limits apply. The value has to be there before the first flag is resolved -
+// an override applied later cannot unsend a request. And the batch is narrowed
+// via Configuration.IsSet, which answers a slightly narrower question than the
+// callback's own "does this key already have a value": it does not see a value
+// that only a pflag default or a non-last alternative key provides. Such a key
+// still keeps its value, its flag is merely evaluated needlessly.
+//
 // Registration has to happen before a configuration is cloned. Clone copies the
 // default value functions that exist at that moment, so a configuration cloned
 // before a flag is registered resolves that flag to false.
@@ -155,9 +180,7 @@ func AddFeatureFlagsToConfig(
 ) {
 	config := engine.GetConfiguration()
 	registry := getOrCreateRegistry(config)
-
-	newFlags := slices.Collect(maps.Values(configKeyToFlag))
-	registry.addFlags(newFlags)
+	registry.addFlags(configKeyToFlag)
 
 	for configKey, flagName := range configKeyToFlag {
 		err := config.AddKeyDependency(configKey, configuration.ORGANIZATION)

--- a/pkg/local_workflows/config_utils/feature_flag_gateway.go
+++ b/pkg/local_workflows/config_utils/feature_flag_gateway.go
@@ -6,7 +6,7 @@ import (
 	"maps"
 	"slices"
 	"sort"
-	"strings"
+	"sync"
 
 	"github.com/google/uuid"
 	featureflaggateway "github.com/snyk/go-application-framework/pkg/apiclients/feature_flag_gateway"
@@ -18,13 +18,84 @@ import (
 var evaluateFlags = featureflaggateway.EvaluateFlags
 var errInvalidEvaluateFlagsResponse = errors.New("invalid evaluateFlags response")
 
+const registryConfigKey = "hidden_feature_flag_registry"
+
+var registryMu sync.Mutex
+
+type flagRegistry struct {
+	mu       sync.RWMutex
+	flags    map[string]struct{}
+	orgFetch sync.Map
+}
+
+type orgFetchResult struct {
+	mu     sync.Mutex
+	values map[string]bool
+	done   bool
+}
+
+func getOrCreateRegistry(config configuration.Configuration) *flagRegistry {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	if v := config.Get(registryConfigKey); v != nil {
+		if r, ok := v.(*flagRegistry); ok {
+			return r
+		}
+	}
+	r := &flagRegistry{flags: make(map[string]struct{})}
+	config.Set(registryConfigKey, r)
+	return r
+}
+
+func (r *flagRegistry) addFlags(flags []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, f := range flags {
+		r.flags[f] = struct{}{}
+	}
+}
+
+func (r *flagRegistry) allFlags() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	result := make([]string, 0, len(r.flags))
+	for f := range r.flags {
+		result = append(result, f)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func (r *flagRegistry) resolve(c configuration.Configuration, engine workflow.Engine, orgID string, flagName string) (bool, error) {
+	fetchI, _ := r.orgFetch.LoadOrStore(orgID, &orgFetchResult{})
+	f := fetchI.(*orgFetchResult)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if !f.done {
+		allFlags := r.allFlags()
+		var err error
+		f.values, err = areFeaturesEnabled(c, engine, orgID, allFlags...)
+		if err != nil {
+			return false, fmt.Errorf("check feature flags batch: %w", err)
+		}
+		f.done = true
+	}
+
+	return f.values[flagName], nil
+}
+
 func AddFeatureFlagsToConfig(
 	engine workflow.Engine,
 	configKeyToFlag map[string]string,
 ) {
 	config := engine.GetConfiguration()
-	flags := slices.Collect(maps.Values(configKeyToFlag))
-	sort.Strings(flags)
+	registry := getOrCreateRegistry(config)
+
+	newFlags := slices.Collect(maps.Values(configKeyToFlag))
+	registry.addFlags(newFlags)
 
 	for configKey, flagName := range configKeyToFlag {
 		err := config.AddKeyDependency(configKey, configuration.ORGANIZATION)
@@ -38,23 +109,7 @@ func AddFeatureFlagsToConfig(
 			}
 
 			orgID := c.GetString(configuration.ORGANIZATION)
-			cacheKey := fmt.Sprintf("hidden_flags_%s:%s", orgID, strings.Join(flags, ","))
-			if cached := c.Get(cacheKey); cached != nil {
-				if m, ok := cached.(map[string]bool); ok {
-					return m[flagName], nil
-				}
-			}
-
-			res, err := areFeaturesEnabled(c, engine, orgID, flags...)
-			if err != nil {
-				return false, fmt.Errorf("check feature flags batch: %w", err)
-			}
-			if err := config.AddKeyDependency(cacheKey, configuration.ORGANIZATION); err != nil {
-				engine.GetLogger().Err(err).Msgf("failed to add dependency for %s", cacheKey)
-			}
-			c.Set(cacheKey, res)
-
-			return res[flagName], nil
+			return registry.resolve(c, engine, orgID, flagName)
 		}
 		config.AddDefaultValue(configKey, callback)
 	}

--- a/pkg/local_workflows/config_utils/feature_flag_gateway.go
+++ b/pkg/local_workflows/config_utils/feature_flag_gateway.go
@@ -3,80 +3,28 @@ package config_utils
 import (
 	"errors"
 	"fmt"
-	"sync"
+	"maps"
+	"slices"
+	"sort"
+	"strings"
 
 	"github.com/google/uuid"
-	"golang.org/x/sync/singleflight"
-
 	featureflaggateway "github.com/snyk/go-application-framework/pkg/apiclients/feature_flag_gateway"
 	v20241015 "github.com/snyk/go-application-framework/pkg/apiclients/feature_flag_gateway/2024-10-15"
 	"github.com/snyk/go-application-framework/pkg/configuration"
-	"github.com/snyk/go-application-framework/pkg/utils"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )
 
 var evaluateFlags = featureflaggateway.EvaluateFlags
 var errInvalidEvaluateFlagsResponse = errors.New("invalid evaluateFlags response")
 
-type flagRegistry struct {
-	mu    sync.Mutex
-	flags map[string]struct{}
-	sf    singleflight.Group
-}
-
-func (r *flagRegistry) addFlags(names []string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	for _, name := range names {
-		r.flags[name] = struct{}{}
-	}
-}
-
-func (r *flagRegistry) allFlags() []string {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return utils.SortedMapKeys(r.flags)
-}
-
-// registries maps Configuration instances to their flag registry.
-// Stored outside the config keyspace to avoid env-var collisions and AllKeys() pollution.
-var registries sync.Map
-
-func getFlagRegistry(config configuration.Configuration) *flagRegistry {
-	if r, ok := registries.Load(config); ok {
-		if reg, ok := r.(*flagRegistry); ok {
-			return reg
-		}
-	}
-	return nil
-}
-
-func getOrCreateFlagRegistry(config configuration.Configuration) *flagRegistry {
-	if r, ok := registries.Load(config); ok {
-		if reg, ok := r.(*flagRegistry); ok {
-			return reg
-		}
-	}
-	created := &flagRegistry{flags: make(map[string]struct{})}
-	actual, _ := registries.LoadOrStore(config, created)
-	if reg, ok := actual.(*flagRegistry); ok {
-		return reg
-	}
-	return created
-}
-
 func AddFeatureFlagsToConfig(
 	engine workflow.Engine,
 	configKeyToFlag map[string]string,
 ) {
 	config := engine.GetConfiguration()
-	registry := getOrCreateFlagRegistry(config)
-
-	flagNames := make([]string, 0, len(configKeyToFlag))
-	for _, flagName := range configKeyToFlag {
-		flagNames = append(flagNames, flagName)
-	}
-	registry.addFlags(flagNames)
+	flags := slices.Collect(maps.Values(configKeyToFlag))
+	sort.Strings(flags)
 
 	for configKey, flagName := range configKeyToFlag {
 		err := config.AddKeyDependency(configKey, configuration.ORGANIZATION)
@@ -90,36 +38,22 @@ func AddFeatureFlagsToConfig(
 			}
 
 			orgID := c.GetString(configuration.ORGANIZATION)
-			cacheKey := fmt.Sprintf("hidden_flags_%s", orgID)
-
+			cacheKey := fmt.Sprintf("hidden_flags_%s:%s", orgID, strings.Join(flags, ","))
 			if cached := c.Get(cacheKey); cached != nil {
 				if m, ok := cached.(map[string]bool); ok {
-					if _, exists := m[flagName]; exists {
-						return m[flagName], nil
-					}
+					return m[flagName], nil
 				}
 			}
 
-			result, err, _ := registry.sf.Do(cacheKey, func() (interface{}, error) {
-				allFlags := registry.allFlags()
-				res, err := areFeaturesEnabled(c, engine, orgID, allFlags...)
-				if err != nil {
-					return nil, err
-				}
-				if addErr := c.AddKeyDependency(cacheKey, configuration.ORGANIZATION); addErr != nil {
-					engine.GetLogger().Err(addErr).Msgf("failed to add dependency for %s", cacheKey)
-				}
-				c.Set(cacheKey, res)
-				return res, nil
-			})
+			res, err := areFeaturesEnabled(c, engine, orgID, flags...)
 			if err != nil {
 				return false, fmt.Errorf("check feature flags batch: %w", err)
 			}
-
-			res, ok := result.(map[string]bool)
-			if !ok {
-				return false, fmt.Errorf("check feature flags batch: unexpected result type")
+			if err := config.AddKeyDependency(cacheKey, configuration.ORGANIZATION); err != nil {
+				engine.GetLogger().Err(err).Msgf("failed to add dependency for %s", cacheKey)
 			}
+			c.Set(cacheKey, res)
+
 			return res[flagName], nil
 		}
 		config.AddDefaultValue(configKey, callback)
@@ -147,24 +81,10 @@ func areFeaturesEnabled(
 	}
 
 	results := make(map[string]bool, len(flags))
-	for _, f := range flags {
-		results[f] = false
-	}
-
 	evaluations := resp.ApplicationvndApiJSON200.Data.Attributes.Evaluations
-	evaluated := make(map[string]struct{}, len(evaluations))
 	for _, e := range evaluations {
-		evaluated[e.Key] = struct{}{}
 		if e.Value != nil {
 			results[e.Key] = *e.Value
-		}
-	}
-
-	if engine != nil {
-		for _, f := range flags {
-			if _, ok := evaluated[f]; !ok {
-				engine.GetLogger().Debug().Msgf("feature flag %q: no evaluation returned, defaulting to false", f)
-			}
 		}
 	}
 

--- a/pkg/local_workflows/config_utils/feature_flag_gateway_test.go
+++ b/pkg/local_workflows/config_utils/feature_flag_gateway_test.go
@@ -4,10 +4,15 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
@@ -20,6 +25,24 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const (
+	testOrgID       = "00000000-0000-0000-0000-000000000001"
+	testAPIEndpoint = "https://api.snyk.io"
+)
+
+func newFlagsResponse(evals []v20241015.FeatureFlagAttributes) *v20241015.ListFeatureFlagsResponse {
+	return &v20241015.ListFeatureFlagsResponse{
+		ApplicationvndApiJSON200: &struct {
+			Data    *v20241015.FeatureFlagsDataItem `json:"data,omitempty"`
+			Jsonapi *v20241015.JsonApi              `json:"jsonapi,omitempty"`
+		}{
+			Data: &v20241015.FeatureFlagsDataItem{
+				Attributes: v20241015.FeatureFlagAttributesList{Evaluations: evals},
+			},
+		},
+	}
+}
 
 func Test_AddFeatureFlagGatewayToConfig_CacheDependentOnOrg(t *testing.T) {
 	testConfigKey := "test_feature_flag"
@@ -59,9 +82,6 @@ func Test_AddFeatureFlagGatewayToConfig_CacheDependentOnOrg(t *testing.T) {
 }
 
 func Test_AddFeatureFlagGatewayToConfig(t *testing.T) {
-	globalOrg := "00000000-0000-0000-0000-000000000001"
-	globalAPIEndpoint := "https://api.snyk.io"
-
 	testConfigKey := "test_feature_flag"
 	testFeatureFlagName := "testFeatureFlag"
 
@@ -71,7 +91,6 @@ func Test_AddFeatureFlagGatewayToConfig(t *testing.T) {
 	httpClient := testutils.NewTestClient(func(req *http.Request) *http.Response {
 		requestedAPIs = append(requestedAPIs, "https://"+req.Host)
 
-		// Extract org from path: /hidden/orgs/<org>/feature_flags/evaluation
 		parts := strings.Split(req.URL.Path, "/")
 		org := ""
 		for i := 0; i < len(parts)-1; i++ {
@@ -82,7 +101,7 @@ func Test_AddFeatureFlagGatewayToConfig(t *testing.T) {
 		}
 		requestedOrgs = append(requestedOrgs, org)
 
-		enabled := org == globalOrg
+		enabled := org == testOrgID
 		response := struct {
 			Data    *v20241015.FeatureFlagsDataItem `json:"data,omitempty"`
 			Jsonapi *v20241015.JsonApi              `json:"jsonapi,omitempty"`
@@ -117,8 +136,9 @@ func Test_AddFeatureFlagGatewayToConfig(t *testing.T) {
 	logger := zerolog.Logger{}
 
 	config := configuration.NewWithOpts()
-	config.Set(configuration.API_URL, globalAPIEndpoint)
-	config.Set(configuration.ORGANIZATION, globalOrg)
+	config.Set(configuration.API_URL, testAPIEndpoint)
+	config.Set(configuration.ORGANIZATION, testOrgID)
+	t.Cleanup(func() { registries.Delete(config) })
 
 	mockEngine.EXPECT().GetConfiguration().Return(config).AnyTimes()
 	mockEngine.EXPECT().GetLogger().Return(&logger).AnyTimes()
@@ -132,15 +152,161 @@ func Test_AddFeatureFlagGatewayToConfig(t *testing.T) {
 	assert.Len(t, requestedOrgs, 0)
 	assert.Len(t, requestedAPIs, 0)
 
-	// Fetch from global config
 	result1 := config.GetBool(testConfigKey)
 	assert.True(t, result1)
-	assert.Equal(t, []string{globalOrg}, requestedOrgs)
-	assert.Equal(t, []string{globalAPIEndpoint}, requestedAPIs)
+	assert.Equal(t, []string{testOrgID}, requestedOrgs)
+	assert.Equal(t, []string{testAPIEndpoint}, requestedAPIs)
+}
+
+func Test_AddFeatureFlagsToConfig_ConcurrentRegistrationAndBatching(t *testing.T) {
+	flagCount := 50
+
+	var apiCallCount int32
+	var capturedFlags []string
+
+	originalEvaluateFlags := evaluateFlags
+	t.Cleanup(func() { evaluateFlags = originalEvaluateFlags })
+
+	evaluateFlags = func(
+		config configuration.Configuration,
+		engine workflow.Engine,
+		flags []string,
+		org uuid.UUID,
+	) (*v20241015.ListFeatureFlagsResponse, error) {
+		atomic.AddInt32(&apiCallCount, 1)
+		capturedFlags = flags
+		trueVal := true
+		evals := make([]v20241015.FeatureFlagAttributes, len(flags))
+		for i, f := range flags {
+			evals[i] = v20241015.FeatureFlagAttributes{Key: f, Value: &trueVal}
+		}
+		return newFlagsResponse(evals), nil
+	}
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockEngine := mocks.NewMockEngine(ctrl)
+	logger := zerolog.Logger{}
+	config := configuration.NewWithOpts()
+	config.Set(configuration.API_URL, testAPIEndpoint)
+	config.Set(configuration.ORGANIZATION, testOrgID)
+	t.Cleanup(func() { registries.Delete(config) })
+
+	mockEngine.EXPECT().GetConfiguration().Return(config).AnyTimes()
+	mockEngine.EXPECT().GetLogger().Return(&logger).AnyTimes()
+
+	var wg sync.WaitGroup
+	for i := 0; i < flagCount; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			configKey := fmt.Sprintf("concurrent_key_%d", i)
+			flagName := fmt.Sprintf("concurrent-flag-%d", i)
+			AddFeatureFlagsToConfig(mockEngine, map[string]string{configKey: flagName})
+		}(i)
+	}
+	wg.Wait()
+
+	registry := getFlagRegistry(config)
+	require.NotNil(t, registry, "registry must exist after registration")
+	registry.mu.Lock()
+	registeredCount := len(registry.flags)
+	registry.mu.Unlock()
+	assert.Equal(t, flagCount, registeredCount,
+		"all concurrently registered flags must be present in the registry")
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&apiCallCount),
+		"no API call before any flag is read")
+
+	result := config.GetBool("concurrent_key_0")
+	assert.True(t, result)
+
+	for i := 1; i < flagCount; i++ {
+		configKey := fmt.Sprintf("concurrent_key_%d", i)
+		assert.True(t, config.GetBool(configKey), "flag %s should be resolvable", configKey)
+	}
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&apiCallCount),
+		"all registered flags must resolve from a single batched API call")
+
+	expectedFlags := make([]string, flagCount)
+	for i := 0; i < flagCount; i++ {
+		expectedFlags[i] = fmt.Sprintf("concurrent-flag-%d", i)
+	}
+	slices.Sort(expectedFlags)
+	assert.Equal(t, expectedFlags, capturedFlags,
+		"batch request must contain all registered flag names")
+}
+
+func Test_AddFeatureFlagsToConfig_ConcurrentReads(t *testing.T) {
+	flagCount := 10
+
+	var apiCallCount int32
+
+	originalEvaluateFlags := evaluateFlags
+	t.Cleanup(func() { evaluateFlags = originalEvaluateFlags })
+
+	evaluateFlags = func(
+		config configuration.Configuration,
+		engine workflow.Engine,
+		flags []string,
+		org uuid.UUID,
+	) (*v20241015.ListFeatureFlagsResponse, error) {
+		atomic.AddInt32(&apiCallCount, 1)
+		time.Sleep(20 * time.Millisecond)
+		trueVal := true
+		evals := make([]v20241015.FeatureFlagAttributes, len(flags))
+		for i, f := range flags {
+			evals[i] = v20241015.FeatureFlagAttributes{Key: f, Value: &trueVal}
+		}
+		return newFlagsResponse(evals), nil
+	}
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockEngine := mocks.NewMockEngine(ctrl)
+	logger := zerolog.Logger{}
+	config := configuration.NewWithOpts()
+	config.Set(configuration.API_URL, testAPIEndpoint)
+	config.Set(configuration.ORGANIZATION, testOrgID)
+	t.Cleanup(func() { registries.Delete(config) })
+
+	mockEngine.EXPECT().GetConfiguration().Return(config).AnyTimes()
+	mockEngine.EXPECT().GetLogger().Return(&logger).AnyTimes()
+
+	for i := 0; i < flagCount; i++ {
+		configKey := fmt.Sprintf("concurrent_read_key_%d", i)
+		flagName := fmt.Sprintf("concurrent-read-flag-%d", i)
+		AddFeatureFlagsToConfig(mockEngine, map[string]string{configKey: flagName})
+	}
+
+	var wg sync.WaitGroup
+	results := make([]bool, flagCount)
+	for i := 0; i < flagCount; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			configKey := fmt.Sprintf("concurrent_read_key_%d", i)
+			results[i] = config.GetBool(configKey)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, r := range results {
+		assert.True(t, r, "flag concurrent_read_key_%d should be true", i)
+	}
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&apiCallCount),
+		"concurrent reads for the same org should coalesce into a single API call")
 }
 
 func TestAreFeaturesEnabled_PartialAndNilValue(t *testing.T) {
 	orgID := uuid.NewString()
+
+	originalEvaluateFlags := evaluateFlags
+	t.Cleanup(func() { evaluateFlags = originalEvaluateFlags })
 
 	tests := []struct {
 		name        string
@@ -195,18 +361,7 @@ func TestAreFeaturesEnabled_PartialAndNilValue(t *testing.T) {
 				flags []string,
 				orgID uuid.UUID,
 			) (*v20241015.ListFeatureFlagsResponse, error) {
-				return &v20241015.ListFeatureFlagsResponse{
-					ApplicationvndApiJSON200: &struct {
-						Data    *v20241015.FeatureFlagsDataItem `json:"data,omitempty"`
-						Jsonapi *v20241015.JsonApi              `json:"jsonapi,omitempty"`
-					}{
-						Data: &v20241015.FeatureFlagsDataItem{
-							Attributes: v20241015.FeatureFlagAttributesList{
-								Evaluations: tc.evaluations,
-							},
-						},
-					},
-				}, nil
+				return newFlagsResponse(tc.evaluations), nil
 			}
 
 			got, err := areFeaturesEnabled(nil, nil, orgID, tc.requested...)
@@ -234,6 +389,10 @@ func TestIsFeatureEnabled_Error_EvaluateFlagsReturnsError(t *testing.T) {
 	flag := "my-flag"
 	orgID := uuid.NewString()
 	expectedErr := errors.New("gateway blew up")
+
+	originalEvaluateFlags := evaluateFlags
+	t.Cleanup(func() { evaluateFlags = originalEvaluateFlags })
+
 	evaluateFlags = func(
 		config configuration.Configuration, engine workflow.Engine, flags []string, orgID uuid.UUID,
 	) (featureFlagsResponse *v20241015.ListFeatureFlagsResponse, retErr error) {
@@ -248,6 +407,9 @@ func TestIsFeatureEnabled_Error_EvaluateFlagsReturnsError(t *testing.T) {
 func TestIsFeatureEnabled_Error_InvalidEvaluateFlagsResponse(t *testing.T) {
 	flag := "my-flag"
 	orgID := uuid.NewString()
+
+	originalEvaluateFlags := evaluateFlags
+	t.Cleanup(func() { evaluateFlags = originalEvaluateFlags })
 
 	evaluateFlags = func(
 		config configuration.Configuration,

--- a/pkg/local_workflows/config_utils/feature_flag_gateway_test.go
+++ b/pkg/local_workflows/config_utils/feature_flag_gateway_test.go
@@ -45,6 +45,82 @@ func newFlagsResponse(evals []v20241015.FeatureFlagAttributes) *v20241015.ListFe
 	}
 }
 
+// flagGatewayStub records every batch evaluateFlags was called with and reports
+// each requested flag as enabled, except for the ones it was told to omit from
+// the response.
+type flagGatewayStub struct {
+	mu      sync.Mutex
+	batches [][]string
+	omit    map[string]bool
+}
+
+func stubFlagGateway(t *testing.T, omitFromResponse ...string) *flagGatewayStub {
+	t.Helper()
+
+	stub := &flagGatewayStub{omit: make(map[string]bool, len(omitFromResponse))}
+	for _, flag := range omitFromResponse {
+		stub.omit[flag] = true
+	}
+
+	originalEvaluateFlags := evaluateFlags
+	t.Cleanup(func() { evaluateFlags = originalEvaluateFlags })
+
+	evaluateFlags = func(
+		config configuration.Configuration,
+		engine workflow.Engine,
+		flags []string,
+		org uuid.UUID,
+	) (*v20241015.ListFeatureFlagsResponse, error) {
+		if len(flags) == 0 {
+			t.Error("evaluateFlags must never be called without flags")
+		}
+
+		stub.mu.Lock()
+		stub.batches = append(stub.batches, slices.Clone(flags))
+		stub.mu.Unlock()
+
+		enabled := true
+		evaluations := make([]v20241015.FeatureFlagAttributes, 0, len(flags))
+		for _, flag := range flags {
+			if stub.omit[flag] {
+				continue
+			}
+			evaluations = append(evaluations, v20241015.FeatureFlagAttributes{Key: flag, Value: &enabled})
+		}
+
+		return newFlagsResponse(evaluations), nil
+	}
+
+	return stub
+}
+
+func (s *flagGatewayStub) recordedBatches() [][]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.batches)
+}
+
+func newFlagTestConfig() configuration.Configuration {
+	config := configuration.NewWithOpts()
+	config.Set(configuration.API_URL, testAPIEndpoint)
+	config.Set(configuration.ORGANIZATION, testOrgID)
+	return config
+}
+
+func newFlagTestEngine(t *testing.T, config configuration.Configuration) workflow.Engine {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	logger := zerolog.Logger{}
+	mockEngine := mocks.NewMockEngine(ctrl)
+	mockEngine.EXPECT().GetConfiguration().Return(config).AnyTimes()
+	mockEngine.EXPECT().GetLogger().Return(&logger).AnyTimes()
+
+	return mockEngine
+}
+
 func Test_AddFeatureFlagGatewayToConfig_CacheDependentOnOrg(t *testing.T) {
 	testConfigKey := "test_feature_flag"
 	flag := "my-flag"
@@ -161,39 +237,9 @@ func Test_AddFeatureFlagGatewayToConfig(t *testing.T) {
 func Test_AddFeatureFlagsToConfig_ConcurrentRegistrationAndBatching(t *testing.T) {
 	flagCount := 50
 
-	var apiCallCount int32
-	var capturedFlags []string
-
-	originalEvaluateFlags := evaluateFlags
-	t.Cleanup(func() { evaluateFlags = originalEvaluateFlags })
-
-	evaluateFlags = func(
-		config configuration.Configuration,
-		engine workflow.Engine,
-		flags []string,
-		org uuid.UUID,
-	) (*v20241015.ListFeatureFlagsResponse, error) {
-		atomic.AddInt32(&apiCallCount, 1)
-		capturedFlags = flags
-		trueVal := true
-		evals := make([]v20241015.FeatureFlagAttributes, len(flags))
-		for i, f := range flags {
-			evals[i] = v20241015.FeatureFlagAttributes{Key: f, Value: &trueVal}
-		}
-		return newFlagsResponse(evals), nil
-	}
-
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-
-	mockEngine := mocks.NewMockEngine(ctrl)
-	logger := zerolog.Logger{}
-	config := configuration.NewWithOpts()
-	config.Set(configuration.API_URL, testAPIEndpoint)
-	config.Set(configuration.ORGANIZATION, testOrgID)
-
-	mockEngine.EXPECT().GetConfiguration().Return(config).AnyTimes()
-	mockEngine.EXPECT().GetLogger().Return(&logger).AnyTimes()
+	stub := stubFlagGateway(t)
+	config := newFlagTestConfig()
+	engine := newFlagTestEngine(t, config)
 
 	var wg sync.WaitGroup
 	for i := 0; i < flagCount; i++ {
@@ -202,7 +248,7 @@ func Test_AddFeatureFlagsToConfig_ConcurrentRegistrationAndBatching(t *testing.T
 			defer wg.Done()
 			configKey := fmt.Sprintf("concurrent_key_%d", i)
 			flagName := fmt.Sprintf("concurrent-flag-%d", i)
-			AddFeatureFlagsToConfig(mockEngine, map[string]string{configKey: flagName})
+			AddFeatureFlagsToConfig(engine, map[string]string{configKey: flagName})
 		}(i)
 	}
 	wg.Wait()
@@ -215,16 +261,98 @@ func Test_AddFeatureFlagsToConfig_ConcurrentRegistrationAndBatching(t *testing.T
 		assert.True(t, config.GetBool(configKey), "flag %s should be resolvable", configKey)
 	}
 
-	assert.Equal(t, int32(1), atomic.LoadInt32(&apiCallCount),
-		"all registered flags must resolve from a single batched API call")
-
 	expectedFlags := make([]string, flagCount)
 	for i := 0; i < flagCount; i++ {
 		expectedFlags[i] = fmt.Sprintf("concurrent-flag-%d", i)
 	}
 	slices.Sort(expectedFlags)
-	assert.Equal(t, expectedFlags, capturedFlags,
-		"batch request must contain all registered flag names")
+
+	assert.Equal(t, [][]string{expectedFlags}, stub.recordedBatches(),
+		"all registered flags must resolve from a single batched API call")
+}
+
+func Test_AddFeatureFlagsToConfig_RegistrationsBeforeFirstAccessShareOneRequest(t *testing.T) {
+	stub := stubFlagGateway(t)
+	config := newFlagTestConfig()
+	engine := newFlagTestEngine(t, config)
+
+	AddFeatureFlagsToConfig(engine, map[string]string{"batched_key_a": "batched-flag-a"})
+	AddFeatureFlagsToConfig(engine, map[string]string{"batched_key_b": "batched-flag-b"})
+	AddFeatureFlagsToConfig(engine, map[string]string{"batched_key_c": "batched-flag-c"})
+
+	assert.True(t, config.GetBool("batched_key_b"))
+	assert.True(t, config.GetBool("batched_key_a"))
+	assert.True(t, config.GetBool("batched_key_c"))
+
+	assert.Equal(t, [][]string{{"batched-flag-a", "batched-flag-b", "batched-flag-c"}}, stub.recordedBatches(),
+		"the first access must look up every flag registered so far")
+}
+
+func Test_AddFeatureFlagsToConfig_LateRegistrationIsLookedUp(t *testing.T) {
+	stub := stubFlagGateway(t)
+	config := newFlagTestConfig()
+	engine := newFlagTestEngine(t, config)
+
+	AddFeatureFlagsToConfig(engine, map[string]string{"early_key": "early-flag"})
+	assert.True(t, config.GetBool("early_key"))
+
+	// registered after the first lookup already happened
+	AddFeatureFlagsToConfig(engine, map[string]string{
+		"late_key_a": "late-flag-a",
+		"late_key_b": "late-flag-b",
+	})
+
+	assert.True(t, config.GetBool("late_key_a"), "a flag registered after an earlier lookup must be looked up")
+	assert.True(t, config.GetBool("late_key_b"))
+
+	assert.Equal(t, [][]string{{"early-flag"}, {"late-flag-a", "late-flag-b"}}, stub.recordedBatches(),
+		"the second lookup must only request the flags that are not known yet")
+}
+
+func Test_AddFeatureFlagsToConfig_ClonedConfigurationSharesLookup(t *testing.T) {
+	stub := stubFlagGateway(t)
+	config := newFlagTestConfig()
+	engine := newFlagTestEngine(t, config)
+
+	AddFeatureFlagsToConfig(engine, map[string]string{"clone_key": "clone-flag"})
+
+	clone := config.Clone()
+	assert.True(t, clone.GetBool("clone_key"))
+	assert.True(t, config.GetBool("clone_key"))
+
+	assert.Equal(t, [][]string{{"clone-flag"}}, stub.recordedBatches(),
+		"a cloned configuration must reuse the lookup of the configuration it was cloned from")
+}
+
+func Test_AddFeatureFlagsToConfig_LookupIsScopedToApiEndpoint(t *testing.T) {
+	stub := stubFlagGateway(t)
+	config := newFlagTestConfig()
+	engine := newFlagTestEngine(t, config)
+
+	AddFeatureFlagsToConfig(engine, map[string]string{"endpoint_key": "endpoint-flag"})
+	assert.True(t, config.GetBool("endpoint_key"))
+
+	otherEndpoint := config.Clone()
+	otherEndpoint.Set(configuration.API_URL, "https://api.eu.snyk.io")
+	assert.True(t, otherEndpoint.GetBool("endpoint_key"))
+
+	assert.Equal(t, [][]string{{"endpoint-flag"}, {"endpoint-flag"}}, stub.recordedBatches(),
+		"a configuration addressing another endpoint must not reuse the lookup")
+}
+
+func Test_AddFeatureFlagsToConfig_FlagMissingFromResponseIsNotRequestedAgain(t *testing.T) {
+	stub := stubFlagGateway(t, "unreported-flag")
+	config := newFlagTestConfig()
+	engine := newFlagTestEngine(t, config)
+
+	AddFeatureFlagsToConfig(engine, map[string]string{"unreported_key": "unreported-flag"})
+
+	for i := 0; i < 3; i++ {
+		assert.False(t, config.GetBool("unreported_key"))
+	}
+
+	assert.Equal(t, [][]string{{"unreported-flag"}}, stub.recordedBatches(),
+		"a flag the gateway does not report must resolve to false without being requested again")
 }
 
 func Test_AddFeatureFlagsToConfig_ConcurrentReads(t *testing.T) {

--- a/pkg/local_workflows/config_utils/feature_flag_gateway_test.go
+++ b/pkg/local_workflows/config_utils/feature_flag_gateway_test.go
@@ -17,13 +17,14 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	v20241015 "github.com/snyk/go-application-framework/pkg/apiclients/feature_flag_gateway/2024-10-15"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	testutils "github.com/snyk/go-application-framework/pkg/local_workflows/test_utils"
 	"github.com/snyk/go-application-framework/pkg/mocks"
 	"github.com/snyk/go-application-framework/pkg/workflow"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -138,7 +139,6 @@ func Test_AddFeatureFlagGatewayToConfig(t *testing.T) {
 	config := configuration.NewWithOpts()
 	config.Set(configuration.API_URL, testAPIEndpoint)
 	config.Set(configuration.ORGANIZATION, testOrgID)
-	t.Cleanup(func() { registries.Delete(config) })
 
 	mockEngine.EXPECT().GetConfiguration().Return(config).AnyTimes()
 	mockEngine.EXPECT().GetLogger().Return(&logger).AnyTimes()
@@ -191,7 +191,6 @@ func Test_AddFeatureFlagsToConfig_ConcurrentRegistrationAndBatching(t *testing.T
 	config := configuration.NewWithOpts()
 	config.Set(configuration.API_URL, testAPIEndpoint)
 	config.Set(configuration.ORGANIZATION, testOrgID)
-	t.Cleanup(func() { registries.Delete(config) })
 
 	mockEngine.EXPECT().GetConfiguration().Return(config).AnyTimes()
 	mockEngine.EXPECT().GetLogger().Return(&logger).AnyTimes()
@@ -207,17 +206,6 @@ func Test_AddFeatureFlagsToConfig_ConcurrentRegistrationAndBatching(t *testing.T
 		}(i)
 	}
 	wg.Wait()
-
-	registry := getFlagRegistry(config)
-	require.NotNil(t, registry, "registry must exist after registration")
-	registry.mu.Lock()
-	registeredCount := len(registry.flags)
-	registry.mu.Unlock()
-	assert.Equal(t, flagCount, registeredCount,
-		"all concurrently registered flags must be present in the registry")
-
-	assert.Equal(t, int32(0), atomic.LoadInt32(&apiCallCount),
-		"no API call before any flag is read")
 
 	result := config.GetBool("concurrent_key_0")
 	assert.True(t, result)
@@ -271,7 +259,6 @@ func Test_AddFeatureFlagsToConfig_ConcurrentReads(t *testing.T) {
 	config := configuration.NewWithOpts()
 	config.Set(configuration.API_URL, testAPIEndpoint)
 	config.Set(configuration.ORGANIZATION, testOrgID)
-	t.Cleanup(func() { registries.Delete(config) })
 
 	mockEngine.EXPECT().GetConfiguration().Return(config).AnyTimes()
 	mockEngine.EXPECT().GetLogger().Return(&logger).AnyTimes()

--- a/pkg/local_workflows/config_utils/feature_flag_gateway_test.go
+++ b/pkg/local_workflows/config_utils/feature_flag_gateway_test.go
@@ -355,6 +355,61 @@ func Test_AddFeatureFlagsToConfig_FlagMissingFromResponseIsNotRequestedAgain(t *
 		"a flag the gateway does not report must resolve to false without being requested again")
 }
 
+func Test_AddFeatureFlagsToConfig_LocallySetKeyIsNotEvaluatedRemotely(t *testing.T) {
+	stub := stubFlagGateway(t)
+	config := newFlagTestConfig()
+	engine := newFlagTestEngine(t, config)
+
+	AddFeatureFlagsToConfig(engine, map[string]string{
+		"overridden_key": "overridden-flag",
+		"remote_key":     "remote-flag",
+	})
+
+	// mimics an application forcing the feature off, e.g. a preview build
+	config.Set("overridden_key", false)
+
+	assert.True(t, config.GetBool("remote_key"))
+	assert.Equal(t, [][]string{{"remote-flag"}}, stub.recordedBatches(),
+		"a key that already holds a value must not be evaluated as part of another key's batch")
+
+	assert.False(t, config.GetBool("overridden_key"), "the local value must win over the remote one")
+	assert.Equal(t, [][]string{{"remote-flag"}}, stub.recordedBatches(),
+		"reading the overridden key must not trigger a lookup either")
+}
+
+// Test_AddFeatureFlagsToConfig_KeySetViaAlternativeKeyIsNotEvaluatedRemotely
+// covers the value sources an application wires up behind an alternative key -
+// an environment variable, a command line flag or a config file entry. Those
+// reach the configuration the same way, so an alternative key stands in for all
+// of them without the test depending on the process environment.
+//
+// Only one alternative key is registered, because that is as far as the lookup
+// reliably sees: Configuration.IsSet decides a multi-alternative key by its last
+// alternative rather than its first, so a value under an earlier alternative is
+// reported as unset and the flag is evaluated needlessly. The key keeps its
+// value either way, so this is a wasted request rather than a wrong result.
+func Test_AddFeatureFlagsToConfig_KeySetViaAlternativeKeyIsNotEvaluatedRemotely(t *testing.T) {
+	stub := stubFlagGateway(t)
+	config := newFlagTestConfig()
+	engine := newFlagTestEngine(t, config)
+
+	config.AddAlternativeKeys("alt_overridden_key", []string{"alt_overridden_key_source"})
+
+	AddFeatureFlagsToConfig(engine, map[string]string{
+		"alt_overridden_key": "alt-overridden-flag",
+		"alt_remote_key":     "alt-remote-flag",
+	})
+
+	config.Set("alt_overridden_key_source", false)
+
+	assert.True(t, config.GetBool("alt_remote_key"))
+	assert.Equal(t, [][]string{{"alt-remote-flag"}}, stub.recordedBatches(),
+		"a key supplied through an alternative key must not be evaluated as part of another key's batch")
+
+	assert.False(t, config.GetBool("alt_overridden_key"), "the alternative key must win over the remote value")
+	assert.Equal(t, [][]string{{"alt-remote-flag"}}, stub.recordedBatches())
+}
+
 func Test_AddFeatureFlagsToConfig_ConcurrentReads(t *testing.T) {
 	flagCount := 10
 


### PR DESCRIPTION
### Description

`AddFeatureFlagsToConfig` looked flags up in one batch per call, so an application that registered flags from several places produced one request per registration group rather than one request overall.

Flags registered against a configuration are now collected in a registry, and the lookup happens lazily per flag:

- The first access to any backed config key looks up **every flag registered so far** in a single request.
- Flags registered **after** an earlier lookup are looked up by the next access that needs them, and flags already known are not requested again.
- Results are memorized per organization **and API endpoint**, so a clone addressing another endpoint does not reuse them, and they are shared across clones of the same configuration so a cloned config does not repeat a lookup.
- Flags the gateway does not report are memorized as disabled, so an unknown flag resolves to `false` instead of being requested on every read.

The registry is attached to the `Configuration` as an immutable default value rather than as a value, so it cannot be persisted or shadowed, and it is shared by every clone.

#### Fixed along the way

An earlier iteration of this branch memorized only *whether* an organization had been looked up. Any flag registered after the first access then resolved to `false` with no request and no error. This was not theoretical: the framework's own extension initializers all run before those of the consuming application, and one of them reads a feature flag while initializing, which sealed the set of known flags during `engine.Init()`. Every flag registered by a downstream extension would have resolved to `false`. `pkg/app/app_test.go` now carries an integration test that registers a flag from a downstream-style extension initializer and asserts it resolves; it fails against that earlier implementation.

#### Notes for reviewers and consumers

- **No API change.** `AddFeatureFlagsToConfig` keeps its signature.
- **Behaviour change:** lookup results are now shared across all clones of a configuration for the lifetime of the process, scoped by organization and API endpoint. There is no TTL, and `ClearCache()` does not clear them.
- **Test fixtures downstream:** the function now calls `Get` and `AddDefaultValue` on the `Configuration`. A test that wires a strict `MockConfiguration` into it will need the corresponding `EXPECT()` calls. No test in this repository is affected.
- **Request count:** for a `snyk test` this brings the lookups down from three requests to two, not one. The remaining request exists because a framework extension reads a flag during `Init()`, before the consuming application has registered its own. Removing that early read is a follow-up, since it changes when and how that extension registers its middleware and hook.

Known trade-offs left for follow-ups: the per-organization lock is held across the request, `EvaluateFlags` has no timeout, a failing lookup is retried per read rather than negatively cached, and one rejected flag name would now fail a whole batch rather than a single registration group.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [ ] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change around when and how often feature flags are fetched, with process-lifetime caching that `ClearCache()` does not reset; incorrect batching or ordering could mis-resolve flags for downstream extensions at init time.
> 
> **Overview**
> **`AddFeatureFlagsToConfig`** no longer issues one gateway request per registration call. Flags for a configuration are accumulated in a shared **`flagRegistry`** (attached as an immutable default on `Configuration`), and the first read of any backed key triggers a **single batched** remote evaluation of every flag registered so far.
> 
> Later registrations are resolved on the next access that needs them; results are **memoized per org and API URL** and reused across configuration clones (a different API URL gets a separate lookup). Flags omitted from the gateway response are cached as **false** so they are not re-requested. Config keys that are already set locally (via `Configuration.IsSet`) are **excluded from batches** so forced on/off values are not evaluated remotely.
> 
> Integration tests in **`app_test`** cover downstream extension flags after `engine.Init()` and locally overridden gitignore flags during startup batching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d926863a1b61d4f7f3a23aa9e0b6bb83a47f4920. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

