### PR TITLE
fix: IANDT-26: contributor capture code response parsing

### DIFF
--- a/pkg/networking/middleware/contributor_capture/body.go
+++ b/pkg/networking/middleware/contributor_capture/body.go
@@ -2,6 +2,7 @@ package contributor_capture
 
 import (
 	"bytes"
+	"compress/gzip"
 	"io"
 	"net/http"
 )
@@ -28,8 +29,10 @@ func peekRequestBody(req *http.Request, maxBytes int64) ([]byte, error) {
 
 // peekResponseBody returns up to maxBytes of res.Body for parsing and splices what
 // it read back in front of the remainder, so res.Body still yields the whole body.
+// Deeproxy bodies arrive gzipped, so for that kind the peeked prefix is decoded
+// before it is returned.
 // fullyRead reports whether the body fit within maxBytes.
-func peekResponseBody(res *http.Response, maxBytes int64) (peeked []byte, fullyRead bool, err error) {
+func peekResponseBody(res *http.Response, kind endpointKind, maxBytes int64) (peeked []byte, fullyRead bool, err error) {
 	if res.Body == nil {
 		return nil, false, nil
 	}
@@ -43,10 +46,35 @@ func peekResponseBody(res *http.Response, maxBytes int64) (peeked []byte, fullyR
 		return nil, false, err
 	}
 
-	if int64(len(buf)) > maxBytes {
-		return buf[:maxBytes], false, nil
+	fullyRead = int64(len(buf)) <= maxBytes
+	if !fullyRead {
+		buf = buf[:maxBytes]
 	}
-	return buf, true, nil
+
+	if kind == endpointDeeproxyReport {
+		buf, err = gunzip(buf, fullyRead)
+		if err != nil {
+			return nil, false, err
+		}
+	}
+
+	return buf, fullyRead, nil
+}
+
+// gunzip decodes a gzip stream. A truncated stream still yields everything that
+// could be decoded.
+func gunzip(buf []byte, complete bool) ([]byte, error) {
+	reader, err := gzip.NewReader(bytes.NewReader(buf))
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	decoded, err := io.ReadAll(reader)
+	if err != nil && complete {
+		return nil, err
+	}
+	return decoded, nil
 }
 
 type stitchedReadCloser struct {

--- a/pkg/networking/middleware/contributor_capture/body_test.go
+++ b/pkg/networking/middleware/contributor_capture/body_test.go
@@ -2,6 +2,7 @@ package contributor_capture_test
 
 import (
 	"bytes"
+	"compress/gzip"
 	"errors"
 	"io"
 	"net/http"
@@ -22,7 +23,7 @@ func TestPeekResponseBody_restoresBodyOnReadError(t *testing.T) {
 	body := &errAfterReadCloser{prefix: append([]byte(nil), prefix...), err: wantErr}
 
 	res := &http.Response{Body: body}
-	_, _, err := cc.PeekResponseBody(res, 64<<10)
+	_, _, err := cc.PeekResponseBody(res, cc.EndpointNone, 64<<10)
 	require.ErrorIs(t, err, wantErr)
 
 	got, readErr := io.ReadAll(res.Body)
@@ -70,7 +71,7 @@ func TestPeekResponseBody(t *testing.T) {
 				Body:          io.NopCloser(bytes.NewReader(tt.body)),
 			}
 
-			peeked, fullyRead, err := cc.PeekResponseBody(res, 64<<10)
+			peeked, fullyRead, err := cc.PeekResponseBody(res, cc.EndpointNone, 64<<10)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantFullyRead, fullyRead)
 			assert.Len(t, peeked, tt.wantPeekedLen)
@@ -164,4 +165,26 @@ func (r *errAfterReadCloser) Read(p []byte) (int, error) {
 func (r *errAfterReadCloser) Close() error {
 	r.closed = true
 	return nil
+}
+
+func TestPeekResponseBody_decodesGzippedDeeproxyBody(t *testing.T) {
+	t.Parallel()
+
+	plain := []byte(`{"status":"COMPLETE","uploadResult":{"projectId":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"}}`)
+	var gzipped bytes.Buffer
+	writer := gzip.NewWriter(&gzipped)
+	_, err := writer.Write(plain)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	compressed := gzipped.Bytes()
+
+	res := &http.Response{Body: io.NopCloser(bytes.NewReader(compressed))}
+	peeked, fullyRead, err := cc.PeekResponseBody(res, cc.EndpointDeeproxyReport, 64<<10)
+	require.NoError(t, err)
+	assert.True(t, fullyRead)
+	assert.Equal(t, plain, peeked)
+
+	rest, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	assert.Equal(t, compressed, rest)
 }

--- a/pkg/networking/middleware/contributor_capture/contributor_capture.go
+++ b/pkg/networking/middleware/contributor_capture/contributor_capture.go
@@ -181,7 +181,7 @@ func (m *ContributorCaptureMiddleware) completeRequestCapture(state captureState
 // content-encoding handling here: this middleware runs above http.Transport, which
 // negotiates and undoes compression before the response reaches us.
 func (m *ContributorCaptureMiddleware) responseCaptureBytes(req *http.Request, res *http.Response, kind endpointKind) ([]byte, bool) {
-	bodyBytes, fullyRead, err := peekResponseBody(res, maxCaptureBodyBytes)
+	bodyBytes, fullyRead, err := peekResponseBody(res, kind, maxCaptureBodyBytes)
 	if err != nil {
 		m.logger.Debug().Err(err).Str("path", req.URL.Path).Msg("contributor capture: could not read response body")
 		return nil, false

--- a/pkg/networking/middleware/contributor_capture/contributor_capture_test.go
+++ b/pkg/networking/middleware/contributor_capture/contributor_capture_test.go
@@ -2,7 +2,9 @@ package contributor_capture_test
 
 import (
 	"bytes"
+	"compress/gzip"
 	"io"
+	"math/rand/v2"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -134,7 +136,7 @@ func TestContributorCaptureMiddleware_skipsUnmatchedRequests(t *testing.T) {
 
 func TestContributorCaptureMiddleware_capturesOnAuthenticatedSubdomain(t *testing.T) {
 	const projectID = "25bcb5ba-5b16-4f56-8620-4e3a508f67ed"
-	reportBody := []byte(`{"status":"COMPLETE","uploadResult":{"projectId":"` + projectID + `"}}`)
+	reportBody := gzipBody(t, []byte(`{"status":"COMPLETE","uploadResult":{"projectId":"`+projectID+`"}}`))
 
 	config := hostConfig("https://api.snyk.io")
 	config.Set(configuration.AUTHENTICATION_SUBDOMAINS, []string{"deeproxy"})
@@ -575,12 +577,12 @@ func TestContributorCaptureMiddleware_capturesDeeproxyReportProjectID(t *testing
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/report/"+reportID, r.URL.Path)
 		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte(`{
+		_, err := w.Write(gzipBody(t, []byte(`{
 			"status": "COMPLETE",
 			"uploadResult": {
-				"projectId": "` + projectID + `"
+				"projectId": "`+projectID+`"
 			}
-		}`))
+		}`)))
 		require.NoError(t, err)
 	}))
 	t.Cleanup(server.Close)
@@ -597,8 +599,10 @@ func TestContributorCaptureMiddleware_capturesDeeproxyReportProjectID(t *testing
 
 func TestContributorCaptureMiddleware_capturesTruncatedDeeproxyReportPrefix(t *testing.T) {
 	const projectID = "25bcb5ba-5b16-4f56-8620-4e3a508f67ed"
-	prefix := `{"status":"COMPLETE","uploadResult":{"projectId":"` + projectID + `"` + `,"analysisResult":{"type":"sarif","data":"`
-	wantBody := append([]byte(prefix), bytes.Repeat([]byte("x"), 70<<10)...)
+	prefix := `{"status":"COMPLETE","uploadResult":{"projectId":"` + projectID + `"},"analysisResult":{"type":"sarif","data":"`
+	// The padding is incompressible so the body still exceeds maxCaptureBodyBytes
+	// once gzipped.
+	wantBody := gzipBody(t, append([]byte(prefix), incompressiblePadding(200<<10)...))
 
 	next := roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
@@ -740,4 +744,26 @@ type trackCloseReadCloser struct {
 func (r *trackCloseReadCloser) Close() error {
 	r.closed = true
 	return nil
+}
+
+func gzipBody(t *testing.T, plain []byte) []byte {
+	t.Helper()
+
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	_, err := writer.Write(plain)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	return compressed.Bytes()
+}
+
+// incompressiblePadding returns padding which gzip cannot shrink.
+func incompressiblePadding(size int) []byte {
+	rng := rand.New(rand.NewPCG(1, 2))
+
+	padding := make([]byte, size)
+	for i := range padding {
+		padding[i] = byte(rng.Uint32())
+	}
+	return padding
 }

--- a/pkg/networking/middleware/contributor_capture/parse.go
+++ b/pkg/networking/middleware/contributor_capture/parse.go
@@ -1,6 +1,7 @@
 package contributor_capture
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 )
@@ -154,35 +155,37 @@ func parseComponentsProjectID(body []byte) string {
 }
 
 // parseDeeproxyReportProjectID extracts a project ID from a legacy Code deeproxy
-// report response when status is COMPLETE.
+// report response. It handles truncated JSON, as long as the project ID and the
+// surrounding object are present.
 func parseDeeproxyReportProjectID(body []byte) string {
-	if len(body) == 0 {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	if tok, err := dec.Token(); err != nil || tok != json.Delim('{') {
 		return ""
 	}
 
-	// Try full JSON unmarshal first
-	var resp struct {
-		Status       string `json:"status"`
-		UploadResult struct {
-			ProjectID      string `json:"projectId"`
-			ProjectIDSnake string `json:"project_id"`
-		} `json:"uploadResult"`
-	}
-	if err := json.Unmarshal(body, &resp); err == nil {
-		if !strings.EqualFold(strings.TrimSpace(resp.Status), "COMPLETE") {
+	for {
+		tok, err := dec.Token()
+		key, isKey := tok.(string)
+		if err != nil || !isKey {
 			return ""
 		}
-		// Try projectId first, fall back to project_id
-		if pid := resp.UploadResult.ProjectID; strings.TrimSpace(pid) != "" {
-			return parseUUID(pid)
-		}
-		if pid := resp.UploadResult.ProjectIDSnake; strings.TrimSpace(pid) != "" {
-			return parseUUID(pid)
-		}
-	}
 
-	// Fallback for truncated bodies where JSON unmarshal failed
-	return extractDeeproxyProjectIDFromTruncated(body)
+		if key != "uploadResult" {
+			var skipped json.RawMessage
+			if err := dec.Decode(&skipped); err != nil {
+				return ""
+			}
+			continue
+		}
+
+		var uploadResult struct {
+			ProjectID string `json:"projectId"`
+		}
+		if err := dec.Decode(&uploadResult); err != nil {
+			return ""
+		}
+		return parseUUID(uploadResult.ProjectID)
+	}
 }
 
 // projectIDFromMonitorURI extracts a project ID from a monitor API response URI.
@@ -210,51 +213,4 @@ func projectIDFromMonitorURI(uri string) string {
 	}
 
 	return parseUUID(uuidCandidate)
-}
-
-// extractDeeproxyProjectIDFromTruncated extracts project ID from truncated/malformed JSON.
-func extractDeeproxyProjectIDFromTruncated(body []byte) string {
-	s := string(body)
-
-	// Check for COMPLETE status
-	if !strings.Contains(strings.ToUpper(s), `"COMPLETE"`) {
-		return ""
-	}
-
-	// Find uploadResult and extract projectId/project_id
-	uploadIdx := strings.Index(s, `"uploadResult"`)
-	if uploadIdx < 0 {
-		return ""
-	}
-
-	searchFrom := uploadIdx
-	for _, fieldName := range []string{`"projectId"`, `"project_id"`} {
-		fieldIdx := strings.Index(s[searchFrom:], fieldName)
-		if fieldIdx < 0 {
-			continue
-		}
-
-		// Find the value after the field
-		valueStart := searchFrom + fieldIdx + len(fieldName)
-		colonIdx := strings.Index(s[valueStart:], ":")
-		if colonIdx < 0 || colonIdx > 10 {
-			continue
-		}
-
-		quoteIdx := strings.Index(s[valueStart+colonIdx:], `"`)
-		if quoteIdx < 0 || quoteIdx > 5 {
-			continue
-		}
-
-		uuidStart := valueStart + colonIdx + quoteIdx + 1
-		if uuidStart+37 > len(s) || s[uuidStart+36] != '"' {
-			continue
-		}
-
-		if projectID := parseUUID(s[uuidStart : uuidStart+36]); projectID != "" {
-			return projectID
-		}
-	}
-
-	return ""
 }

--- a/pkg/networking/middleware/contributor_capture/parse_test.go
+++ b/pkg/networking/middleware/contributor_capture/parse_test.go
@@ -231,24 +231,34 @@ func TestParseDeeproxyReportProjectID(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "complete with projectId",
-			body:     `{"status":"COMPLETE","uploadResult":{"projectId":"` + projectID + `"}}`,
+			name:     "complete body",
+			body:     `{"status":"COMPLETE","uploadResult":{"projectId":"` + projectID + `","snapshotId":"abc"},"analysisResults":{}}`,
 			expected: projectID,
 		},
 		{
-			name:     "complete with project_id",
-			body:     `{"status":"COMPLETE","uploadResult":{"project_id":"` + projectID + `"}}`,
+			name:     "truncated in a later sibling",
+			body:     `{"status":"COMPLETE","uploadResult":{"projectId":"` + projectID + `"},"analysisResults":{"files":[{"data":"` + strings.Repeat("x", 100),
 			expected: projectID,
 		},
 		{
-			name:     "incomplete status",
-			body:     `{"status":"IN_PROGRESS","uploadResult":{"projectId":"` + projectID + `"}}`,
+			name:     "truncated at top level after uploadResult",
+			body:     `{"status":"COMPLETE","uploadResult":{"projectId":"` + projectID + `"},"analysisRes`,
+			expected: projectID,
+		},
+		{
+			name:     "projectId not first key in uploadResult",
+			body:     `{"status":"COMPLETE","uploadResult":{"bundleHash":"abc","projectId":"` + projectID + `"}}`,
+			expected: projectID,
+		},
+		{
+			name:     "nested uploadResult ignored",
+			body:     `{"status":"COMPLETE","analysisResults":{"uploadResult":{"projectId":"` + projectID + `"}}}`,
 			expected: "",
 		},
 		{
-			name:     "truncated body (fallback parsing)",
-			body:     `{"status":"COMPLETE","uploadResult":{"projectId":"` + projectID + `","analysisResult":{"type":"sarif","data":"` + strings.Repeat("x", 100),
-			expected: projectID,
+			name:     "truncated inside uploadResult",
+			body:     `{"status":"COMPLETE","uploadResult":{"projectId":"` + projectID + `","snapshotId"`,
+			expected: "",
 		},
 		{
 			name:     "truncated mid project id",
@@ -256,8 +266,38 @@ func TestParseDeeproxyReportProjectID(t *testing.T) {
 			expected: "",
 		},
 		{
-			name:     "truncated at end of project id",
-			body:     `{"status":"COMPLETE","uploadResult":{"projectId":"` + projectID,
+			name:     "no uploadResult",
+			body:     `{"status":"WAITING","progress":0.5}`,
+			expected: "",
+		},
+		{
+			name:     "uploadResult without projectId",
+			body:     `{"status":"COMPLETE","uploadResult":{"bundleHash":"abc"}}`,
+			expected: "",
+		},
+		{
+			name:     "uploadResult is not an object",
+			body:     `{"status":"COMPLETE","uploadResult":"nope"}`,
+			expected: "",
+		},
+		{
+			name:     "projectId is not a uuid",
+			body:     `{"status":"COMPLETE","uploadResult":{"projectId":"not-a-uuid"}}`,
+			expected: "",
+		},
+		{
+			name:     "invalid json",
+			body:     `{invalid}`,
+			expected: "",
+		},
+		{
+			name:     "empty body",
+			body:     ``,
+			expected: "",
+		},
+		{
+			name:     "top level array",
+			body:     `[1,2,3]`,
 			expected: "",
 		},
 	}


### PR DESCRIPTION
### Description

This PR follows #703 and resolves an issue where compressed responses from the legacy code flow were not handled correctly - it also tightens up the parsing of truncated (for performance reasons) responses to select the exact keys required rather than fuzzily matching.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.
