### PR TITLE
feat: add TOON flags

### DIFF
--- a/pkg/instrumentation/categories.go
+++ b/pkg/instrumentation/categories.go
@@ -193,6 +193,8 @@ var known_flags = []string{
 	"tfc-endpoint",
 	"tfc-token",
 	"to",
+	"toon",
+	"toon-file-output",
 	"traverse-node-modules",
 	"trust-policies",
 	"unmanaged",

--- a/pkg/local_workflows/output_workflow.go
+++ b/pkg/local_workflows/output_workflow.go
@@ -26,6 +26,8 @@ func InitOutputWorkflow(engine workflow.Engine) error {
 	outputConfig.String(output_workflow.OUTPUT_CONFIG_KEY_SARIF_FILE, "", "Write sarif output to file")
 	outputConfig.Bool(output_workflow.OUTPUT_CONFIG_KEY_HTML, false, "Print html output to console")
 	outputConfig.String(output_workflow.OUTPUT_CONFIG_KEY_HTML_FILE, "", "Write html output to file")
+	outputConfig.Bool(output_workflow.OUTPUT_CONFIG_KEY_TOON, false, "Print toon output to console")
+	outputConfig.String(output_workflow.OUTPUT_CONFIG_KEY_TOON_FILE, "", "Write toon output to file")
 	outputConfig.Bool(configuration.FLAG_INCLUDE_IGNORES, false, "Include ignored findings in the output")
 	outputConfig.String(configuration.FLAG_SEVERITY_THRESHOLD, "low", "Severity threshold for findings to be included in the output")
 

--- a/pkg/local_workflows/output_workflow_test.go
+++ b/pkg/local_workflows/output_workflow_test.go
@@ -145,6 +145,12 @@ func Test_Output_InitOutputWorkflow(t *testing.T) {
 
 	htmlFileOutput := config.Get("html-file-output")
 	assert.Equal(t, "", htmlFileOutput)
+
+	toon := config.Get("toon")
+	assert.Equal(t, false, toon)
+
+	toonFileOutput := config.Get("toon-file-output")
+	assert.Equal(t, "", toonFileOutput)
 }
 
 type testOutputDestination struct {


### PR DESCRIPTION
### Checklist

- [x] Tests added and all succeed (`make test`)
- [x] Regenerated mocks, etc. (`make generate`)
- [x] Linted (`make lint`)
- [x] Test your changes work for the CLI
  1. Clone / pull the latest [CLI](https://github.com/snyk/cli) main.
  2. Run `go get github.com/snyk/go-application-framework@YOUR_LATEST_GAF_COMMIT` in the `cliv2` directory.
      - Tip: for local testing, you can uncomment the line near the bottom of the CLI's [`go.mod`](https://github.com/snyk/cli/blob/main/cliv2/go.mod) to point to your local GAF code.
  3. Run `go mod tidy` in the `cliv2` directory.
  4. Run the CLI tests and do any required manual testing.
  5. Open a PR in the CLI repo **now** with the `go.mod` and `go.sum` changes.
  - Once this PR is merged, repeat these steps, but pointing to the latest GAF commit on main and update your CLI PR.

Related PR: https://github.com/snyk/cli/pull/7255

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag registration and telemetry allowlist only; no changes to rendering or auth paths in this diff.
> 
> **Overview**
> Adds **TOON** as a first-class output option alongside JSON, SARIF, and HTML by registering `--toon` (stdout) and `--toon-file-output` (file) on the output workflow flag set.
> 
> Also adds `toon` and `toon-file-output` to the instrumentation **known flags** list so CLI usage of these options is categorized correctly. Init tests assert the new flags default to **off** and an **empty** file path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3266b3f8e1754a499d06b34cf3909d15261352e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->