### PR TITLE
fix: scrub the username from analytics values only, not JSON keys [CLI-1819]

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -346,26 +346,90 @@ func SanitizeValuesByKey(keysToFilter []string, replacementValue string, content
 	return content, nil
 }
 
-// SanitizeUsername sanitizes the given content by replacing the given username with the replacement string.
+// SanitizeUsername sanitizes the given content by replacing the given username with the
+// replacement string.
+//
+// The username matches on a word boundary, the same rule the shape-based username pattern in the
+// scrub dictionary already applies (see addMandatoryMasking in pkg/logging). The home directory is
+// a full path rather than a bare word, so it stays a plain substring match.
+//
+// When content is valid JSON the replacement runs over string leaf values only. Object keys, and
+// numbers, booleans and null, pass through untouched. Replacing the username as a plain literal
+// across marshaled JSON used to rewrite keys too, so on a host running as user `app` the key
+// `gaf.app.defaultfunc.organization.lookup` arrived as `gaf.***.defaultfunc.organization.lookup`,
+// minting a fresh field path per user and fragmenting the analytics facet space (CLI-1819).
 func SanitizeUsername(rawUserName string, userHomeDir string, replacementValue string, content []byte) ([]byte, error) {
-	valuesToSanitize := []string{rawUserName, strings.ReplaceAll(userHomeDir, "\\", "\\\\")}
+	userNames := []string{rawUserName}
 
 	if strings.Contains(rawUserName, "\\") {
 		segments := strings.Split(rawUserName, "\\")
-		segmentsLen := len(segments)
-		if segmentsLen < 2 {
-			// this should never happen because we already checked for the existence of a backslash
-			return nil, fmt.Errorf("could not sanitize username")
-		} else if segmentsLen == 2 {
-			valuesToSanitize = append(valuesToSanitize, segments[1])
-		} else {
+		if len(segments) != 2 {
 			// don't recognize this format
-			fmt.Println(segments)
 			return nil, fmt.Errorf("could not sanitize username - unrecognized format")
 		}
+		userNames = append(userNames, segments[1])
 	}
 
-	return SanitizeStaticValues(valuesToSanitize, replacementValue, content)
+	// QuoteMeta guarantees the pattern compiles, so MustCompile can't panic here.
+	patterns := make([]*regexp.Regexp, 0, len(userNames))
+	for _, userName := range userNames {
+		if userName == "" {
+			continue
+		}
+		patterns = append(patterns, regexp.MustCompile(`\b`+regexp.QuoteMeta(userName)+`\b`))
+	}
+
+	redact := func(value string) string {
+		for _, pattern := range patterns {
+			value = pattern.ReplaceAllLiteralString(value, replacementValue)
+		}
+		if userHomeDir != "" {
+			value = strings.ReplaceAll(value, userHomeDir, replacementValue)
+		}
+		return value
+	}
+
+	if !json.Valid(content) {
+		return []byte(redact(string(content))), nil
+	}
+
+	return redactJSONStringLeaves(content, redact)
+}
+
+// redactJSONStringLeaves applies redact to every string leaf of content, leaving object keys
+// alone. Numbers decode as json.Number so re-marshaling reproduces them verbatim instead of
+// reformatting them through float64.
+func redactJSONStringLeaves(content []byte, redact func(string) string) ([]byte, error) {
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	decoder.UseNumber()
+
+	var document interface{}
+	if err := decoder.Decode(&document); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(redactJSONValue(document, redact))
+}
+
+// redactJSONValue mutates document in place; it was decoded by redactJSONStringLeaves and so is a
+// fresh tree with no cycles and no other references into it.
+func redactJSONValue(document interface{}, redact func(string) string) interface{} {
+	switch value := document.(type) {
+	case string:
+		return redact(value)
+	case map[string]interface{}:
+		for key, item := range value {
+			value[key] = redactJSONValue(item, redact)
+		}
+		return value
+	case []interface{}:
+		for i, item := range value {
+			value[i] = redactJSONValue(item, redact)
+		}
+		return value
+	default:
+		return document
+	}
 }
 
 // SanitizeStaticValues replaces every occurrence of each valuesToSanitize entry in content with

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -349,16 +349,26 @@ func SanitizeValuesByKey(keysToFilter []string, replacementValue string, content
 // SanitizeUsername sanitizes the given content by replacing the given username with the
 // replacement string.
 //
-// The username matches on a word boundary, the same rule the shape-based username pattern in the
-// scrub dictionary already applies (see addMandatoryMasking in pkg/logging). The home directory is
-// a full path rather than a bare word, so it stays a plain substring match.
+// The username matches on a word boundary, via the same logging.UsernameScrubPattern the scrub
+// dictionary compiles, so the two paths can't drift apart. The home directory is a full path
+// rather than a bare word, so it stays a plain substring match.
 //
 // When content is valid JSON the replacement runs over string leaf values only. Object keys, and
 // numbers, booleans and null, pass through untouched. Replacing the username as a plain literal
 // across marshaled JSON used to rewrite keys too, so on a host running as user `app` the key
 // `gaf.app.defaultfunc.organization.lookup` arrived as `gaf.***.defaultfunc.organization.lookup`,
 // minting a fresh field path per user and fragmenting the analytics facet space (CLI-1819).
+//
+// Content that nothing matches is returned byte for byte, so the overwhelmingly common payload --
+// one carrying no username at all -- keeps its original key order and its original escaping. A
+// payload that does get redacted is re-encoded, and re-encoding a JSON object sorts its keys;
+// that's accepted, since JSON object members are unordered by definition and every consumer of
+// this payload parses it rather than pattern-matching the bytes.
 func SanitizeUsername(rawUserName string, userHomeDir string, replacementValue string, content []byte) ([]byte, error) {
+	if rawUserName == "" && userHomeDir == "" {
+		return content, nil
+	}
+
 	userNames := []string{rawUserName}
 
 	if strings.Contains(rawUserName, "\\") {
@@ -370,36 +380,39 @@ func SanitizeUsername(rawUserName string, userHomeDir string, replacementValue s
 		userNames = append(userNames, segments[1])
 	}
 
-	// QuoteMeta guarantees the pattern compiles, so MustCompile can't panic here.
 	patterns := make([]*regexp.Regexp, 0, len(userNames))
 	for _, userName := range userNames {
 		if userName == "" {
 			continue
 		}
-		patterns = append(patterns, regexp.MustCompile(`\b`+regexp.QuoteMeta(userName)+`\b`))
+		pattern, err := regexp.Compile(logging.UsernameScrubPattern(userName))
+		if err != nil {
+			return nil, err
+		}
+		patterns = append(patterns, pattern)
 	}
 
+	redacted := false
 	redact := func(value string) string {
+		result := value
 		for _, pattern := range patterns {
-			value = pattern.ReplaceAllLiteralString(value, replacementValue)
+			result = pattern.ReplaceAllLiteralString(result, replacementValue)
 		}
 		if userHomeDir != "" {
-			value = strings.ReplaceAll(value, userHomeDir, replacementValue)
+			result = strings.ReplaceAll(result, userHomeDir, replacementValue)
 		}
-		return value
+		if result != value {
+			redacted = true
+		}
+		return result
 	}
 
 	if !json.Valid(content) {
 		return []byte(redact(string(content))), nil
 	}
 
-	return redactJSONStringLeaves(content, redact)
-}
-
-// redactJSONStringLeaves applies redact to every string leaf of content, leaving object keys
-// alone. Numbers decode as json.Number so re-marshaling reproduces them verbatim instead of
-// reformatting them through float64.
-func redactJSONStringLeaves(content []byte, redact func(string) string) ([]byte, error) {
+	// UseNumber so a number survives the round trip verbatim instead of being reformatted through
+	// float64.
 	decoder := json.NewDecoder(bytes.NewReader(content))
 	decoder.UseNumber()
 
@@ -408,28 +421,37 @@ func redactJSONStringLeaves(content []byte, redact func(string) string) ([]byte,
 		return nil, err
 	}
 
-	return json.Marshal(redactJSONValue(document, redact))
+	switch document.(type) {
+	case string, map[string]interface{}, []interface{}:
+		document = redactStringLeaves(document, redact)
+	default:
+		// A document that is a bare number, boolean or null holds no string leaf to walk, but the
+		// whole document is still a value rather than a key, so a username standing there is
+		// redacted like any other. The result is text and goes out quoted, the same shape
+		// SanitizeStaticValues produces when it replaces a bare JSON value.
+		document = redact(string(bytes.TrimSpace(content)))
+	}
+
+	if !redacted {
+		return content, nil
+	}
+
+	return marshalWithoutHTMLEscaping(document)
 }
 
-// redactJSONValue mutates document in place; it was decoded by redactJSONStringLeaves and so is a
-// fresh tree with no cycles and no other references into it.
-func redactJSONValue(document interface{}, redact func(string) string) interface{} {
-	switch value := document.(type) {
-	case string:
-		return redact(value)
-	case map[string]interface{}:
-		for key, item := range value {
-			value[key] = redactJSONValue(item, redact)
-		}
-		return value
-	case []interface{}:
-		for i, item := range value {
-			value[i] = redactJSONValue(item, redact)
-		}
-		return value
-	default:
-		return document
+// marshalWithoutHTMLEscaping marshals document with json.Marshal's HTML escaping switched off.
+// SanitizeUsername is a redaction pass over a payload someone else built, so turning a `<`, `>` or
+// `&` that it was never asked to touch into `\u003c`, `\u003e` or `\u0026` would be a wire change
+// nobody requested.
+func marshalWithoutHTMLEscaping(document interface{}) ([]byte, error) {
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(document); err != nil {
+		return nil, err
 	}
+	// Encode terminates every value with a newline; the callers here want the bare value.
+	return bytes.TrimSuffix(buffer.Bytes(), []byte("\n")), nil
 }
 
 // SanitizeStaticValues replaces every occurrence of each valuesToSanitize entry in content with

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -238,14 +238,20 @@ func Test_SanitizeUsername(t *testing.T) {
 // Test_SanitizeUsername_NumericUsernameCollision guards against a numeric username -- a realistic
 // value in containerized environments where $USER is set to a raw UID with no matching
 // /etc/passwd entry -- colliding with an unrelated bare JSON number and corrupting the payload.
+//
+// The assertion on "count" was reversed for CLI-1819. It used to expect `"count":"***"`, because
+// the username was replaced as a plain literal across the whole marshaled payload and a bare
+// number that happened to read the same got rewritten (and quoted, to keep the JSON parseable).
+// Redaction now runs over string leaf values only, so an unrelated number keeps its own value
+// instead of being replaced by a redaction marker of a different type.
 func Test_SanitizeUsername_NumericUsernameCollision(t *testing.T) {
-	input := []byte(`{"durationMs":10001234,"count":1000,"other":"x"}`)
+	input := []byte(`{"durationMs":10001234,"count":1000,"note":"ran as 1000 here","other":"x"}`)
 
 	output, err := SanitizeUsername("1000", "/home/1000", "***", input)
 	assert.NoError(t, err)
 
 	assert.True(t, json.Valid(output), "sanitizing produced invalid JSON: %s", output)
-	assert.Equal(t, `{"durationMs":10001234,"count":"***","other":"x"}`, string(output))
+	assert.JSONEq(t, `{"durationMs":10001234,"count":1000,"note":"ran as *** here","other":"x"}`, string(output))
 }
 
 // Test_SanitizeStaticValues_NonJSONSnippetIsNotStrayQuoted covers SanitizeStaticValues being

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -254,6 +254,142 @@ func Test_SanitizeUsername_NumericUsernameCollision(t *testing.T) {
 	assert.JSONEq(t, `{"durationMs":10001234,"count":1000,"note":"ran as *** here","other":"x"}`, string(output))
 }
 
+// Test_SanitizeUsername_WordBoundary pins the matching rule the username pass shares with the
+// scrub dictionary (logging.UsernameScrubPattern): whole words only, in string leaf values only.
+func Test_SanitizeUsername_WordBoundary(t *testing.T) {
+	t.Run("a standalone occurrence is redacted", func(t *testing.T) {
+		output, err := SanitizeUsername("app", "/home/app", "***", []byte(`{"note":"ran as app here"}`))
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{"note":"ran as *** here"}`, string(output))
+	})
+
+	t.Run("an occurrence inside a longer word is left alone", func(t *testing.T) {
+		input := []byte(`{"mood":"happy","plural":"apps","path":"/happ/appy"}`)
+
+		output, err := SanitizeUsername("app", "/home/app", "***", input)
+		assert.NoError(t, err)
+		assert.Equal(t, string(input), string(output))
+	})
+
+	// A hyphen is a word boundary, so a hostname built out of the username still gets redacted.
+	// That is intended: such a hostname does leak the username (CLI-1819).
+	t.Run("a hyphen counts as a word boundary", func(t *testing.T) {
+		output, err := SanitizeUsername("app", "/home/app", "***", []byte(`{"host":"app-runner"}`))
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{"host":"***-runner"}`, string(output))
+	})
+
+	t.Run("an object key is left alone", func(t *testing.T) {
+		input := []byte(`{"gaf.app.defaultfunc.organization.lookup":"env"}`)
+
+		output, err := SanitizeUsername("app", "/home/app", "***", input)
+		assert.NoError(t, err)
+		assert.Equal(t, string(input), string(output))
+	})
+}
+
+// Test_SanitizeUsername_UnmatchedContentIsReturnedVerbatim covers the payload this function sees
+// most of the time: one carrying no username at all. Decoding and re-marshaling such a payload
+// would sort its object keys and re-escape its strings for no gain, so content nothing matched
+// comes back byte for byte instead.
+func Test_SanitizeUsername_UnmatchedContentIsReturnedVerbatim(t *testing.T) {
+	input := []byte(`{"zeta":1,"alpha":"a","nested":{"yankee":true,"bravo":"b"}}`)
+
+	output, err := SanitizeUsername("app", "/home/app", "***", input)
+	assert.NoError(t, err)
+	assert.Equal(t, string(input), string(output))
+}
+
+// Test_SanitizeUsername_DoesNotEscapeHTMLCharacters guards the wire format. json.Marshal rewrites
+// `<`, `>` and `&` as \u003c, \u003e and \u0026; this function is a redaction pass over a payload
+// someone else built, so it must not silently re-encode characters it was never asked to touch.
+func Test_SanitizeUsername_DoesNotEscapeHTMLCharacters(t *testing.T) {
+	t.Run("content with no match", func(t *testing.T) {
+		input := []byte(`{"url":"https://x/?a=1&b=2<tag>"}`)
+
+		output, err := SanitizeUsername("app", "/home/app", "***", input)
+		assert.NoError(t, err)
+		assert.Equal(t, string(input), string(output))
+	})
+
+	t.Run("content that is redacted", func(t *testing.T) {
+		input := []byte(`{"url":"https://x/?a=1&b=2<tag>&user=app"}`)
+
+		output, err := SanitizeUsername("app", "/home/app", "***", input)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"url":"https://x/?a=1&b=2<tag>&user=***"}`, string(output))
+	})
+}
+
+// Test_SanitizeUsername_BareScalarDocument covers a whole document that is a single scalar. There
+// is no string leaf to walk, but the document is still a value rather than a key, so a username
+// standing there is redacted -- as text, quoted, so the result stays parseable.
+func Test_SanitizeUsername_BareScalarDocument(t *testing.T) {
+	t.Run("a bare number that is the username", func(t *testing.T) {
+		output, err := SanitizeUsername("1000", "/home/1000", "***", []byte("1000"))
+		assert.NoError(t, err)
+		assert.Equal(t, `"***"`, string(output))
+	})
+
+	t.Run("a bare number that only contains the username", func(t *testing.T) {
+		output, err := SanitizeUsername("1000", "/home/1000", "***", []byte("10001234"))
+		assert.NoError(t, err)
+		assert.Equal(t, "10001234", string(output))
+	})
+
+	t.Run("a bare string that is the username", func(t *testing.T) {
+		output, err := SanitizeUsername("app", "/home/app", "***", []byte(`"app"`))
+		assert.NoError(t, err)
+		assert.Equal(t, `"***"`, string(output))
+	})
+
+	t.Run("a bare boolean", func(t *testing.T) {
+		output, err := SanitizeUsername("app", "/home/app", "***", []byte("true"))
+		assert.NoError(t, err)
+		assert.Equal(t, "true", string(output))
+	})
+}
+
+// Test_SanitizeUsername_JSONArrayDocument covers a valid JSON document that is not an object: the
+// walk has to reach string leaves through arrays too.
+//
+// The home directory comes out as `/home/***` rather than `***` because the username pass runs
+// first and takes its own name out of the path, leaving nothing for the home directory literal to
+// match. That ordering predates CLI-1819 and is left as it is; either way the username is gone.
+func Test_SanitizeUsername_JSONArrayDocument(t *testing.T) {
+	output, err := SanitizeUsername("app", "/home/app", "***", []byte(`["ran as app",1000,["/home/app/x"]]`))
+	assert.NoError(t, err)
+	assert.JSONEq(t, `["ran as ***",1000,["/home/***/x"]]`, string(output))
+}
+
+// Test_SanitizeUsername_EmptyUserNameAndHomeDir covers a caller with nothing to redact -- an
+// unresolvable user record leaves both fields empty. The redaction is then the identity, so the
+// content must come back untouched rather than round-tripped through the JSON decoder.
+func Test_SanitizeUsername_EmptyUserNameAndHomeDir(t *testing.T) {
+	t.Run("both empty is a no-op", func(t *testing.T) {
+		input := []byte(`{"zeta":1,"alpha":"app"}`)
+
+		output, err := SanitizeUsername("", "", "***", input)
+		assert.NoError(t, err)
+		assert.Equal(t, string(input), string(output))
+	})
+
+	t.Run("an empty username still redacts the home directory", func(t *testing.T) {
+		output, err := SanitizeUsername("", "/home/app", "***", []byte(`{"path":"/home/app/project"}`))
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{"path":"***/project"}`, string(output))
+	})
+}
+
+// Test_SanitizeUsername_NonJSONContent covers content that isn't valid JSON at all. It's exported
+// API, so a caller isn't bound to the marshaled payloads the callers in this package pass, and a
+// plain-text snippet still has to get the username taken out of it.
+func Test_SanitizeUsername_NonJSONContent(t *testing.T) {
+	output, err := SanitizeUsername("app", "/home/app", "***", []byte("ran as app from /home/app/project, apps untouched"))
+	assert.NoError(t, err)
+	assert.Equal(t, "ran as *** from /home/***/project, apps untouched", string(output))
+}
+
 // Test_SanitizeStaticValues_NonJSONSnippetIsNotStrayQuoted covers SanitizeStaticValues being
 // called on a non-JSON snippet, not the full valid JSON its current callers always pass -- it's
 // exported API, so a future caller isn't bound to that. Without gating on content's own validity,

--- a/pkg/analytics/instrumentation_collector.go
+++ b/pkg/analytics/instrumentation_collector.go
@@ -235,18 +235,27 @@ func (ic *instrumentationCollectorImpl) sanitizeExtensionData(options *serialize
 	return result
 }
 
-// scrubExtensionMap and scrubExtensionValue redact string leaves of an arbitrary
-// AddExtension payload without ever serializing it to JSON bytes first, so a redaction
-// can't run past the field it matched in and corrupt or bleed into a sibling field.
+// scrubExtensionMap redacts the string leaves of an arbitrary AddExtension payload against the
+// scrub dictionary without ever serializing it to JSON bytes first, so a redaction can't run past
+// the field it matched in and corrupt or bleed into a sibling field.
 func scrubExtensionMap(m map[string]interface{}, dict logging.ScrubbingDict) map[string]interface{} {
-	return scrubExtensionMapSeen(m, dict, map[uintptr]bool{})
+	return redactMapStringLeaves(m, func(value string) string {
+		return string(logging.ScrubValue([]byte(value), dict))
+	}, map[uintptr]bool{})
 }
 
-// seen tracks map/slice pointers on the current recursion path, guarding against
-// cycles a caller of AddExtension could construct (e.g. a map containing itself).
-// It is deleted on the way back up so a value referenced from two non-cyclic
-// branches (a diamond, not a cycle) is still scrubbed both times.
-func scrubExtensionMapSeen(m map[string]interface{}, dict logging.ScrubbingDict, seen map[uintptr]bool) map[string]interface{} {
+// redactStringLeaves returns a copy of value with redact applied to every string leaf. Map keys
+// are left alone: they name the field rather than carry its content, and rewriting one mints a
+// fresh analytics field path (CLI-1819).
+//
+// Shared by scrubExtensionMap, which walks a live extension payload, and by SanitizeUsername,
+// which walks a decoded JSON document -- one walk, so the two can't disagree about what counts as
+// a leaf.
+func redactStringLeaves(value interface{}, redact func(string) string) interface{} {
+	return redactStringLeavesSeen(value, redact, map[uintptr]bool{})
+}
+
+func redactMapStringLeaves(m map[string]interface{}, redact func(string) string, seen map[uintptr]bool) map[string]interface{} {
 	ptr := reflect.ValueOf(m).Pointer()
 	if seen[ptr] {
 		return nil
@@ -254,19 +263,23 @@ func scrubExtensionMapSeen(m map[string]interface{}, dict logging.ScrubbingDict,
 	seen[ptr] = true
 	defer delete(seen, ptr)
 
-	scrubbed := make(map[string]interface{}, len(m))
+	redacted := make(map[string]interface{}, len(m))
 	for k, v := range m {
-		scrubbed[k] = scrubExtensionValueSeen(v, dict, seen)
+		redacted[k] = redactStringLeavesSeen(v, redact, seen)
 	}
-	return scrubbed
+	return redacted
 }
 
-func scrubExtensionValueSeen(v interface{}, dict logging.ScrubbingDict, seen map[uintptr]bool) interface{} {
-	switch val := v.(type) {
+// seen tracks map/slice pointers on the current recursion path, guarding against
+// cycles a caller of AddExtension could construct (e.g. a map containing itself).
+// It is deleted on the way back up so a value referenced from two non-cyclic
+// branches (a diamond, not a cycle) is still redacted both times.
+func redactStringLeavesSeen(value interface{}, redact func(string) string, seen map[uintptr]bool) interface{} {
+	switch val := value.(type) {
 	case string:
-		return string(logging.ScrubValue([]byte(val), dict))
+		return redact(val)
 	case map[string]interface{}:
-		return scrubExtensionMapSeen(val, dict, seen)
+		return redactMapStringLeaves(val, redact, seen)
 	case []interface{}:
 		ptr := reflect.ValueOf(val).Pointer()
 		if ptr != 0 && seen[ptr] {
@@ -276,13 +289,13 @@ func scrubExtensionValueSeen(v interface{}, dict logging.ScrubbingDict, seen map
 			seen[ptr] = true
 			defer delete(seen, ptr)
 		}
-		scrubbed := make([]interface{}, len(val))
+		redacted := make([]interface{}, len(val))
 		for i, item := range val {
-			scrubbed[i] = scrubExtensionValueSeen(item, dict, seen)
+			redacted[i] = redactStringLeavesSeen(item, redact, seen)
 		}
-		return scrubbed
+		return redacted
 	default:
-		return v
+		return value
 	}
 }
 

--- a/pkg/analytics/instrumentation_collector_test.go
+++ b/pkg/analytics/instrumentation_collector_test.go
@@ -396,64 +396,25 @@ func Test_InstrumentationCollector(t *testing.T) {
 		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
 	})
 
-	// The username these two cases redact is whatever the test process runs as: the seam reads it
-	// from user.Current() itself rather than taking it as an argument, so the expectations are
-	// built from the same source. Config is omitted so the only redaction under test is the
-	// username pass; the scrub dictionary is not involved.
-	t.Run("it should redact the current username in extension values but never in keys", func(t *testing.T) {
+	// This case reads the username from user.Current() because the seam does too, and asserts only
+	// that the key survives verbatim. That holds whatever the process runs as, so a machine whose
+	// user is named after some other value in the payload can't flip the result -- the failure mode
+	// IDE-2499 hit in dev containers running as `dev`. What the username pass does to *values* is
+	// pinned against a synthetic username in Test_SanitizeUsername_* instead.
+	t.Run("it should never redact the current username inside an extension key", func(t *testing.T) {
 		currentUser, err := user.Current()
 		assert.NoError(t, err)
 
 		ic := setupBaseCollector(t)
-		expectedV2InstrumentationObject := buildExpectedBaseObject(t)
-
 		// A short username used to rewrite this key into gaf.***.defaultfunc.organization.lookup,
 		// minting a fresh field path per user (CLI-1819).
 		keyPath := "gaf." + currentUser.Username + ".defaultfunc.organization.lookup"
 		ic.AddExtension(keyPath, "env")
-		ic.AddExtension("standalone", "ran as "+currentUser.Username+"!")
-		ic.AddExtension("longerWord", "host "+currentUser.Username+"land!")
-		ic.AddExtension("count", 1000)
-		ic.AddExtension("enabled", true)
-
-		mockExtension := map[string]interface{}{
-			"strings":    "hello world",
-			keyPath:      "env",
-			"standalone": "ran as ***!",
-			"longerWord": "host " + currentUser.Username + "land!",
-			"count":      1000,
-			"enabled":    true,
-		}
-
-		expectedV2InstrumentationObject.Data.Attributes.Interaction.Extension = &mockExtension
-
-		actualV2InstrumentationObject, err := GetV2InstrumentationObject(ic, WithLogger(&logger))
-		assert.NoError(t, err)
-		expectedV2InstrumentationJson, err := json.Marshal(expectedV2InstrumentationObject)
-		assert.NoError(t, err)
-		actualV2InstrumentationJson, err := json.Marshal(actualV2InstrumentationObject)
-		assert.NoError(t, err)
-
-		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
-	})
-
-	t.Run("it should redact the current home directory in extension values", func(t *testing.T) {
-		currentUser, err := user.Current()
-		assert.NoError(t, err)
-
-		ic := setupBaseCollector(t)
-		ic.AddExtension("path", currentUser.HomeDir+"/project")
 
 		actualV2InstrumentationObject, err := GetV2InstrumentationObject(ic, WithLogger(&logger))
 		assert.NoError(t, err)
 
-		extension := *actualV2InstrumentationObject.Data.Attributes.Interaction.Extension
-		path, ok := extension["path"].(string)
-		assert.True(t, ok)
-		// The home directory is a full path, not a bare word, so it keeps matching as a plain
-		// substring rather than on a word boundary.
-		assert.NotContains(t, path, currentUser.HomeDir)
-		assert.Contains(t, path, "/project")
+		assert.Contains(t, *actualV2InstrumentationObject.Data.Attributes.Interaction.Extension, keyPath)
 	})
 
 	t.Run("it should get the category vector", func(t *testing.T) {

--- a/pkg/analytics/instrumentation_collector_test.go
+++ b/pkg/analytics/instrumentation_collector_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/user"
 	"sync"
 	"testing"
 	"time"
@@ -393,6 +394,66 @@ func Test_InstrumentationCollector(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
+	})
+
+	// The username these two cases redact is whatever the test process runs as: the seam reads it
+	// from user.Current() itself rather than taking it as an argument, so the expectations are
+	// built from the same source. Config is omitted so the only redaction under test is the
+	// username pass; the scrub dictionary is not involved.
+	t.Run("it should redact the current username in extension values but never in keys", func(t *testing.T) {
+		currentUser, err := user.Current()
+		assert.NoError(t, err)
+
+		ic := setupBaseCollector(t)
+		expectedV2InstrumentationObject := buildExpectedBaseObject(t)
+
+		// A short username used to rewrite this key into gaf.***.defaultfunc.organization.lookup,
+		// minting a fresh field path per user (CLI-1819).
+		keyPath := "gaf." + currentUser.Username + ".defaultfunc.organization.lookup"
+		ic.AddExtension(keyPath, "env")
+		ic.AddExtension("standalone", "ran as "+currentUser.Username+"!")
+		ic.AddExtension("longerWord", "host "+currentUser.Username+"land!")
+		ic.AddExtension("count", 1000)
+		ic.AddExtension("enabled", true)
+
+		mockExtension := map[string]interface{}{
+			"strings":    "hello world",
+			keyPath:      "env",
+			"standalone": "ran as ***!",
+			"longerWord": "host " + currentUser.Username + "land!",
+			"count":      1000,
+			"enabled":    true,
+		}
+
+		expectedV2InstrumentationObject.Data.Attributes.Interaction.Extension = &mockExtension
+
+		actualV2InstrumentationObject, err := GetV2InstrumentationObject(ic, WithLogger(&logger))
+		assert.NoError(t, err)
+		expectedV2InstrumentationJson, err := json.Marshal(expectedV2InstrumentationObject)
+		assert.NoError(t, err)
+		actualV2InstrumentationJson, err := json.Marshal(actualV2InstrumentationObject)
+		assert.NoError(t, err)
+
+		assert.JSONEq(t, string(expectedV2InstrumentationJson), string(actualV2InstrumentationJson))
+	})
+
+	t.Run("it should redact the current home directory in extension values", func(t *testing.T) {
+		currentUser, err := user.Current()
+		assert.NoError(t, err)
+
+		ic := setupBaseCollector(t)
+		ic.AddExtension("path", currentUser.HomeDir+"/project")
+
+		actualV2InstrumentationObject, err := GetV2InstrumentationObject(ic, WithLogger(&logger))
+		assert.NoError(t, err)
+
+		extension := *actualV2InstrumentationObject.Data.Attributes.Interaction.Extension
+		path, ok := extension["path"].(string)
+		assert.True(t, ok)
+		// The home directory is a full path, not a bare word, so it keeps matching as a plain
+		// substring rather than on a word boundary.
+		assert.NotContains(t, path, currentUser.HomeDir)
+		assert.Contains(t, path, "/project")
 	})
 
 	t.Run("it should get the category vector", func(t *testing.T) {

--- a/pkg/logging/scrubbingLogWriter.go
+++ b/pkg/logging/scrubbingLogWriter.go
@@ -268,7 +268,7 @@ func addMandatoryMasking(dict ScrubbingDict) ScrubbingDict {
 	// Hide whatever is the current username
 	u, err := user.Current()
 	if err == nil {
-		s = fmt.Sprintf(`\b%s\b`, regexp.QuoteMeta(u.Username))
+		s = UsernameScrubPattern(u.Username)
 		addRegexTermToDict(s, 0, dict)
 	}
 
@@ -397,6 +397,17 @@ func scrub(p []byte, scrubDict ScrubbingDict, jsonAware bool) []byte {
 		s = redactMatchedGroup(s, entry.regex, entry.groupToRedact)
 	}
 	return []byte(s)
+}
+
+// UsernameScrubPattern returns the regular expression source matching username as a whole word.
+//
+// This is the one definition of how a username is recognized for redaction. The mandatory scrub
+// dictionary above and analytics.SanitizeUsername both compile it, so the boundary rule can't
+// drift between the log path and the analytics path. Without the boundary an occurrence inside a
+// longer word is rewritten too, which is how a short username came to corrupt unrelated analytics
+// field paths (CLI-1819).
+func UsernameScrubPattern(username string) string {
+	return fmt.Sprintf(`\b%s\b`, regexp.QuoteMeta(username))
 }
 
 // RedactStaticTerm replaces every occurrence of term in s with replacement, quoting the


### PR DESCRIPTION
Fixes the second of the two causes in [CLI-1819](https://snyksec.atlassian.net/browse/CLI-1819).

## What was wrong

The analytics extension pass replaced the current OS username and home directory as plain literals in the marshalled JSON. Two consequences: it hit object keys as readily as values, and it had no word boundary.

On a machine running as user `app`, the key `gaf.app.defaultfunc.organization.lookup` arrived as `gaf.***.defaultfunc.organization.lookup`. Every corrupted key mints a new indexed field path, which fragments the facet space and silently breaks any dashboard querying the real key. At 338,797 events over two weeks it was the single largest contributor to the redaction spike, 66x its baseline.

## What changed

`SanitizeUsername` now runs over string leaf values only. Object keys are left alone, and so are numbers, booleans and null. The username matches on a word boundary.

Four details worth calling out, each of which came out of review on the earlier, now-closed PR #717:

- A payload that nothing matched comes back byte for byte, so the common case is never decoded and re-encoded and object key order survives.
- Re-encoding switches HTML escaping off, so `<`, `>` and `&` in analytics values are not rewritten as `<` and friends.
- The word-boundary rule has one definition, `logging.UsernameScrubPattern`. Both the mandatory scrub dictionary and `SanitizeUsername` compile it, so the log path and the analytics path cannot drift apart.
- The seam tests pin value behaviour against synthetic usernames rather than reading the machine's own. A test that reads the real username fails on a host whose user collides with fixture data, which is what IDE-2499 hit in dev containers running as `dev`.

A hyphen counts as a word boundary, so `app-runner` still becomes `***-runner`. That is intended. A hostname built from the username does leak the username.

## Reversed assertion

`Test_SanitizeUsername_NumericUsernameCollision` used to expect `"count":"***"`, because a bare JSON number that happened to read the same as the username got rewritten and quoted. Leaf values only means an unrelated number keeps its own value. The comment records the reversal.

## Relationship to the other half

The other cause, the CLI's argv and environment sweep reaching analytics, is fixed separately in snyk/cli. The two are independent and can ship in either order, so either can be reverted without reverting the other.

## Provenance

These are the four commits from the closed PR #717, unchanged. That PR was closed when the CLI-side approach it was grouped with got superseded, but this half was never in question and the spec asks for exactly these four details. The branch was already based on main's current tip, so it applies without conflict.

## Test plan

- `go test ./pkg/analytics/... ./pkg/logging/...`


[CLI-1819]: https://snyksec.atlassian.net/browse/CLI-1819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ