### PR TITLE
feat: IANDT-27: add contributors post invoke hook

### DIFF
--- a/internal/contributors/analytics.go
+++ b/internal/contributors/analytics.go
@@ -1,0 +1,98 @@
+package contributors
+
+import (
+	"context"
+	"errors"
+)
+
+// Analytics keys reporting what the post-invoke hook did with the invocation.
+const (
+	analyticsKeyResult = "contributors.collection_result"
+	analyticsKeyCount  = "contributors.count"
+)
+
+// collectionResult is the outcome reported under [analyticsKeyResult].
+type collectionResult string
+
+const (
+	resultEmitted collectionResult = "emitted"
+
+	// Nothing was captured, so there was no entity to attribute contributors to.
+	resultNoRelevantRequest     collectionResult = "no_relevant_request"
+	resultCaptureErrorStatus    collectionResult = "capture_error_status"
+	resultCaptureBodyTooLarge   collectionResult = "capture_body_too_large"
+	resultCaptureBodyUnreadable collectionResult = "capture_body_unreadable"
+	resultCaptureNoEntity       collectionResult = "capture_no_entity"
+	resultCapturePanic          collectionResult = "capture_panic"
+
+	// An entity was captured, but reporting failed.
+	resultOrgIDInvalid      collectionResult = "org_id_invalid"
+	resultNoInputDirectory  collectionResult = "no_input_directory"
+	resultEmitterInitFailed collectionResult = "emitter_init_failed"
+	resultTimedOut          collectionResult = "timed_out"
+	resultCollectFailed     collectionResult = "collect_failed"
+	resultSubmitFailed      collectionResult = "submit_failed"
+
+	// No contributors were collected.
+	resultNotAGitRepo    collectionResult = "not_a_git_repo"
+	resultNoContributors collectionResult = "no_contributors"
+)
+
+// MissReason explains why a request the contributor_capture middleware matched did not yield an entity.
+type MissReason int
+
+const (
+	// MissNone means no miss recorded.
+	MissNone MissReason = iota
+
+	// MissErrorStatus is a matched request whose response was an HTTP error.
+	MissErrorStatus
+
+	// MissBodyTooLarge is a response body too large to parse.
+	MissBodyTooLarge
+
+	// MissBodyUnreadable is a request or response body that could not be read.
+	MissBodyUnreadable
+
+	// MissNoEntity is a body parsed successfully that held no entity to record.
+	MissNoEntity
+
+	// MissPanic is a panic recovered during capture.
+	MissPanic
+)
+
+// missResult maps what the capture middleware reported to the outcome to record.
+func missResult(reason MissReason) collectionResult {
+	switch reason {
+	case MissErrorStatus:
+		return resultCaptureErrorStatus
+	case MissBodyTooLarge:
+		return resultCaptureBodyTooLarge
+	case MissBodyUnreadable:
+		return resultCaptureBodyUnreadable
+	case MissNoEntity:
+		return resultCaptureNoEntity
+	case MissPanic:
+		return resultCapturePanic
+	case MissNone:
+		return resultNoRelevantRequest
+	default:
+		return resultNoRelevantRequest
+	}
+}
+
+// emitResult maps a failure to emit to the outcome to record.
+func emitResult(err error) collectionResult {
+	switch {
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return resultTimedOut
+	case errors.Is(err, ErrNotAGitRepository):
+		return resultNotAGitRepo
+	case errors.Is(err, ErrNoContributors):
+		return resultNoContributors
+	case errors.Is(err, ErrCollect):
+		return resultCollectFailed
+	default:
+		return resultSubmitFailed
+	}
+}

--- a/internal/contributors/collect.go
+++ b/internal/contributors/collect.go
@@ -43,10 +43,7 @@ const contributorWindowDays = 90
 // Authors are case-insensitively deduplicated and reported in lowercase.Results
 // are sorted by email so payloads are stable.
 //
-// A path that is not a git repository, or a repository with no commits, yields no
-// contributors and no error, because we proceed with a contributor count of 0. A
-// shallow repository yields the contributors of the history it holds, which
-// undercounts the repository as a whole.
+// A path that is not a git repository yields [ErrNotAGitRepository].
 func collectContributors(ctx context.Context, path string, now time.Time) ([]contributors_ingest.Contributor, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -54,7 +51,7 @@ func collectContributors(ctx context.Context, path string, now time.Time) ([]con
 
 	repo, closeRepo, err := openRepositoryFast(path)
 	if errors.Is(err, git.ErrRepositoryNotExists) {
-		return nil, nil
+		return nil, ErrNotAGitRepository
 	}
 	if err != nil {
 		return nil, fmt.Errorf("open repository: %w", err)

--- a/internal/contributors/collect_test.go
+++ b/internal/contributors/collect_test.go
@@ -99,7 +99,7 @@ func TestCollectContributors_SortsByEmail(t *testing.T) {
 
 func TestCollectContributors_ReturnsNothingForNonRepository(t *testing.T) {
 	contributors, err := collectContributors(t.Context(), t.TempDir(), time.Now())
-	require.NoError(t, err, "scanning a directory that is not a repository is normal, not an error")
+	require.ErrorIs(t, err, ErrNotAGitRepository, "scanning a directory that is not a repository is normal, but callers must be able to tell")
 	assert.Empty(t, contributors)
 }
 
@@ -139,11 +139,13 @@ func TestCollectContributors_ExcludesCommitWhoseCommitterDateEndsIterationButAut
 	assert.Empty(t, contributors, "the committer-time early stop excludes this commit before its author date is checked")
 }
 
-func TestCollectContributors_ReturnsNothingForBareRepositoryWithoutCommits(t *testing.T) {
+func TestCollectContributors_ReportsBareRepositoryAsNoRepository(t *testing.T) {
 	repo := newEmptyTestRepo(t, "--bare")
 
+	// Detecting a repository by its .git directory, which is how a scan target is
+	// resolved, finds nothing in a bare repository. We have never read one.
 	contributors, err := collectContributors(t.Context(), repo.path(), time.Now())
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNotAGitRepository)
 	assert.Empty(t, contributors)
 }
 
@@ -266,7 +268,7 @@ func TestCollectContributors_ReturnsNothingForWorktreeWithoutItsRepository(t *te
 	source.remove()
 
 	contributors, err := collectContributors(t.Context(), worktree.path(), now)
-	require.NoError(t, err, "an unusable repository is a contributor count of 0, not an error")
+	require.ErrorIs(t, err, ErrNotAGitRepository, "a worktree cut off from its objects reads as no repository at all")
 	assert.Empty(t, contributors)
 }
 

--- a/internal/contributors/emit_integration_test.go
+++ b/internal/contributors/emit_integration_test.go
@@ -34,10 +34,12 @@ func TestEmit_ReachesTheIngestEndpoint(t *testing.T) {
 	config.Set(configuration.API_URL, server.URL)
 
 	logger := zerolog.Nop()
-	emitter, err := New(server.Client(), config, &logger)
+	emitter, err := NewEmitter(server.Client(), config, &logger)
 	require.NoError(t, err)
 
-	require.NoError(t, emitter.Emit(t.Context(), repo.path(), testOrgID, validItem()))
+	count, err := emitter.Emit(t.Context(), repo.path(), testOrgID, validItem())
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
 
 	assert.Equal(t, "/hidden/orgs/"+testOrgID.String()+"/contributing_devs", gotPath)
 	assert.Contains(t, gotBody, "alice@example.com", "the contributors collected from git must reach the API")

--- a/internal/contributors/emitter.go
+++ b/internal/contributors/emitter.go
@@ -16,6 +16,14 @@ import (
 	"github.com/snyk/go-application-framework/pkg/configuration"
 )
 
+// Outcomes of [Emitter.Emit].
+var (
+	ErrNotAGitRepository = errors.New("not a git repository")
+	ErrNoContributors    = errors.New("no contributors in the contributor window")
+	ErrCollect           = errors.New("collect contributors")
+	ErrSubmit            = errors.New("submit contributors")
+)
+
 // Item identifies the entity that contributors are attributed to.
 type Item struct {
 	EntityType contributors_ingest.EntityType
@@ -46,13 +54,12 @@ type ingestClient interface {
 // Emitter synchronously collects and reports contributors for a given repository.
 type Emitter struct {
 	ingest ingestClient
-	logger *zerolog.Logger
 	now    func() time.Time
 }
 
-// New returns an Emitter that reports contributors of a repository, sending
+// NewEmitter returns an Emitter that reports contributors of a repository, sending
 // requests over httpClient to the API configured in config.
-func New(httpClient *http.Client, config configuration.Configuration, logger *zerolog.Logger) (*Emitter, error) {
+func NewEmitter(httpClient *http.Client, config configuration.Configuration, logger *zerolog.Logger) (*Emitter, error) {
 	if httpClient == nil || config == nil || logger == nil {
 		return nil, errors.New("http client, configuration, and logger are required")
 	}
@@ -68,40 +75,34 @@ func New(httpClient *http.Client, config configuration.Configuration, logger *ze
 
 	return &Emitter{
 		ingest: ingest,
-		logger: logger,
 		now:    time.Now,
 	}, nil
 }
 
-// Emit reports the repository's current contributors against item.
+// Emit reports the repository's current contributors against item, returning how
+// many it collected.
 //
-// It returns nil when there is no git repository or no commits in the contributor
-// window.
-func (e *Emitter) Emit(ctx context.Context, repoPath string, orgID uuid.UUID, item Item) error {
-	if orgID == uuid.Nil {
-		return errors.New("org ID is required")
-	}
+// Every outcome other than a successful emission is returned as an error.
+// A canceled context surfaces wrapped in [ErrCollect] or [ErrSubmit].
+func (e *Emitter) Emit(ctx context.Context, repoPath string, orgID uuid.UUID, item Item) (int, error) {
 	if err := item.validate(); err != nil {
-		return err
+		return 0, err
 	}
 
 	contributors, err := collectContributors(ctx, repoPath, e.now())
+	if errors.Is(err, ErrNotAGitRepository) {
+		return 0, err
+	}
 	if err != nil {
-		return fmt.Errorf("collect contributors: %w", err)
+		return 0, fmt.Errorf("%w: %w", ErrCollect, err)
 	}
 	if len(contributors) == 0 {
-		e.logger.Debug().Str("repo_path", repoPath).Msg("contributor billing: no contributors to report")
-		return nil
+		return 0, ErrNoContributors
 	}
 
 	if err := e.ingest.SubmitContributors(ctx, orgID, item.EntityType, item.EntityID, contributors); err != nil {
-		return fmt.Errorf("emit contributor billing: %w", err)
+		return len(contributors), fmt.Errorf("%w: %w", ErrSubmit, err)
 	}
 
-	e.logger.Debug().
-		Int("contributors", len(contributors)).
-		Str("entity_id", item.EntityID).
-		Msg("contributor billing: emitted")
-
-	return nil
+	return len(contributors), nil
 }

--- a/internal/contributors/emitter_test.go
+++ b/internal/contributors/emitter_test.go
@@ -16,38 +16,38 @@ import (
 	"github.com/snyk/go-application-framework/pkg/configuration"
 )
 
-func TestNew_BuildsEmitterFromConfiguration(t *testing.T) {
+func TestNewEmitter_BuildsEmitterFromConfiguration(t *testing.T) {
 	config := configuration.NewWithOpts()
 	config.Set(configuration.API_URL, "https://api.snyk.io")
 	logger := zerolog.Nop()
 
-	emitter, err := New(http.DefaultClient, config, &logger)
+	emitter, err := NewEmitter(http.DefaultClient, config, &logger)
 	require.NoError(t, err)
 
 	assert.NotNil(t, emitter.ingest)
 	assert.NotNil(t, emitter.now)
 }
 
-func TestNew_RejectsUnusableAPIURL(t *testing.T) {
+func TestNewEmitter_RejectsUnusableAPIURL(t *testing.T) {
 	config := configuration.NewWithOpts()
 	config.Set(configuration.API_URL, "not-a-url")
 	logger := zerolog.Nop()
 
-	_, err := New(http.DefaultClient, config, &logger)
+	_, err := NewEmitter(http.DefaultClient, config, &logger)
 	assert.Error(t, err)
 }
 
-func TestNew_RequiresHTTPClientConfigurationAndLogger(t *testing.T) {
+func TestNewEmitter_RequiresHTTPClientConfigurationAndLogger(t *testing.T) {
 	config := configuration.NewWithOpts()
 	logger := zerolog.Nop()
 
-	_, err := New(nil, config, &logger)
+	_, err := NewEmitter(nil, config, &logger)
 	assert.Error(t, err)
 
-	_, err = New(http.DefaultClient, nil, &logger)
+	_, err = NewEmitter(http.DefaultClient, nil, &logger)
 	assert.Error(t, err)
 
-	_, err = New(http.DefaultClient, config, nil)
+	_, err = NewEmitter(http.DefaultClient, config, nil)
 	assert.Error(t, err)
 }
 
@@ -61,35 +61,51 @@ func TestEmit_SendsCollectedContributors(t *testing.T) {
 	ingest := &fakeIngest{}
 	emitter := newTestEmitter(t, ingest, now)
 
-	err := emitter.Emit(t.Context(), repo.path(), testOrgID, Item{
-		EntityType: contributors_ingest.EntityTypeProject,
+	count, err := emitter.Emit(t.Context(), repo.path(), testOrgID, Item{
+		EntityType: EntityTypeProject,
 		EntityID:   "22222222-2222-2222-2222-222222222222",
 	})
 	require.NoError(t, err)
+	assert.Equal(t, 2, count)
 
 	assert.Equal(t, 1, ingest.calls)
 	assert.Equal(t, testOrgID, ingest.orgID)
-	assert.Equal(t, contributors_ingest.EntityTypeProject, ingest.entityType)
+	assert.Equal(t, EntityTypeProject, ingest.entityType)
 	assert.Equal(t, "22222222-2222-2222-2222-222222222222", ingest.entityID)
 	assert.Equal(t, []string{"alice@example.com", "bob@example.com"}, emails(ingest.contributors))
 }
 
 func TestEmit_SkipsIngestWhenThereAreNoContributors(t *testing.T) {
-	tests := map[string]string{
-		"not a git repository": t.TempDir(),
-		"repository with no commits in window": newTestRepo(t, commit{
-			email: "old@example.com",
-			when:  time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
-		}).path(),
+	tests := map[string]struct {
+		repo      string
+		wantErr   error
+		wantCount int
+	}{
+		"not a git repository": {
+			repo:      t.TempDir(),
+			wantErr:   ErrNotAGitRepository,
+			wantCount: 0,
+		},
+		"repository with no commits in window": {
+			repo: newTestRepo(t, commit{
+				email: "old@example.com",
+				when:  time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			}).path(),
+			wantErr:   ErrNoContributors,
+			wantCount: 0,
+		},
 	}
 
-	for name, repo := range tests {
+	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			ingest := &fakeIngest{}
 			emitter := newTestEmitter(t, ingest, time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC))
 
-			assert.NoError(t, emitter.Emit(t.Context(), repo, testOrgID, validItem()))
-			assert.Zero(t, ingest.calls, "nothing to report is not a failure, but must not POST")
+			count, err := emitter.Emit(t.Context(), tc.repo, testOrgID, validItem())
+			assert.ErrorIs(t, err, tc.wantErr, "nothing to report must be distinguishable from an emission")
+			assert.NotErrorIs(t, err, ErrCollect, "nothing to report is not a collection failure")
+			assert.Equal(t, tc.wantCount, count)
+			assert.Zero(t, ingest.calls, "nothing to report must not POST")
 		})
 	}
 }
@@ -99,13 +115,9 @@ func TestEmit_RejectsInvalidInput(t *testing.T) {
 		orgID uuid.UUID
 		item  Item
 	}{
-		"missing org ID": {
-			orgID: uuid.Nil,
-			item:  validItem(),
-		},
 		"missing entity ID": {
 			orgID: testOrgID,
-			item:  Item{EntityType: contributors_ingest.EntityTypeProject},
+			item:  Item{EntityType: EntityTypeProject},
 		},
 		"missing entity type": {
 			orgID: testOrgID,
@@ -125,7 +137,9 @@ func TestEmit_RejectsInvalidInput(t *testing.T) {
 			ingest := &fakeIngest{}
 			emitter := newTestEmitter(t, ingest, now)
 
-			assert.Error(t, emitter.Emit(t.Context(), repo.path(), tc.orgID, tc.item))
+			count, err := emitter.Emit(t.Context(), repo.path(), tc.orgID, tc.item)
+			require.Error(t, err)
+			assert.Zero(t, count)
 			assert.Zero(t, ingest.calls, "invalid input must be caught before any git or network work")
 		})
 	}
@@ -139,9 +153,11 @@ func TestEmit_ReturnsIngestFailure(t *testing.T) {
 	ingest := &fakeIngest{err: wantErr}
 	emitter := newTestEmitter(t, ingest, now)
 
-	err := emitter.Emit(t.Context(), repo.path(), testOrgID, validItem())
+	count, err := emitter.Emit(t.Context(), repo.path(), testOrgID, validItem())
 	require.Error(t, err)
 	assert.ErrorIs(t, err, wantErr)
+	assert.ErrorIs(t, err, ErrSubmit)
+	assert.Equal(t, 1, count, "a failed submission still knows how many contributors it collected")
 }
 
 func TestEmit_SkipsIngestWhenContextIsCancelled(t *testing.T) {
@@ -154,8 +170,9 @@ func TestEmit_SkipsIngestWhenContextIsCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	err := emitter.Emit(ctx, repo.path(), testOrgID, validItem())
+	count, err := emitter.Emit(ctx, repo.path(), testOrgID, validItem())
 	require.ErrorIs(t, err, context.Canceled)
+	assert.Zero(t, count)
 	assert.Zero(t, ingest.calls, "a canceled emit must not POST")
 }
 
@@ -165,7 +182,7 @@ var testOrgID = uuid.MustParse("11111111-1111-1111-1111-111111111111")
 type fakeIngest struct {
 	calls        int
 	orgID        uuid.UUID
-	entityType   contributors_ingest.EntityType
+	entityType   EntityType
 	entityID     string
 	contributors []contributors_ingest.Contributor
 	err          error
@@ -174,7 +191,7 @@ type fakeIngest struct {
 func (f *fakeIngest) SubmitContributors(
 	_ context.Context,
 	orgID uuid.UUID,
-	entityType contributors_ingest.EntityType,
+	entityType EntityType,
 	entityID string,
 	contributors []contributors_ingest.Contributor,
 ) error {
@@ -190,17 +207,15 @@ func (f *fakeIngest) SubmitContributors(
 func newTestEmitter(t *testing.T, ingest *fakeIngest, now time.Time) *Emitter {
 	t.Helper()
 
-	logger := zerolog.Nop()
 	return &Emitter{
 		ingest: ingest,
-		logger: &logger,
 		now:    func() time.Time { return now },
 	}
 }
 
 func validItem() Item {
 	return Item{
-		EntityType: contributors_ingest.EntityTypeProject,
+		EntityType: EntityTypeProject,
 		EntityID:   "22222222-2222-2222-2222-222222222222",
 	}
 }

--- a/internal/contributors/hook/init.go
+++ b/internal/contributors/hook/init.go
@@ -1,0 +1,41 @@
+package hook
+
+import (
+	"context"
+
+	"github.com/snyk/go-application-framework/internal/contributors"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/config_utils"
+	"github.com/snyk/go-application-framework/pkg/networking/middleware/contributor_capture"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+)
+
+const (
+	featureFlagEnableEntityContributorsPublish = "enable-entity-contributors-publish"
+	configEnableEntityContributorsPublish      = "internal_snyk_contributors_enabled"
+)
+
+var flagMap = map[string]string{
+	configEnableEntityContributorsPublish: featureFlagEnableEntityContributorsPublish,
+}
+
+// Init registers a post-invoke hook that reports contributors for the
+// captured entity, together with the middleware to capture the entities.
+func Init(engine workflow.Engine) error {
+	config_utils.AddFeatureFlagsToConfig(engine, flagMap)
+	config, logger := engine.GetConfiguration(), engine.GetLogger()
+
+	if config.GetBool(configEnableEntityContributorsPublish) {
+		sink := &contributors.Sink{}
+		hook := func(ctx context.Context, e workflow.Engine, _ workflow.InvokeOutput) {
+			contributors.Report(ctx, e, sink)
+		}
+		middleware := contributor_capture.NewContributorCaptureMiddleware(config, sink, logger)
+
+		engine.GetNetworkAccess().AddMiddleware(middleware)
+		if err := workflow.AddPostInvokeHook(engine, hook); err != nil {
+			logger.Debug().Err(err).Msg("contributors: failed to register post-invoke hook")
+		}
+	}
+
+	return nil
+}

--- a/internal/contributors/report.go
+++ b/internal/contributors/report.go
@@ -1,0 +1,113 @@
+package contributors
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/google/uuid"
+
+	"github.com/snyk/go-application-framework/internal/metrics"
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+)
+
+// Report emits contributors and records the result.
+func Report(ctx context.Context, engine workflow.Engine, sink *Sink) {
+	report(ctx, engine, sink, engine.GetAnalytics())
+}
+
+// report implements the functionality for [Report]. This unexported variant uses an
+// interface instead of getting the analytics.Analytics implementation from the engine
+// to facilitate testing.
+func report(ctx context.Context, engine workflow.Engine, sink *Sink, recorder metrics.Recorder) {
+	item, alreadyReported := sink.take()
+	if alreadyReported {
+		return
+	}
+
+	if item == nil {
+		result := missResult(sink.miss())
+		recorder.AddExtensionStringValue(analyticsKeyResult, string(result))
+		return
+	}
+
+	// Record a provisional timeout value, to be overwritten later unless a timeout occurs.
+	recorder.AddExtensionStringValue(analyticsKeyResult, string(resultTimedOut))
+
+	result, count := emit(ctx, engine, *item)
+
+	recorder.AddExtensionStringValue(analyticsKeyResult, string(result))
+	if result == resultEmitted {
+		recorder.AddExtensionIntegerValue(analyticsKeyCount, count)
+	}
+}
+
+// emit reports contributors for the captured entity, returning the outcome and how
+// many contributors were collected, or zero when a failure occurs.
+func emit(ctx context.Context, engine workflow.Engine, item Item) (collectionResult, int) {
+	logger := engine.GetLogger()
+	config := engine.GetConfiguration()
+
+	orgID, err := config.GetStringWithError(configuration.ORGANIZATION)
+	if err != nil {
+		return resultOrgIDInvalid, 0
+	}
+	orgUUID, err := uuid.Parse(orgID)
+	if err != nil {
+		return resultOrgIDInvalid, 0
+	}
+
+	dirs := config.GetStringSlice(configuration.INPUT_DIRECTORY)
+	if len(dirs) == 0 || dirs[0] == "" {
+		return resultNoInputDirectory, 0
+	}
+
+	emitter, err := NewEmitter(engine.GetNetworkAccess().GetHttpClient(), config, logger)
+	if err != nil {
+		return resultEmitterInitFailed, 0
+	}
+
+	count, err := emitter.Emit(ctx, dirs[0], orgUUID, item)
+	if err != nil {
+		result := emitResult(err)
+		return result, count
+	}
+
+	return resultEmitted, count
+}
+
+type Sink struct {
+	item       atomic.Pointer[Item]
+	taken      atomic.Bool
+	missReason atomic.Int32
+}
+
+// RecordEntity records the first entity reported to the sink for later emission.
+func (s *Sink) RecordEntity(entityType EntityType, entityID string) {
+	s.item.CompareAndSwap(nil, &Item{EntityType: entityType, EntityID: entityID})
+}
+
+// RecordMiss keeps the first reason for a miss reported for analytics.
+func (s *Sink) RecordMiss(reason MissReason) {
+	s.missReason.CompareAndSwap(int32(MissNone), int32(reason))
+}
+
+func (s *Sink) miss() MissReason {
+	return MissReason(s.missReason.Load())
+}
+
+// take hands the captured entity to the first caller after a capture.
+// alreadyTaken distinguishes the nil item case where nothing was recorded from
+// the case where it has already been emitted.
+func (s *Sink) take() (item *Item, alreadyTaken bool) {
+	captured := s.item.Load()
+	if captured == nil {
+		return nil, false
+	}
+
+	if !s.taken.CompareAndSwap(false, true) {
+		return nil, true
+	}
+
+	return captured, false
+}

--- a/internal/contributors/report_test.go
+++ b/internal/contributors/report_test.go
@@ -1,0 +1,386 @@
+package contributors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/go-application-framework/internal/metrics"
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/mocks"
+)
+
+func TestReport_RecordsEmissionWithContributorCount(t *testing.T) {
+	var posted bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		posted = true
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(server.Close)
+
+	s := capturedSink(t)
+	recorder := metrics.NewRecorderFake()
+	engine := newTestEngine(t, testConfig(server.URL, testOrgID.String(), newRepoWithCommit(t)), server.Client())
+
+	report(t.Context(), engine, s, recorder)
+
+	assert.True(t, posted, "an emission must reach the ingest API")
+	assert.Equal(t, string(resultEmitted), recorder.StringValues[analyticsKeyResult])
+	assert.Equal(t, 1, recorder.IntValues[analyticsKeyCount])
+}
+
+// The count is meaningless before collection finishes, so it must be absent
+// rather than reported as a misleading zero.
+func TestReport_OmitsContributorCountWhenNothingWasCollected(t *testing.T) {
+	s := capturedSink(t)
+	recorder := metrics.NewRecorderFake()
+	engine := newTestEngine(t, testConfig("https://api.snyk.io", "", t.TempDir()), http.DefaultClient)
+
+	report(t.Context(), engine, s, recorder)
+
+	require.Equal(t, string(resultOrgIDInvalid), recorder.StringValues[analyticsKeyResult])
+	assert.NotContains(t, recorder.IntValues, analyticsKeyCount)
+}
+
+func TestReport_RecordsWhyNothingWasCaptured(t *testing.T) {
+	tests := map[string]struct {
+		reason MissReason
+		want   collectionResult
+	}{
+		"no request worth capturing from": {reason: MissNone, want: resultNoRelevantRequest},
+		"error response":                  {reason: MissErrorStatus, want: resultCaptureErrorStatus},
+		"oversized body":                  {reason: MissBodyTooLarge, want: resultCaptureBodyTooLarge},
+		"unreadable body":                 {reason: MissBodyUnreadable, want: resultCaptureBodyUnreadable},
+		"no entity in body":               {reason: MissNoEntity, want: resultCaptureNoEntity},
+		"panic during capture":            {reason: MissPanic, want: resultCapturePanic},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			s := &Sink{}
+			if tc.reason != MissNone {
+				s.RecordMiss(tc.reason)
+			}
+			recorder := metrics.NewRecorderFake()
+			engine := newTestEngine(t, testConfig("https://api.snyk.io", testOrgID.String(), t.TempDir()), http.DefaultClient)
+
+			report(t.Context(), engine, s, recorder)
+
+			assert.Equal(t, string(tc.want), recorder.StringValues[analyticsKeyResult])
+			assert.NotContains(t, recorder.IntValues, analyticsKeyCount)
+		})
+	}
+}
+
+func TestReport_RecordsWhyACapturedEntityWasNotEmitted(t *testing.T) {
+	rejectingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+	}))
+	t.Cleanup(rejectingServer.Close)
+
+	tests := map[string]struct {
+		apiURL   string
+		orgID    string
+		inputDir string
+		canceled bool
+		want     collectionResult
+	}{
+		"organization id is empty": {
+			apiURL: "https://api.snyk.io", orgID: "", inputDir: newRepoWithCommit(t),
+			want: resultOrgIDInvalid,
+		},
+		"no directory to collect from": {
+			apiURL: "https://api.snyk.io", orgID: testOrgID.String(), inputDir: "",
+			want: resultNoInputDirectory,
+		},
+		"API URL is unusable": {
+			apiURL: "not-a-url", orgID: testOrgID.String(), inputDir: newRepoWithCommit(t),
+			want: resultEmitterInitFailed,
+		},
+		"directory is not a repository": {
+			apiURL: "https://api.snyk.io", orgID: testOrgID.String(), inputDir: t.TempDir(),
+			want: resultNotAGitRepo,
+		},
+		"repository has no contributors in the window": {
+			apiURL: "https://api.snyk.io", orgID: testOrgID.String(), inputDir: newRepoWithOldCommit(t),
+			want: resultNoContributors,
+		},
+		"ingest rejects the submission": {
+			apiURL: rejectingServer.URL, orgID: testOrgID.String(), inputDir: newRepoWithCommit(t),
+			want: resultSubmitFailed,
+		},
+		"invocation was canceled": {
+			apiURL: "https://api.snyk.io", orgID: testOrgID.String(), inputDir: newRepoWithCommit(t),
+			canceled: true, want: resultTimedOut,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := t.Context()
+			if tc.canceled {
+				canceled, cancel := context.WithCancel(ctx)
+				cancel()
+				ctx = canceled
+			}
+
+			s := capturedSink(t)
+			recorder := metrics.NewRecorderFake()
+			engine := newTestEngine(t, testConfig(tc.apiURL, tc.orgID, tc.inputDir), rejectingServer.Client())
+
+			report(ctx, engine, s, recorder)
+
+			assert.Equal(t, string(tc.want), recorder.StringValues[analyticsKeyResult])
+			assert.NotContains(t, recorder.IntValues, analyticsKeyCount)
+		})
+	}
+}
+
+// A hook abandoned at POST_INVOKE_HOOK_TIMEOUT never reaches its final write, so
+// the outcome recorded before any work starts is the one that survives.
+func TestReport_RecordsTheTimeoutBeforeDoingAnyWork(t *testing.T) {
+	s := capturedSink(t)
+	recorder := &sequenceRecorder{}
+	engine := newTestEngine(t, testConfig("https://api.snyk.io", testOrgID.String(), t.TempDir()), http.DefaultClient)
+
+	report(t.Context(), engine, s, recorder)
+
+	require.Len(t, recorder.results, 2)
+	assert.Equal(t, string(resultTimedOut), recorder.results[0])
+	assert.Equal(t, string(resultNotAGitRepo), recorder.results[1])
+}
+
+func TestReport_KeepsTheOutcomeOfTheInvocationThatReported(t *testing.T) {
+	var posts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		posts++
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(server.Close)
+
+	s := capturedSink(t)
+	recorder := metrics.NewRecorderFake()
+	engine := newTestEngine(t, testConfig(server.URL, testOrgID.String(), newRepoWithCommit(t)), server.Client())
+
+	for range 3 {
+		report(t.Context(), engine, s, recorder)
+	}
+
+	assert.Equal(t, 1, posts, "contributors must be emitted once, not once per invocation")
+	assert.Equal(t, string(resultEmitted), recorder.StringValues[analyticsKeyResult])
+	assert.Equal(t, 1, recorder.IntValues[analyticsKeyCount])
+}
+
+func TestReport_StillReportsACaptureMadeAfterAnEarlierInvocation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(server.Close)
+
+	s := &Sink{}
+	recorder := metrics.NewRecorderFake()
+	engine := newTestEngine(t, testConfig(server.URL, testOrgID.String(), newRepoWithCommit(t)), server.Client())
+
+	report(t.Context(), engine, s, recorder)
+	require.Equal(t, string(resultNoRelevantRequest), recorder.StringValues[analyticsKeyResult])
+
+	s.RecordEntity(EntityTypeProject, "22222222-2222-2222-2222-222222222222")
+	report(t.Context(), engine, s, recorder)
+
+	assert.Equal(t, string(resultEmitted), recorder.StringValues[analyticsKeyResult])
+	assert.Equal(t, 1, recorder.IntValues[analyticsKeyCount])
+}
+
+func TestEmitResult_MapsFailuresThatEndToEndTestsCannotProvoke(t *testing.T) {
+	tests := map[string]struct {
+		err  error
+		want collectionResult
+	}{
+		"unreadable repository": {
+			err:  fmt.Errorf("%w: %w", ErrCollect, errors.New("read commits")),
+			want: resultCollectFailed,
+		},
+		// Cancelation surfaces wrapped in whichever stage was interrupted, so it
+		// has to outrank that stage rather than be hidden by it.
+		"cancelation during collection": {
+			err:  fmt.Errorf("%w: %w", ErrCollect, context.Canceled),
+			want: resultTimedOut,
+		},
+		"cancelation during submission": {
+			err:  fmt.Errorf("%w: %w", ErrSubmit, context.DeadlineExceeded),
+			want: resultTimedOut,
+		},
+		// A malformed item cannot come from the capture middleware, but it is
+		// rejected in place of the submission it would have been sent in.
+		"malformed item": {
+			err:  errors.New("unsupported entity type"),
+			want: resultSubmitFailed,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, emitResult(tc.err))
+		})
+	}
+}
+
+func TestSink_PrefersACapturedEntityOverAnyMiss(t *testing.T) {
+	s := &Sink{}
+	s.RecordMiss(MissErrorStatus)
+	s.RecordEntity(EntityTypeProject, "22222222-2222-2222-2222-222222222222")
+
+	item, alreadyTaken := s.take()
+	require.NotNil(t, item)
+	assert.False(t, alreadyTaken)
+	assert.Equal(t, "22222222-2222-2222-2222-222222222222", item.EntityID)
+}
+
+func TestSink_DistinguishesAnAlreadyTakenCaptureFromNoCapture(t *testing.T) {
+	empty := &Sink{}
+	item, alreadyTaken := empty.take()
+	assert.Nil(t, item)
+	assert.False(t, alreadyTaken)
+
+	s := capturedSink(t)
+	_, alreadyTaken = s.take()
+	require.False(t, alreadyTaken)
+
+	item, alreadyTaken = s.take()
+	assert.Nil(t, item)
+	assert.True(t, alreadyTaken)
+}
+
+func TestSink_KeepsTheFirstMissReported(t *testing.T) {
+	s := &Sink{}
+	s.RecordMiss(MissErrorStatus)
+	s.RecordMiss(MissPanic)
+
+	assert.Equal(t, MissErrorStatus, s.miss())
+}
+
+// sequenceRecorder keeps every outcome written, in order, which the shared
+// recorder fake cannot express because it holds only the latest value per key.
+type sequenceRecorder struct {
+	results []string
+	counts  []int
+}
+
+func (r *sequenceRecorder) AddExtensionStringValue(key string, value string) {
+	if key == analyticsKeyResult {
+		r.results = append(r.results, value)
+	}
+}
+
+func (r *sequenceRecorder) AddExtensionIntegerValue(key string, value int) {
+	if key == analyticsKeyCount {
+		r.counts = append(r.counts, value)
+	}
+}
+
+func (r *sequenceRecorder) AddExtensionBoolValue(string, bool) {}
+
+// capturedSink returns a sink holding an entity, as the capture middleware would
+// have left it.
+func capturedSink(t *testing.T) *Sink {
+	t.Helper()
+
+	s := &Sink{}
+	s.RecordEntity(EntityTypeProject, "22222222-2222-2222-2222-222222222222")
+	return s
+}
+
+func testConfig(apiURL, orgID, inputDir string) configuration.Configuration {
+	config := configuration.NewWithOpts()
+	config.Set(configuration.API_URL, apiURL)
+	if orgID != "" {
+		config.Set(configuration.ORGANIZATION, orgID)
+	}
+	config.Set(configuration.INPUT_DIRECTORY, []string{inputDir})
+	return config
+}
+
+func newTestEngine(t *testing.T, config configuration.Configuration, client *http.Client) *mocks.MockEngine {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	logger := zerolog.Nop()
+
+	network := mocks.NewMockNetworkAccess(ctrl)
+	network.EXPECT().GetHttpClient().Return(client).AnyTimes()
+
+	engine := mocks.NewMockEngine(ctrl)
+	engine.EXPECT().GetLogger().Return(&logger).AnyTimes()
+	engine.EXPECT().GetConfiguration().Return(config).AnyTimes()
+	engine.EXPECT().GetNetworkAccess().Return(network).AnyTimes()
+	return engine
+}
+
+// newRepoWithCommit returns a repository with one commit authored now, so it has
+// exactly one contributor in the window.
+func newRepoWithCommit(t *testing.T) string {
+	t.Helper()
+
+	return newRepo(t, time.Now())
+}
+
+// newRepoWithOldCommit returns a repository whose only commit predates the
+// contributor window.
+func newRepoWithOldCommit(t *testing.T) string {
+	t.Helper()
+
+	return newRepo(t, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+}
+
+func newRepo(t *testing.T, when time.Time) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	home := t.TempDir()
+
+	var env []string
+	for _, kv := range os.Environ() {
+		if !strings.HasPrefix(kv, "GIT_") {
+			env = append(env, kv)
+		}
+	}
+	env = append(env,
+		"HOME="+home,
+		"GIT_CONFIG_GLOBAL="+os.DevNull,
+		"GIT_CONFIG_SYSTEM="+os.DevNull,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_AUTHOR_NAME=Alice",
+		"GIT_AUTHOR_EMAIL=alice@example.com",
+		"GIT_AUTHOR_DATE="+when.Format(time.RFC3339),
+		"GIT_COMMITTER_NAME=Alice",
+		"GIT_COMMITTER_EMAIL=alice@example.com",
+		"GIT_COMMITTER_DATE="+when.Format(time.RFC3339),
+	)
+
+	git := func(args ...string) {
+		t.Helper()
+
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = env
+		out, err := cmd.CombinedOutput()
+		require.NoErrorf(t, err, "git %s: %s", strings.Join(args, " "), out)
+	}
+
+	git("init", "--initial-branch=main", ".")
+	git("commit", "--allow-empty", "-m", "a commit")
+	return dir
+}

--- a/pkg/local_workflows/local_workflows.go
+++ b/pkg/local_workflows/local_workflows.go
@@ -1,6 +1,7 @@
 package localworkflows
 
 import (
+	contributors "github.com/snyk/go-application-framework/internal/contributors/hook"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/doctor_workflow"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )
@@ -19,6 +20,7 @@ func Init(engine workflow.Engine) error {
 		InitDataTransformationWorkflow,
 		InitFilterFindingsWorkflow,
 		doctor_workflow.InitDoctorWorkflow,
+		contributors.Init,
 	}
 
 	for i := range initMethods {

--- a/pkg/networking/middleware/contributor_capture/contributor_capture.go
+++ b/pkg/networking/middleware/contributor_capture/contributor_capture.go
@@ -22,9 +22,26 @@ type ContributorCaptureMiddleware struct {
 	pendingTests *pendingTests
 }
 
+// testState encodes ongoing test's state.
+type testState int
+
+const (
+	// testUnknown is a test whose creation the middleware never saw.
+	testUnknown testState = iota
+
+	// testNotPublishing is a test created without publish_report.
+	testNotPublishing
+
+	// testPending is a publishing test where a project ID has not yet been recorded.
+	testPending
+
+	// testCaptured is a publishing test whose project ID has been recorded.
+	testCaptured
+)
+
 type pendingTests struct {
-	mu  sync.Mutex
-	ids map[string]struct{}
+	mu     sync.Mutex
+	states map[string]testState
 }
 
 // NewContributorCaptureMiddleware returns a middleware that wraps a round tripper
@@ -34,7 +51,7 @@ func NewContributorCaptureMiddleware(
 	sink Sink,
 	logger *zerolog.Logger,
 ) networktypes.MiddlewareFunc {
-	pt := pendingTests{ids: make(map[string]struct{})}
+	pt := pendingTests{states: make(map[string]testState)}
 	if logger == nil {
 		logger = new(zerolog.Nop())
 	}
@@ -52,8 +69,13 @@ func NewContributorCaptureMiddleware(
 // captureState carries everything gathered from a matched request before it
 // is sent, needed to capture entities from its response once it returns.
 type captureState struct {
-	kind                   endpointKind
-	publishReportRequested bool
+	kind endpointKind
+
+	// publishReport is true when a create test request asks to publish a report.
+	publishReport bool
+
+	// publishReportKnown is true if the value of publishReport was read successfully.
+	publishReportKnown bool
 }
 
 func (m *ContributorCaptureMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -79,7 +101,7 @@ func (m *ContributorCaptureMiddleware) RoundTrip(req *http.Request) (*http.Respo
 // beginRequestCapture performs whatever capture the request alone allows and
 // reports whether the response still has to be processed to finish the job.
 func (m *ContributorCaptureMiddleware) beginRequestCapture(req *http.Request) (state captureState, needsResponse bool) {
-	defer m.recover(req)
+	defer m.recover()
 
 	kind, matched := m.classifyRequest(req)
 	if !matched {
@@ -93,7 +115,7 @@ func (m *ContributorCaptureMiddleware) beginRequestCapture(req *http.Request) (s
 		m.record(contributors.EntityTypeRevision, parseAIBomUploadRevisionID(m.requestBody(req)))
 		return state, false
 	case endpointTestCreate:
-		state.publishReportRequested = parseCreateTestPublishReport(m.requestBody(req))
+		state.publishReport, state.publishReportKnown = parseCreateTestPublishReport(m.requestBody(req))
 	default:
 	}
 
@@ -132,13 +154,6 @@ func (m *ContributorCaptureMiddleware) isKnownHost(req *http.Request) bool {
 		return true
 	}
 
-	m.logger.Debug().
-		Str("path", req.URL.Path).
-		Str("host", req.URL.Host).
-		Str("api_url", apiURL).
-		Err(err).
-		Bool("known_host", known).
-		Msg("contributor capture: host not recognized")
 	return false
 }
 
@@ -148,7 +163,7 @@ func (m *ContributorCaptureMiddleware) isKnownHost(req *http.Request) bool {
 func (m *ContributorCaptureMiddleware) requestBody(req *http.Request) []byte {
 	bodyBytes, err := peekRequestBody(req, maxCaptureBodyBytes)
 	if err != nil {
-		m.logger.Debug().Err(err).Str("path", req.URL.Path).Msg("contributor capture: could not read request body")
+		m.sink.RecordMiss(contributors.MissBodyUnreadable)
 		return nil
 	}
 	return bodyBytes
@@ -157,40 +172,43 @@ func (m *ContributorCaptureMiddleware) requestBody(req *http.Request) []byte {
 // completeRequestCapture extracts and records entities from a matched
 // request's response, using the state beginRequestCapture gathered.
 func (m *ContributorCaptureMiddleware) completeRequestCapture(state captureState, req *http.Request, res *http.Response) {
-	defer m.recover(req)
+	defer m.recover()
 
 	if res.StatusCode >= http.StatusBadRequest {
+		m.sink.RecordMiss(contributors.MissErrorStatus)
 		return
 	}
 
-	parseBytes, ok := m.responseCaptureBytes(req, res, state.kind)
+	parseBytes, ok := m.responseCaptureBytes(res, state.kind)
 	if !ok {
 		return
 	}
 
-	if state.kind == endpointTestCreate {
-		m.markTestPending(parseBytes, state.publishReportRequested)
+	switch state.kind {
+	case endpointTestCreate:
+		m.recordCreatedTest(parseBytes, state.publishReport, state.publishReportKnown)
 		return
+	case endpointTestComponents:
+		m.captureComponents(req.URL.Path, parseBytes)
+		return
+	default:
 	}
 
-	projectIDs := m.projectIDsFromResponse(state.kind, req.URL.Path, parseBytes)
+	projectIDs := projectIDsFromResponse(state.kind, parseBytes)
 	m.record(contributors.EntityTypeProject, projectIDs...)
 }
 
 // responseCaptureBytes returns the part of res's body worth parsing. Bodies need no
 // content-encoding handling here: this middleware runs above http.Transport, which
 // negotiates and undoes compression before the response reaches us.
-func (m *ContributorCaptureMiddleware) responseCaptureBytes(req *http.Request, res *http.Response, kind endpointKind) ([]byte, bool) {
+func (m *ContributorCaptureMiddleware) responseCaptureBytes(res *http.Response, kind endpointKind) ([]byte, bool) {
 	bodyBytes, fullyRead, err := peekResponseBody(res, kind, maxCaptureBodyBytes)
 	if err != nil {
-		m.logger.Debug().Err(err).Str("path", req.URL.Path).Msg("contributor capture: could not read response body")
+		m.sink.RecordMiss(contributors.MissBodyUnreadable)
 		return nil, false
 	}
 	if !fullyRead && !captureAllowsTruncatedBodyParse(kind) {
-		m.logger.Debug().
-			Int("body_bytes", len(bodyBytes)).
-			Str("path", req.URL.Path).
-			Msg("contributor capture: skipping parse for oversized response body")
+		m.sink.RecordMiss(contributors.MissBodyTooLarge)
 		return nil, false
 	}
 
@@ -201,14 +219,12 @@ func captureAllowsTruncatedBodyParse(kind endpointKind) bool {
 	return kind == endpointDeeproxyReport
 }
 
-func (m *ContributorCaptureMiddleware) projectIDsFromResponse(kind endpointKind, path string, parseBytes []byte) []string {
+func projectIDsFromResponse(kind endpointKind, parseBytes []byte) []string {
 	switch kind {
 	case endpointRegistryMonitor:
 		return []string{parseMonitorProjectID(parseBytes)}
 	case endpointRegistryIaCShare:
 		return parseIaCShareProjectIDs(parseBytes)
-	case endpointTestComponents:
-		return m.projectIDsFromComponentsResponse(path, parseBytes)
 	case endpointDeeproxyReport:
 		return []string{parseDeeproxyReportProjectID(parseBytes)}
 	default:
@@ -216,65 +232,83 @@ func (m *ContributorCaptureMiddleware) projectIDsFromResponse(kind endpointKind,
 	}
 }
 
-func (m *ContributorCaptureMiddleware) projectIDsFromComponentsResponse(path string, parseBytes []byte) []string {
+// captureComponents records the project ID a components response carries, for a
+// test that is still waiting to yield one.
+func (m *ContributorCaptureMiddleware) captureComponents(path string, parseBytes []byte) {
+	testID := testIDFromPath(path)
+
+	switch m.testState(testID) {
+	case testNotPublishing, testCaptured:
+		return
+	case testUnknown:
+		m.sink.RecordMiss(contributors.MissNoEntity)
+		return
+	case testPending:
+	}
+
 	projectID := parseComponentsProjectID(parseBytes)
 	if projectID == "" {
-		return nil
-	}
-	testID := testIDFromPath(path)
-	if testID == "" || !m.takeTestIfPending(testID) {
-		return nil
-	}
-	return []string{projectID}
-}
-
-// markTestPending records that a test ID asked for publish_report.
-func (m *ContributorCaptureMiddleware) markTestPending(bodyBytes []byte, publishReportRequested bool) {
-	if !publishReportRequested {
+		m.sink.RecordMiss(contributors.MissNoEntity)
 		return
 	}
+
+	m.setTestState(testID, testCaptured)
+	m.sink.RecordEntity(contributors.EntityTypeProject, projectID)
+}
+
+// recordCreatedTest notes what a create-test response means for the components
+// polls that follow it.
+func (m *ContributorCaptureMiddleware) recordCreatedTest(bodyBytes []byte, publishReport, publishReportKnown bool) {
+	if !publishReportKnown {
+		m.sink.RecordMiss(contributors.MissBodyUnreadable)
+		return
+	}
+
 	testID := parseCreateTestID(bodyBytes)
 	if testID == "" {
+		if publishReport {
+			m.sink.RecordMiss(contributors.MissNoEntity)
+		}
 		return
 	}
 
-	m.pendingTests.mu.Lock()
-	m.pendingTests.ids[testID] = struct{}{}
-	m.pendingTests.mu.Unlock()
+	if publishReport {
+		m.setTestState(testID, testPending)
+		return
+	}
+	m.setTestState(testID, testNotPublishing)
 }
 
-// takeTestIfPending reports whether testID was previously marked pending, and
-// clears it if the result is true.
-func (m *ContributorCaptureMiddleware) takeTestIfPending(testID string) bool {
+func (m *ContributorCaptureMiddleware) setTestState(testID string, state testState) {
 	m.pendingTests.mu.Lock()
 	defer m.pendingTests.mu.Unlock()
-	_, ok := m.pendingTests.ids[testID]
-	if ok {
-		delete(m.pendingTests.ids, testID)
-	}
-	return ok
+	m.pendingTests.states[testID] = state
 }
 
-// record reports each captured ID to the sink. An empty ID means the parser
-// found nothing, so callers can hand over whatever they extracted unchecked.
+func (m *ContributorCaptureMiddleware) testState(testID string) testState {
+	m.pendingTests.mu.Lock()
+	defer m.pendingTests.mu.Unlock()
+	return m.pendingTests.states[testID]
+}
+
+// record reports each captured ID to the sink.
 func (m *ContributorCaptureMiddleware) record(entityType contributors.EntityType, entityIDs ...string) {
+	recorded := false
 	for _, entityID := range entityIDs {
 		if entityID == "" {
 			continue
 		}
 		m.sink.RecordEntity(entityType, entityID)
+		recorded = true
+	}
+
+	if !recorded {
+		m.sink.RecordMiss(contributors.MissNoEntity)
 	}
 }
 
-func (m *ContributorCaptureMiddleware) recover(req *http.Request) {
+func (m *ContributorCaptureMiddleware) recover() {
 	if recovered := recover(); recovered != nil {
-		path := ""
-		if req != nil && req.URL != nil {
-			path = req.URL.Path
-		}
-		m.logger.Debug().
-			Interface("panic", recovered).
-			Str("path", path).
-			Msg("contributor capture: recovered from panic")
+		m.sink.RecordMiss(contributors.MissPanic)
 	}
 }

--- a/pkg/networking/middleware/contributor_capture/contributor_capture_test.go
+++ b/pkg/networking/middleware/contributor_capture/contributor_capture_test.go
@@ -179,7 +179,8 @@ func TestContributorCaptureMiddleware_skipsNonSuccessResponses(t *testing.T) {
 				require.NoError(t, err)
 			}))
 			t.Cleanup(server.Close)
-			rt, _ := newTestMiddleware(t, http.DefaultTransport, server.URL)
+			rt, sink := newTestMiddleware(t, http.DefaultTransport, server.URL)
+			sink.EXPECT().RecordMiss(contributors.MissErrorStatus)
 
 			req, err := http.NewRequest(http.MethodPut, server.URL+"/v1/monitor/npm", http.NoBody)
 			require.NoError(t, err)
@@ -228,7 +229,8 @@ func TestContributorCaptureMiddleware_preservesOversizedResponseBodyWithoutConte
 		require.NoError(t, err)
 	}))
 	t.Cleanup(server.Close)
-	rt, _ := newTestMiddleware(t, http.DefaultTransport, server.URL)
+	rt, sink := newTestMiddleware(t, http.DefaultTransport, server.URL)
+	sink.EXPECT().RecordMiss(contributors.MissBodyTooLarge)
 
 	req, err := http.NewRequest(http.MethodPut, server.URL+"/v1/monitor/npm", http.NoBody)
 	require.NoError(t, err)
@@ -258,7 +260,8 @@ func TestContributorCaptureMiddleware_closesUnderlyingBodyOnOversizedResponse(t 
 			Request:    req,
 		}, nil
 	})
-	rt, _ := newTestMiddleware(t, next, "https://api.snyk.io")
+	rt, sink := newTestMiddleware(t, next, "https://api.snyk.io")
+	sink.EXPECT().RecordMiss(contributors.MissBodyTooLarge)
 
 	req, err := http.NewRequest(http.MethodPut, "https://api.snyk.io/v1/monitor/npm", http.NoBody)
 	require.NoError(t, err)
@@ -346,7 +349,10 @@ func TestContributorCaptureMiddleware_doesNotTruncateOversizedCreateTestRequestB
 		require.NoError(t, err)
 	}))
 	t.Cleanup(server.Close)
-	rt, _ := newTestMiddleware(t, http.DefaultTransport, server.URL)
+	rt, sink := newTestMiddleware(t, http.DefaultTransport, server.URL)
+	// The truncated peek loses the report flag, leaving us unable to say whether
+	// this test was one we should have followed.
+	sink.EXPECT().RecordMiss(contributors.MissBodyUnreadable)
 
 	createReq, err := http.NewRequest(http.MethodPost, server.URL+"/hidden/orgs/"+orgID+"/tests", bytes.NewReader(createBody))
 	require.NoError(t, err)
@@ -356,7 +362,37 @@ func TestContributorCaptureMiddleware_doesNotTruncateOversizedCreateTestRequestB
 	require.NoError(t, createRes.Body.Close())
 }
 
-func TestContributorCaptureMiddleware_doesNotCaptureComponents_whenNeverCreatedWithPublishReport(t *testing.T) {
+// A test created without publish_report can never yield an entity, so neither it
+// nor the polls that follow it are capture failures. Every non-reporting scan
+// takes this path, so reporting them would drown the failures worth seeing.
+func TestContributorCaptureMiddleware_reportsNoMissForATestThatDeclinedToPublish(t *testing.T) {
+	const (
+		orgID     = "77777777-7777-4777-8777-777777777777"
+		testID    = "77777777-7777-4777-8777-777777777777"
+		projectID = "33333333-3333-4333-8333-333333333333"
+	)
+
+	server := newTestComponentsServer(t, componentsServerOpts{orgID: orgID, testID: testID, projectID: projectID})
+	// A strict mock with no expectations: any call at all fails the test.
+	rt, _ := newTestMiddleware(t, http.DefaultTransport, server.URL)
+
+	createBody := []byte(`{"data":{"attributes":{"configuration":{"output":{"report":false}}}}}`)
+	createReq, err := http.NewRequest(http.MethodPost, server.URL+"/hidden/orgs/"+orgID+"/tests", bytes.NewReader(createBody))
+	require.NoError(t, err)
+	createRes, err := rt.RoundTrip(createReq)
+	require.NoError(t, err)
+	require.NoError(t, createRes.Body.Close())
+
+	for range 2 {
+		componentsReq, err := http.NewRequest(http.MethodGet, server.URL+"/hidden/orgs/"+orgID+"/tests/"+testID+"/components", http.NoBody)
+		require.NoError(t, err)
+		componentsRes, err := rt.RoundTrip(componentsReq)
+		require.NoError(t, err)
+		require.NoError(t, componentsRes.Body.Close())
+	}
+}
+
+func TestContributorCaptureMiddleware_doesNotCaptureComponents_whenTheTestWasNeverCreated(t *testing.T) {
 	const (
 		orgID     = "55555555-5555-4555-8555-555555555555"
 		testID    = "55555555-5555-4555-8555-555555555555"
@@ -369,7 +405,9 @@ func TestContributorCaptureMiddleware_doesNotCaptureComponents_whenNeverCreatedW
 		require.NoError(t, err)
 	}))
 	t.Cleanup(server.Close)
-	rt, _ := newTestMiddleware(t, http.DefaultTransport, server.URL)
+	rt, sink := newTestMiddleware(t, http.DefaultTransport, server.URL)
+	// Never having seen the create means we lost a test we should have followed.
+	sink.EXPECT().RecordMiss(contributors.MissNoEntity)
 
 	// No create-test call happened for this test ID, so it was never marked pending.
 	componentsReq, err := http.NewRequest(http.MethodGet, server.URL+"/hidden/orgs/"+orgID+"/tests/"+testID+"/components", http.NoBody)
@@ -392,6 +430,9 @@ func TestContributorCaptureMiddleware_componentsPollingSurvivesThenStopsAfterSuc
 	})
 	rt, sink := newTestMiddleware(t, http.DefaultTransport, server.URL)
 	sink.EXPECT().RecordEntity(contributors.EntityTypeProject, projectID).Times(1)
+	// Polls 1-2 carry no project ID while the test is still pending. Poll 4 arrives
+	// after the capture, which is expected rather than a failure.
+	sink.EXPECT().RecordMiss(contributors.MissNoEntity).Times(2)
 
 	createBody := []byte(`{"data":{"attributes":{"configuration":{"output":{"report":true}}}}}`)
 	createReq, err := http.NewRequest(http.MethodPost, server.URL+"/hidden/orgs/"+orgID+"/tests", bytes.NewReader(createBody))
@@ -540,7 +581,8 @@ func TestContributorCaptureMiddleware_recordsNothingWhenResponseHasNoProjectID(t
 		}, nil
 	})
 	// A junk ID should be dropped, not recorded as an empty entity.
-	rt, _ := newTestMiddleware(t, next, "https://api.snyk.io")
+	rt, sink := newTestMiddleware(t, next, "https://api.snyk.io")
+	sink.EXPECT().RecordMiss(contributors.MissNoEntity)
 
 	req, err := http.NewRequest(http.MethodPut, "https://api.snyk.io/v1/monitor/npm", http.NoBody)
 	require.NoError(t, err)
@@ -555,7 +597,8 @@ func TestContributorCaptureMiddleware_recordsNothingWhenAIBomUploadHasNoRevision
 		return &http.Response{StatusCode: http.StatusCreated, Body: http.NoBody, Request: req}, nil
 	})
 	// A missing revision ID should be dropped too, not recorded empty.
-	rt, _ := newTestMiddleware(t, next, "https://api.snyk.io")
+	rt, sink := newTestMiddleware(t, next, "https://api.snyk.io")
+	sink.EXPECT().RecordMiss(contributors.MissNoEntity)
 
 	url := "https://api.snyk.io/rest/orgs/d5341082-085f-4458-a223-90c16aae2435/ai_boms/upload"
 	uploadBody := `{"data":{"attributes":{"repo_name":"acme/app"},"type":"ai_bom_file_upload"}}`
@@ -680,6 +723,7 @@ func panickingSink(t *testing.T) *MockSink {
 	sink.EXPECT().RecordEntity(gomock.Any(), gomock.Any()).
 		Do(func(contributors.EntityType, string) { panic("boom") }).
 		Times(1)
+	sink.EXPECT().RecordMiss(contributors.MissPanic).Times(1)
 	return sink
 }
 

--- a/pkg/networking/middleware/contributor_capture/parse.go
+++ b/pkg/networking/middleware/contributor_capture/parse.go
@@ -7,10 +7,8 @@ import (
 )
 
 // parseCreateTestPublishReport reports whether a CreateTest request body asked for
-// publish_report. Supports the Code hidden Test API (configuration.output.report)
-// and OSS/IaC/SCA flows (config.publish_report). Native monitor (config.monitor)
-// is intentionally excluded.
-func parseCreateTestPublishReport(body []byte) bool {
+// publish_report, and whether the body was read successfully.
+func parseCreateTestPublishReport(body []byte) (report bool, known bool) {
 	// Try legacy format first (OSS/IaC/SCA)
 	var legacyReq struct {
 		Data struct {
@@ -25,10 +23,10 @@ func parseCreateTestPublishReport(body []byte) bool {
 	if err := json.Unmarshal(body, &legacyReq); err == nil {
 		cfg := legacyReq.Data.Attributes.Config
 		if cfg.Monitor {
-			return false
+			return false, true
 		}
 		if cfg.PublishReport {
-			return true
+			return true, true
 		}
 	}
 
@@ -45,10 +43,10 @@ func parseCreateTestPublishReport(body []byte) bool {
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(body, &newReq); err == nil {
-		return newReq.Data.Attributes.Configuration.Output.Report
+		return newReq.Data.Attributes.Configuration.Output.Report, true
 	}
 
-	return false
+	return false, false
 }
 
 // parseCreateTestID extracts the test ID from a successful CreateTest response.

--- a/pkg/networking/middleware/contributor_capture/parse_test.go
+++ b/pkg/networking/middleware/contributor_capture/parse_test.go
@@ -48,41 +48,55 @@ func TestParseCreateTestPublishReport(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		body     string
-		expected bool
+		name      string
+		body      string
+		expected  bool
+		wantKnown bool
 	}{
 		{
-			name:     "new style report true",
-			body:     `{"data":{"attributes":{"configuration":{"output":{"report":true}}}}}`,
-			expected: true,
+			name:      "new style report true",
+			body:      `{"data":{"attributes":{"configuration":{"output":{"report":true}}}}}`,
+			expected:  true,
+			wantKnown: true,
 		},
 		{
-			name:     "new style report false",
-			body:     `{"data":{"attributes":{"configuration":{"output":{"report":false}}}}}`,
-			expected: false,
+			name:      "new style report false",
+			body:      `{"data":{"attributes":{"configuration":{"output":{"report":false}}}}}`,
+			expected:  false,
+			wantKnown: true,
 		},
 		{
-			name:     "legacy publish_report true",
-			body:     `{"data":{"attributes":{"config":{"publish_report":true}}}}`,
-			expected: true,
+			name:      "legacy publish_report true",
+			body:      `{"data":{"attributes":{"config":{"publish_report":true}}}}`,
+			expected:  true,
+			wantKnown: true,
 		},
 		{
-			name:     "legacy monitor only (rejected)",
-			body:     `{"data":{"attributes":{"config":{"monitor":true,"scan_config":{"sca":{}}}}}}`,
-			expected: false,
+			name:      "legacy monitor only (rejected)",
+			body:      `{"data":{"attributes":{"config":{"monitor":true,"scan_config":{"sca":{}}}}}}`,
+			expected:  false,
+			wantKnown: true,
 		},
 		{
-			name:     "invalid json",
-			body:     `{invalid}`,
-			expected: false,
+			name:      "invalid json",
+			body:      `{invalid}`,
+			expected:  false,
+			wantKnown: false,
+		},
+		{
+			name:      "truncated json",
+			body:      `{"data":{"attributes":{"configuration":{"output":{"rep`,
+			expected:  false,
+			wantKnown: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.expected, cc.ParseCreateTestPublishReport([]byte(tt.body)))
+			report, known := cc.ParseCreateTestPublishReport([]byte(tt.body))
+			assert.Equal(t, tt.expected, report)
+			assert.Equal(t, tt.wantKnown, known, "an unreadable body must not read as a declined report")
 		})
 	}
 }

--- a/pkg/networking/middleware/contributor_capture/sink.go
+++ b/pkg/networking/middleware/contributor_capture/sink.go
@@ -9,4 +9,5 @@ import "github.com/snyk/go-application-framework/internal/contributors"
 // non-blocking.
 type Sink interface {
 	RecordEntity(entityType contributors.EntityType, entityID string)
+	RecordMiss(reason contributors.MissReason)
 }

--- a/pkg/networking/middleware/contributor_capture/sink_mock_test.go
+++ b/pkg/networking/middleware/contributor_capture/sink_mock_test.go
@@ -45,3 +45,15 @@ func (mr *MockSinkMockRecorder) RecordEntity(entityType, entityID interface{}) *
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordEntity", reflect.TypeOf((*MockSink)(nil).RecordEntity), entityType, entityID)
 }
+
+// RecordMiss mocks base method.
+func (m *MockSink) RecordMiss(reason contributors.MissReason) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RecordMiss", reason)
+}
+
+// RecordMiss indicates an expected call of RecordMiss.
+func (mr *MockSinkMockRecorder) RecordMiss(reason interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordMiss", reflect.TypeOf((*MockSink)(nil).RecordMiss), reason)
+}


### PR DESCRIPTION
### Description

This PR adds a new call to the local workflow initialisers which registers a contributor capture post-invoke hook and middleware introduced in #703, when the appropriate feature flag is set. It uses the contributor capture functionality introduced in #697. This method of registration means the CLI will automatically begin using the functionality when the go-application-framework dependency is updated.

The middleware and contributor capture functionality are extended to support returning the reason why contributor capture did not occur, which is then recorded using the analytics package. No changes are made beyond those to support this mechanism.

### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.
